### PR TITLE
fix: add null check for async_client in as_langchain methods

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/azureopenai_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/azureopenai_embedding.py
@@ -102,7 +102,14 @@ class AzureOpenAIEmbedding(Embedding):
         self._initialize_clients()
 
         from langchain_community.embeddings.azure_openai import AzureOpenAIEmbeddings
-        return AzureOpenAIEmbeddings(openai_api_key=self.azure_api_key, client=self.client.embeddings, async_client=self.async_client.embeddings, azure_endpoint=f"https://{self.resource_name}.openai.azure.com/")
+        kwargs = {
+            "openai_api_key": self.azure_api_key,
+            "client": self.client.embeddings if self.client else None,
+            "azure_endpoint": f"https://{self.resource_name}.openai.azure.com/"
+        }
+        if self.async_client is not None:
+            kwargs["async_client"] = self.async_client.embeddings
+        return AzureOpenAIEmbeddings(**kwargs)
 
 
     def _initialize_by_component_configer(self, embedding_configer: ComponentConfiger) -> 'Embedding':

--- a/agentuniverse/agent/action/knowledge/embedding/openai_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/openai_embedding.py
@@ -95,8 +95,13 @@ class OpenAIEmbedding(Embedding):
 
     def as_langchain(self) -> OpenAIEmbeddings:
         """Convert the agentUniverse(aU) openai embedding class to the langchain openai embedding class."""
-        return OpenAIEmbeddings(openai_api_key=self.openai_api_key,
-                                client=self.client.embeddings, async_client=self.async_client.embeddings)
+        kwargs = {
+            "openai_api_key": self.openai_api_key,
+            "client": self.client.embeddings if self.client else None,
+        }
+        if self.async_client is not None:
+            kwargs["async_client"] = self.async_client.embeddings
+        return OpenAIEmbeddings(**kwargs)
 
     def _initialize_by_component_configer(self,
                                           embedding_configer: ComponentConfiger) \


### PR DESCRIPTION
## Problem

When using `as_langchain()` method before calling async methods, `async_client` is `None`, causing:

```
AttributeError: 'NoneType' object has no attribute 'embeddings'
```

Related to #188

## Solution

- Add null check for `async_client` in both `OpenAIEmbedding` and `AzureOpenAIEmbedding`
- Only include `async_client` in kwargs when it's not None
- Maintain backward compatibility

## Changes

- `agentuniverse/agent/action/knowledge/embedding/openai_embedding.py`
- `agentuniverse/agent/action/knowledge/embedding/azureopenai_embedding.py`

## Testing

- Syntax check passed
- No breaking changes to existing API