### PR TITLE
feat: add HuggingFace Hub LLM component

### DIFF
--- a/agentuniverse/llm/default/huggingface_hub_llm.py
+++ b/agentuniverse/llm/default/huggingface_hub_llm.py
@@ -1,0 +1,225 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/06
+# @FileName: huggingface_hub_llm.py
+
+from typing import Any, Optional, Union, Iterator, AsyncIterator
+
+from pydantic import Field
+
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm import LLM, LLMOutput
+
+try:
+    import tiktoken
+except ImportError:
+    tiktoken = None
+
+HUGGINGFACE_HUB_MAX_CONTEXT_LENGTH = {
+    "meta-llama/Llama-3.1-8B-Instruct": 128072,
+    "meta-llama/Llama-3.1-70B-Instruct": 128072,
+    "meta-llama/Llama-3.2-1B-Instruct": 128072,
+    "meta-llama/Llama-3.2-3B-Instruct": 128072,
+    "meta-llama/Llama-3.2-11B-Vision-Instruct": 128072,
+    "meta-llama/Llama-3.2-90B-Vision-Instruct": 128072,
+    "mistralai/Mistral-7B-Instruct-v0.3": 32768,
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": 32768,
+    "mistralai/Mistral-Nemo-Instruct-2407": 128000,
+    "Qwen/Qwen2.5-7B-Instruct": 32768,
+    "Qwen/Qwen2.5-72B-Instruct": 32768,
+    "Qwen/Qwen2.5-Coder-32B-Instruct": 32768,
+    "google/gemma-2-2b-it": 8192,
+    "google/gemma-2-9b-it": 8192,
+    "google/gemma-2-27b-it": 8192,
+}
+
+
+def _to_raw(obj: Any) -> Any:
+    """Serialize a HuggingFace BaseInferenceType (dict subclass) to a plain dict."""
+    if hasattr(obj, 'model_dump'):
+        return obj.model_dump()
+    if isinstance(obj, dict):
+        return dict(obj)
+    return str(obj)
+
+
+class HuggingFaceHubLLM(LLM):
+    """HuggingFace Hub LLM component.
+
+    Uses huggingface_hub.InferenceClient to interact with models
+    deployed on the HuggingFace Inference API or a dedicated TGI endpoint.
+
+    Attributes:
+        api_key: HuggingFace API token (env: HF_TOKEN or HUGGINGFACEHUB_API_TOKEN).
+        api_base: Optional custom inference endpoint URL.
+        model_name: HuggingFace model id (e.g. meta-llama/Llama-3.2-3B-Instruct).
+    """
+
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("HF_TOKEN")
+        or get_from_env("HUGGINGFACEHUB_API_TOKEN")
+    )
+    api_base: Optional[str] = Field(
+        default_factory=lambda: get_from_env("HUGGINGFACEHUB_API_BASE")
+    )
+
+    def _build_kwargs(self) -> dict:
+        """Build common kwargs for InferenceClient / AsyncInferenceClient."""
+        kwargs = {"token": self.api_key, "timeout": self.request_timeout}
+        if self.api_base:
+            kwargs["url"] = self.api_base
+        else:
+            kwargs["model"] = self.model_name
+        return kwargs
+
+    def _new_client(self):
+        """Initialize the HuggingFace InferenceClient."""
+        if self.client is not None:
+            return self.client
+        from huggingface_hub import InferenceClient
+        self.client = InferenceClient(**self._build_kwargs())
+        return self.client
+
+    def _new_async_client(self):
+        """Initialize the async HuggingFace InferenceClient."""
+        if self.async_client is not None:
+            return self.async_client
+        from huggingface_hub import AsyncInferenceClient
+        self.async_client = AsyncInferenceClient(**self._build_kwargs())
+        return self.async_client
+
+    def _call(
+        self, messages: list, **kwargs: Any
+    ) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Run the HuggingFace Hub LLM synchronously.
+
+        Args:
+            messages: The messages list (each item is a dict with role/content).
+            **kwargs: Additional arguments (streaming, temperature, max_tokens, etc.).
+        """
+        client = self._new_client()
+        streaming = kwargs.pop("streaming", self.streaming)
+        temperature = kwargs.pop("temperature", self.temperature)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
+        model = kwargs.pop("model", self.model_name)
+
+        if streaming:
+            stream = client.chat_completion(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=True,
+                **kwargs,
+            )
+            return self._generate_stream_result(stream)
+        else:
+            response = client.chat_completion(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=False,
+                **kwargs,
+            )
+            text = response.choices[0].message.content
+            return LLMOutput(text=text, raw=_to_raw(response))
+
+    async def _acall(
+        self, messages: list, **kwargs: Any
+    ) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Run the HuggingFace Hub LLM asynchronously.
+
+        Args:
+            messages: The messages list (each item is a dict with role/content).
+            **kwargs: Additional arguments (streaming, temperature, max_tokens, etc.).
+        """
+        client = self._new_async_client()
+        streaming = kwargs.pop("streaming", self.streaming)
+        temperature = kwargs.pop("temperature", self.temperature)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
+        model = kwargs.pop("model", self.model_name)
+
+        if streaming:
+            stream = await client.chat_completion(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=True,
+                **kwargs,
+            )
+            return self._agenerate_stream_result(stream)
+        else:
+            response = await client.chat_completion(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=False,
+                **kwargs,
+            )
+            text = response.choices[0].message.content
+            return LLMOutput(text=text, raw=_to_raw(response))
+
+    def _generate_stream_result(self, stream) -> Iterator[LLMOutput]:
+        """Generate LLMOutput from a sync stream."""
+        for chunk in stream:
+            text = ""
+            if hasattr(chunk, 'choices') and len(chunk.choices) > 0:
+                delta = chunk.choices[0].delta
+                if delta and delta.content:
+                    text = delta.content
+            yield LLMOutput(text=text, raw=_to_raw(chunk))
+
+    async def _agenerate_stream_result(self, stream) -> AsyncIterator[LLMOutput]:
+        """Generate LLMOutput from an async stream."""
+        async for chunk in stream:
+            text = ""
+            if hasattr(chunk, 'choices') and len(chunk.choices) > 0:
+                delta = chunk.choices[0].delta
+                if delta and delta.content:
+                    text = delta.content
+            yield LLMOutput(text=text, raw=_to_raw(chunk))
+
+    def get_num_tokens(self, text: str) -> int:
+        """Get the number of tokens present in the text.
+
+        Uses tiktoken's cl100k_base encoding as an approximation
+        for HuggingFace models that don't have a native tokenizer available.
+
+        Args:
+            text: The string input to tokenize.
+
+        Returns:
+            The integer number of tokens in the text.
+        """
+        if tiktoken is None:
+            return len(text) // 4
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))
+
+    def max_context_length(self) -> int:
+        """Max context length for common HuggingFace Hub models."""
+        if super().max_context_length():
+            return super().max_context_length()
+        return HUGGINGFACE_HUB_MAX_CONTEXT_LENGTH.get(self.model_name, 4096)
+
+    def initialize_by_component_configer(self, component_configer) -> 'LLM':
+        """Initialize from config, handling api_base field."""
+        super().initialize_by_component_configer(component_configer)
+        if component_configer.configer.value.get('api_base'):
+            self.api_base = component_configer.configer.value.get('api_base')
+        elif component_configer.configer.value.get('api_base_env'):
+            self.api_base = get_from_env(
+                component_configer.configer.value.get('api_base_env'))
+        if component_configer.configer.value.get('api_key'):
+            self.api_key = component_configer.configer.value.get('api_key')
+        elif component_configer.configer.value.get('api_key_env'):
+            self.api_key = get_from_env(
+                component_configer.configer.value.get('api_key_env'))
+        return self

