### PR TITLE
fix law_chat_bot

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -78,7 +78,8 @@ class ChromaStore(Store):
         Returns:
             List[Document]: List of documents retrieved by the query.
         """
-
+        if self.collection is None:
+            self._new_client()
         embedding = query.embeddings
         if self.embedding_model is not None and len(embedding) == 0:
             embedding = EmbeddingManager().get_instance_obj(

--- a/agentuniverse/agent/action/knowledge/store/sqlite_store.py
+++ b/agentuniverse/agent/action/knowledge/store/sqlite_store.py
@@ -178,6 +178,8 @@ class SQLiteStore(Store):
         # Get doc_id from inverted index.
         relevant_docs = set()
         inverted_index = {}
+        if not self.conn:
+            self._new_client()
         with self.conn:
             for keyword in query_terms:
                 cursor = self.conn.cursor()

--- a/sample_standard_app/app/core/rag_router/nlu_rag_router.yaml
+++ b/sample_standard_app/app/core/rag_router/nlu_rag_router.yaml
@@ -2,8 +2,8 @@ name: 'nlu_rag_router'
 description: 'base rag router map query to all store'
 store_amount: 2
 llm:
-  name: demo_llm
-  model_name: gpt-4o
+  name: 'qwen_llm'
+  model_name: 'qwen-max'
 metadata:
   type: 'RAG_ROUTER'
   module: 'agentuniverse.agent.action.knowledge.rag_router.nlu_rag_router'


### PR DESCRIPTION
<h2 id="yreJ2">问题定位与解决</h2>
<h3 id="kfWTw">Bug1</h3>
在添加 qwen 的 API KEY 后 sample_standard_app/app/examples/law_chat_bot.py 无法跑通，报错如下：

![image](https://github.com/user-attachments/assets/a64c2b1b-8641-4b2d-97a8-f2bed7fc8b1f)

在配置文件 sample_standard_app/app/core/agent/rag_agent_case/law_rag_agent.yaml 中显示，law_chat_bot.py 使用的 agent 为 law_rag_agent，其调用的模型为 qwen_llm

```yaml
info:
  name: 'law_rag_agent'
  description: '一个法律顾问，可以根据给出的事件，以及提供的背景知识做出客观的司法判断。'
profile:
  introduction: 你是一位精通信息分析的ai法律顾问。
  target: 你的目标是根据给出的事件，以及提供的背景知识做出客观的司法判断。
  instruction: |
    你需要遵守的规则是:
    1. 必须使用中文结合背景信息做出判决，没有在背景知识中的条例不允许引用。
    2. 结构化答案生成，必要时通过空行提升阅读体验。
    3. 多考虑背景知识和场景的关联性。
    4. 多使用“根据民法典第XX条”“根据刑法第XX条”这种句式开头，但要求事件内容确实和对应条目相关，否则不要提及。
    5. 如果背景信息和内容无关则不要引用，引用条例时不要再强调“根据背景信息”这一点。
    

    背景信息是:
    {background}

    事件是: {input}
  llm_model:
    name: 'qwen_llm'
    model_name: 'qwen-max'
plan:
  planner:
    name: 'rag_planner'
action:
  knowledge:
    - 'law_knowledge'
metadata:
  type: 'AGENT'
  module: 'sample_standard_app.app.core.agent.rag_agent_case.law_rag_agent'
  class: 'LawRagAgent'
```

对比 demo_rag_agent 的配置文件sample_standard_app/app/core/agent/rag_agent_case/demo_rag_agent.yaml，law_rag_agent 中增加了 law_knowledge（sample_standard_app/app/core/agent/rag_agent_case/law_rag_agent.yaml）：

```yaml
name: "law_knowledge"
description: "中国民法与刑法相关的知识库"
stores:
    - "civil_law_chroma_store"
    - "criminal_law_chroma_store"
    - "civil_law_sqlite_store"
    - "criminal_law_sqlite_store"
query_paraphrasers:
    - "custom_query_keyword_extractor"
insert_processors:
    - "recursive_character_text_splitter"
rag_router: "nlu_rag_router"
post_processors:
    - "dashscope_reranker"
readers:
    pdf: "default_pdf_reader"

metadata:
  type: 'KNOWLEDGE'
  module: 'sample_standard_app.app.core.knowledge.law_knowledge'
  class: 'LawKnowledge'
```

其中的 nlu_rag_router （sample_standard_app/app/core/rag_router/nlu_rag_router.yaml）也调用了 llm，且默认为 gpt：

```yaml
name: 'nlu_rag_router'
description: 'base rag router map query to all store'
store_amount: 2
llm:
  name: demo_llm
  model_name: gpt-4o
metadata:
  type: 'RAG_ROUTER'
  module: 'agentuniverse.agent.action.knowledge.rag_router.nlu_rag_router'
  class: 'NluRagRouter'
```

将 demo_llm 修改为 qwen_llm 后，该 Bug 解决。

<h3 id="HzGhJ">Bug2</h3>
Bug1 解决后再次运行 law_chat_bot.py 虽有输出，但仍有报错，且输出的 retrieved background 为空：

![image](https://github.com/user-attachments/assets/5074591f-130e-4b58-8286-43ce9b5094cc)

![image](https://github.com/user-attachments/assets/b354db85-0288-4ba2-b681-d36b058de82b)

定位报错信息的 agentuniverse/agent/action/knowledge/knowledge.py 的 190 附近，原因是 futures 的返回结果为空，此处应该是在知识库 civil_law_chroma_store 和 civil_law_sqlite_store 中进行检索

![image](https://github.com/user-attachments/assets/51182f93-2b7f-4dab-a502-ff06efb45612)

![image](https://github.com/user-attachments/assets/5985b5fc-9434-4113-ad5c-55e4c85ef071)

单独运行 StoreManager().get_instance_obj().query()，出现报错：

![image](https://github.com/user-attachments/assets/ffb5d963-8efd-4de2-884e-942e2343db3c)

![image](https://github.com/user-attachments/assets/4280f723-cbfa-4b26-b78a-1bf1495fa6a0)

![image](https://github.com/user-attachments/assets/a1e1fd3c-f6e7-42cb-abaa-c18390b2f44c)

<h4 id="xo8hz">Bug2.1</h4>
报错是因为 agentuniverse/agent/action/knowledge/store/chroma_store.py 中 self.collection 为 None，根本原因是 self.collection 在 _new_client 中被赋值，但 _new_client 未被调用：

![image](https://github.com/user-attachments/assets/c167a35c-b852-4bea-a048-b1da962d6f54)

![image](https://github.com/user-attachments/assets/acc72334-92ef-453e-841c-b732a38d9083)
在 self.collection 为 None 时增加 _new_client 的调用后该 Bug 消失：

![image](https://github.com/user-attachments/assets/c9157923-bfd7-48cb-b405-a5f1728b6406)

<h4 id="GCp9y">Bug2.2</h4>
Bug2.1 解决后再次运行 law_chat_bot.py 仍有报错：

![image](https://github.com/user-attachments/assets/a1ca0d2f-4db5-4e90-942f-ce17bc0c24d2)

![image](https://github.com/user-attachments/assets/eaf3c563-044a-4aaf-ac06-cbb2a7f300ea)

报错是因为 agentuniverse/agent/action/knowledge/store/sqlite_store.py 中 self.conn 为 None，根本原因同样是 self.conn 在 _new_client 中被赋值，但 _new_client 未被调用：

![image](https://github.com/user-attachments/assets/43fe9db8-e496-4e31-9f40-e898d852054a)

![image](https://github.com/user-attachments/assets/34b232e6-6a7c-4458-a7f3-8fe29f11031f)

同样在 self.conn 为 None 时增加 _new_client 的调用： 

![image](https://github.com/user-attachments/assets/13dcd7f4-8802-4a01-a61a-096dc90fcc67)



解决完 Bug2.1 和 Bug2.2 后 futures 的返回结果正常，最终输出结果的 retrieved background 不为空：

![image](https://github.com/user-attachments/assets/eeaa2bc7-a0b6-4f44-b156-6fd33e9ebdf6)

![image](https://github.com/user-attachments/assets/296d92f8-035a-4fa9-af02-3ccfe545dac8)

