### PR TITLE
refactor: refactor startup process into phased architecture

### DIFF
--- a/agentuniverse/base/startup/__init__.py
+++ b/agentuniverse/base/startup/__init__.py
@@ -1,0 +1,27 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: __init__.py
+
+"""Startup framework for AgentUniverse.
+
+This package provides a phased startup approach that:
+- Eliminates duplicate configuration loading
+- Provides clear dependency management between phases
+- Supports error recovery and rollback
+- Makes the startup process extensible and testable
+"""
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.base.startup.startup_orchestrator import StartupOrchestrator
+
+__all__ = [
+    'StartupPhase',
+    'StartupPhaseEnum',
+    'StartupContext',
+    'StartupOrchestrator',
+]

--- a/agentuniverse/base/startup/phases/__init__.py
+++ b/agentuniverse/base/startup/phases/__init__.py
@@ -1,0 +1,23 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: __init__.py
+
+"""Startup phases for AgentUniverse framework initialization."""
+
+from agentuniverse.base.startup.phases.config_phase import ConfigPhase
+from agentuniverse.base.startup.phases.logging_phase import LoggingPhase
+from agentuniverse.base.startup.phases.telemetry_phase import TelemetryPhase
+from agentuniverse.base.startup.phases.web_phase import WebPhase
+from agentuniverse.base.startup.phases.component_phase import ComponentPhase
+
+__all__ = [
+    'ConfigPhase',
+    'LoggingPhase',
+    'TelemetryPhase',
+    'WebPhase',
+    'ComponentPhase',
+]

--- a/agentuniverse/base/startup/phases/component_phase.py
+++ b/agentuniverse/base/startup/phases/component_phase.py
@@ -1,0 +1,86 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: component_phase.py
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.agent_serve.web.post_fork_queue import POST_FORK_QUEUE
+
+
+class ComponentPhase(StartupPhase):
+    """Component scanning and registration phase.
+
+    This phase handles:
+    1. Scanning all component packages
+    2. Registering components with their respective managers
+    3. Executing post-fork queue tasks (if in core mode)
+
+    This is the final and most complex phase, depending on all previous phases.
+    The actual scanning and registration logic is delegated to the AgentUniverse
+    instance to maintain backward compatibility.
+    """
+
+    def __init__(self, agent_universe_instance):
+        """Initialize the component phase.
+
+        Args:
+            agent_universe_instance: The AgentUniverse instance that contains
+                                    the scan and register methods
+        """
+        super().__init__(StartupPhaseEnum.COMPONENTS)
+        self._agent_universe = agent_universe_instance
+
+    def execute(self, context: StartupContext) -> None:
+        """Execute the component scanning and registration phase.
+
+        Args:
+            context: The startup context
+
+        Raises:
+            Exception: If component scanning or registration fails
+        """
+        try:
+            # Delegate to the existing scan_and_register method
+            # This maintains backward compatibility with the existing implementation
+            self._agent_universe._AgentUniverse__scan_and_register(context.app_configer)
+
+            # Execute post-fork queue tasks if in core mode
+            if context.core_mode:
+                for _func, args, kwargs in POST_FORK_QUEUE:
+                    _func(*args, **kwargs)
+
+            # Mark phase as completed
+            self._mark_completed()
+
+        except Exception as e:
+            self._mark_failed(e)
+            raise
+
+    def rollback(self, context: StartupContext) -> None:
+        """Rollback the component phase.
+
+        Args:
+            context: The startup context
+
+        Note:
+            Component unregistration is complex and typically not needed
+            during startup failures. This is a no-op for safety.
+        """
+        pass
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        """Return the list of phases this phase depends on.
+
+        Returns:
+            List containing all previous phases
+        """
+        return [
+            StartupPhaseEnum.CONFIG,
+            StartupPhaseEnum.LOGGING,
+            StartupPhaseEnum.TELEMETRY,
+            StartupPhaseEnum.WEB
+        ]

