### PR TITLE
Feat:Monitoring statistics

### DIFF
--- a/PR_INFO.md
+++ b/PR_INFO.md
@@ -1,0 +1,150 @@
+# PR 信息 / PR Information
+
+## 测试文件路径和测试结果 / Test Files and Results
+
+### 测试文件路径 / Test File Paths
+
+- `tests/test_agentuniverse/unit/base/util/test_monitor.py`
+
+### 测试覆盖范围 / Test Coverage
+
+新增的测试文件包含以下测试用例：
+
+1. **`test_get_llm_statistics_empty`** - 测试空数据情况下的LLM统计查询
+2. **`test_get_agent_statistics_empty`** - 测试空数据情况下的Agent统计查询
+3. **`test_get_llm_statistics_with_data`** - 测试带数据的LLM统计查询
+4. **`test_get_agent_statistics_with_data`** - 测试带数据的Agent统计查询
+5. **`test_get_llm_statistics_with_date_filter`** - 测试带日期过滤的LLM统计查询
+6. **`test_get_llm_statistics_with_source_filter`** - 测试带source过滤的LLM统计查询
+7. **`test_estimate_cost`** - 测试成本估算功能
+8. **`test_get_daily_summary`** - 测试每日汇总功能
+9. **`test_trace_agent_invocation_with_token_usage`** - 测试Agent调用记录中的token使用量
+
+### 运行测试 / Running Tests
+
+```bash
+# 运行所有监控相关测试
+python -m pytest tests/test_agentuniverse/unit/base/util/test_monitor.py -v
+
+# 运行特定测试
+python -m pytest tests/test_agentuniverse/unit/base/util/test_monitor.py::MonitorTest::test_estimate_cost -v
+```
+
+### 测试结果说明 / Test Results Note
+
+**注意**: 测试需要安装项目依赖（包括 `jsonlines` 和 `loguru`）。如果环境中缺少依赖，部分测试会自动跳过（使用 `skipTest`）。
+
+测试使用临时目录来隔离测试数据，不会影响实际的监控数据目录。
+
+---
+
+## 新增或修改的文档 / Added or Modified Documentation
+
+### 修改的文档 / Modified Documents
+
+1. **`docs/guidebook/zh/token_usage_monitor.md`**
+   - 新增了"Agent 调用记录增强"章节
+   - 新增了"内置统计查询功能"章节，包含：
+     - LLM 调用统计 (`get_llm_statistics`)
+     - Agent 调用统计 (`get_agent_statistics`)
+     - 每日汇总 (`get_daily_summary`)
+   - 新增了"成本估算功能"章节
+   - 新增了"完整示例：生成每日统计报告"章节
+   - 更新了"推荐的使用姿势"章节
+
+### 文档内容概览 / Documentation Overview
+
+文档详细说明了以下新功能：
+
+1. **统计查询功能**
+   - `Monitor.get_llm_statistics()` - 按时间、模型等维度统计LLM调用
+   - `Monitor.get_agent_statistics()` - 按时间、Agent等维度统计Agent调用
+   - `Monitor.get_daily_summary()` - 获取每日汇总
+
+2. **成本估算功能**
+   - `Monitor.estimate_cost()` - 基于token价格估算成本
+
+3. **增强的监控记录**
+   - Agent调用记录现在包含token使用量和性能指标
+
+4. **完整示例代码**
+   - 提供了生成每日统计报告的完整示例代码
+
+---
+
+## 代码变更摘要 / Code Changes Summary
+
+### 修改的文件 / Modified Files
+
+1. **`agentuniverse/base/util/monitor/monitor.py`**
+   - 增强了 `trace_agent_invocation` 方法，添加了token使用量和性能指标记录
+   - 新增 `get_llm_statistics()` 方法：LLM调用统计查询
+   - 新增 `get_agent_statistics()` 方法：Agent调用统计查询
+   - 新增 `estimate_cost()` 方法：成本估算
+   - 新增 `get_daily_summary()` 方法：每日汇总
+
+### 新增的功能 / New Features
+
+1. **统计查询功能**
+   - 支持按时间范围过滤
+   - 支持按source（模型/Agent）过滤
+   - 自动计算平均响应时间等性能指标
+   - 按source分组统计
+
+2. **成本估算功能**
+   - 支持分别设置prompt和completion的token价格
+   - 基于token使用量计算成本
+
+3. **增强的监控记录**
+   - Agent调用记录包含完整的token使用信息
+   - Agent调用记录包含性能指标（响应时间）
+
+---
+
+## 使用示例 / Usage Examples
+
+### 统计查询示例
+
+```python
+from agentuniverse.base.util.monitor.monitor import Monitor
+
+monitor = Monitor()
+
+# 查询所有LLM调用统计
+stats = monitor.get_llm_statistics()
+
+# 按时间范围查询
+stats = monitor.get_llm_statistics(
+    start_date="2025-12-01",
+    end_date="2025-12-03"
+)
+
+# 查询特定模型的统计
+stats = monitor.get_llm_statistics(source="openai_gpt_4o")
+```
+
+### 成本估算示例
+
+```python
+token_usage = {
+    "prompt_tokens": 1000,
+    "completion_tokens": 500
+}
+
+cost = monitor.estimate_cost(
+    token_usage,
+    prompt_price_per_1k=0.01,
+    completion_price_per_1k=0.03
+)
+```
+
+### 每日汇总示例
+
+```python
+# 获取今天的汇总
+summary = monitor.get_daily_summary()
+
+# 获取指定日期的汇总
+summary = monitor.get_daily_summary("2025-12-01")
+```
+

--- a/agentuniverse/base/util/monitor/monitor.py
+++ b/agentuniverse/base/util/monitor/monitor.py
@@ -8,7 +8,8 @@
 import datetime
 import json
 import os
-from typing import Union, Optional
+from typing import Union, Optional, Dict, List
+from collections import defaultdict
 from loguru import logger
 
 from pydantic import BaseModel
@@ -53,13 +54,54 @@ class Monitor(BaseModel):
     @staticmethod
     def trace_llm_invocation(source: str, llm_input: Union[str, dict], llm_output: Union[str, dict],
                              cost_time: float = None) -> None:
+        """
+        Trace the llm invocation.
+
+        This method will:
+        1. 打印一条包含 token 使用量的结构化日志，便于集中日志检索。
+        2. 在开启 Monitor.activate 的情况下，将调用明细（含 token 使用量）写入 jsonl 文件，
+           方便后续做离线统计与分析。
+        """
+        used_token = Monitor.get_token_usage()
+
+        # 1. 结构化日志，便于在日志系统中检索
         logger.bind(
             log_type=LogTypeEnum.llm_invocation,
-            used_token=Monitor.get_token_usage(),
+            used_token=used_token,
             cost_time=cost_time,
             llm_output=llm_output,
             context_prefix=get_context_prefix()
         ).info("Trace llm invocation.")
