### PR TITLE
Add some notes in 1_3_快速开始

### DIFF
--- a/docs/guidebook/zh/1_3_快速开始.md
+++ b/docs/guidebook/zh/1_3_快速开始.md
@@ -201,9 +201,40 @@ class RagAgentTest(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
 ```
+
 在`test_rag_agent`方法中，我们通过`AgentManager().get_instance_obj`获取了`demo_rag_agent`的实例对象，然后通过`instance.run`方法执行了agent的逻辑。
 
 通过测试，你可以观察agent的思路与答案是否符合你的预期，并且优化对应的设定、增强工具与知识，不断的重复这个步骤直到效果达到满意。
+
+### 运行测试
+
+#### 目录结构要求
+agentUniverse期望从 `app/bootstrap` 目录启动，这样才能正确解析配置文件路径。agentUniverse 使用相对路径来定位配置文件，并且以 `bootstrap` 目录作为基准点。
+
+#### 正确的测试运行方式
+```bash
+# 1. 进入 bootstrap 目录
+cd sample_standard_app/app/bootstrap
+
+# 2. 设置 PYTHONPATH 以确保能够正确导入依赖
+export PYTHONPATH=/path/to/your/agentUniverse  # 替换为你的 agentUniverse 实际路径
+
+# 3. 运行测试
+python -m pytest ../test/test_rag_agent.py
+```
+
+#### 常见问题
+1. **配置文件找不到**
+   ```
+   FileNotFoundError: [Errno 2] No such file or directory: '../../config/config.toml'
+   ```
+   这通常是因为没有从 `bootstrap` 目录运行测试导致的。请确保按照上述步骤在正确的目录下运行测试。
+
+2. **警告信息**
+   ```
+   Warn: Boot file is not located under directory 'bootstrap'
+   ```
+   这个警告表明当前不是在 `bootstrap` 目录下运行，可能会导致路径解析问题。
 
 ## 对agent进行快速服务化
 ### 使用配置注册服务
@@ -226,8 +257,11 @@ cd `your bootstrap directory path`
 python server_application.py
 ```
 
-当出现如下命令行说明监听成功，默认监听127.0.0.1地址8000端口，worker数为5，可在`config/gunicorn_config.toml`中修改配置。（注意windows系统与直接使用flask启动的目前默认监听8888端口）
+当出现如下命令行说明监听成功，默认监听127.0.0.1地址8000端口，worker数为5，可在`config/gunicorn_config.toml`中修改配置。（注意windows系统与直接使用`flask`启动的目前默认监听8888端口）
 ![image](../_picture/1_3_Quick%20Start_0.png)
+
+
+我们已经将启动服务的必要的步骤写在了 `agentUniverse/sample_standard_app/quick_start.sh` (或者 `quick_start.ps1` 或者 `quick_start.bat`) 中，你可以使用 `quick_start` 脚本启动服务。
 
 ### 服务访问
 #### 本机或局域网访问


### PR DESCRIPTION
## 问题描述
在运行测试时，如果不是从正确的目录（app/bootstrap）启动，会遇到配置文件找不到的问题。发现框架使用相对路径解析配置文件，并 从 system_util#get_project_root_path 中可以看到框架期望从 bootstrap 目录启动。

## 改进内容
- 在文档中添加了关于测试运行的详细说明
- 解释了目录结构要求和正确的运行步骤
- 列出了常见问题和解决方案

## 相关问题
- 配置文件路径解析依赖于启动目录
- 缺少相关文档说明导致用户可能遇到困惑

## 测试
本人按照更新后的文档说明才能够正常运行测试。可以进行复核。