--- a/agentuniverse/base/startup/phases/config_phase.py
+++ b/agentuniverse/base/startup/phases/config_phase.py
@@ -1,0 +1,159 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: config_phase.py
+
+import sys
+from pathlib import Path
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.base.config.configer import Configer
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.custom_configer.custom_key_configer import CustomKeyConfiger
+from agentuniverse.base.util.system_util import get_project_root_path
+from agentuniverse.base.util import character_util
+
+
+class ConfigPhase(StartupPhase):
+    """Configuration loading phase.
+
+    This phase handles:
+    1. Loading the main configuration file
+    2. Loading custom keys (API keys, secrets)
+    3. Parsing sub-configuration paths
+    4. Setting up the application configuration manager
+
+    Note: This phase loads configuration ONCE, eliminating the duplicate
+    loading issue in the original implementation.
+    """
+
+    def __init__(self):
+        """Initialize the configuration phase."""
+        super().__init__(StartupPhaseEnum.CONFIG)
+
+    def execute(self, context: StartupContext) -> None:
+        """Execute the configuration loading phase.
+
+        Args:
+            context: The startup context
+
+        Raises:
+            Exception: If configuration loading fails
+        """
+        try:
+            # Show startup banner
+            character_util.show_au_start_banner()
+
+            # Get project root path and update sys.path
+            project_root_path = get_project_root_path()
+            context.project_root_path = project_root_path
+            sys.path.append(str(project_root_path.parent))
+            self._add_to_sys_path(project_root_path, ['intelligence', 'app'])
+
+            # Determine config path
+            if not context.config_path:
+                context.config_path = str(project_root_path / 'config' / 'config.toml')
+
+            # Load main configuration
+            configer = Configer(path=context.config_path).load()
+
+            # Parse and load custom key configuration first
+            custom_key_configer_path = self._parse_sub_config_path(
+                configer.value.get('SUB_CONFIG_PATH', {}).get('custom_key_path'),
+                context.config_path
+            )
+            context.custom_key_configer_path = custom_key_configer_path
+
+            # Initialize custom key configer (this loads API keys into environment)
+            if custom_key_configer_path:
+                CustomKeyConfiger(custom_key_configer_path)
+
+            # Reload configuration after custom keys are loaded
+            # This allows config values to reference environment variables set by custom keys
+            configer = Configer(path=context.config_path).load()
+            context.configer = configer
+
+            # Load application configuration
+            app_configer = AppConfiger().load_by_configer(configer)
+            context.app_configer = app_configer
+
+            # Initialize configuration container
+            config_container = ApplicationConfigManager()
+            config_container.app_configer = app_configer
+            context.config_container = config_container
+
+            # Parse other sub-configuration paths
+            context.log_config_path = self._parse_sub_config_path(
+                configer.value.get('SUB_CONFIG_PATH', {}).get('log_config_path'),
+                context.config_path
+            )
+
+            context.gunicorn_config_path = self._parse_sub_config_path(
+                configer.value.get('GUNICORN', {}).get('gunicorn_config_path'),
+                context.config_path
+            )
+
+            # Mark phase as completed
+            self._mark_completed()
+
+        except Exception as e:
+            self._mark_failed(e)
+            raise
+
+    def rollback(self, context: StartupContext) -> None:
+        """Rollback the configuration phase.
+
+        Args:
+            context: The startup context
+        """
+        # Clear configuration objects
+        context.configer = None
+        context.app_configer = None
+        context.config_container = None
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        """Return the list of phases this phase depends on.
+
+        Returns:
+            Empty list (no dependencies)
+        """
+        return []
+
+    def _parse_sub_config_path(self, input_path: str, reference_file_path: str) -> str | None:
+        """Resolve a sub config file path according to main config file.
+
+        Args:
+            input_path: Absolute or relative path of sub config file
+            reference_file_path: Main config file path
+
+        Returns:
+            A file path or None when no such file
+        """
+        if not input_path:
+            return None
+
+        input_path_obj = Path(input_path)
+        if input_path_obj.is_absolute():
+            combined_path = input_path_obj
+        else:
+            reference_file_path_obj = Path(reference_file_path)
+            combined_path = reference_file_path_obj.parent / input_path_obj
+
+        return str(combined_path)
+
+    def _add_to_sys_path(self, root_path: Path, sub_dirs: list[str]) -> None:
+        """Add subdirectories to sys.path.
+
+        Args:
+            root_path: The root path
+            sub_dirs: List of subdirectory names
+        """
+        for sub_dir in sub_dirs:
+            app_path = root_path / sub_dir
+            if app_path.exists():
+                sys.path.append(str(app_path))

--- a/agentuniverse/base/startup/phases/logging_phase.py
+++ b/agentuniverse/base/startup/phases/logging_phase.py
@@ -1,0 +1,63 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: logging_phase.py
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.base.util.logging.logging_util import init_loggers
+
+
+class LoggingPhase(StartupPhase):
+    """Logging initialization phase.
+
+    This phase initializes the logging system using loguru.
+    It depends on the CONFIG phase to get the log configuration path.
+    """
+
+    def __init__(self):
+        """Initialize the logging phase."""
+        super().__init__(StartupPhaseEnum.LOGGING)
+
+    def execute(self, context: StartupContext) -> None:
+        """Execute the logging initialization phase.
+
+        Args:
+            context: The startup context
+
+        Raises:
+            Exception: If logging initialization fails
+        """
+        try:
+            # Initialize loguru loggers with the configuration
+            init_loggers(context.log_config_path)
+
+            # Mark phase as completed
+            self._mark_completed()
+
+        except Exception as e:
+            self._mark_failed(e)
+            raise
+
+    def rollback(self, context: StartupContext) -> None:
+        """Rollback the logging phase.
+
+        Args:
+            context: The startup context
+
+        Note:
+            Logging rollback is typically not needed as loguru handles
+            cleanup automatically. This is a no-op for safety.
+        """
+        pass
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        """Return the list of phases this phase depends on.
+
+        Returns:
+            List containing CONFIG phase
+        """
+        return [StartupPhaseEnum.CONFIG]

--- a/agentuniverse/base/startup/phases/telemetry_phase.py
+++ b/agentuniverse/base/startup/phases/telemetry_phase.py
@@ -1,0 +1,71 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: telemetry_phase.py
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.base.tracing.otel.telemetry_manager import TelemetryManager
+from agentuniverse.base.util.monitor.monitor import Monitor
+
+
+class TelemetryPhase(StartupPhase):
+    """Telemetry and monitoring initialization phase.
+
+    This phase initializes:
+    1. OpenTelemetry (OTEL) for distributed tracing
+    2. Monitoring system
+
+    It depends on CONFIG and LOGGING phases.
+    """
+
+    def __init__(self):
+        """Initialize the telemetry phase."""
+        super().__init__(StartupPhaseEnum.TELEMETRY)
+
+    def execute(self, context: StartupContext) -> None:
+        """Execute the telemetry initialization phase.
+
+        Args:
+            context: The startup context
+
+        Raises:
+            Exception: If telemetry initialization fails
+        """
+        try:
+            # Initialize OpenTelemetry
+            otel_config = context.configer.value.get('OTEL', {})
+            TelemetryManager().init_from_config(otel_config)
+
+            # Initialize monitoring module
+            Monitor(configer=context.configer)
+
+            # Mark phase as completed
+            self._mark_completed()
+
+        except Exception as e:
+            self._mark_failed(e)
+            raise
+
+    def rollback(self, context: StartupContext) -> None:
+        """Rollback the telemetry phase.
+
+        Args:
+            context: The startup context
+
+        Note:
+            Telemetry cleanup is handled by the respective managers.
+            This is a no-op for safety.
+        """
+        pass
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        """Return the list of phases this phase depends on.
+
+        Returns:
+            List containing CONFIG and LOGGING phases
+        """
+        return [StartupPhaseEnum.CONFIG, StartupPhaseEnum.LOGGING]

