### PR TITLE
fix: support list and dict types in service request query param

### DIFF
--- a/agentuniverse/agent_serve/web/dal/entity/request_do.py
+++ b/agentuniverse/agent_serve/web/dal/entity/request_do.py
@@ -7,7 +7,7 @@
 # @FileName: request_do.py
 
 import datetime
-from typing import Optional
+from typing import Optional, Union, List, Dict
 
 from pydantic import BaseModel, Field
 
@@ -18,7 +18,7 @@ class RequestDO(BaseModel):
     id: Optional[int] = Field(description="ID", default=None)
     request_id: str = Field(description="Unique request id.")
     session_id: str = Field(description="Session id of the request.")
-    query: str = Field(description="The query contents.")
+    query: Union[str, List, Dict] = Field(description="The query contents.")
     state: str = Field(description="State of the request.")
     result: dict = Field(description="Exec result.")
     steps: list = Field(description="Exec steps.")

--- a/agentuniverse/agent_serve/web/dal/request_library.py
+++ b/agentuniverse/agent_serve/web/dal/request_library.py
@@ -51,7 +51,7 @@ class RequestLibrary:
             __tablename__ = request_table_name
             id = Column(Integer, primary_key=True, autoincrement=True)
             request_id = Column(String(50), nullable=False)
-            query = Column(Text)
+            query = Column(JSON)
             session_id = Column(String(50))
             state = Column(String(20))
             result = Column(JSON)
@@ -167,6 +167,12 @@ class RequestLibrary:
             gmt_modified=datetime.datetime.now(),
         )
         for column in request_orm.__table__.columns:
-            setattr(request_obj, column.name,
-                    getattr(request_orm, column.name))
+            value = getattr(request_orm, column.name)
+            if column.name == 'query' and isinstance(value, str):
+                import json as _json
+                try:
+                    value = _json.loads(value)
+                except (ValueError, TypeError):
+                    pass
+            setattr(request_obj, column.name, value)
         return request_obj

--- a/tests/test_agentuniverse/unit/agent_serve/test_request_do.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_request_do.py
@@ -1,0 +1,57 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/06
+# @FileName: test_request_do.py
+
+import pytest
+
+from agentuniverse.agent_serve.web.dal.entity.request_do import RequestDO
+
+
+def test_request_do_with_string_query():
+    """RequestDO should accept a string query."""
+    do = RequestDO(
+        request_id="req-1",
+        session_id="sess-1",
+        query="hello world",
+        state="init",
+        result=dict(),
+        steps=[],
+        additional_args=dict(),
+    )
+    assert do.query == "hello world"
+
+
+def test_request_do_with_list_query():
+    """RequestDO should accept a list query (issue #583)."""
+    query_list = ["item1", "item2"]
+    do = RequestDO(
+        request_id="req-2",
+        session_id="sess-2",
+        query=query_list,
+        state="init",
+        result=dict(),
+        steps=[],
+        additional_args=dict(),
+    )
+    assert do.query == query_list
+
+
+def test_request_do_with_dict_query():
+    """RequestDO should accept a dict query (issue #583)."""
+    query_dict = {"key": "value"}
+    do = RequestDO(
+        request_id="req-3",
+        session_id="sess-3",
+        query=query_dict,
+        state="init",
+        result=dict(),
+        steps=[],
+        additional_args=dict(),
+    )
+    assert do.query == query_dict
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])


### PR DESCRIPTION
## Summary
- Fixes #583: `RequestDO.query` field was typed as `str`, causing `pydantic.ValidationError` when users passed `list` or `dict` values in service request params
- Changed `query` field type from `str` to `Union[str, list, dict]` in `RequestDO`
- Updated ORM `query` column from `Text` to `JSON` for proper serialization of non-string values

## Test plan
- [x] Added `test_request_do.py` with 3 test cases covering string, list, and dict query types
- [x] All 3 tests pass
```
tests/test_agentuniverse/unit/agent_serve/test_request_do.py::test_request_do_with_string_query PASSED
tests/test_agentuniverse/unit/agent_serve/test_request_do.py::test_request_do_with_list_query PASSED
tests/test_agentuniverse/unit/agent_serve/test_request_do.py::test_request_do_with_dict_query PASSED
```