--- a/agentuniverse/llm/default/huggingface_hub_llm.yaml
+++ b/agentuniverse/llm/default/huggingface_hub_llm.yaml
@@ -1,0 +1,9 @@
+name: 'default_huggingface_hub_llm'
+description: 'default huggingface hub llm with spi'
+model_name: 'meta-llama/Llama-3.2-3B-Instruct'
+max_tokens: 1000
+api_key: '${HF_TOKEN}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.huggingface_hub_llm'
+  class: 'HuggingFaceHubLLM'

--- a/tests/test_agentuniverse/unit/llm/test_huggingface_hub_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_huggingface_hub_llm.py
@@ -1,0 +1,171 @@
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import asyncio
+
+from agentuniverse.llm.default.huggingface_hub_llm import HuggingFaceHubLLM
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+
+
+def _make_choice(text="Hello"):
+    choice = MagicMock()
+    choice.message.content = text
+    return choice
+
+
+def _make_response(text="Hello"):
+    resp = MagicMock()
+    resp.choices = [_make_choice(text)]
+    return resp
+
+
+def _make_stream_chunk(text="Hi"):
+    chunk = MagicMock()
+    delta = MagicMock()
+    delta.content = text
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta = delta
+    return chunk
+
+
+class TestHuggingFaceHubLLM(unittest.TestCase):
+
+    def setUp(self):
+        app_configer = AppConfiger()
+        ApplicationConfigManager().app_configer = app_configer
+
+        self.llm = HuggingFaceHubLLM(
+            model_name="meta-llama/Llama-3.2-3B-Instruct",
+            api_key="test-token",
+        )
+        self.llm.client = None
+        self.llm.async_client = None
+
+    def test_call_non_streaming(self):
+        """Test synchronous non-streaming call."""
+        mock_client = MagicMock()
+        mock_client.chat_completion.return_value = _make_response("Hello world")
+        self.llm.client = mock_client
+
+        messages = [{"role": "user", "content": "hi"}]
+        output = self.llm.call(messages=messages, streaming=False)
+        self.assertEqual(output.text, "Hello world")
+        mock_client.chat_completion.assert_called_once()
+
+    def test_call_streaming(self):
+        """Test synchronous streaming call."""
+        mock_client = MagicMock()
+        mock_client.chat_completion.return_value = iter([
+            _make_stream_chunk("Hello "),
+            _make_stream_chunk("world"),
+        ])
+        self.llm.client = mock_client
+
+        messages = [{"role": "user", "content": "hi"}]
+        chunks = list(self.llm.call(messages=messages, streaming=True))
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].text, "Hello ")
+        self.assertEqual(chunks[1].text, "world")
+
+    def test_acall_non_streaming(self):
+        """Test asynchronous non-streaming call."""
+        mock_client = AsyncMock()
+        mock_client.chat_completion.return_value = _make_response("Async hello")
+        self.llm.async_client = mock_client
+
+        messages = [{"role": "user", "content": "hi"}]
+        output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+        self.assertEqual(output.text, "Async hello")
+
+    def test_acall_streaming(self):
+        """Test asynchronous streaming call."""
+
+        async def _async_iter():
+            yield _make_stream_chunk("A1")
+            yield _make_stream_chunk("A2")
+
+        mock_client = AsyncMock()
+
+        async def _chat_completion(**kwargs):
+            if kwargs.get("stream"):
+                return _async_iter()
+            return _make_response("fallback")
+
+        mock_client.chat_completion = _chat_completion
+        self.llm.async_client = mock_client
+
+        messages = [{"role": "user", "content": "hi"}]
+
+        async def _run():
+            gen = await self.llm.acall(messages=messages, streaming=True)
+            chunks = []
+            async for c in gen:
+                chunks.append(c)
+            return chunks
+
+        chunks = asyncio.run(_run())
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].text, "A1")
+        self.assertEqual(chunks[1].text, "A2")
+
+    def test_client_caching(self):
+        """Test that _new_client caches the client."""
+        with patch("huggingface_hub.InferenceClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            c1 = self.llm._new_client()
+            c2 = self.llm._new_client()
+            self.assertIs(c1, c2)
+            mock_cls.assert_called_once()
+
+    def test_async_client_caching(self):
+        """Test that _new_async_client caches the async client."""
+        with patch("huggingface_hub.AsyncInferenceClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            c1 = self.llm._new_async_client()
+            c2 = self.llm._new_async_client()
+            self.assertIs(c1, c2)
+            mock_cls.assert_called_once()
+
+    def test_async_client_is_not_sync_client(self):
+        """Test that _new_async_client creates AsyncInferenceClient, not reuses sync."""
+        self.llm.client = MagicMock()
+        self.llm.async_client = None
+        with patch("huggingface_hub.AsyncInferenceClient") as mock_async_cls:
+            mock_async_cls.return_value = MagicMock(name="async_client")
+            c = self.llm._new_async_client()
+            mock_async_cls.assert_called_once()
+            self.assertIsNotNone(self.llm.async_client)
+            self.assertIsNot(self.llm.async_client, self.llm.client)
+
+    def test_max_context_length_known(self):
+        llm = HuggingFaceHubLLM(model_name="meta-llama/Llama-3.2-3B-Instruct")
+        self.assertEqual(llm.max_context_length(), 128072)
+
+    def test_max_context_length_unknown(self):
+        llm = HuggingFaceHubLLM(model_name="unknown/model")
+        self.assertEqual(llm.max_context_length(), 4096)
+
+    def test_build_kwargs_with_api_base(self):
+        llm = HuggingFaceHubLLM(
+            model_name="test/model",
+            api_key="tok",
+            api_base="https://custom.endpoint.com",
+        )
+        kwargs = llm._build_kwargs()
+        self.assertEqual(kwargs["url"], "https://custom.endpoint.com")
+        self.assertNotIn("model", kwargs)
+
+    def test_build_kwargs_without_api_base(self):
+        llm = HuggingFaceHubLLM(model_name="test/model", api_key="tok")
+        kwargs = llm._build_kwargs()
+        self.assertEqual(kwargs["model"], "test/model")
+        self.assertNotIn("url", kwargs)
+
+    def test_get_num_tokens(self):
+        text = "Hello, this is a test string."
+        token_count = self.llm.get_num_tokens(text)
+        self.assertGreater(token_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `HuggingFaceHubLLM` — a new LLM component that uses `huggingface_hub.InferenceClient` to interact with models deployed on the HuggingFace Inference API or dedicated TGI endpoints.

### Features
- Sync and async chat completions via `InferenceClient` / `AsyncInferenceClient`
- Streaming support
- Configurable temperature, max_tokens, model selection
- Context length lookup for common HF models (Llama, Mistral, Qwen, Gemma)
- YAML config with env var support (`HF_TOKEN`, `HUGGINGFACEHUB_API_TOKEN`, `HUGGINGFACEHUB_API_BASE`)

### Files Changed
- `agentuniverse/llm/default/huggingface_hub_llm.py` — Main component
- `agentuniverse/llm/default/huggingface_hub_llm.yaml` — Default config
- `tests/test_agentuniverse/unit/llm/test_huggingface_hub_llm.py` — 12 unit tests

### Implementation Details
- **Async client**: Uses separate `AsyncInferenceClient` instance (not shared sync client)
- **API correctness**: Uses `client.chat_completion()` — the correct HF Hub API, not `chat_completions.create()` (OpenAI style)
- **Code quality**: Extracted `_build_kwargs()` and `_to_raw()` helpers to reduce duplication
- **Token counting**: Implements `get_num_tokens()` using tiktoken with `cl100k_base` fallback
- **Tests**: 12 mocked unit tests covering sync/async calls, streaming, client caching, and config

### Checklist
- [x] DCO signed
- [x] Unit tests pass (12/12)
- [x] No breaking changes (new component only)