--- a/agentuniverse/base/startup/phases/web_phase.py
+++ b/agentuniverse/base/startup/phases/web_phase.py
@@ -1,0 +1,133 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: web_phase.py
+
+import importlib
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.agent_serve.web.request_task import RequestLibrary
+from agentuniverse.agent_serve.web.rpc.grpc.grpc_server_booster import set_grpc_config
+from agentuniverse.agent_serve.web.web_booster import ACTIVATE_OPTIONS
+from agentuniverse.agent_serve.web.web_util import FlaskServerManager
+
+
+class WebPhase(StartupPhase):
+    """Web services initialization phase.
+
+    This phase initializes:
+    1. Web request task database
+    2. HTTP server configuration
+    3. gRPC server (if enabled)
+    4. Gunicorn server (if enabled)
+    5. Extension modules
+
+    It depends on CONFIG, LOGGING, and TELEMETRY phases.
+    """
+
+    def __init__(self):
+        """Initialize the web phase."""
+        super().__init__(StartupPhaseEnum.WEB)
+
+    def execute(self, context: StartupContext) -> None:
+        """Execute the web services initialization phase.
+
+        Args:
+            context: The startup context
+
+        Raises:
+            Exception: If web services initialization fails
+        """
+        try:
+            configer = context.configer
+
+            # Initialize web request task database
+            RequestLibrary(configer=configer)
+
+            # Configure HTTP server timeout
+            sync_service_timeout = configer.value.get('HTTP_SERVER', {}).get('sync_service_timeout')
+            if sync_service_timeout:
+                FlaskServerManager().sync_service_timeout = sync_service_timeout
+
+            # Initialize gRPC if enabled
+            grpc_activate = configer.value.get('GRPC', {}).get('activate')
+            if grpc_activate and grpc_activate.lower() == 'true':
+                ACTIVATE_OPTIONS["grpc"] = True
+                set_grpc_config(configer)
+
+            # Initialize Gunicorn if enabled
+            gunicorn_activate = configer.value.get('GUNICORN', {}).get('activate')
+            if gunicorn_activate and gunicorn_activate.lower() == 'true':
+                ACTIVATE_OPTIONS["gunicorn"] = True
+                if context.gunicorn_config_path:
+                    from agentuniverse.agent_serve.web.gunicorn_server import GunicornApplication
+                    GunicornApplication(config_path=context.gunicorn_config_path)
+
+            # Initialize extension modules
+            self._init_extension_modules(configer, context)
+
+            # Mark phase as completed
+            self._mark_completed()
+
+        except Exception as e:
+            self._mark_failed(e)
+            raise
+
+    def rollback(self, context: StartupContext) -> None:
+        """Rollback the web phase.
+
+        Args:
+            context: The startup context
+
+        Note:
+            Web service cleanup is complex and typically handled by
+            the respective managers. This is a no-op for safety.
+        """
+        pass
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        """Return the list of phases this phase depends on.
+
+        Returns:
+            List containing CONFIG, LOGGING, and TELEMETRY phases
+        """
+        return [StartupPhaseEnum.CONFIG, StartupPhaseEnum.LOGGING, StartupPhaseEnum.TELEMETRY]
+
+    def _init_extension_modules(self, configer, context: StartupContext) -> None:
+        """Initialize extension modules.
+
+        Args:
+            configer: The configuration object
+            context: The startup context
+        """
+        ext_classes = configer.value.get('EXTENSION_MODULES', {}).get('class_list')
+        if not isinstance(ext_classes, list):
+            return
+
+        for ext_class in ext_classes:
+            if "YamlFuncExtension" in ext_class:
+                # Store YAML function extension instance in config container
+                instance = self._dynamic_import_and_init(ext_class)
+                context.config_container.app_configer.yaml_func_instance = instance
+            else:
+                # Initialize other extensions with configer
+                self._dynamic_import_and_init(ext_class, configer)
+
+    def _dynamic_import_and_init(self, class_path: str, configer=None):
+        """Dynamically import and initialize a class.
+
+        Args:
+            class_path: Full class path like package_name.class_name
+            configer: Optional configer to pass to constructor
+
+        Returns:
+            Instance of the imported class
+        """
+        module_path, _, class_name = class_path.rpartition('.')
+        module = importlib.import_module(module_path)
+        cls = getattr(module, class_name)
+        return cls(configer) if configer else cls()

