### PR TITLE
fix: use async request methods in RequestTool

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/request_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/request_tool.py
@@ -7,7 +7,7 @@
 # @FileName: request_tool.py
 
 
-from typing import Optional
+from typing import Any, Optional
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
@@ -39,6 +39,18 @@ class RequestTool(Tool):
                 return str(e)
         else:
             return self.execute_by_method(input_params)
+
+    async def async_execute(self, input: str) -> Any:
+        """Execute an HTTP request without blocking the event loop."""
+        input_params: str = input
+        if self.json_parser:
+            try:
+                parse_data = parse_json_markdown(input_params)
+                return await self.async_execute_by_method(**parse_data)
+            except Exception as e:
+                LOGGER.error(f'execute request error input{input_params} error{e}')
+                return str(e)
+        return await self.async_execute_by_method(input_params)
 
     async def async_execute_by_method(self, url: str, data: dict = None, **kwargs):
         url = self._clean_url(url)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py
@@ -1,0 +1,61 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from agentuniverse.agent.action.tool.common_tool.request_tool import RequestTool
+
+
+class RequestToolAsyncTest(unittest.IsolatedAsyncioTestCase):
+    """Test cases for RequestTool asynchronous execution."""
+
+    async def test_async_get_uses_async_requests_wrapper(self) -> None:
+        requests_wrapper = SimpleNamespace(
+            aget=AsyncMock(return_value='response body')
+        )
+        tool = RequestTool(
+            method='GET',
+            json_parser=False
+        )
+        tool.requests_wrapper = requests_wrapper
+
+        result = await tool.async_execute('"https://example.com/resource"')
+
+        self.assertEqual(result, 'response body')
+        requests_wrapper.aget.assert_awaited_once_with(
+            'https://example.com/resource'
+        )
+
+    async def test_async_post_parses_json_input(self) -> None:
+        requests_wrapper = SimpleNamespace(
+            apost=AsyncMock(return_value={'created': True})
+        )
+        tool = RequestTool(
+            method='POST',
+            json_parser=True
+        )
+        tool.requests_wrapper = requests_wrapper
+
+        result = await tool.async_execute(
+            '{"url": "https://example.com/items", '
+            '"data": {"name": "agentUniverse"}}'
+        )
+
+        self.assertEqual(result, {'created': True})
+        requests_wrapper.apost.assert_awaited_once_with(
+            'https://example.com/items',
+            data={'name': 'agentUniverse'}
+        )
+
+    async def test_async_execute_rejects_unsupported_method(self) -> None:
+        tool = RequestTool(
+            method='PATCH',
+            json_parser=False
+        )
+        tool.requests_wrapper = SimpleNamespace()
+
+        with self.assertRaisesRegex(ValueError, 'Unsupported method: PATCH'):
+            await tool.async_execute('https://example.com/resource')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Checklist**

- [x] Read the contributor guidelines.
- [x] Checked existing issues and pull requests for duplicate work.
- [x] Added tests for the bug fix.
- [x] Accept maintainer suggestions to modify or close this PR.

**Changes**

- Add `RequestTool.async_execute` so async calls use the existing native async request methods.
- Keep JSON parsing and error handling consistent with synchronous execution.
- Add coverage for async GET, parsed async POST, and unsupported HTTP methods.

Previously, `RequestTool` inherited the base `Tool.async_execute`, which ran the synchronous
`execute` method in a worker thread. The existing `aget`, `apost`, `aput`, and `adelete`
paths were therefore not used.

**Tests**

`tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py`

```
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py -q
```

Result: `3 passed`.

**Documentation**

None. This does not change the public configuration or API.
