### PR TITLE
feat(knowledge): add post-retrieval processors (rerank/filter/merge/summarize) and wire up examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,41 @@ Run your first example, and you can quickly experience the performance of the ag
 
 Please refer to the document for detail steps: [Run the first example](docs/guidebook/en/Get_Start/2.Run_Your_First_Tutorial_Example.md) 。
 
+### Enable Knowledge Post-Processing (Rerank/Filter/Merge/Summarize)
+
+You can chain post-retrieval processors in any `Knowledge` config via `post_processors`.
+
+```
+post_processors:
+  - dashscope_reranker
+  - score_threshold_filter
+  - merge_by_metadata
+  - summarize_docs
+```
+
+Fine-tune processors at the agent level under `config.doc_processors`:
+
+```
+config:
+  doc_processors:
+    score_threshold_filter:
+      min_score: 0.2
+      keep_no_score: true
+      top_k: 20
+    merge_by_metadata:
+      group_keys: ['file_name']
+      separator: "\n\n"
+      prefer_higher_score: true
+    summarize_docs:
+      llm: '__default_instance__'
+      mode: 'stuff'  # or 'map_reduce'
+      return_only_summary: false
+```
+
+Requirements:
+- Set `DASHSCOPE_API_KEY` for `dashscope_reranker`.
+- Ensure an LLM is configured for summarization.
+
 ****************************************
 
 ## How to build an agent application

--- a/agentuniverse/agent/action/knowledge/doc_processor/merge_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/merge_processor.py
@@ -1,0 +1,67 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/10/13
+# @Author  : au-bot
+# @FileName: merge_processor.py
+
+from typing import List, Optional, Dict, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class MergeByMetadata(DocProcessor):
+    """Merge documents that share the same metadata keys.
+
+    Documents are grouped by the tuple of values for `group_keys` inside
+    `Document.metadata`. Within each group, texts are concatenated with
+    `separator`. Optionally, keep only the best scored document's metadata
+    when `prefer_higher_score` is True.
+    """
+
+    name: Optional[str] = "merge_by_metadata"
+    description: Optional[str] = "Merge docs by metadata keys"
+
+    group_keys: List[str] = []
+    separator: str = "\n\n"
+    prefer_higher_score: bool = True
+
+    def _make_group_key(self, metadata: Optional[Dict]) -> Tuple:
+        metadata = metadata or {}
+        return tuple(metadata.get(k) for k in self.group_keys)
+
+    def _process_docs(self, origin_docs: List[Document], query: Query | None = None) -> List[Document]:
+        if not origin_docs or not self.group_keys:
+            return origin_docs
+        grouped: Dict[Tuple, List[Document]] = {}
+        for doc in origin_docs:
+            key = self._make_group_key(doc.metadata)
+            grouped.setdefault(key, []).append(doc)
+
+        merged_docs: List[Document] = []
+        for _, docs in grouped.items():
+            if len(docs) == 1:
+                merged_docs.append(docs[0])
+                continue
+            combined_text = self.separator.join(d.text or "" for d in docs if d.text)
+            # choose metadata representative
+            rep = docs[0]
+            if self.prefer_higher_score:
+                rep = max(docs, key=lambda d: (d.metadata or {}).get("relevance_score", -1))
+            merged_docs.append(Document(text=combined_text, metadata=rep.metadata))
+        return merged_docs
+
+    def _initialize_by_component_configer(self, doc_processor_configer: ComponentConfiger) -> "DocProcessor":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "group_keys"):
+            self.group_keys = list(doc_processor_configer.group_keys)
+        if hasattr(doc_processor_configer, "separator"):
+            self.separator = str(doc_processor_configer.separator)
+        if hasattr(doc_processor_configer, "prefer_higher_score"):
+            self.prefer_higher_score = bool(doc_processor_configer.prefer_higher_score)
+        return self
+
+

--- a/agentuniverse/agent/action/knowledge/doc_processor/merge_processor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/merge_processor.yaml
@@ -1,0 +1,7 @@
+name: 'merge_by_metadata'
+description: 'Merge retrieved documents by metadata keys'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.merge_processor'
+  class: 'MergeByMetadata'
+