--- a/agentuniverse/base/startup/startup_context.py
+++ b/agentuniverse/base/startup/startup_context.py
@@ -1,0 +1,121 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: startup_context.py
+
+from pathlib import Path
+from typing import Any, Optional
+from agentuniverse.base.startup.startup_phase import StartupPhaseEnum
+
+
+class StartupContext:
+    """Context object that holds shared data during startup process.
+
+    This context is passed between startup phases to share configuration,
+    instances, and state information.
+    """
+
+    def __init__(self, config_path: Optional[str] = None, core_mode: bool = False):
+        """Initialize the startup context.
+
+        Args:
+            config_path: Path to the main configuration file
+            core_mode: Whether to run in core mode
+        """
+        self.config_path = config_path
+        self.core_mode = core_mode
+        self.project_root_path: Optional[Path] = None
+
+        # Phase completion tracking (list to preserve order)
+        self._completed_phases: list[StartupPhaseEnum] = []
+
+        # Shared data storage
+        self._data: dict[str, Any] = {}
+
+        # Configuration objects
+        self.configer: Optional[Any] = None
+        self.app_configer: Optional[Any] = None
+        self.custom_key_configer: Optional[Any] = None
+        self.default_llm_configer: Optional[Any] = None
+
+        # Manager instances
+        self.config_container: Optional[Any] = None
+        self.application_container: Optional[Any] = None
+
+        # Paths
+        self.log_config_path: Optional[str] = None
+        self.custom_key_configer_path: Optional[str] = None
+        self.gunicorn_config_path: Optional[str] = None
+
+    def mark_phase_completed(self, phase: StartupPhaseEnum) -> None:
+        """Mark a phase as completed.
+
+        Args:
+            phase: The phase that has completed
+        """
+        if phase not in self._completed_phases:
+            self._completed_phases.append(phase)
+
+    def is_phase_completed(self, phase: StartupPhaseEnum) -> bool:
+        """Check if a phase has been completed.
+
+        Args:
+            phase: The phase to check
+
+        Returns:
+            True if the phase has completed
+        """
+        return phase in self._completed_phases
+
+    def get_completed_phases(self) -> list[StartupPhaseEnum]:
+        """Get list of all completed phases in order.
+
+        Returns:
+            List of completed phase enums in the order they were completed
+        """
+        return self._completed_phases.copy()
+
+    def set_data(self, key: str, value: Any) -> None:
+        """Store arbitrary data in the context.
+
+        Args:
+            key: The data key
+            value: The data value
+        """
+        self._data[key] = value
+
+    def get_data(self, key: str, default: Any = None) -> Any:
+        """Retrieve data from the context.
+
+        Args:
+            key: The data key
+            default: Default value if key not found
+
+        Returns:
+            The stored value or default
+        """
+        return self._data.get(key, default)
+
+    def has_data(self, key: str) -> bool:
+        """Check if data exists in the context.
+
+        Args:
+            key: The data key
+
+        Returns:
+            True if the key exists
+        """
+        return key in self._data
+
+    def clear_phase_data(self) -> None:
+        """Clear all phase completion tracking (for testing/reset)."""
+        self._completed_phases.clear()
+
+    def __repr__(self) -> str:
+        """Return string representation of the context."""
+        return (f"StartupContext(config_path={self.config_path}, "
+                f"core_mode={self.core_mode}, "
+                f"completed_phases={len(self._completed_phases)})")

--- a/agentuniverse/base/startup/startup_orchestrator.py
+++ b/agentuniverse/base/startup/startup_orchestrator.py
@@ -1,0 +1,164 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: startup_orchestrator.py
+
+from typing import Callable, Optional, List
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+
+class StartupOrchestrator:
+    """Orchestrates the execution of startup phases.
+
+    This class manages the startup process by:
+    1. Executing phases in dependency order
+    2. Handling phase failures and rollback
+    3. Providing progress callbacks
+    4. Ensuring all dependencies are satisfied
+    """
+
+    def __init__(self):
+        """Initialize the startup orchestrator."""
+        self._phases: List[StartupPhase] = []
+        self._progress_callback: Optional[Callable[[StartupPhase, StartupContext], None]] = None
+
+    def add_phase(self, phase: StartupPhase) -> 'StartupOrchestrator':
+        """Add a startup phase to the orchestrator.
+
+        Args:
+            phase: The startup phase to add
+
+        Returns:
+            Self for method chaining
+        """
+        self._phases.append(phase)
+        return self
+
+    def set_progress_callback(self, callback: Callable[[StartupPhase, StartupContext], None]) -> 'StartupOrchestrator':
+        """Set a callback to be called after each phase completes.
+
+        Args:
+            callback: Function that takes (phase, context) as arguments
+
+        Returns:
+            Self for method chaining
+        """
+        self._progress_callback = callback
+        return self
+
+    def execute(self, context: StartupContext) -> None:
+        """Execute all startup phases in dependency order.
+
+        Args:
+            context: The startup context
+
+        Raises:
+            Exception: If any phase fails to execute
+        """
+        # Sort phases by dependencies (topological sort)
+        sorted_phases = self._topological_sort()
+
+        executed_phases: List[StartupPhase] = []
+
+        try:
+            for phase in sorted_phases:
+                # Check if phase can execute (all dependencies satisfied)
+                if not phase.can_execute(context):
+                    raise RuntimeError(
+                        f"Phase {phase.name} cannot execute: dependencies not satisfied"
+                    )
+
+                # Execute the phase
+                LOGGER.info(f"Starting phase: {phase.name}")
+                phase.execute(context)
+                context.mark_phase_completed(phase.phase_type)
+                executed_phases.append(phase)
+                LOGGER.info(f"Completed phase: {phase.name}")
+
+                # Call progress callback if set
+                if self._progress_callback:
+                    self._progress_callback(phase, context)
+
+        except Exception as e:
+            LOGGER.error(f"Startup failed during phase: {executed_phases[-1].name if executed_phases else 'unknown'}")
+            LOGGER.error(f"Error: {str(e)}")
+
+            # Rollback executed phases in reverse order
+            self._rollback(executed_phases, context)
+
+            # Re-raise the exception
+            raise
+
+    def _topological_sort(self) -> List[StartupPhase]:
+        """Sort phases by their dependencies using topological sort.
+
+        Returns:
+            List of phases in execution order
+
+        Raises:
+            RuntimeError: If circular dependencies are detected
+        """
+        # Build dependency graph
+        graph = {phase.phase_type: phase.get_dependencies() for phase in self._phases}
+        phase_map = {phase.phase_type: phase for phase in self._phases}
+
+        # Kahn's algorithm for topological sort
+        # in_degree[A] = number of dependencies A has (how many phases A depends on)
+        in_degree = {phase_type: len(dependencies) for phase_type, dependencies in graph.items()}
+
+        # Find phases with no dependencies (in_degree == 0)
+        queue = [phase_type for phase_type, degree in in_degree.items() if degree == 0]
+        sorted_phase_types = []
+
+        while queue:
+            # Remove a phase with no dependencies
+            current = queue.pop(0)
+            sorted_phase_types.append(current)
+
+            # For each phase that depends on current, reduce its in-degree
+            for phase_type, dependencies in graph.items():
+                if current in dependencies:
+                    in_degree[phase_type] -= 1
+                    if in_degree[phase_type] == 0:
+                        queue.append(phase_type)
+
+        # Check for circular dependencies
+        if len(sorted_phase_types) != len(self._phases):
+            raise RuntimeError("Circular dependencies detected in startup phases")
+
+        # Convert phase types back to phase objects
+        return [phase_map[phase_type] for phase_type in sorted_phase_types]
+
+    def _rollback(self, executed_phases: List[StartupPhase], context: StartupContext) -> None:
+        """Rollback executed phases in reverse order.
+
+        Args:
+            executed_phases: List of phases that were executed
+            context: The startup context
+        """
+        LOGGER.info("Rolling back executed phases...")
+
+        for phase in reversed(executed_phases):
+            try:
+                LOGGER.info(f"Rolling back phase: {phase.name}")
+                phase.rollback(context)
+                LOGGER.info(f"Rolled back phase: {phase.name}")
+            except Exception as rollback_error:
+                # Log rollback errors but continue rolling back other phases
+                LOGGER.error(f"Error rolling back phase {phase.name}: {str(rollback_error)}")
+
+        LOGGER.info("Rollback completed")
+
+    def get_phases(self) -> List[StartupPhase]:
+        """Get the list of registered phases.
+
+        Returns:
+            List of startup phases
+        """
+        return self._phases.copy()