+
+        # 2. 按小时将调用明细落盘到 jsonl 文件，便于后续做离线统计
+        monitor = Monitor()
+        if monitor.activate:
+            try:
+                import jsonlines
+            except ImportError:
+                # 与 agent 监控保持一致：只在使用者显式开启监控时才需要额外依赖
+                raise ImportError(
+                    "jsonlines is required to trace llm invocation: `pip install jsonlines`"
+                )
+
+            date = datetime.datetime.now()
+            record = {
+                "source": source,
+                "date": date.strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": llm_input,
+                "llm_output": llm_output,
+                "token_usage": used_token,
+                "cost_time": cost_time,
+            }
+
+            filename = f"llm_{source}_{date.strftime('%Y-%m-%d-%H')}.jsonl"
+            path_save = os.path.join(
+                str(monitor._get_or_create_subdir(LLM_INVOCATION_SUBDIR)),
+                filename
+            )
+
+            with jsonlines.open(path_save, 'a') as writer:
+                writer.write(record)
 
     def trace_llm_token_usage(self, llm_obj: object, llm_input: dict, output: LLMOutput) -> None:
         """ Trace the token usage of the given LLM object.
@@ -91,6 +133,9 @@ class Monitor(BaseModel):
     def trace_agent_invocation(self, source: str, agent_input: Union[str, dict],
                                agent_output: OutputObject, cost_time: float = None) -> None:
         """Trace the agent invocation and save it to the monitor jsonl file."""
+        # Get token usage for this agent invocation
+        token_usage = Monitor.get_token_usage()
+        
         if self.activate:
             try:
                 import jsonlines
@@ -105,6 +150,8 @@ class Monitor(BaseModel):
                 "date": date.strftime("%Y-%m-%d %H:%M:%S"),
                 "agent_input": self.serialize_obj(agent_input),
                 "agent_output": self.serialize_obj(agent_output),
+                "token_usage": token_usage,
+                "cost_time": cost_time,
             }
             # files are stored in hours
             filename = f"agent_{source}_{date.strftime('%Y-%m-%d-%H')}.jsonl"
@@ -119,6 +166,7 @@ class Monitor(BaseModel):
             logger.bind(
                 log_type=LogTypeEnum.agent_invocation,
                 cost_time=cost_time,
+                token_usage=token_usage,
                 agent_output=agent_output,
                 context_prefix=get_context_prefix()
             ).info("Trace agent invocation.")
@@ -371,3 +419,316 @@ class Monitor(BaseModel):
                 return o
 
         return recursive_filter(obj)
+
+    def get_llm_statistics(self, start_date: Optional[str] = None, 
+                          end_date: Optional[str] = None,
+                          source: Optional[str] = None) -> Dict:
+        """
+        统计LLM调用数据。
+        
+        Args:
+            start_date: 开始日期，格式 "YYYY-MM-DD" 或 "YYYY-MM-DD HH:MM:SS"
+            end_date: 结束日期，格式 "YYYY-MM-DD" 或 "YYYY-MM-DD HH:MM:SS"
+            source: 过滤特定的LLM source，如果为None则统计所有source
+            
+        Returns:
+            dict: 包含以下字段的统计结果：
+                - total_calls: 总调用次数
+                - total_tokens: 总token数
+                - total_prompt_tokens: 总prompt tokens
+                - total_completion_tokens: 总completion tokens
+                - avg_cost_time: 平均响应时间（秒）
+                - by_source: 按source分组的统计
+        """
+        try:
+            import jsonlines
+        except ImportError:
+            raise ImportError("jsonlines is required: `pip install jsonlines`")
+        
+        llm_dir = self._get_or_create_subdir(LLM_INVOCATION_SUBDIR)
+        if not os.path.exists(llm_dir):
+            return {
+                "total_calls": 0,
+                "total_tokens": 0,
+                "total_prompt_tokens": 0,
+                "total_completion_tokens": 0,
+                "avg_cost_time": 0.0,
+                "by_source": {}
+            }
+        
+        # Parse date filters
+        start_dt = None
+        end_dt = None
+        if start_date:
+            try:
+                start_dt = datetime.datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                try:
+                    start_dt = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+                except ValueError:
+                    pass
+        if end_date:
+            try:
+                end_dt = datetime.datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                try:
+                    end_dt = datetime.datetime.strptime(end_date, "%Y-%m-%d")
+                    end_dt = end_dt.replace(hour=23, minute=59, second=59)
+                except ValueError:
+                    pass
+        
+        stats = {
+            "total_calls": 0,
+            "total_tokens": 0,
+            "total_prompt_tokens": 0,
+            "total_completion_tokens": 0,
+            "total_cost_time": 0.0,
+            "by_source": defaultdict(lambda: {
+                "calls": 0,
+                "tokens": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "cost_time": 0.0
+            })
+        }
+        
+        # Scan all jsonl files
+        for filename in os.listdir(llm_dir):
+            if not filename.startswith("llm_") or not filename.endswith(".jsonl"):
+                continue
+            
+            file_source = filename.replace("llm_", "").split("_")[0]
+            if source and file_source != source:
+                continue
+            
+            filepath = os.path.join(llm_dir, filename)
+            try:
+                with jsonlines.open(filepath, 'r') as reader:
+                    for record in reader:
+                        record_date_str = record.get("date", "")
+                        if record_date_str:
+                            try:
+                                record_date = datetime.datetime.strptime(record_date_str, "%Y-%m-%d %H:%M:%S")
+                                if start_dt and record_date < start_dt:
+                                    continue
+                                if end_dt and record_date > end_dt:
+                                    continue
+                            except ValueError:
+                                pass
+                        
+                        stats["total_calls"] += 1
+                        source_stats = stats["by_source"][file_source]
+                        source_stats["calls"] += 1
+                        
+                        token_usage = record.get("token_usage", {})
+                        if isinstance(token_usage, dict):
+                            total = token_usage.get("total_tokens", 0)
+                            prompt = token_usage.get("prompt_tokens", 0)
+                            completion = token_usage.get("completion_tokens", 0)
+                            
+                            stats["total_tokens"] += total
+                            stats["total_prompt_tokens"] += prompt
+                            stats["total_completion_tokens"] += completion
+                            
+                            source_stats["tokens"] += total
+                            source_stats["prompt_tokens"] += prompt
+                            source_stats["completion_tokens"] += completion
+                        
+                        cost_time = record.get("cost_time")
+                        if cost_time is not None:
+                            stats["total_cost_time"] += cost_time
+                            source_stats["cost_time"] += cost_time
+            except Exception as e:
+                logger.warning(f"Error reading file {filename}: {e}")
+                continue
+        
+        # Calculate averages
+        if stats["total_calls"] > 0:
+            stats["avg_cost_time"] = stats["total_cost_time"] / stats["total_calls"]
+        else:
+            stats["avg_cost_time"] = 0.0
+        
+        # Calculate averages for each source
+        for source_key in stats["by_source"]:
+            source_stats = stats["by_source"][source_key]
+            if source_stats["calls"] > 0:
+                source_stats["avg_cost_time"] = source_stats["cost_time"] / source_stats["calls"]
+            else:
+                source_stats["avg_cost_time"] = 0.0
+        
+        stats["by_source"] = dict(stats["by_source"])
+        del stats["total_cost_time"]  # Remove intermediate field
+        
+        return stats
+
+    def get_agent_statistics(self, start_date: Optional[str] = None,
+                            end_date: Optional[str] = None,
+                            source: Optional[str] = None) -> Dict:
+        """
+        统计Agent调用数据。
+        
+        Args:
+            start_date: 开始日期，格式 "YYYY-MM-DD" 或 "YYYY-MM-DD HH:MM:SS"
+            end_date: 结束日期，格式 "YYYY-MM-DD" 或 "YYYY-MM-DD HH:MM:SS"
+            source: 过滤特定的Agent source，如果为None则统计所有source
+            
+        Returns:
+            dict: 包含以下字段的统计结果：
+                - total_calls: 总调用次数
+                - total_tokens: 总token数
+                - avg_cost_time: 平均响应时间（秒）
+                - by_source: 按source分组的统计
+        """
+        try:
+            import jsonlines
+        except ImportError:
+            raise ImportError("jsonlines is required: `pip install jsonlines`")
+        
+        agent_dir = self._get_or_create_subdir(AGENT_INVOCATION_SUBDIR)
+        if not os.path.exists(agent_dir):
+            return {
+                "total_calls": 0,
+                "total_tokens": 0,
+                "avg_cost_time": 0.0,
+                "by_source": {}
+            }
+        
+        # Parse date filters
+        start_dt = None
+        end_dt = None
+        if start_date:
+            try:
+                start_dt = datetime.datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                try:
+                    start_dt = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+                except ValueError:
+                    pass
+        if end_date:
+            try:
+                end_dt = datetime.datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                try:
+                    end_dt = datetime.datetime.strptime(end_date, "%Y-%m-%d")
+                    end_dt = end_dt.replace(hour=23, minute=59, second=59)
+                except ValueError:
+                    pass
+        
+        stats = {
+            "total_calls": 0,
+            "total_tokens": 0,
+            "total_cost_time": 0.0,
+            "by_source": defaultdict(lambda: {
+                "calls": 0,
+                "tokens": 0,
+                "cost_time": 0.0
+            })
+        }
+        
+        # Scan all jsonl files
+        for filename in os.listdir(agent_dir):
+            if not filename.startswith("agent_") or not filename.endswith(".jsonl"):
+                continue
+            
+            file_source = filename.replace("agent_", "").split("_")[0]
+            if source and file_source != source:
+                continue
+            
+            filepath = os.path.join(agent_dir, filename)
+            try:
+                with jsonlines.open(filepath, 'r') as reader:
+                    for record in reader:
+                        record_date_str = record.get("date", "")
+                        if record_date_str:
+                            try:
+                                record_date = datetime.datetime.strptime(record_date_str, "%Y-%m-%d %H:%M:%S")
+                                if start_dt and record_date < start_dt:
+                                    continue
+                                if end_dt and record_date > end_dt:
+                                    continue
+                            except ValueError:
+                                pass
+                        
+                        stats["total_calls"] += 1
+                        source_stats = stats["by_source"][file_source]
+                        source_stats["calls"] += 1
+                        
+                        token_usage = record.get("token_usage", {})
+                        if isinstance(token_usage, dict):
+                            total = token_usage.get("total_tokens", 0)
+                            stats["total_tokens"] += total
+                            source_stats["tokens"] += total
+                        
+                        cost_time = record.get("cost_time")
+                        if cost_time is not None:
+                            stats["total_cost_time"] += cost_time
+                            source_stats["cost_time"] += cost_time
+            except Exception as e:
+                logger.warning(f"Error reading file {filename}: {e}")
+                continue
+        
+        # Calculate averages
+        if stats["total_calls"] > 0:
+            stats["avg_cost_time"] = stats["total_cost_time"] / stats["total_calls"]
+        else:
+            stats["avg_cost_time"] = 0.0
+        
+        # Calculate averages for each source
+        for source_key in stats["by_source"]:
+            source_stats = stats["by_source"][source_key]
+            if source_stats["calls"] > 0:
+                source_stats["avg_cost_time"] = source_stats["cost_time"] / source_stats["calls"]
+            else:
+                source_stats["avg_cost_time"] = 0.0
+        
+        stats["by_source"] = dict(stats["by_source"])
+        del stats["total_cost_time"]  # Remove intermediate field
+        
+        return stats
+
+    def estimate_cost(self, token_usage: Dict, 
+                     prompt_price_per_1k: float = 0.0,
+                     completion_price_per_1k: float = 0.0) -> float:
+        """
+        估算token使用成本。
+        
+        Args:
+            token_usage: token使用量字典，包含 prompt_tokens 和 completion_tokens
+            prompt_price_per_1k: 每1000个prompt tokens的价格（单位：元或美元）
+            completion_price_per_1k: 每1000个completion tokens的价格（单位：元或美元）
+            
+        Returns:
+            float: 估算的总成本
+        """
+        prompt_tokens = token_usage.get("prompt_tokens", 0)
+        completion_tokens = token_usage.get("completion_tokens", 0)
+        
+        prompt_cost = (prompt_tokens / 1000.0) * prompt_price_per_1k
+        completion_cost = (completion_tokens / 1000.0) * completion_price_per_1k
+        
+        return prompt_cost + completion_cost
+
+    def get_daily_summary(self, date: Optional[str] = None) -> Dict:
+        """
+        获取指定日期的每日汇总统计。
+        
+        Args:
+            date: 日期，格式 "YYYY-MM-DD"，如果为None则使用今天
+            
+        Returns:
+            dict: 包含LLM和Agent的统计汇总
+        """
+        if date is None:
+            date = datetime.datetime.now().strftime("%Y-%m-%d")
+        
+        start_date = f"{date} 00:00:00"
+        end_date = f"{date} 23:59:59"
+        
+        llm_stats = self.get_llm_statistics(start_date, end_date)
+        agent_stats = self.get_agent_statistics(start_date, end_date)
+        
+        return {
+            "date": date,
+            "llm": llm_stats,
+            "agent": agent_stats
+        }

--- a/docs/guidebook/zh/token_usage_monitor.md
+++ b/docs/guidebook/zh/token_usage_monitor.md
@@ -1,0 +1,558 @@
+## Token 使用量监控与统计说明
+
+本篇文档介绍 AgentUniverse 中 **LLM Token 使用量** 的监控方案，包括：
+
+- **在线调用返回中的 token 统计结果**
+- **落盘到 `monitor` 目录下的调用明细 jsonl 文件**
+- **内置的统计查询与成本估算功能**
+- **如何基于这些数据做简单的离线统计分析**
+
+---
+
+### 一、整体机制概览
+
+框架在 LLM 调用链路中已经内置了以下能力：
+
+- **调用链跟踪**：通过 `Monitor.init_invocation_chain_bak()` / `Monitor.get_invocation_chain_bak()` 等方法，在一次 agent 对话中记录完整的调用链。
+- **Token 使用量聚合**：`Monitor.init_token_usage()` 初始化上下文中本次请求的 token 统计，通过 `Monitor.add_token_usage()` 逐次累加；调用结束时可通过 `Monitor.get_token_usage()` 拿到最终结果。
+- **OTel 指标**：`agentuniverse.base.tracing.otel.instrumentation.llm.LLMInstrumentor` 中已经对 token 使用量暴露了多项 metrics，便于通过 Prometheus / 其他后端系统统一采集。
+
+本次扩展在此基础上做了以下优化：
+
+1. **统一在 LLM 调用日志中带出 token 使用量**（字段 `used_token`）。
+2. **在开启 Monitor 的情况下，将 LLM 调用明细（含 token 使用量）按小时写入 jsonl 文件**，方便后续离线统计。
+3. **增强 Agent 调用记录**：Agent 调用记录中也包含 token 使用量和性能指标。
+4. **内置统计查询功能**：提供 `get_llm_statistics()` 和 `get_agent_statistics()` 方法，支持按时间、模型、Agent 等维度聚合统计。
+5. **成本估算功能**：提供 `estimate_cost()` 方法，基于 token 价格估算使用成本。
+6. **每日汇总功能**：提供 `get_daily_summary()` 方法，快速获取指定日期的统计汇总。
+
+---
+
+### 二、Monitor 配置与开关
+
+`Monitor` 的核心实现位于：
+
+- `agentuniverse/base/util/monitor/monitor.py`
+
+关键配置字段：
+
+- **`dir`**：监控数据落盘目录，默认 `./monitor`
+- **`activate`**：是否开启落盘到 jsonl 文件的能力（包括 agent 与 llm）
+- **`log_activate`**：是否在日志系统中输出结构化日志
+
+通常通过框架的 `Configer` 来注入配置，例如（伪代码）：
+
+```python
+MONITOR = {
+    "dir": "./monitor",
+    "activate": True,
+    "log_activate": True,
+}
+```
+
+只要 `activate=True`，则本次新增的 LLM 调用明细也会一并落盘。
+
+---
+
+### 三、在线调用返回中的 Token 使用量
+
+在产品层的 `AgentService` 中，已经对 token 使用量做了一次聚合，并回传给调用方：
+
+- 代码位置：`agentuniverse_product/service/agent_service/agent_service.py`
+- 相关方法：
+  - `chat(...)`
+  - `stream_chat(...)`
+  - `async_stream_chat(...)`
+
+调用 `chat` 时的典型返回结构（简化）：
+
+```python
+result = AgentService.chat(agent_id, session_id, input)
+
+print(result.keys())
+# dict_keys(['response_time', 'message_id', 'session_id', 'output',
+#            'start_time', 'end_time', 'invocation_chain', 'token_usage'])
+
+token_usage = result["token_usage"]
+```
+
+其中：
+
+- **`token_usage`** 为一个字典，来源于 `LLMOutput.usage.to_dict()` 的统计结果，主要字段包括：
+  - `prompt_tokens`
+  - `completion_tokens`
+  - `total_tokens`
+  - 以及 `prompt_tokens_details` / `completion_tokens_details` 中的细分字段
+
+在不依赖任何落盘文件的前提下，你可以直接在业务层拿到本次对话整体的 token 使用量。
+
+---
+
+### 四、LLM 调用明细 jsonl 文件
+
+为支持更灵活的 **离线统计与分析**，`Monitor.trace_llm_invocation` 做了增强：
+
+- 代码位置：`agentuniverse/base/util/monitor/monitor.py`
+- 方法签名：
+
+```python
+@staticmethod
+def trace_llm_invocation(
+    source: str,
+    llm_input: Union[str, dict],
+    llm_output: Union[str, dict],
+    cost_time: float = None,
+) -> None:
+    ...
+```
+
+增强后的行为包括两部分：
+
+1. **输出结构化日志**
+
+   日志中会包含：
+
+   - `log_type=LogTypeEnum.llm_invocation`
+   - `used_token=Monitor.get_token_usage()` —— 当前 trace 下聚合后的 token 使用量
+   - `cost_time`：本次 LLM 调用耗时
+   - `llm_output`：模型输出文本/数据
+
+2. **在 Monitor.activate=True 时写入 jsonl 文件**
+
+   - 子目录：`{monitor.dir}/llm_invocation`
+   - 文件命名：`llm_{source}_YYYY-MM-DD-HH.jsonl`
+   - 每条记录的结构示例：
+
+   ```json
+   {
+     "source": "openai_gpt_4o",
+     "date": "2025-12-03 10:23:45",
+     "llm_input": { "...": "..." },
+     "llm_output": "模型返回的文本或结构化结果",
+     "token_usage": {
+       "prompt_tokens": 123,
+       "completion_tokens": 456,
+       "total_tokens": 579,
+       "prompt_tokens_details": {
+         "text_tokens": 123
+       },
+       "completion_tokens_details": {
+         "text_tokens": 456
+       }
+     },
+     "cost_time": 1.234
+   }
+   ```
+
+这样，你可以非常方便地：
+
+- 按 **模型/时间/业务 source** 做 token 使用量统计
+- 对比不同模型或 prompt 策略下的 token 成本与响应耗时
+
+> 注意：写入 jsonl 依赖 `jsonlines` 包，如未安装会抛出：
+> `jsonlines is required to trace llm invocation: pip install jsonlines`
+
+---
+
+### 五、Agent 调用记录增强
+
+从本次优化开始，`Monitor.trace_agent_invocation` 方法也会记录 token 使用量和性能指标：
+
+- 代码位置：`agentuniverse/base/util/monitor/monitor.py`
+- Agent 调用记录的文件结构示例：
+
+```json
+{
+  "source": "my_agent",
+  "date": "2025-12-03 10:23:45",
+  "agent_input": { "...": "..." },
+  "agent_output": { "...": "..." },
+  "token_usage": {
+    "prompt_tokens": 123,
+    "completion_tokens": 456,
+    "total_tokens": 579
+  },
+  "cost_time": 2.345
+}
+```
+
+这样，你可以同时追踪 Agent 和 LLM 两个层面的 token 使用情况。
+
+---
+
+### 六、内置统计查询功能
+
+框架提供了便捷的统计查询方法，无需手动解析 jsonl 文件。
+
+#### 6.1 LLM 调用统计
+
+```python
+from agentuniverse.base.util.monitor.monitor import Monitor
+
+monitor = Monitor()
+
+# 查询所有 LLM 调用的统计
+stats = monitor.get_llm_statistics()
+
+# 按时间范围查询
+stats = monitor.get_llm_statistics(
+    start_date="2025-12-01",
+    end_date="2025-12-03"
+)
+
+# 查询特定模型的统计
+stats = monitor.get_llm_statistics(source="openai_gpt_4o")
+
+# 返回结果示例
+{
+    "total_calls": 200,
+    "total_tokens": 100000,
+    "total_prompt_tokens": 60000,
+    "total_completion_tokens": 40000,
+    "avg_cost_time": 1.234,
+    "by_source": {
+        "openai_gpt_4o": {
+            "calls": 120,
+            "tokens": 60000,
+            "prompt_tokens": 36000,
+            "completion_tokens": 24000,
+            "avg_cost_time": 1.5
+        },
+        "zhipu_glm_4": {
+            "calls": 80,
+            "tokens": 40000,
+            "prompt_tokens": 24000,
+            "completion_tokens": 16000,
+            "avg_cost_time": 0.9
+        }
+    }
+}
+```
+
+#### 6.2 Agent 调用统计
+
+```python
+# 查询所有 Agent 调用的统计
+agent_stats = monitor.get_agent_statistics()
+
+# 按时间范围查询
+agent_stats = monitor.get_agent_statistics(
+    start_date="2025-12-01 00:00:00",
+    end_date="2025-12-01 23:59:59"
+)
+
+# 查询特定 Agent 的统计
+agent_stats = monitor.get_agent_statistics(source="my_agent")
+
+# 返回结果示例
+{
+    "total_calls": 50,
+    "total_tokens": 50000,
+    "avg_cost_time": 2.5,
+    "by_source": {
+        "my_agent": {
+            "calls": 50,
+            "tokens": 50000,
+            "avg_cost_time": 2.5
+        }
+    }
+}
+```
+
+#### 6.3 每日汇总
+
+```python
+# 获取今天的汇总
+summary = monitor.get_daily_summary()
+
+# 获取指定日期的汇总
+summary = monitor.get_daily_summary("2025-12-01")
+
+# 返回结果示例
+{
+    "date": "2025-12-01",
+    "llm": {
+        "total_calls": 200,
+        "total_tokens": 100000,
+        ...
+    },
+    "agent": {
+        "total_calls": 50,
+        "total_tokens": 50000,
+        ...
+    }
+}
+```
+
+---
+
+### 七、成本估算功能
+
+框架提供了基于 token 价格的成本估算方法：
+
+```python
+# 假设 token 使用量
+token_usage = {
+    "prompt_tokens": 1000,
+    "completion_tokens": 500,
+    "total_tokens": 1500
+}
+
+# 估算成本（假设 prompt 每 1k tokens 0.01 元，completion 每 1k tokens 0.03 元）
+cost = monitor.estimate_cost(
+    token_usage,
+    prompt_price_per_1k=0.01,    # 每 1000 个 prompt tokens 的价格
+    completion_price_per_1k=0.03  # 每 1000 个 completion tokens 的价格
+)
+
+print(f"估算成本: {cost:.4f} 元")
+# 输出: 估算成本: 0.0250 元
+```
+
+结合统计查询功能，可以计算一段时间内的总成本：
+
+```python
+# 获取统计结果
+stats = monitor.get_llm_statistics(start_date="2025-12-01", end_date="2025-12-03")
+
+# 计算总成本（假设使用 GPT-4 的价格）
+total_cost = 0.0
+for source, source_stats in stats["by_source"].items():
+    token_usage = {
+        "prompt_tokens": source_stats["prompt_tokens"],
+        "completion_tokens": source_stats["completion_tokens"]
+    }
+    # 根据不同的模型设置不同的价格
+    if "gpt_4" in source:
+        cost = monitor.estimate_cost(token_usage, 0.03, 0.06)
+    else:
+        cost = monitor.estimate_cost(token_usage, 0.01, 0.03)
+    total_cost += cost
+
+print(f"总成本: {total_cost:.2f} 元")
+```
+
+---
+
+### 八、简单的离线统计示例
+
+下面给出一个独立脚本示例，展示如何基于 `monitor/llm_invocation/*.jsonl` 做按模型聚合的 token 统计。
+
+> 该脚本不在框架内置，只是一个使用参考。你可以将它保存为项目中的 `scripts/token_usage_report.py` 或自行调整。
+
+```python
+import glob
+import json
+from collections import defaultdict
+from pathlib import Path
+
+MONITOR_DIR = Path("./monitor/llm_invocation")
+
+
+def load_records():
+    for path in glob.glob(str(MONITOR_DIR / "llm_*.jsonl")):
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except Exception:
+                    continue
+
+
+def aggregate_by_source():
+    stats = defaultdict(lambda: {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "count": 0})
+
+    for record in load_records():
+        source = record.get("source", "unknown")
+        usage = record.get("token_usage") or {}
+
+        prompt = usage.get("prompt_tokens", 0)
+        completion = usage.get("completion_tokens", 0)
+        total = usage.get("total_tokens", prompt + completion)
+
+        stats[source]["prompt_tokens"] += prompt
+        stats[source]["completion_tokens"] += completion
+        stats[source]["total_tokens"] += total
+        stats[source]["count"] += 1
+
+    return stats
+
+
+if __name__ == "__main__":
+    result = aggregate_by_source()
+    for source, s in result.items():
+        print(f"[{source}] calls={s['count']}, "
+              f"prompt_tokens={s['prompt_tokens']}, "
+              f"completion_tokens={s['completion_tokens']}, "
+              f"total_tokens={s['total_tokens']}")
+```
+
+运行示例：
+
+```bash
+python scripts/token_usage_report.py
+```
+
+输出示例：
+
+```text
+[openai_gpt_4o] calls=120, prompt_tokens=34567, completion_tokens=8910, total_tokens=43477
+[zhipu_glm_4]  calls=80,  prompt_tokens=21000, completion_tokens=5600, total_tokens=26600
+```
+
+---
+
+### 九、推荐的使用姿势
+
+- **在线监控**：
+  - 通过现有的 OTel 指标（`LLM_TOTAL_TOKENS` / `LLM_PROMPT_TOKENS` / `LLM_COMPLETION_TOKENS` 等）接入 Prometheus / Grafana 做实时监控与告警。
+- **快速统计查询**：
+  - 使用 `Monitor.get_llm_statistics()` 和 `Monitor.get_agent_statistics()` 方法，无需手动解析 jsonl 文件，即可获取聚合统计结果。
+- **成本核算**：
+  - 开启 `Monitor.activate=True`，使用 `get_llm_statistics()` 获取统计结果，结合 `estimate_cost()` 方法计算成本。
+  - 使用 `get_daily_summary()` 快速生成每日成本报告。
+- **业务优化**：
+  - 对比不同 Agent/Workflow/Prompt 版本在 token 使用量和响应耗时上的差异，优化整体性价比。
+  - 通过 `by_source` 字段分析不同模型或 Agent 的使用情况。
+
+如果你有更个性化的统计需求（例如：按用户 ID / 业务线 / 场景标签等维度拆分），可以在业务调用时通过：
+
+- 自定义 `source` 字段（不同的 agent 或场景定义不同的 source）
+- 在 `llm_input` 中附带额外的业务标识
+
+然后在离线统计脚本中根据这些字段做更细粒度的聚合分析，或者扩展 `Monitor` 类添加自定义的统计方法。
+
+---
+
+### 十、完整示例：生成每日统计报告
+
+下面是一个完整的示例，展示如何使用新增的统计功能生成每日报告：
+
+```python
+from agentuniverse.base.util.monitor.monitor import Monitor
+from datetime import datetime, timedelta
+
+def generate_daily_report(date_str: str = None):
+    """生成指定日期的统计报告"""
+    monitor = Monitor()
+    
+    # 获取每日汇总
+    summary = monitor.get_daily_summary(date_str)
+    
+    print("=" * 60)
+    print(f"日期: {summary['date']}")
+    print("=" * 60)
+    
+    # LLM 统计
+    llm_stats = summary['llm']
+    print("\n【LLM 调用统计】")
+    print(f"  总调用次数: {llm_stats['total_calls']}")
+    print(f"  总 Token 数: {llm_stats['total_tokens']:,}")
+    print(f"  Prompt Tokens: {llm_stats['total_prompt_tokens']:,}")
+    print(f"  Completion Tokens: {llm_stats['total_completion_tokens']:,}")
+    print(f"  平均响应时间: {llm_stats['avg_cost_time']:.2f} 秒")
+    
+    print("\n  按模型分组:")
+    for source, stats in llm_stats['by_source'].items():
+        print(f"    [{source}]")
+        print(f"      调用次数: {stats['calls']}")
+        print(f"      Token 数: {stats['tokens']:,}")
+        print(f"      平均响应时间: {stats['avg_cost_time']:.2f} 秒")
+    
+    # Agent 统计
+    agent_stats = summary['agent']
+    print("\n【Agent 调用统计】")
+    print(f"  总调用次数: {agent_stats['total_calls']}")
+    print(f"  总 Token 数: {agent_stats['total_tokens']:,}")
+    print(f"  平均响应时间: {agent_stats['avg_cost_time']:.2f} 秒")
+    
+    print("\n  按 Agent 分组:")
+    for source, stats in agent_stats['by_source'].items():
+        print(f"    [{source}]")
+        print(f"      调用次数: {stats['calls']}")
+        print(f"      Token 数: {stats['tokens']:,}")
+        print(f"      平均响应时间: {stats['avg_cost_time']:.2f} 秒")
+    
+    # 成本估算（示例）
+    print("\n【成本估算】")
+    total_cost = 0.0
+    for source, stats in llm_stats['by_source'].items():
+        token_usage = {
+            "prompt_tokens": stats['prompt_tokens'],
+            "completion_tokens": stats['completion_tokens']
+        }
+        # 根据模型类型设置价格（示例）
+        if "gpt_4" in source:
+            cost = monitor.estimate_cost(token_usage, 0.03, 0.06)
+        elif "gpt_3" in source:
+            cost = monitor.estimate_cost(token_usage, 0.0015, 0.002)
+        else:
+            cost = monitor.estimate_cost(token_usage, 0.01, 0.03)
+        total_cost += cost
+        print(f"  [{source}]: {cost:.4f} 元")
+    
+    print(f"\n  总成本: {total_cost:.2f} 元")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    # 生成今天的报告
+    generate_daily_report()
+    
+    # 生成指定日期的报告
+    # generate_daily_report("2025-12-01")
+```
+
+运行示例：
+
+```bash
+python scripts/daily_report.py
+```
+
+输出示例：
+
+```text
+============================================================
+日期: 2025-12-03
+============================================================
+
+【LLM 调用统计】
+  总调用次数: 200
+  总 Token 数: 100,000
+  Prompt Tokens: 60,000
+  Completion Tokens: 40,000
+  平均响应时间: 1.23 秒
+
+  按模型分组:
+    [openai_gpt_4o]
+      调用次数: 120
+      Token 数: 60,000
+      平均响应时间: 1.50 秒
+    [zhipu_glm_4]
+      调用次数: 80
+      Token 数: 40,000
+      平均响应时间: 0.90 秒
+
+【Agent 调用统计】
+  总调用次数: 50
+  总 Token 数: 50,000
+  平均响应时间: 2.50 秒
+
+  按 Agent 分组:
+    [my_agent]
+      调用次数: 50
+      Token 数: 50,000
+      平均响应时间: 2.50 秒
+
+【成本估算】
+  [openai_gpt_4o]: 4.2000 元
+  [zhipu_glm_4]: 1.3000 元
+
+  总成本: 5.50 元
+============================================================
+```
+
+

--- a/tests/test_agentuniverse/unit/base/util/test_monitor.py
+++ b/tests/test_agentuniverse/unit/base/util/test_monitor.py
@@ -1,0 +1,339 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/12/03
+# @Author  : AgentUniverse Team
+# @FileName: test_monitor.py
+
+import unittest
+import os
+import tempfile
+import shutil
+import datetime
+from unittest.mock import patch, MagicMock
+
+from agentuniverse.base.util.monitor.monitor import Monitor
+from agentuniverse.agent.output_object import OutputObject
+
+
+class MonitorTest(unittest.TestCase):
+    """
+    Test cases for Monitor class statistics and monitoring features
+    """
+
+    def setUp(self) -> None:
+        """Set up test fixtures"""
+        # Create a temporary directory for monitor data
+        self.temp_dir = tempfile.mkdtemp()
+        self.monitor = Monitor()
+        self.monitor.dir = self.temp_dir
+        self.monitor.activate = True
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures"""
+        # Remove temporary directory
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_get_llm_statistics_empty(self) -> None:
+        """Test get_llm_statistics with no data"""
+        stats = self.monitor.get_llm_statistics()
+        
+        self.assertEqual(stats["total_calls"], 0)
+        self.assertEqual(stats["total_tokens"], 0)
+        self.assertEqual(stats["avg_cost_time"], 0.0)
+        self.assertEqual(len(stats["by_source"]), 0)
+
+    def test_get_agent_statistics_empty(self) -> None:
+        """Test get_agent_statistics with no data"""
+        stats = self.monitor.get_agent_statistics()
+        
+        self.assertEqual(stats["total_calls"], 0)
+        self.assertEqual(stats["total_tokens"], 0)
+        self.assertEqual(stats["avg_cost_time"], 0.0)
+        self.assertEqual(len(stats["by_source"]), 0)
+
+    def test_get_llm_statistics_with_data(self) -> None:
+        """Test get_llm_statistics with mock data"""
+        try:
+            import jsonlines
+        except ImportError:
+            self.skipTest("jsonlines not installed")
+        
+        # Create mock LLM invocation data
+        llm_dir = self.monitor._get_or_create_subdir("llm_invocation")
+        filename = f"llm_test_model_{datetime.datetime.now().strftime('%Y-%m-%d-%H')}.jsonl"
+        filepath = os.path.join(llm_dir, filename)
+        
+        records = [
+            {
+                "source": "test_model",
+                "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {"test": "input"},
+                "llm_output": "test output",
+                "token_usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150
+                },
+                "cost_time": 1.5
+            },
+            {
+                "source": "test_model",
+                "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {"test": "input2"},
+                "llm_output": "test output2",
+                "token_usage": {
+                    "prompt_tokens": 200,
+                    "completion_tokens": 100,
+                    "total_tokens": 300
+                },
+                "cost_time": 2.0
+            }
+        ]
+        
+        with jsonlines.open(filepath, 'w') as writer:
+            for record in records:
+                writer.write(record)
+        
+        # Test statistics
+        stats = self.monitor.get_llm_statistics()
+        
+        self.assertEqual(stats["total_calls"], 2)
+        self.assertEqual(stats["total_tokens"], 450)
+        self.assertEqual(stats["total_prompt_tokens"], 300)
+        self.assertEqual(stats["total_completion_tokens"], 150)
+        self.assertAlmostEqual(stats["avg_cost_time"], 1.75, places=2)
+        self.assertIn("test_model", stats["by_source"])
+
+    def test_get_agent_statistics_with_data(self) -> None:
+        """Test get_agent_statistics with mock data"""
+        try:
+            import jsonlines
+        except ImportError:
+            self.skipTest("jsonlines not installed")
+        
+        # Create mock Agent invocation data
+        agent_dir = self.monitor._get_or_create_subdir("agent_invocation")
+        filename = f"agent_test_agent_{datetime.datetime.now().strftime('%Y-%m-%d-%H')}.jsonl"
+        filepath = os.path.join(agent_dir, filename)
+        
+        records = [
+            {
+                "source": "test_agent",
+                "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "agent_input": {"test": "input"},
+                "agent_output": {"test": "output"},
+                "token_usage": {
+                    "total_tokens": 500
+                },
+                "cost_time": 3.0
+            }
+        ]
+        
+        with jsonlines.open(filepath, 'w') as writer:
+            for record in records:
+                writer.write(record)
+        
+        # Test statistics
+        stats = self.monitor.get_agent_statistics()
+        
+        self.assertEqual(stats["total_calls"], 1)
+        self.assertEqual(stats["total_tokens"], 500)
+        self.assertAlmostEqual(stats["avg_cost_time"], 3.0, places=2)
+        self.assertIn("test_agent", stats["by_source"])
+
+    def test_get_llm_statistics_with_date_filter(self) -> None:
+        """Test get_llm_statistics with date filtering"""
+        try:
+            import jsonlines
+        except ImportError:
+            self.skipTest("jsonlines not installed")
+        
+        # Create mock data with different dates
+        llm_dir = self.monitor._get_or_create_subdir("llm_invocation")
+        filename = f"llm_test_model_{datetime.datetime.now().strftime('%Y-%m-%d-%H')}.jsonl"
+        filepath = os.path.join(llm_dir, filename)
+        
+        today = datetime.datetime.now()
+        yesterday = today - datetime.timedelta(days=1)
+        
+        records = [
+            {
+                "source": "test_model",
+                "date": today.strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {"test": "input"},
+                "llm_output": "test output",
+                "token_usage": {"total_tokens": 100},
+                "cost_time": 1.0
+            },
+            {
+                "source": "test_model",
+                "date": yesterday.strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {"test": "input2"},
+                "llm_output": "test output2",
+                "token_usage": {"total_tokens": 200},
+                "cost_time": 2.0
+            }
+        ]
+        
+        with jsonlines.open(filepath, 'w') as writer:
+            for record in records:
+                writer.write(record)
+        
+        # Test with date filter (only today)
+        start_date = today.strftime("%Y-%m-%d")
+        stats = self.monitor.get_llm_statistics(start_date=start_date)
+        
+        # Should only count today's record
+        self.assertEqual(stats["total_calls"], 1)
+        self.assertEqual(stats["total_tokens"], 100)
+
+    def test_get_llm_statistics_with_source_filter(self) -> None:
+        """Test get_llm_statistics with source filtering"""
+        try:
+            import jsonlines
+        except ImportError:
+            self.skipTest("jsonlines not installed")
+        
+        # Create mock data with different sources
+        llm_dir = self.monitor._get_or_create_subdir("llm_invocation")
+        now = datetime.datetime.now()
+        
+        # Create file for model1
+        filename1 = f"llm_model1_{now.strftime('%Y-%m-%d-%H')}.jsonl"
+        filepath1 = os.path.join(llm_dir, filename1)
+        with jsonlines.open(filepath1, 'w') as writer:
+            writer.write({
+                "source": "model1",
+                "date": now.strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {},
+                "llm_output": "output1",
+                "token_usage": {"total_tokens": 100},
+                "cost_time": 1.0
+            })
+        
+        # Create file for model2
+        filename2 = f"llm_model2_{now.strftime('%Y-%m-%d-%H')}.jsonl"
+        filepath2 = os.path.join(llm_dir, filename2)
+        with jsonlines.open(filepath2, 'w') as writer:
+            writer.write({
+                "source": "model2",
+                "date": now.strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {},
+                "llm_output": "output2",
+                "token_usage": {"total_tokens": 200},
+                "cost_time": 2.0
+            })
+        
+        # Test with source filter
+        stats = self.monitor.get_llm_statistics(source="model1")
+        
+        self.assertEqual(stats["total_calls"], 1)
+        self.assertEqual(stats["total_tokens"], 100)
+        self.assertIn("model1", stats["by_source"])
+        self.assertNotIn("model2", stats["by_source"])
+
+    def test_estimate_cost(self) -> None:
+        """Test cost estimation"""
+        token_usage = {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500
+        }
+        
+        cost = self.monitor.estimate_cost(
+            token_usage,
+            prompt_price_per_1k=0.01,
+            completion_price_per_1k=0.03
+        )
+        
+        # Expected: (1000/1000)*0.01 + (500/1000)*0.03 = 0.01 + 0.015 = 0.025
+        self.assertAlmostEqual(cost, 0.025, places=4)
+
+    def test_get_daily_summary(self) -> None:
+        """Test get_daily_summary"""
+        try:
+            import jsonlines
+        except ImportError:
+            self.skipTest("jsonlines not installed")
+        
+        # Create mock data
+        today = datetime.datetime.now().strftime("%Y-%m-%d")
+        
+        # Create LLM data
+        llm_dir = self.monitor._get_or_create_subdir("llm_invocation")
+        llm_filename = f"llm_test_model_{datetime.datetime.now().strftime('%Y-%m-%d-%H')}.jsonl"
+        llm_filepath = os.path.join(llm_dir, llm_filename)
+        with jsonlines.open(llm_filepath, 'w') as writer:
+            writer.write({
+                "source": "test_model",
+                "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "llm_input": {},
+                "llm_output": "output",
+                "token_usage": {"total_tokens": 100},
+                "cost_time": 1.0
+            })
+        
+        # Create Agent data
+        agent_dir = self.monitor._get_or_create_subdir("agent_invocation")
+        agent_filename = f"agent_test_agent_{datetime.datetime.now().strftime('%Y-%m-%d-%H')}.jsonl"
+        agent_filepath = os.path.join(agent_dir, agent_filename)
+        with jsonlines.open(agent_filepath, 'w') as writer:
+            writer.write({
+                "source": "test_agent",
+                "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "agent_input": {},
+                "agent_output": {},
+                "token_usage": {"total_tokens": 200},
+                "cost_time": 2.0
+            })
+        
+        # Test daily summary
+        summary = self.monitor.get_daily_summary(today)
+        
+        self.assertEqual(summary["date"], today)
+        self.assertIn("llm", summary)
+        self.assertIn("agent", summary)
+        self.assertEqual(summary["llm"]["total_calls"], 1)
+        self.assertEqual(summary["agent"]["total_calls"], 1)
+
+    def test_trace_agent_invocation_with_token_usage(self) -> None:
+        """Test that trace_agent_invocation includes token_usage"""
+        try:
+            import jsonlines
+        except ImportError:
+            self.skipTest("jsonlines not installed")
+        
+        # Mock token usage
+        with patch.object(Monitor, 'get_token_usage', return_value={
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }):
+            output = OutputObject()
+            self.monitor.trace_agent_invocation(
+                source="test_agent",
+                agent_input={"input": "test"},
+                agent_output=output,
+                cost_time=1.5
+            )
+        
+        # Verify the record was written
+        agent_dir = self.monitor._get_or_create_subdir("agent_invocation")
+        files = [f for f in os.listdir(agent_dir) if f.startswith("agent_test_agent")]
+        self.assertGreater(len(files), 0)
+        
+        # Read and verify the record
+        filepath = os.path.join(agent_dir, files[0])
+        with jsonlines.open(filepath, 'r') as reader:
+            records = list(reader)
+            if records:
+                last_record = records[-1]
+                self.assertIn("token_usage", last_record)
+                self.assertIn("cost_time", last_record)
+                self.assertEqual(last_record["cost_time"], 1.5)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [x] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