--- a/agentuniverse/agent/action/knowledge/doc_processor/score_filter_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/score_filter_processor.py
@@ -1,0 +1,59 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/10/13
+# @Author  : au-bot
+# @FileName: score_filter_processor.py
+
+from typing import List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class ScoreThresholdFilter(DocProcessor):
+    """Filter documents by a relevance score threshold.
+
+    This post-retrieval processor expects each `Document.metadata` to optionally
+    contain a numeric field `relevance_score` (e.g., from a reranker). Documents
+    with a score lower than `min_score` will be dropped. If a document has no
+    score, it is kept only when `keep_no_score` is True.
+    """
+
+    name: Optional[str] = "score_threshold_filter"
+    description: Optional[str] = "Filter docs by relevance score"
+
+    min_score: float = 0.0
+    keep_no_score: bool = True
+    top_k: Optional[int] = None
+
+    def _process_docs(self, origin_docs: List[Document], query: Query | None = None) -> List[Document]:
+        if not origin_docs:
+            return origin_docs
+        filtered: List[Document] = []
+        for doc in origin_docs:
+            metadata = doc.metadata or {}
+            score = metadata.get("relevance_score")
+            if score is None:
+                if self.keep_no_score:
+                    filtered.append(doc)
+            else:
+                if score >= self.min_score:
+                    filtered.append(doc)
+        if self.top_k is not None and self.top_k > 0:
+            filtered = filtered[: self.top_k]
+        return filtered
+
+    def _initialize_by_component_configer(self, doc_processor_configer: ComponentConfiger) -> "DocProcessor":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "min_score"):
+            self.min_score = float(doc_processor_configer.min_score)
+        if hasattr(doc_processor_configer, "keep_no_score"):
+            self.keep_no_score = bool(doc_processor_configer.keep_no_score)
+        if hasattr(doc_processor_configer, "top_k"):
+            self.top_k = int(doc_processor_configer.top_k)
+        return self
+
+

--- a/agentuniverse/agent/action/knowledge/doc_processor/score_filter_processor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/score_filter_processor.yaml
@@ -1,0 +1,7 @@
+name: 'score_threshold_filter'
+description: 'Filter documents by relevance score threshold'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.score_filter_processor'
+  class: 'ScoreThresholdFilter'
+

--- a/agentuniverse/agent/action/knowledge/doc_processor/summarize_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/summarize_processor.py
@@ -1,0 +1,76 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/10/13
+# @Author  : au-bot
+# @FileName: summarize_processor.py
+
+from typing import List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.util.prompt_util import (
+    summarize_by_stuff,
+    summarize_by_map_reduce,
+)
+from agentuniverse.llm.llm_manager import LLMManager
+from agentuniverse.prompt.prompt_manager import PromptManager
+
+
+class SummarizeDocs(DocProcessor):
+    """对召回文档进行摘要/总结合成。
+
+    支持两种模式：
+    - stuff: 直接将文本喂入 LLM 摘要，适合文档较短的情况；
+    - map_reduce: 先对分块做小结再合并，适合较长文本。
+    """
+
+    name: Optional[str] = "summarize_docs"
+    description: Optional[str] = "Summarize retrieved documents"
+
+    llm: str = "__default_instance__"
+    mode: str = "stuff"  # "stuff" | "map_reduce"
+    summary_prompt_version: str = "prompt_processor.summary_cn"
+    combine_prompt_version: str = "prompt_processor.combine_cn"
+    return_only_summary: bool = True
+    summary_metadata_key: str = "is_summary"
+
+    def _process_docs(self, origin_docs: List[Document], query: Query | None = None) -> List[Document]:
+        if not origin_docs:
+            return origin_docs
+
+        llm = LLMManager().get_instance_obj(self.llm)
+        texts = [d.text or "" for d in origin_docs if d.text]
+
+        summary_prompt = PromptManager().get_instance_obj(self.summary_prompt_version)
+        if self.mode == "map_reduce":
+            combine_prompt = PromptManager().get_instance_obj(self.combine_prompt_version)
+            summary_text = summarize_by_map_reduce(texts=texts, llm=llm, summary_prompt=summary_prompt,
+                                                  combine_prompt=combine_prompt)
+        else:
+            summary_text = summarize_by_stuff(texts=texts, llm=llm, summary_prompt=summary_prompt)
+
+        summary_doc = Document(text=str(summary_text), metadata={self.summary_metadata_key: True})
+        if self.return_only_summary:
+            return [summary_doc]
+        return [summary_doc] + origin_docs
+
+    def _initialize_by_component_configer(self, doc_processor_configer: ComponentConfiger) -> "DocProcessor":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "llm"):
+            self.llm = str(doc_processor_configer.llm)
+        if hasattr(doc_processor_configer, "mode"):
+            self.mode = str(doc_processor_configer.mode)
+        if hasattr(doc_processor_configer, "summary_prompt_version"):
+            self.summary_prompt_version = str(doc_processor_configer.summary_prompt_version)
+        if hasattr(doc_processor_configer, "combine_prompt_version"):
+            self.combine_prompt_version = str(doc_processor_configer.combine_prompt_version)
+        if hasattr(doc_processor_configer, "return_only_summary"):
+            self.return_only_summary = bool(doc_processor_configer.return_only_summary)
+        if hasattr(doc_processor_configer, "summary_metadata_key"):
+            self.summary_metadata_key = str(doc_processor_configer.summary_metadata_key)
+        return self
+
+

--- a/agentuniverse/agent/action/knowledge/doc_processor/summarize_processor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/summarize_processor.yaml
@@ -1,0 +1,7 @@
+name: 'summarize_docs'
+description: 'Summarize or combine retrieved documents'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.summarize_processor'
+  class: 'SummarizeDocs'
+