--- a/agentuniverse/base/startup/startup_phase.py
+++ b/agentuniverse/base/startup/startup_phase.py
@@ -1,0 +1,112 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: startup_phase.py
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Optional
+
+
+class StartupPhaseEnum(Enum):
+    """Enumeration of startup phases in execution order."""
+    CONFIG = "config"
+    LOGGING = "logging"
+    TELEMETRY = "telemetry"
+    WEB = "web"
+    COMPONENTS = "components"
+    POST_INIT = "post_init"
+
+
+class StartupPhase(ABC):
+    """Abstract base class for startup phases.
+
+    Each phase represents a distinct initialization step with clear
+    responsibilities, dependencies, and rollback capabilities.
+    """
+
+    def __init__(self, phase_type: StartupPhaseEnum):
+        """Initialize the startup phase.
+
+        Args:
+            phase_type: The type of this startup phase
+        """
+        self.phase_type = phase_type
+        self._completed = False
+        self._error: Optional[Exception] = None
+
+    @property
+    def name(self) -> str:
+        """Return the human-readable name of this phase."""
+        return self.phase_type.value
+
+    @property
+    def completed(self) -> bool:
+        """Check if this phase has completed successfully."""
+        return self._completed
+
+    @property
+    def error(self) -> Optional[Exception]:
+        """Return the error that occurred during execution, if any."""
+        return self._error
+
+    @abstractmethod
+    def execute(self, context: 'StartupContext') -> None:
+        """Execute this startup phase.
+
+        Args:
+            context: The startup context containing shared data
+
+        Raises:
+            Exception: If the phase execution fails
+        """
+        pass
+
+    @abstractmethod
+    def rollback(self, context: 'StartupContext') -> None:
+        """Rollback this phase if execution fails.
+
+        Args:
+            context: The startup context containing shared data
+        """
+        pass
+
+    @abstractmethod
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        """Return the list of phases this phase depends on.
+
+        Returns:
+            List of phase types that must complete before this phase
+        """
+        pass
+
+    def _mark_completed(self) -> None:
+        """Mark this phase as completed."""
+        self._completed = True
+
+    def _mark_failed(self, error: Exception) -> None:
+        """Mark this phase as failed.
+
+        Args:
+            error: The exception that caused the failure
+        """
+        self._error = error
+        self._completed = False
+
+    def can_execute(self, context: 'StartupContext') -> bool:
+        """Check if this phase can be executed.
+
+        Args:
+            context: The startup context
+
+        Returns:
+            True if all dependencies are satisfied
+        """
+        dependencies = self.get_dependencies()
+        for dep in dependencies:
+            if not context.is_phase_completed(dep):
+                return False
+        return True

--- a/tests/test_agentuniverse/mock/agent_serve/mock_agent.py
+++ b/tests/test_agentuniverse/mock/agent_serve/mock_agent.py
@@ -17,7 +17,7 @@ class MockOutPut:
         try:  
             return json.dumps(self.__output, ensure_ascii=False)  
         except (TypeError, ValueError) as e:  
-            raise ValueError(f"Failed to serialize output to JSON: {e}")"
+            raise ValueError(f"Failed to serialize output to JSON: {e}")
 
 
 class MockAgent:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
@@ -9,8 +9,10 @@ import os
 import cv2
 import numpy as np
 import unittest
-from readimage_tool import (enhance_image, detect_text_regions, ocr_on_regions,
-                            clean_extracted_text, save_text_to_file, extract_text_from_image)
+from agentuniverse.agent.action.tool.common_tool.readimage_tool import (
+    enhance_image, detect_text_regions, ocr_on_regions,
+    clean_extracted_text, save_text_to_file, extract_text_from_image
+)
 
 class TestReadImageTool(unittest.TestCase):
     def setUp(self):

--- a/tests/test_agentuniverse/unit/base/startup/__init__.py
+++ b/tests/test_agentuniverse/unit/base/startup/__init__.py
@@ -1,0 +1,7 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: __init__.py

