### PR TITLE
fix(tool): restrict file tools to base directory

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/file_path_utils.py
+++ b/agentuniverse/agent/action/tool/common_tool/file_path_utils.py
@@ -1,0 +1,25 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import os
+
+
+def resolve_safe_path(file_path: str, base_dir: str = ".") -> str:
+    """Resolve file_path and ensure it stays under base_dir."""
+    if not isinstance(file_path, str) or not file_path:
+        raise ValueError("file_path must be a non-empty string")
+
+    base = os.path.realpath(os.path.abspath(base_dir or "."))
+    if os.path.isabs(file_path):
+        resolved = os.path.realpath(file_path)
+    else:
+        resolved = os.path.realpath(os.path.join(base, file_path))
+
+    try:
+        common_path = os.path.commonpath([base, resolved])
+    except ValueError as exc:
+        raise ValueError(f"Path {file_path!r} escapes the allowed directory: {base}") from exc
+
+    if os.path.normcase(common_path) != os.path.normcase(base):
+        raise ValueError(f"Path {file_path!r} escapes the allowed directory: {base}")
+    return resolved

--- a/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
@@ -10,14 +10,33 @@ import os
 import json
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
 
 
 class ViewFileTool(Tool):
+    base_dir: str = "."
+
     def execute(self,
-                file_path: str,
+                file_path: str | ToolInput,
                 start_line: int = 0,
                 end_line: int = None
                 ) -> str:
+        if isinstance(file_path, ToolInput):
+            params = file_path.to_dict()
+            start_line = params.get('start_line', start_line)
+            end_line = params.get('end_line', end_line)
+            file_path = params.get('file_path')
+
+        try:
+            safe_file_path = resolve_safe_path(file_path, self.base_dir)
+        except ValueError as e:
+            return json.dumps({
+                "error": str(e),
+                "file_path": file_path,
+                "status": "error"
+            })
+
+        file_path = safe_file_path
         if not file_path or not os.path.isfile(file_path):
             return json.dumps({
                 "error": f"File not found: {file_path}",

--- a/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
@@ -10,13 +10,32 @@ import os
 import json
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
 
 
 class WriteFileTool(Tool):
+    base_dir: str = "."
+
     def execute(self,
-                file_path: str,
+                file_path: str | ToolInput,
                 content: str = '',
                 append: bool = False) -> str:
+        if isinstance(file_path, ToolInput):
+            params = file_path.to_dict()
+            content = params.get('content', content)
+            append = params.get('append', append)
+            file_path = params.get('file_path')
+
+        try:
+            safe_file_path = resolve_safe_path(file_path, self.base_dir)
+        except ValueError as e:
+            return json.dumps({
+                "error": str(e),
+                "file_path": file_path,
+                "status": "error"
+            })
+
+        file_path = safe_file_path
         directory = os.path.dirname(file_path)
         if directory and not os.path.exists(directory):
             try:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
@@ -38,7 +38,7 @@ class ViewFileToolTest(unittest.TestCase):
         result = json.loads(result_json)
 
         self.assertEqual(result['status'], 'success')
-        self.assertEqual(result['file_path'], self.temp_file_path)
+        self.assertEqual(result['file_path'], os.path.realpath(self.temp_file_path))
         self.assertEqual(result['content'],
                          "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n")
         self.assertEqual(result['total_lines'], 5)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
@@ -8,6 +8,7 @@
 
 import os
 import json
+import shutil
 import tempfile
 import unittest
 
@@ -17,17 +18,16 @@ from agentuniverse.agent.action.tool.common_tool.view_file_tool import ViewFileT
 
 class ViewFileToolTest(unittest.TestCase):
     def setUp(self):
-        self.tool = ViewFileTool()
-        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
-        self.temp_file_path = self.temp_file.name
+        self.temp_dir = tempfile.mkdtemp()
+        self.tool = ViewFileTool(base_dir=self.temp_dir)
+        self.temp_file_path = os.path.join(self.temp_dir, 'test.txt')
 
         test_content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
-        self.temp_file.write(test_content.encode('utf-8'))
-        self.temp_file.close()
+        with open(self.temp_file_path, 'w', encoding='utf-8') as temp_file:
+            temp_file.write(test_content)
 
     def tearDown(self):
-        if os.path.exists(self.temp_file_path):
-            os.unlink(self.temp_file_path)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_view_entire_file(self):
         tool_input = ToolInput({
@@ -60,7 +60,7 @@ class ViewFileToolTest(unittest.TestCase):
 
     def test_invalid_file_path(self):
         tool_input = ToolInput({
-            'file_path': '/path/to/nonexistent/file.txt'
+            'file_path': 'nonexistent/file.txt'
         })
 
         result_json = self.tool.execute(tool_input)
@@ -68,6 +68,18 @@ class ViewFileToolTest(unittest.TestCase):
 
         self.assertEqual(result['status'], 'error')
         self.assertIn('File not found', result['error'])
+
+    def test_reject_path_traversal(self):
+        outside_file = tempfile.NamedTemporaryFile(delete=False)
+        outside_file.write(b'secret')
+        outside_file.close()
+        self.addCleanup(lambda: os.path.exists(outside_file.name) and os.unlink(outside_file.name))
+
+        result_json = self.tool.execute(file_path=outside_file.name)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('escapes the allowed directory', result['error'])
 
 
 if __name__ == '__main__':

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
@@ -37,7 +37,7 @@ class WriteFileToolTest(unittest.TestCase):
         result = json.loads(result_json)
         
         self.assertEqual(result['status'], 'success')
-        self.assertEqual(result['file_path'], file_path)
+        self.assertEqual(result['file_path'], os.path.realpath(file_path))
         self.assertTrue(os.path.exists(file_path))
         
         with open(file_path, 'r') as f:
@@ -95,7 +95,7 @@ class WriteFileToolTest(unittest.TestCase):
 
         expected_path = os.path.join(self.temp_dir, 'relative', 'test.txt')
         self.assertEqual(result['status'], 'success')
-        self.assertEqual(result['file_path'], expected_path)
+        self.assertEqual(result['file_path'], os.path.realpath(expected_path))
         self.assertTrue(os.path.exists(expected_path))
 
     def test_reject_path_traversal(self):

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
@@ -8,6 +8,7 @@
 
 import os
 import json
+import shutil
 import tempfile
 import unittest
 
@@ -17,16 +18,11 @@ from agentuniverse.agent.action.tool.common_tool.write_file_tool import WriteFil
 
 class WriteFileToolTest(unittest.TestCase):
     def setUp(self):
-        self.tool = WriteFileTool()
         self.temp_dir = tempfile.mkdtemp()
+        self.tool = WriteFileTool(base_dir=self.temp_dir)
         
     def tearDown(self):
-        for root, dirs, files in os.walk(self.temp_dir, topdown=False):
-            for name in files:
-                os.unlink(os.path.join(root, name))
-            for name in dirs:
-                os.rmdir(os.path.join(root, name))
-        os.rmdir(self.temp_dir)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
     
     def test_write_new_file(self):
         file_path = os.path.join(self.temp_dir, 'test_new.txt')
@@ -89,6 +85,33 @@ class WriteFileToolTest(unittest.TestCase):
         self.assertTrue(os.path.exists(file_path))
         
         self.assertTrue(os.path.isdir(os.path.join(self.temp_dir, 'nested/dir/structure')))
+
+    def test_write_relative_path_under_base_dir(self):
+        result_json = self.tool.execute(
+            file_path='relative/test.txt',
+            content='relative content'
+        )
+        result = json.loads(result_json)
+
+        expected_path = os.path.join(self.temp_dir, 'relative', 'test.txt')
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['file_path'], expected_path)
+        self.assertTrue(os.path.exists(expected_path))
+
+    def test_reject_path_traversal(self):
+        outside_name = f"{os.path.basename(self.temp_dir)}_outside.txt"
+        outside_path = os.path.join(os.path.dirname(self.temp_dir), outside_name)
+        self.addCleanup(lambda: os.path.exists(outside_path) and os.unlink(outside_path))
+
+        result_json = self.tool.execute(
+            file_path=f'../{outside_name}',
+            content='should not be written'
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('escapes the allowed directory', result['error'])
+        self.assertFalse(os.path.exists(outside_path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

Fixes #571.

This PR restricts `WriteFileTool` and `ViewFileTool` to a configurable base directory to prevent arbitrary filesystem reads/writes.

Changes:
- Add shared safe path resolution helper.
- Add `base_dir` support for `WriteFileTool` and `ViewFileTool`.
- Reject absolute paths and path traversal attempts that escape the allowed directory.
- Add tests for allowed file access and rejected unsafe paths.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

Test files:
- `tests/agent/action/tool/common_tool/test_file_path_utils.py`
- `tests/agent/action/tool/common_tool/test_write_file_tool.py`
- `tests/agent/action/tool/common_tool/test_view_file_tool.py`

Local checks:
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/file_path_utils.py agentuniverse/agent/action/tool/common_tool/write_file_tool.py agentuniverse/agent/action/tool/common_tool/view_file_tool.py`
- `git diff --check`

Full unit tests were not run locally because required dependencies such as `langchain` are missing in the current environment.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

None.