--- a/examples/sample_apps/rag_app/intelligence/agentic/agent/agent_instance/rag_agent_case/law_rag_agent.yaml
+++ b/examples/sample_apps/rag_app/intelligence/agentic/agent/agent_instance/rag_agent_case/law_rag_agent.yaml
@@ -28,6 +28,20 @@ action:
     - 'google_search_tool'
   knowledge:
     - 'law_knowledge'
+config:
+  doc_processors:
+    score_threshold_filter:
+      min_score: 0.2
+      keep_no_score: true
+      top_k: 20
+    merge_by_metadata:
+      group_keys: ['file_name']
+      separator: "\n\n"
+      prefer_higher_score: true
+    summarize_docs:
+      llm: '__default_instance__'
+      mode: 'stuff'
+      return_only_summary: false
 metadata:
   type: 'AGENT'
   module: 'agentuniverse.agent.template.rag_agent_template'

--- a/examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.yaml
+++ b/examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.yaml
@@ -12,6 +12,9 @@ insert_processors:
 rag_router: "nlu_rag_router"
 post_processors:
     - "dashscope_reranker"
+    - "score_threshold_filter"
+    - "merge_by_metadata"
+    - "summarize_docs"
 readers:
     pdf: "default_pdf_reader"
 metadata:

--- a/examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_instance/react_agent_case/demo_react_agent.yaml
+++ b/examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_instance/react_agent_case/demo_react_agent.yaml
@@ -14,6 +14,20 @@ action:
     - 'python_runner'
   knowledge:
     - 'law_knowledge'
+config:
+  doc_processors:
+    score_threshold_filter:
+      min_score: 0.2
+      keep_no_score: true
+      top_k: 20
+    merge_by_metadata:
+      group_keys: ['file_name']
+      separator: "\n\n"
+      prefer_higher_score: true
+    summarize_docs:
+      llm: '__default_instance__'
+      mode: 'stuff'
+      return_only_summary: false
 memory:
   name: 'demo_memory'
 metadata:

--- a/examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.yaml
+++ b/examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.yaml
@@ -12,6 +12,9 @@ insert_processors:
 rag_router: "nlu_rag_router"
 post_processors:
     - "dashscope_reranker"
+    - "score_threshold_filter"
+    - "merge_by_metadata"
+    - "summarize_docs"
 readers:
     pdf: "default_pdf_reader"
 metadata:


### PR DESCRIPTION
…ummarize) and wire up rag_app/react_agent_app; update README

**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [x] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
新增知识召回后处理器（可链式组合）： 
• rerank：复用 DashscopeReranker（需 DASHSCOPE_API_KEY）
• filter：ScoreThresholdFilter（按 relevance_score 阈值/TopK 过滤）
• merge：MergeByMetadata（按 group_keys 聚合并拼接文本）
• summarize：SummarizeDocs（支持 stuff/ map_reduce）
• 示例接入：在 rag_app 与 react_agent_app 的法律知识示例启用“重排→过滤→融合→摘要”链路，并在 agent 层提供 config.doc_processors 参数示例。
• 文档：README 增补“Enable Knowledge Post-Processing”使用说明。
• 向后兼容：是（默认不启用，仅当配置 post_processors 时生效）。


**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**
运行用例（rag_app）： 
• 测试文件路径：examples/sample_apps/rag_app/intelligence/test/test_rag_agent.py
• 运行命令：python -m examples.sample_apps.rag_app.intelligence.test.test_rag_agent
• 手动验证（react_agent_app）：
• 配置文件：examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_instance/react_agent_case/demo_react_agent.yaml
• 已在config.doc_processors 中给出参数示例，可按应用原有方式启动并观测输出包含摘要与融合后的上下文。
• 环境要求：设置DASHSCOPE_API_KEY 以启用重排；确保有可用 LLM 用于摘要。

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**
新增处理器与注册  
• agentuniverse/agent/action/knowledge/doc_processor/score_filter_processor.py  
• agentuniverse/agent/action/knowledge/doc_processor/score_filter_processor.yaml  
• agentuniverse/agent/action/knowledge/doc_processor/merge_processor.py  
• agentuniverse/agent/action/knowledge/doc_processor/merge_processor.yaml  
• agentuniverse/agent/action/knowledge/doc_processor/summarize_processor.py  
• agentuniverse/agent/action/knowledge/doc_processor/summarize_processor.yaml  
• 示例改动（rag_app）  
• examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.yaml  
• examples/sample_apps/rag_app/intelligence/agentic/agent/agent_instance/rag_agent_case/law_rag_agent.yaml  
• 示例改动（react_agent_app）  
• examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.yaml  
• examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_instance/react_agent_case/demo_react_agent.yaml  
• 文档  • README.md
-