### PR TITLE
fix:修复非空字符串验证误报问题

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
@@ -25,7 +25,8 @@ class ArxivToolTest(unittest.TestCase):
             'mode': SearchMode.SEARCH.value
         })
         result = self.tool.execute(tool_input)
-        self.assertTrue(result!= "")
+        self.assertIsNotNone(result)
+        self.assertGreater(len(result.strip()), 0)
 
     def test_get_paper_detail(self) -> None:
         tool_input = ToolInput({


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- 当 `tool_input` 的 `'input'` 为任意合法关键词（如 'machine learning'），但 `ArxivTool.execute()` 方法返回 `None` 或仅含空格/换行符的字符串时，原测试仍可能通过或误报。将原单一 `assertTrue` 拆分为两个断言：首先确保 `result` 不为 `None`，然后通过 `strip()` 去除空白字符后检查长度是否大于 0，从而更严格地验证返回内容的有效性和非空性。

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

-

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

-