### PR TITLE
FIX: mcp tool can't pass env correctly

### DIFF
--- a/agentuniverse/base/context/mcp_session_manager.py
+++ b/agentuniverse/base/context/mcp_session_manager.py
@@ -343,6 +343,7 @@ class MCPSessionManager:
         server_params = StdioServerParameters(
             command=command,
             args=args,
+            env=env,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
         )
@@ -397,6 +398,7 @@ class MCPSessionManager:
         server_params = StdioServerParameters(
             command=command,
             args=args,
+            env=env,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
         )


### PR DESCRIPTION
FIX: mcp tool can't pass env correctly