### PR TITLE
fix: preserve agent input during prompt processing

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -435,7 +435,7 @@ class Agent(ComponentBase, ABC):
         return "\n\n".join(knowledge_results)
 
     def process_prompt(self, agent_input: dict, **kwargs) -> ChatPrompt:
-        expert_framework = agent_input.pop('expert_framework', '') or ''
+        expert_framework = agent_input.get('expert_framework', '') or ''
 
         profile: dict = self.agent_model.profile
 
@@ -461,11 +461,11 @@ class Agent(ComponentBase, ABC):
             profile_prompt_model = profile_prompt_model + version_prompt_model
 
         chat_prompt = ChatPrompt().build_prompt(profile_prompt_model, ['introduction', 'target', 'instruction'])
-        image_urls: list = agent_input.pop('image_urls', []) or []
+        image_urls: list = agent_input.get('image_urls', []) or []
         if image_urls:
             chat_prompt.generate_image_prompt(image_urls)
 
-        audio_url: str = agent_input.pop('audio_url') or ''
+        audio_url: str = agent_input.get('audio_url', '') or ''
         if audio_url:
             chat_prompt.generate_audio_prompt(audio_url)
         return chat_prompt

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -1,0 +1,43 @@
+from copy import deepcopy
+
+from agentuniverse.agent.agent import Agent
+from agentuniverse.agent.agent_model import AgentModel
+from agentuniverse.agent.input_object import InputObject
+
+
+class _StubAgent(Agent):
+    def input_keys(self) -> list[str]:
+        return []
+
+    def output_keys(self) -> list[str]:
+        return []
+
+    def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        return agent_input
+
+    def parse_result(self, agent_result: dict) -> dict:
+        return agent_result
+
+
+def test_process_prompt_preserves_agent_input_for_repeated_calls():
+    agent = _StubAgent()
+    agent.agent_model = AgentModel(
+        profile={
+            "introduction": "Introduction",
+            "target": "Target",
+            "instruction": "Instruction",
+        }
+    )
+    agent_input = {
+        "expert_framework": "Expert framework: ",
+        "image_urls": [{"url": "https://example.com/image.png"}],
+        "audio_url": "https://example.com/audio.mp3",
+        "input": "Question",
+    }
+    original_input = deepcopy(agent_input)
+
+    first_prompt = agent.process_prompt(agent_input)
+    second_prompt = agent.process_prompt(agent_input)
+
+    assert agent_input == original_input
+    assert first_prompt.messages == second_prompt.messages


### PR DESCRIPTION
Fixes #540.

**Checklist**

- [x] Read the contributor guidelines.
- [x] Checked existing issues and pull requests for duplicate work.
- [x] Added a regression test for the bug fix.
- [x] Accept maintainer suggestions to modify or close this PR.

**Changes**

- Read prompt-specific values without removing them from `agent_input`.
- Preserve `expert_framework`, `image_urls`, and `audio_url` across repeated prompt construction.
- Add coverage that builds the prompt twice with the same input and verifies both results are identical.

`Agent.process_prompt` previously used `dict.pop` for these values. Contextual iteration can build multiple prompt versions from the same dictionary, so the first build removed data needed by later builds and `audio_url` could raise `KeyError`.

**Tests**

```text
python -m pytest tests/test_agentuniverse/unit/agent/test_agent.py -q
```

Result: `1 passed`.