-
-
-

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**
# PR 信息 / PR Information

## 测试文件路径和测试结果 / Test Files and Results

### 测试文件路径 / Test File Paths

- `tests/test_agentuniverse/unit/base/util/test_monitor.py`

### 测试覆盖范围 / Test Coverage

新增的测试文件包含以下测试用例：

1. **`test_get_llm_statistics_empty`** - 测试空数据情况下的LLM统计查询
2. **`test_get_agent_statistics_empty`** - 测试空数据情况下的Agent统计查询
3. **`test_get_llm_statistics_with_data`** - 测试带数据的LLM统计查询
4. **`test_get_agent_statistics_with_data`** - 测试带数据的Agent统计查询
5. **`test_get_llm_statistics_with_date_filter`** - 测试带日期过滤的LLM统计查询
6. **`test_get_llm_statistics_with_source_filter`** - 测试带source过滤的LLM统计查询
7. **`test_estimate_cost`** - 测试成本估算功能
8. **`test_get_daily_summary`** - 测试每日汇总功能
9. **`test_trace_agent_invocation_with_token_usage`** - 测试Agent调用记录中的token使用量

### 运行测试 / Running Tests

```bash
# 运行所有监控相关测试
python -m pytest tests/test_agentuniverse/unit/base/util/test_monitor.py -v

# 运行特定测试
python -m pytest tests/test_agentuniverse/unit/base/util/test_monitor.py::MonitorTest::test_estimate_cost -v
```