--- a/tests/test_agentuniverse/unit/base/startup/test_startup_context.py
+++ b/tests/test_agentuniverse/unit/base/startup/test_startup_context.py
@@ -1,0 +1,92 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: test_startup_context.py
+
+import pytest
+from pathlib import Path
+
+from agentuniverse.base.startup.startup_context import StartupContext
+from agentuniverse.base.startup.startup_phase import StartupPhaseEnum
+
+
+class TestStartupContext:
+    """Test cases for StartupContext."""
+
+    def test_context_initialization(self):
+        """Test context initialization with parameters."""
+        context = StartupContext(config_path="/test/config.toml", core_mode=True)
+
+        assert context.config_path == "/test/config.toml"
+        assert context.core_mode is True
+        assert context.project_root_path is None
+        assert len(context.get_completed_phases()) == 0
+
+    def test_context_initialization_defaults(self):
+        """Test context initialization with default values."""
+        context = StartupContext()
+
+        assert context.config_path is None
+        assert context.core_mode is False
+
+    def test_mark_phase_completed(self):
+        """Test marking phases as completed."""
+        context = StartupContext()
+
+        context.mark_phase_completed(StartupPhaseEnum.CONFIG)
+        assert context.is_phase_completed(StartupPhaseEnum.CONFIG)
+        assert not context.is_phase_completed(StartupPhaseEnum.LOGGING)
+
+    def test_multiple_phases_completed(self):
+        """Test marking multiple phases as completed."""
+        context = StartupContext()
+
+        context.mark_phase_completed(StartupPhaseEnum.CONFIG)
+        context.mark_phase_completed(StartupPhaseEnum.LOGGING)
+        context.mark_phase_completed(StartupPhaseEnum.TELEMETRY)
+
+        completed = context.get_completed_phases()
+        assert len(completed) == 3
+        assert StartupPhaseEnum.CONFIG in completed
+        assert StartupPhaseEnum.LOGGING in completed
+        assert StartupPhaseEnum.TELEMETRY in completed
+
+    def test_data_storage(self):
+        """Test storing and retrieving arbitrary data."""
+        context = StartupContext()
+
+        context.set_data("test_key", "test_value")
+        assert context.get_data("test_key") == "test_value"
+        assert context.has_data("test_key")
+
+    def test_data_default_value(self):
+        """Test retrieving non-existent data with default."""
+        context = StartupContext()
+
+        assert context.get_data("nonexistent", "default") == "default"
+        assert not context.has_data("nonexistent")
+
+    def test_clear_phase_data(self):
+        """Test clearing phase completion data."""
+        context = StartupContext()
+
+        context.mark_phase_completed(StartupPhaseEnum.CONFIG)
+        context.mark_phase_completed(StartupPhaseEnum.LOGGING)
+        assert len(context.get_completed_phases()) == 2
+
+        context.clear_phase_data()
+        assert len(context.get_completed_phases()) == 0
+
+    def test_context_repr(self):
+        """Test string representation of context."""
+        context = StartupContext(config_path="/test/config.toml", core_mode=True)
+        context.mark_phase_completed(StartupPhaseEnum.CONFIG)
+
+        repr_str = repr(context)
+        assert "StartupContext" in repr_str
+        assert "/test/config.toml" in repr_str
+        assert "core_mode=True" in repr_str
+        assert "completed_phases=1" in repr_str

