### PR TITLE
fix(agent_serve): allow list and dict types for RequestDO.query

### DIFF
--- a/agentuniverse/agent_serve/web/dal/entity/request_do.py
+++ b/agentuniverse/agent_serve/web/dal/entity/request_do.py
@@ -7,7 +7,7 @@
 # @FileName: request_do.py
 
 import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -18,7 +18,7 @@ class RequestDO(BaseModel):
     id: Optional[int] = Field(description="ID", default=None)
     request_id: str = Field(description="Unique request id.")
     session_id: str = Field(description="Session id of the request.")
-    query: str = Field(description="The query contents.")
+    query: Union[str, list, dict] = Field(description="The query contents.")
     state: str = Field(description="State of the request.")
     result: dict = Field(description="Exec result.")
     steps: list = Field(description="Exec steps.")

--- a/tests/test_agentuniverse/unit/agent_serve/test_request_do.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_request_do.py
@@ -1,0 +1,53 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/6/21
+# @FileName: test_request_do.py
+
+import pytest
+
+from agentuniverse.agent_serve.web.dal.entity.request_do import RequestDO
+
+
+def _make_request_do(query) -> RequestDO:
+    """Helper to build a RequestDO with only the required fields."""
+    return RequestDO(
+        request_id="test-request-id",
+        session_id="test-session-id",
+        query=query,
+        state="init",
+        result=dict(),
+        steps=[],
+        additional_args=dict(),
+    )
+
+
+def test_request_do_accepts_string_query():
+    request_do = _make_request_do("what is the weather today?")
+    assert request_do.query == "what is the weather today?"
+
+
+def test_request_do_accepts_list_query():
+    query = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    request_do = _make_request_do(query)
+    assert request_do.query == query
+
+
+def test_request_do_accepts_dict_query():
+    query = {"input": "hello", "context": {"lang": "zh"}}
+    request_do = _make_request_do(query)
+    assert request_do.query == query
+
+
+def test_request_do_model_dump_preserves_non_string_query():
+    query = {"input": "hello"}
+    request_do = _make_request_do(query)
+    dumped = request_do.model_dump()
+    assert dumped["query"] == query
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])


### PR DESCRIPTION
The RequestDO Pydantic model previously constrained query to str, causing a validation error when service requests passed list or dict parameters (e.g. input: []). This change relaxes the type to Union[str, list, dict] so that non-string request payloads are accepted.

Adds unit tests covering string, list, and dict query values, plus a model_dump round-trip assertion.

