### PR TITLE
fix: support structured service query input

### DIFF
--- a/agentuniverse/agent_serve/web/dal/entity/request_do.py
+++ b/agentuniverse/agent_serve/web/dal/entity/request_do.py
@@ -7,7 +7,7 @@
 # @FileName: request_do.py
 
 import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -18,7 +18,8 @@ class RequestDO(BaseModel):
     id: Optional[int] = Field(description="ID", default=None)
     request_id: str = Field(description="Unique request id.")
     session_id: str = Field(description="Session id of the request.")
-    query: str = Field(description="The query contents.")
+    query: str | list[Any] | dict[str, Any] = Field(
+        description="The query contents.")
     state: str = Field(description="State of the request.")
     result: dict = Field(description="Exec result.")
     steps: list = Field(description="Exec steps.")

--- a/agentuniverse/agent_serve/web/dal/request_library.py
+++ b/agentuniverse/agent_serve/web/dal/request_library.py
@@ -6,6 +6,8 @@
 # @Email   : fanen.lhy@antgroup.com
 # @FileName: request_library.py
 import datetime
+import json
+from typing import Any
 
 from sqlalchemy import JSON, Integer, String, DateTime, Text, Column
 from sqlalchemy import select
@@ -21,6 +23,7 @@ from agentuniverse.database.sqldb_wrapper import SQLDBWrapper
 from agentuniverse.database.sqldb_wrapper_manager import SQLDBWrapperManager
 
 REQUEST_TABLE_NAME = 'request_task'
+STRUCTURED_QUERY_PREFIX = "__agentuniverse_structured_query__:"
 Base = declarative_base()
 
 
@@ -117,7 +120,8 @@ class RequestLibrary:
         """
         session = self.get_session()
         try:
-            request_orm = self.request_orm(**request_do.model_dump())
+            request_orm = self.request_orm(
+                **self.__request_do_to_orm_data(request_do))
             session.add(request_orm)
             session.commit()
             return request_orm.id
@@ -132,7 +136,8 @@ class RequestLibrary:
             db_request_do = session.query(self.request_orm).filter(
                 self.request_orm.request_id == request_do.request_id).first()
             if db_request_do:
-                update_data = request_do.model_dump(exclude_unset=True)
+                update_data = self.__request_do_to_orm_data(
+                    request_do, exclude_unset=True)
                 for key, value in update_data.items():
                     setattr(db_request_do, key, value)
                 session.commit()
@@ -168,5 +173,34 @@ class RequestLibrary:
         )
         for column in request_orm.__table__.columns:
             setattr(request_obj, column.name,
-                    getattr(request_orm, column.name))
+                    self.__deserialize_query(getattr(request_orm, column.name))
+                    if column.name == "query"
+                    else getattr(request_orm, column.name))
         return request_obj
+
+    def __request_do_to_orm_data(self, request_do: RequestDO, **kwargs) -> dict:
+        """Convert RequestDO data into ORM-safe values."""
+        request_data = request_do.model_dump(**kwargs)
+        if "query" in request_data:
+            request_data["query"] = self.__serialize_query(request_data["query"])
+        return request_data
+
+    @staticmethod
+    def __serialize_query(query: Any) -> Any:
+        """Serialize structured query values for the Text-backed ORM column."""
+        if isinstance(query, (list, dict)):
+            return STRUCTURED_QUERY_PREFIX + json.dumps(
+                query, ensure_ascii=False)
+        return query
+
+    @staticmethod
+    def __deserialize_query(query: Any) -> Any:
+        """Restore structured query values saved by __serialize_query."""
+        if not isinstance(query, str):
+            return query
+        if not query.startswith(STRUCTURED_QUERY_PREFIX):
+            return query
+        try:
+            return json.loads(query[len(STRUCTURED_QUERY_PREFIX):])
+        except json.JSONDecodeError:
+            return query

--- a/tests/test_agentuniverse/unit/agent_serve/test_request_task.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_request_task.py
@@ -1,0 +1,25 @@
+import pytest
+
+from agentuniverse.agent_serve.web.dal.entity.request_do import RequestDO
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        [],
+        {"messages": [{"role": "user", "content": "hello"}]},
+    ],
+    ids=["list", "dict"],
+)
+def test_request_do_accepts_structured_query(query):
+    request = RequestDO(
+        request_id="request-id",
+        session_id="session-id",
+        query=query,
+        state="init",
+        result={},
+        steps=[],
+        additional_args={},
+    )
+
+    assert request.query == query

--- a/tests/test_agentuniverse/unit/agent_serve/test_request_task.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_request_task.py
@@ -1,6 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 
+from agentuniverse.agent_serve.web.dal.request_library import RequestLibrary
 from agentuniverse.agent_serve.web.dal.entity.request_do import RequestDO
+from tests.test_agentuniverse.mock.agent_serve.mock_application_config_manager import (
+    MockApplicationConfigManager,
+)
 
 
 @pytest.mark.parametrize(
@@ -23,3 +29,43 @@ def test_request_do_accepts_structured_query(query):
     )
 
     assert request.query == query
+
+
+def test_request_library_add_request_round_trips_structured_query(tmp_path):
+    with patch(
+        "agentuniverse.database.sqldb_wrapper.ApplicationConfigManager",
+        new=MockApplicationConfigManager,
+    ):
+        library = RequestLibrary(
+            configer={
+                "DB": {
+                    "system_db_uri": f"sqlite:///{tmp_path.as_posix()}/request.db",
+                    "request_table_name": "request_task",
+                }
+            }
+        )
+    cases = [
+        ("request-list-query", ["hello", {"role": "user"}]),
+        (
+            "request-dict-query",
+            {"messages": [{"role": "user", "content": "hello"}]},
+        ),
+    ]
+
+    for request_id, query in cases:
+        library.add_request(
+            RequestDO(
+                request_id=request_id,
+                session_id="session-id",
+                query=query,
+                state="init",
+                result={},
+                steps=[],
+                additional_args={},
+            )
+        )
+
+        saved_request = library.query_request_by_request_id(request_id)
+
+        assert saved_request is not None
+        assert saved_request.query == query


### PR DESCRIPTION
Fixes #583.

**Checklist**

- [x] Read the contributor guidelines.
- [x] Checked existing issues and pull requests for duplicate work.
- [x] Added regression tests for the bug fix.
- [x] Accept maintainer suggestions to modify or close this PR.

**Changes**

- Allow `RequestDO.query` to contain a string, list, or dictionary.
- Preserve structured service input instead of rejecting it during request task creation.
- Add coverage for list and dictionary query values.

`RequestTask` extracts common query fields such as `input` and stores the value in `RequestDO`. The model previously required a string, so valid JSON arrays and objects failed Pydantic validation before the service could run.

**Tests**

```text
python -m pytest tests/test_agentuniverse/unit/agent_serve/test_request_task.py -q
```

Result: `2 passed`.
