### PR TITLE
fix:修复行号索引语义

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
@@ -46,15 +46,15 @@ class ViewFileToolTest(unittest.TestCase):
     def test_view_specific_lines(self):
         tool_input = ToolInput({
             'file_path': self.temp_file_path,
-            'start_line': 1,
-            'end_line': 3
+            'start_line': 2,
+            'end_line': 4
         })
 
         result_json = self.tool.execute(tool_input)
         result = json.loads(result_json)
 
         self.assertEqual(result['status'], 'success')
-        self.assertEqual(result['content'], "Line 2\nLine 3\n")
+        self.assertEqual(result['content'], "Line 2\nLine 3\nLine 4\n")
         self.assertEqual(result['start_line'], 1)
         self.assertEqual(result['end_line'], 2)
 


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- 若 `start_line=1` 表示第一行（即 \"Line 1\"），则应返回从第二行开始的内容；但实际断言内容为 `\"Line 2\
Line 3\
\"`，暗示工具将 `start_line=1` 解释为跳过首行，即按 0-based 索引处理起始位置，但命名使用 `start_line` 易误解为 1-based，接口设计模糊，测试断言与参数语义冲突。

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

-

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

-