### 测试结果说明 / Test Results Note

**注意**: 测试需要安装项目依赖（包括 `jsonlines` 和 `loguru`）。如果环境中缺少依赖，部分测试会自动跳过（使用 `skipTest`）。

测试使用临时目录来隔离测试数据，不会影响实际的监控数据目录。
-

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**
## 新增或修改的文档 / Added or Modified Documentation

### 修改的文档 / Modified Documents

1. **`docs/guidebook/zh/token_usage_monitor.md`**
   - 新增了"Agent 调用记录增强"章节
   - 新增了"内置统计查询功能"章节，包含：
     - LLM 调用统计 (`get_llm_statistics`)
     - Agent 调用统计 (`get_agent_statistics`)
     - 每日汇总 (`get_daily_summary`)
   - 新增了"成本估算功能"章节
   - 新增了"完整示例：生成每日统计报告"章节
   - 更新了"推荐的使用姿势"章节

### 文档内容概览 / Documentation Overview

文档详细说明了以下新功能：

1. **统计查询功能**
   - `Monitor.get_llm_statistics()` - 按时间、模型等维度统计LLM调用
   - `Monitor.get_agent_statistics()` - 按时间、Agent等维度统计Agent调用
   - `Monitor.get_daily_summary()` - 获取每日汇总