--- a/tests/test_agentuniverse/unit/base/startup/test_startup_orchestrator.py
+++ b/tests/test_agentuniverse/unit/base/startup/test_startup_orchestrator.py
@@ -1,0 +1,219 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: test_startup_orchestrator.py
+
+import pytest
+
+from agentuniverse.base.startup.startup_orchestrator import StartupOrchestrator
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+
+
+class MockPhase(StartupPhase):
+    """Mock phase for testing."""
+
+    def __init__(self, phase_type, dependencies=None, should_fail=False):
+        super().__init__(phase_type)
+        self._dependencies = dependencies or []
+        self.should_fail = should_fail
+        self.executed = False
+        self.rolled_back = False
+
+    def execute(self, context: StartupContext) -> None:
+        if self.should_fail:
+            error = RuntimeError(f"Phase {self.name} failed")
+            self._mark_failed(error)
+            raise error
+        self.executed = True
+        self._mark_completed()
+
+    def rollback(self, context: StartupContext) -> None:
+        self.rolled_back = True
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        return self._dependencies
+
+
+class TestStartupOrchestrator:
+    """Test cases for StartupOrchestrator."""
+
+    def test_orchestrator_initialization(self):
+        """Test orchestrator initialization."""
+        orchestrator = StartupOrchestrator()
+        assert len(orchestrator.get_phases()) == 0
+
+    def test_add_phase(self):
+        """Test adding phases to orchestrator."""
+        orchestrator = StartupOrchestrator()
+        phase1 = MockPhase(StartupPhaseEnum.CONFIG)
+        phase2 = MockPhase(StartupPhaseEnum.LOGGING)
+
+        orchestrator.add_phase(phase1).add_phase(phase2)
+
+        phases = orchestrator.get_phases()
+        assert len(phases) == 2
+        assert phase1 in phases
+        assert phase2 in phases
+
+    def test_execute_single_phase(self):
+        """Test executing a single phase."""
+        orchestrator = StartupOrchestrator()
+        phase = MockPhase(StartupPhaseEnum.CONFIG)
+        orchestrator.add_phase(phase)
+
+        context = StartupContext()
+        orchestrator.execute(context)
+
+        assert phase.executed
+        assert context.is_phase_completed(StartupPhaseEnum.CONFIG)
+
+    def test_execute_phases_in_dependency_order(self):
+        """Test phases are executed in dependency order."""
+        orchestrator = StartupOrchestrator()
+
+        # Create phases with dependencies
+        config_phase = MockPhase(StartupPhaseEnum.CONFIG, dependencies=[])
+        logging_phase = MockPhase(
+            StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG]
+        )
+        telemetry_phase = MockPhase(
+            StartupPhaseEnum.TELEMETRY,
+            dependencies=[StartupPhaseEnum.CONFIG, StartupPhaseEnum.LOGGING]
+        )
+
+        # Add in reverse order to test sorting
+        orchestrator.add_phase(telemetry_phase)
+        orchestrator.add_phase(logging_phase)
+        orchestrator.add_phase(config_phase)
+
+        context = StartupContext()
+        orchestrator.execute(context)
+
+        # All phases should be executed
+        assert config_phase.executed
+        assert logging_phase.executed
+        assert telemetry_phase.executed
+
+        # Check execution order via context
+        completed = context.get_completed_phases()
+        config_idx = completed.index(StartupPhaseEnum.CONFIG)
+        logging_idx = completed.index(StartupPhaseEnum.LOGGING)
+        telemetry_idx = completed.index(StartupPhaseEnum.TELEMETRY)
+
+        assert config_idx < logging_idx < telemetry_idx
+
+    def test_execute_with_failure_triggers_rollback(self):
+        """Test that phase failure triggers rollback of completed phases."""
+        orchestrator = StartupOrchestrator()
+
+        phase1 = MockPhase(StartupPhaseEnum.CONFIG)
+        phase2 = MockPhase(
+            StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG],
+            should_fail=True
+        )
+
+        orchestrator.add_phase(phase1).add_phase(phase2)
+
+        context = StartupContext()
+
+        with pytest.raises(RuntimeError, match="Phase logging failed"):
+            orchestrator.execute(context)
+
+        # First phase should be executed and rolled back
+        assert phase1.executed
+        assert phase1.rolled_back
+
+        # Second phase should not be marked as completed
+        assert not context.is_phase_completed(StartupPhaseEnum.LOGGING)
+
+    def test_circular_dependency_detection(self):
+        """Test detection of circular dependencies."""
+        orchestrator = StartupOrchestrator()
+
+        # This would create a circular dependency if both were added
+        # For this test, we'll create a simpler case
+        phase1 = MockPhase(
+            StartupPhaseEnum.CONFIG,
+            dependencies=[StartupPhaseEnum.LOGGING]
+        )
+        phase2 = MockPhase(
+            StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG]
+        )
+
+        orchestrator.add_phase(phase1).add_phase(phase2)
+
+        context = StartupContext()
+
+        with pytest.raises(RuntimeError, match="Circular dependencies detected"):
+            orchestrator.execute(context)
+
+    def test_progress_callback(self):
+        """Test progress callback is called after each phase."""
+        orchestrator = StartupOrchestrator()
+        phase1 = MockPhase(StartupPhaseEnum.CONFIG)
+        phase2 = MockPhase(
+            StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG]
+        )
+
+        orchestrator.add_phase(phase1).add_phase(phase2)
+
+        # Track callback invocations
+        callback_phases = []
+
+        def progress_callback(phase, ctx):
+            callback_phases.append(phase.phase_type)
+
+        orchestrator.set_progress_callback(progress_callback)
+
+        context = StartupContext()
+        orchestrator.execute(context)
+
+        # Callback should be called for each phase
+        assert len(callback_phases) == 2
+        assert StartupPhaseEnum.CONFIG in callback_phases
+        assert StartupPhaseEnum.LOGGING in callback_phases
+
+    def test_rollback_continues_on_error(self):
+        """Test rollback continues even if a phase rollback fails."""
+        orchestrator = StartupOrchestrator()
+
+        class FailingRollbackPhase(MockPhase):
+            def rollback(self, context: StartupContext) -> None:
+                super().rollback(context)
+                raise RuntimeError("Rollback failed")
+
+        phase1 = FailingRollbackPhase(StartupPhaseEnum.CONFIG)
+        phase2 = MockPhase(
+            StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG],
+            should_fail=True
+        )
+
+        orchestrator.add_phase(phase1).add_phase(phase2)
+
+        context = StartupContext()
+
+        # Should still raise the original error, not the rollback error
+        with pytest.raises(RuntimeError, match="Phase logging failed"):
+            orchestrator.execute(context)
+
+        # Both phases should have attempted rollback
+        assert phase1.rolled_back
+
+    def test_empty_orchestrator(self):
+        """Test executing orchestrator with no phases."""
+        orchestrator = StartupOrchestrator()
+        context = StartupContext()
+
+        # Should not raise any errors
+        orchestrator.execute(context)
+
+        assert len(context.get_completed_phases()) == 0

