### PR TITLE
fix: replace 9 bare excepts with except Exception

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py
@@ -112,7 +112,7 @@ class YuqueReader(Reader):
         """Close HTTP session"""
         try:
             self.session.close()
-        except:
+        except Exception:
             pass
 
 # if __name__ == '__main__':

--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -399,7 +399,7 @@ class Agent(ComponentBase, ABC):
             try:
                 tool_input = {key: input_object.get_data(key) for key in tool.input_keys}
                 tool_results.append(str(tool.run(**tool_input)))
-            except:
+            except Exception:
                 LOGGER.warn(f'Tool {tool_name} call failed, maybe invalid or lack arguments')
         return "\n\n".join(tool_results)
 

--- a/agentuniverse/agent/template/planning_agent_template.py
+++ b/agentuniverse/agent/template/planning_agent_template.py
@@ -61,7 +61,7 @@ class PlanningAgentTemplate(AgentTemplate):
             return
         try:
             output = parse_json_markdown(agent_output).get('framework')
-        except:
+        except Exception:
             output = agent_output
         # add planning agent final result into the stream output.
         stream_output(output_stream,

--- a/agentuniverse/base/component/component_base.py
+++ b/agentuniverse/base/component/component_base.py
@@ -54,5 +54,5 @@ class ComponentBase(BaseModel):
     def create_copy(self):
         try:
             return self.model_copy(deep=True)
-        except:
+        except Exception:
             return self.model_copy()

--- a/agentuniverse/base/context/framework_context_manager.py
+++ b/agentuniverse/base/context/framework_context_manager.py
@@ -104,7 +104,7 @@ class FrameworkContextManager:
             for var_name in self.context_dict.keys():
                 try:
                     context_values[var_name] = copy.deepcopy(self.get_context(var_name))
-                except:
+                except Exception:
                     context_values[var_name] = self.get_context(var_name)
         return context_values
 

--- a/agentuniverse/base/tracing/otel/instrumentation/llm/llm_instrumentor.py
+++ b/agentuniverse/base/tracing/otel/instrumentation/llm/llm_instrumentor.py
@@ -95,7 +95,7 @@ class LLMSpanManager:
                     get_current_token_usage(self.span.context.span_id),
                     self.span.parent.span_id
                 )
-            except:
+            except Exception:
                 pass
             self.span.end()
             self.span = None

--- a/agentuniverse/base/tracing/otel/propagator/au_session_propagator.py
+++ b/agentuniverse/base/tracing/otel/propagator/au_session_propagator.py
@@ -65,7 +65,7 @@ class AUSessionPropagator(textmap.TextMapPropagator):
                 span = trace.get_current_span(context)
                 try:
                     span.set_attribute(SPAN_SESSION_ID_KEY, _value[0])
-                except:
+                except Exception:
                     pass
                 break
         return context

--- a/agentuniverse/base/util/monitor/monitor.py
+++ b/agentuniverse/base/util/monitor/monitor.py
@@ -243,7 +243,7 @@ class Monitor(BaseModel):
                 for key, value in cur_token_usage.items():
                     try:
                         result_usage[key] = old_token_usage[key] + value if key in old_token_usage else value
-                    except:
+                    except Exception:
                         # not addable value
                         pass
                 FrameworkContextManager().set_context(trace_id + '_token_usage', result_usage)

--- a/agentuniverse_product/service/util/agent_util.py
+++ b/agentuniverse_product/service/util/agent_util.py
@@ -229,7 +229,7 @@ def assemble_peer_planner_members(planner: dict, agent_model: AgentModel) -> lis
         for i, member_key in enumerate(member_keys):
             planner_data.setdefault(member_key, default_member_names[i])
         return assemble_planner_members(planner_data, member_keys)
-    except:
+    except Exception:
         return []
 
 


### PR DESCRIPTION
Replace 9 bare `except:` with `except Exception:` across 9 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.