### PR TITLE
fix: allow missing async embedding client

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/openai_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/openai_embedding.py
@@ -95,8 +95,10 @@ class OpenAIEmbedding(Embedding):
 
     def as_langchain(self) -> OpenAIEmbeddings:
         """Convert the agentUniverse(aU) openai embedding class to the langchain openai embedding class."""
+        client = self.client.embeddings if self.client else None
+        async_client = self.async_client.embeddings if self.async_client else None
         return OpenAIEmbeddings(openai_api_key=self.openai_api_key,
-                                client=self.client.embeddings, async_client=self.async_client.embeddings)
+                                client=client, async_client=async_client)
 
     def _initialize_by_component_configer(self,
                                           embedding_configer: ComponentConfiger) \

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_openai_embedding_clients.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_openai_embedding_clients.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.embedding.openai_embedding import (
+    OpenAIEmbedding,
+)
+
+
+def test_as_langchain_allows_uninitialized_async_client():
+    sync_client = MagicMock()
+    langchain_embedding = MagicMock()
+    embedding = OpenAIEmbedding(
+        embedding_model_name="text-embedding-3-small",
+        openai_api_key="test-key",
+        client=sync_client,
+    )
+
+    with patch(
+        "agentuniverse.agent.action.knowledge.embedding.openai_embedding.OpenAIEmbeddings",
+        return_value=langchain_embedding,
+    ) as langchain_client:
+        result = embedding.as_langchain()
+
+    assert result is langchain_embedding
+    langchain_client.assert_called_once_with(
+        openai_api_key="test-key",
+        client=sync_client.embeddings,
+        async_client=None,
+    )


### PR DESCRIPTION
Fixes #188.

**Checklist**

- [x] Read the contributor guidelines.
- [x] Checked existing issues and pull requests for duplicate work.
- [x] Added a regression test for the bug fix.
- [x] Accept maintainer suggestions to modify or close this PR.

**Changes**

- Make `OpenAIEmbedding.as_langchain` tolerate an uninitialized synchronous or asynchronous client.
- Pass `None` for a missing client so LangChain can initialize it normally.
- Add coverage for converting an embedding after only the synchronous client has been initialized.

Previously, `as_langchain` accessed `self.async_client.embeddings` unconditionally. Calling it before an asynchronous embedding request therefore raised `AttributeError`.

**Tests**

```text
python -m pytest tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_openai_embedding_clients.py -q
```

Result: `1 passed`.