--- a/tests/test_agentuniverse/unit/base/startup/test_startup_phase.py
+++ b/tests/test_agentuniverse/unit/base/startup/test_startup_phase.py
@@ -1,0 +1,158 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025-10-31
+# @Author  : SaladDay
+# @Email   : fanjing.luo@zju.edu.cn
+# @FileName: test_startup_phase.py
+
+import pytest
+
+from agentuniverse.base.startup.startup_phase import StartupPhase, StartupPhaseEnum
+from agentuniverse.base.startup.startup_context import StartupContext
+
+
+class MockPhase(StartupPhase):
+    """Mock phase for testing."""
+
+    def __init__(self, phase_type=StartupPhaseEnum.CONFIG, dependencies=None):
+        super().__init__(phase_type)
+        self._dependencies = dependencies or []
+        self.executed = False
+        self.rolled_back = False
+
+    def execute(self, context: StartupContext) -> None:
+        self.executed = True
+        self._mark_completed()
+
+    def rollback(self, context: StartupContext) -> None:
+        self.rolled_back = True
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        return self._dependencies
+
+
+class FailingPhase(StartupPhase):
+    """Phase that always fails for testing."""
+
+    def __init__(self):
+        super().__init__(StartupPhaseEnum.LOGGING)
+
+    def execute(self, context: StartupContext) -> None:
+        error = RuntimeError("Test failure")
+        self._mark_failed(error)
+        raise error
+
+    def rollback(self, context: StartupContext) -> None:
+        pass
+
+    def get_dependencies(self) -> list[StartupPhaseEnum]:
+        return [StartupPhaseEnum.CONFIG]
+
+
+class TestStartupPhase:
+    """Test cases for StartupPhase."""
+
+    def test_phase_initialization(self):
+        """Test phase initialization."""
+        phase = MockPhase(StartupPhaseEnum.CONFIG)
+
+        assert phase.phase_type == StartupPhaseEnum.CONFIG
+        assert phase.name == "config"
+        assert not phase.completed
+        assert phase.error is None
+
+    def test_phase_execution(self):
+        """Test successful phase execution."""
+        phase = MockPhase()
+        context = StartupContext()
+
+        phase.execute(context)
+
+        assert phase.executed
+        assert phase.completed
+        assert phase.error is None
+
+    def test_phase_failure(self):
+        """Test phase failure handling."""
+        phase = FailingPhase()
+        context = StartupContext()
+
+        with pytest.raises(RuntimeError, match="Test failure"):
+            phase.execute(context)
+
+        assert not phase.completed
+        assert phase.error is not None
+        assert isinstance(phase.error, RuntimeError)
+
+    def test_phase_rollback(self):
+        """Test phase rollback."""
+        phase = MockPhase()
+        context = StartupContext()
+
+        phase.rollback(context)
+
+        assert phase.rolled_back
+
+    def test_phase_dependencies(self):
+        """Test phase dependency declaration."""
+        phase = MockPhase(
+            phase_type=StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG]
+        )
+
+        deps = phase.get_dependencies()
+        assert len(deps) == 1
+        assert StartupPhaseEnum.CONFIG in deps
+
+    def test_can_execute_with_satisfied_dependencies(self):
+        """Test can_execute when dependencies are satisfied."""
+        phase = MockPhase(
+            phase_type=StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG]
+        )
+        context = StartupContext()
+        context.mark_phase_completed(StartupPhaseEnum.CONFIG)
+
+        assert phase.can_execute(context)
+
+    def test_can_execute_with_unsatisfied_dependencies(self):
+        """Test can_execute when dependencies are not satisfied."""
+        phase = MockPhase(
+            phase_type=StartupPhaseEnum.LOGGING,
+            dependencies=[StartupPhaseEnum.CONFIG]
+        )
+        context = StartupContext()
+
+        assert not phase.can_execute(context)
+
+    def test_can_execute_with_no_dependencies(self):
+        """Test can_execute when phase has no dependencies."""
+        phase = MockPhase(phase_type=StartupPhaseEnum.CONFIG, dependencies=[])
+        context = StartupContext()
+
+        assert phase.can_execute(context)
+
+    def test_can_execute_with_multiple_dependencies(self):
+        """Test can_execute with multiple dependencies."""
+        phase = MockPhase(
+            phase_type=StartupPhaseEnum.WEB,
+            dependencies=[
+                StartupPhaseEnum.CONFIG,
+                StartupPhaseEnum.LOGGING,
+                StartupPhaseEnum.TELEMETRY
+            ]
+        )
+        context = StartupContext()
+
+        # No dependencies satisfied
+        assert not phase.can_execute(context)
+
+        # Partial dependencies satisfied
+        context.mark_phase_completed(StartupPhaseEnum.CONFIG)
+        assert not phase.can_execute(context)
+
+        # All dependencies satisfied
+        context.mark_phase_completed(StartupPhaseEnum.LOGGING)
+        context.mark_phase_completed(StartupPhaseEnum.TELEMETRY)
+        assert phase.can_execute(context)


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [x] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

## 问题
当前AgentUniverse.start()方法存在两个主要问题：
1. 配置被加载了两次：先加载配置 → 加载custom key → 再次重载配置，造成不必要的性能开销
2. 代码耦合严重：81行代码将配置、日志、遥测、Web服务、组件扫描等所有启动逻辑混在一起，难以维护和扩展

## 解决方案
将启动流程重构为分阶段架构，拆分为5个独立阶段：
1. ConfigPhase: 配置加载
2. LoggingPhase: 日志初始化
3. TelemetryPhase: 遥测监控
4. WebPhase: Web服务（gRPC/Gunicorn/扩展模块）
5. ComponentPhase: 组件扫描注册
通过StartupOrchestrator编排器管理各阶段的依赖关系和执行顺序，支持拓扑排序和错误回滚。

## 特性
- 消除配置重复加载，提升启动性能
- 清晰的模块边界，每个Phase职责单一
- 显式的依赖声明，自动依赖解析
- 支持错误回滚机制
- 易于扩展新的启动阶段
- 完全向后兼容，使用方式完全不变


**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**
- 测试文件:`tests/test_agentuniverse/unit/base/startup/`
<img width="702" height="444" alt="image" src="https://github.com/user-attachments/assets/b0586ed7-fbe4-421c-8749-242b5f1f276f" />


## 注意：
高级用户可自定义启动流程：
```
from agentuniverse.base.startup import StartupOrchestrator, StartupContext
from agentuniverse.base.startup.phases import ConfigPhase, LoggingPhase

context = StartupContext(config_path='./config/config.toml')
orchestrator = StartupOrchestrator()
orchestrator.add_phase(ConfigPhase())
orchestrator.add_phase(LoggingPhase())
orchestrator.add_phase(MyCustomPhase())  # 可扩展
orchestrator.execute(context)
```