2. **成本估算功能**
   - `Monitor.estimate_cost()` - 基于token价格估算成本

3. **增强的监控记录**
   - Agent调用记录现在包含token使用量和性能指标

4. **完整示例代码**
   - 提供了生成每日统计报告的完整示例代码

---

## 代码变更摘要 / Code Changes Summary

### 修改的文件 / Modified Files

1. **`agentuniverse/base/util/monitor/monitor.py`**
   - 增强了 `trace_agent_invocation` 方法，添加了token使用量和性能指标记录
   - 新增 `get_llm_statistics()` 方法：LLM调用统计查询
   - 新增 `get_agent_statistics()` 方法：Agent调用统计查询
   - 新增 `estimate_cost()` 方法：成本估算
   - 新增 `get_daily_summary()` 方法：每日汇总

### 新增的功能 / New Features

1. **统计查询功能**
   - 支持按时间范围过滤
   - 支持按source（模型/Agent）过滤
   - 自动计算平均响应时间等性能指标
   - 按source分组统计

2. **成本估算功能**
   - 支持分别设置prompt和completion的token价格
   - 基于token使用量计算成本

3. **增强的监控记录**
   - Agent调用记录包含完整的token使用信息
   - Agent调用记录包含性能指标（响应时间）

---

## 使用示例 / Usage Examples

### 统计查询示例

```python
from agentuniverse.base.util.monitor.monitor import Monitor

monitor = Monitor()

# 查询所有LLM调用统计
stats = monitor.get_llm_statistics()

# 按时间范围查询
stats = monitor.get_llm_statistics(
    start_date="2025-12-01",
    end_date="2025-12-03"
)

# 查询特定模型的统计
stats = monitor.get_llm_statistics(source="openai_gpt_4o")
```

### 成本估算示例

```python
token_usage = {
    "prompt_tokens": 1000,
    "completion_tokens": 500
}

cost = monitor.estimate_cost(
    token_usage,
    prompt_price_per_1k=0.01,
    completion_price_per_1k=0.03
)
```

### 每日汇总示例

```python
# 获取今天的汇总
summary = monitor.get_daily_summary()

# 获取指定日期的汇总
summary = monitor.get_daily_summary("2025-12-01")
```
-