### PR TITLE
feat: add PubMed search tool

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/pubmed_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/pubmed_tool.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""A lightweight PubMed search tool based on NCBI E-utilities."""
+
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.env_util import get_from_env
+
+
+class PubMedTool(Tool):
+    """Search PubMed and return structured article metadata."""
+
+    base_url: str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+    timeout: float = Field(default=15.0, description="HTTP request timeout in seconds")
+    email: Optional[str] = Field(default_factory=lambda: get_from_env("NCBI_EMAIL"))
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("NCBI_API_KEY"))
+    ncbi_tool_name: str = "agentuniverse_pubmed_tool"
+
+    def execute(self, query: str, max_results: int = 5) -> Dict[str, Any]:
+        """Search PubMed for articles matching a query.
+
+        Args:
+            query: PubMed search expression or keywords.
+            max_results: Maximum number of articles to return, from 1 to 20.
+
+        Returns:
+            A dictionary containing the query, result counts, and article
+            metadata. Network and response parsing failures are returned in
+            a structured ``error`` field.
+
+        Raises:
+            ValueError: If the query is empty or max_results is invalid.
+        """
+        query = query.strip() if isinstance(query, str) else ""
+        if not query:
+            raise ValueError("query must not be empty")
+        if isinstance(max_results, bool) or not isinstance(max_results, int):
+            raise ValueError("max_results must be an integer between 1 and 20")
+        if not 1 <= max_results <= 20:
+            raise ValueError("max_results must be between 1 and 20")
+
+        try:
+            search_data = self._search(query, max_results)
+            search_result = search_data.get("esearchresult", {})
+            pmids = search_result.get("idlist", [])
+            total_results = int(search_result.get("count", 0))
+
+            papers = self._fetch_articles(pmids) if pmids else []
+            return {
+                "query": query,
+                "total_results": total_results,
+                "returned_results": len(papers),
+                "papers": papers,
+            }
+        except requests.Timeout:
+            return self._error_result(query, "request_timeout", "PubMed request timed out.")
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            message = f"PubMed returned HTTP status {status_code}." if status_code else "PubMed HTTP request failed."
+            return self._error_result(query, "http_error", message)
+        except requests.RequestException as exc:
+            return self._error_result(query, "request_error", f"PubMed request failed: {exc}")
+        except (ElementTree.ParseError, KeyError, TypeError, ValueError) as exc:
+            return self._error_result(query, "invalid_response", f"Unable to parse PubMed response: {exc}")
+
+    def _search(self, query: str, max_results: int) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/esearch.fcgi",
+            params={
+                **self._common_params(),
+                "db": "pubmed",
+                "term": query,
+                "retmode": "json",
+                "retmax": max_results,
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict) or not isinstance(data.get("esearchresult"), dict):
+            raise ValueError("missing esearchresult")
+        return data
+
+    def _fetch_articles(self, pmids: List[str]) -> List[Dict[str, Any]]:
+        response = requests.get(
+            f"{self.base_url}/efetch.fcgi",
+            params={
+                **self._common_params(),
+                "db": "pubmed",
+                "id": ",".join(pmids),
+                "retmode": "xml",
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        root = ElementTree.fromstring(response.content)
+        return [self._parse_article(article) for article in root.findall(".//PubmedArticle")]
+
+    def _common_params(self) -> Dict[str, str]:
+        params = {"tool": self.ncbi_tool_name}
+        if self.email:
+            params["email"] = self.email
+        if self.api_key:
+            params["api_key"] = self.api_key
+        return params
+
+    @classmethod
+    def _parse_article(cls, article: ElementTree.Element) -> Dict[str, Any]:
+        pmid = cls._element_text(article.find(".//MedlineCitation/PMID"))
+        title = cls._element_text(article.find(".//Article/ArticleTitle"))
+        journal = cls._element_text(article.find(".//Article/Journal/Title"))
+
+        authors = []
+        for author in article.findall(".//Article/AuthorList/Author"):
+            collective_name = cls._element_text(author.find("CollectiveName"))
+            if collective_name:
+                authors.append(collective_name)
+                continue
+            fore_name = cls._element_text(author.find("ForeName"))
+            last_name = cls._element_text(author.find("LastName"))
+            full_name = " ".join(part for part in (fore_name, last_name) if part)
+            if full_name:
+                authors.append(full_name)
+
+        abstract_parts = []
+        for abstract in article.findall(".//Article/Abstract/AbstractText"):
+            text = cls._element_text(abstract)
+            if not text:
+                continue
+            label = abstract.attrib.get("Label")
+            abstract_parts.append(f"{label}: {text}" if label else text)
+
+        doi = ""
+        for article_id in article.findall(".//PubmedData/ArticleIdList/ArticleId"):
+            if article_id.attrib.get("IdType") == "doi":
+                doi = cls._element_text(article_id)
+                break
+
+        return {
+            "pmid": pmid,
+            "title": title,
+            "authors": authors,
+            "abstract": "\n".join(abstract_parts),
+            "journal": journal,
+            "published": cls._publication_date(article),
+            "doi": doi,
+            "entry_url": f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/" if pmid else "",
+        }
+
+    @classmethod
+    def _publication_date(cls, article: ElementTree.Element) -> str:
+        pub_date = article.find(".//Article/Journal/JournalIssue/PubDate")
+        if pub_date is None:
+            return ""
+        medline_date = cls._element_text(pub_date.find("MedlineDate"))
+        if medline_date:
+            return medline_date
+        parts = [
+            cls._element_text(pub_date.find("Year")),
+            cls._element_text(pub_date.find("Month")),
+            cls._element_text(pub_date.find("Day")),
+        ]
+        return "-".join(part for part in parts if part)
+
+    @staticmethod
+    def _element_text(element: Optional[ElementTree.Element]) -> str:
+        if element is None:
+            return ""
+        return " ".join("".join(element.itertext()).split())
+
+    @staticmethod
+    def _error_result(query: str, error_type: str, message: str) -> Dict[str, Any]:
+        return {
+            "query": query,
+            "total_results": 0,
+            "returned_results": 0,
+            "papers": [],
+            "error": {"type": error_type, "message": message},
+        }

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -105,6 +105,39 @@ os.environ['SEARCHAPI_API_KEY'] = 'xxxxxx'
 SEARCHAPI_API_KEY="xxxxxx"
 ```
 
+### 1.4 PubMed论文搜索
+
+PubMed工具通过NCBI E-utilities检索生物医学与生命科学论文，无需API Key即可基础使用。
+
+工具配置：
+
+```yaml
+name: 'pubmed_tool'
+description: '根据关键词检索PubMed论文并返回结构化元信息'
+tool_type: 'api'
+input_keys: ['query']
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.pubmed_tool'
+  class: 'PubMedTool'
+```
+
+调用示例：
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj('pubmed_tool')
+result = tool.run(
+    query='large language models in medicine',
+    max_results=5,
+)
+```
+
+返回结果包含PMID、标题、作者、摘要、期刊、发布日期、DOI和PubMed页面地址。工具仅返回论文元信息，不下载或总结论文全文。
+
+可以按需通过环境变量配置`NCBI_EMAIL`和`NCBI_API_KEY`。未配置API Key时，工具仍可正常进行基础检索。
+
 
 ## 2. 代码工具
 

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/pubmed_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/pubmed_tool.yaml
@@ -1,0 +1,22 @@
+name: 'pubmed_tool'
+description: |
+  Search PubMed for biomedical and life-sciences papers and return structured metadata.
+
+  Input parameters:
+    - query (required): PubMed keywords or a PubMed search expression.
+    - max_results (optional): Number of papers to return, from 1 to 20. Defaults to 5.
+
+  Example input:
+    {
+      "query": "large language models in medicine",
+      "max_results": 5
+    }
+
+  Each result may contain PMID, title, authors, abstract, journal, publication date,
+  DOI, and a PubMed entry URL. This tool does not download or summarize full text.
+tool_type: 'api'
+input_keys: ['query']
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.pubmed_tool'
+  class: 'PubMedTool'

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_pubmed_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_pubmed_tool.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from agentuniverse.agent.action.tool.common_tool.pubmed_tool import PubMedTool
+
+
+SAMPLE_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>12345678</PMID>
+      <Article>
+        <ArticleTitle>Effect of <i>AI</i> in medicine</ArticleTitle>
+        <Abstract>
+          <AbstractText Label="BACKGROUND">First section.</AbstractText>
+          <AbstractText Label="METHODS">Second section.</AbstractText>
+        </Abstract>
+        <AuthorList>
+          <Author><LastName>Smith</LastName><ForeName>Alice</ForeName></Author>
+          <Author><CollectiveName>Example Research Group</CollectiveName></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Example Journal</Title>
+          <JournalIssue><PubDate><Year>2026</Year><Month>May</Month><Day>12</Day></PubDate></JournalIssue>
+        </Journal>
+      </Article>
+    </MedlineCitation>
+    <PubmedData>
+      <ArticleIdList><ArticleId IdType="doi">10.1000/example</ArticleId></ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>
+"""
+
+
+def response_mock(*, json_data=None, content=b""):
+    response = Mock()
+    response.json.return_value = json_data
+    response.content = content
+    response.raise_for_status.return_value = None
+    return response
+
+
+class PubMedToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = PubMedTool()
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_search_returns_structured_metadata(self, mock_get: Mock) -> None:
+        mock_get.side_effect = [
+            response_mock(json_data={"esearchresult": {"count": "42", "idlist": ["12345678"]}}),
+            response_mock(content=SAMPLE_XML),
+        ]
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["total_results"], 42)
+        self.assertEqual(result["returned_results"], 1)
+        paper = result["papers"][0]
+        self.assertEqual(paper["pmid"], "12345678")
+        self.assertEqual(paper["title"], "Effect of AI in medicine")
+        self.assertEqual(paper["authors"], ["Alice Smith", "Example Research Group"])
+        self.assertEqual(paper["abstract"], "BACKGROUND: First section.\nMETHODS: Second section.")
+        self.assertEqual(paper["published"], "2026-May-12")
+        self.assertEqual(paper["doi"], "10.1000/example")
+        self.assertEqual(paper["entry_url"], "https://pubmed.ncbi.nlm.nih.gov/12345678/")
+
+        search_call = mock_get.call_args_list[0]
+        self.assertEqual(search_call.kwargs["params"]["retmax"], 5)
+        self.assertEqual(search_call.kwargs["params"]["tool"], "agentuniverse_pubmed_tool")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_empty_search_does_not_fetch_articles(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={"esearchresult": {"count": "0", "idlist": []}}
+        )
+
+        result = self.tool.execute(query="no matching paper", max_results=3)
+
+        self.assertEqual(result["papers"], [])
+        self.assertEqual(result["returned_results"], 0)
+        mock_get.assert_called_once()
+        self.assertEqual(mock_get.call_args.kwargs["params"]["retmax"], 3)
+
+    def test_invalid_input(self) -> None:
+        with self.assertRaisesRegex(ValueError, "query must not be empty"):
+            self.tool.execute(query="  ")
+        with self.assertRaisesRegex(ValueError, "between 1 and 20"):
+            self.tool.execute(query="cancer", max_results=0)
+        with self.assertRaisesRegex(ValueError, "integer"):
+            self.tool.execute(query="cancer", max_results=True)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_timeout_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.Timeout("timed out")
+
+        result = self.tool.execute(query="cancer")
+
+        self.assertEqual(result["error"]["type"], "request_timeout")
+        self.assertEqual(result["papers"], [])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_invalid_xml_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = [
+            response_mock(json_data={"esearchresult": {"count": "1", "idlist": ["1"]}}),
+            response_mock(content=b"<not-valid"),
+        ]
+
+        result = self.tool.execute(query="cancer")
+
+        self.assertEqual(result["error"]["type"], "invalid_response")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes). | 我已经提交了测试文件并可提供测试结果截图。
- [x] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [x] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Added a lightweight PubMed search tool based on the official NCBI E-utilities API, without introducing additional dependencies or requiring an API key for basic usage.
- Added support for `query` and optional `max_results` parameters. The tool returns structured metadata including PMID, title, authors, abstract, journal, publication date, DOI, and PubMed URL.
- Added input validation, structured error responses, optional `NCBI_EMAIL`/`NCBI_API_KEY` support, YAML configuration, usage documentation, and offline unit tests. Full-text download, RAG, and paper summarization are intentionally out of scope.

Related to #252.

**Please provide the path of test files and submit screenshots or files of the test results:** | **请填写测试文件路径并提供测试结果截图或文件:**

- Test file: `tests/test_agentuniverse/unit/agent/action/tool/test_pubmed_tool.py`
- Test command: `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_pubmed_tool -v`
- Result: 5 tests passed.

<img width="868" height="307" alt="image" src="https://github.com/user-attachments/assets/470a0bea-60fe-4e95-a3b3-2656096dcb04" />

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**

- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md`
- `examples/sample_standard_app/intelligence/agentic/tool/buildin/pubmed_tool.yaml`