### PR TITLE
fix: add default value to audio_url pop in agent.py

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -465,7 +465,7 @@ class Agent(ComponentBase, ABC):
         if image_urls:
             chat_prompt.generate_image_prompt(image_urls)
 
-        audio_url: str = agent_input.pop('audio_url') or ''
+        audio_url: str = agent_input.pop('audio_url', '') or ''
         if audio_url:
             chat_prompt.generate_audio_prompt(audio_url)
         return chat_prompt


### PR DESCRIPTION
## Fix for Issue #540

### Problem
When using multiple prompt templates in the same agent, the second call fails because `agent_input.pop('audio_url')` doesn't have a default value. The key gets removed on the first call, causing a `KeyError` on subsequent calls.

### Solution
Changed `agent_input.pop('audio_url')` to `agent_input.pop('audio_url', '')` to match the pattern already used for `image_urls` on line 466.

### Changes
- Line 468 in `agentuniverse/agent/agent.py`: Added default value to pop() call

Fixes #540