### PR TITLE
feat: add Yahoo Finance tool plugin

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py
@@ -1,0 +1,216 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/06
+# @FileName: yahoo_finance_tool.py
+
+from typing import Optional, Any, Dict, List, Union
+from enum import Enum
+from dataclasses import dataclass
+
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.annotation.retry import retry
+
+
+class FinanceMode(Enum):
+    QUOTE = "quote"
+    HISTORY = "history"
+    INFO = "info"
+    FINANCIALS = "financials"
+
+
+@dataclass
+class StockQuote:
+    symbol: str
+    name: str
+    price: float
+    currency: str
+    market_cap: str
+    pe_ratio: float
+    day_high: float
+    day_low: float
+    volume: int
+    change: float
+    change_percent: float
+
+
+class YahooFinanceTool(Tool):
+    """Yahoo Finance tool for retrieving stock market data.
+
+    Uses the yfinance library to fetch real-time and historical
+    financial data from Yahoo Finance.
+
+    Modes:
+        quote: Get current stock quote (price, market cap, P/E, etc.)
+        history: Get historical price data
+        info: Get company information (sector, industry, description)
+        financials: Get financial statements (income, balance sheet, cash flow)
+    """
+
+    max_results: int = Field(default=30, description="Max number of historical data points")
+
+    def execute(
+        self,
+        symbol: str,
+        mode: str,
+        period: str = "1mo",
+        interval: str = "1d",
+        statement: str = "income",
+    ) -> Union[Dict, str]:
+        """Execute the Yahoo Finance tool.
+
+        Args:
+            symbol: Stock ticker symbol (e.g. AAPL, GOOGL, MSFT).
+            mode: One of quote, history, info, financials.
+            period: Time period for historical data (1d,5d,1mo,3mo,6mo,1y,2y,5y,max).
+            interval: Data interval for historical data (1m,2m,5m,15m,30m,60m,90m,1h,1d,5d,1wk,1mo,3mo).
+            statement: Financial statement type for financials mode (income, balance, cashflow).
+        """
+        try:
+            import yfinance as yf
+        except ImportError:
+            raise ImportError(
+                "yfinance is required. Install with: pip install yfinance"
+            )
+
+        if mode not in [m.value for m in FinanceMode]:
+            raise ValueError(
+                f"Invalid mode: {mode}. Must be one of {[m.value for m in FinanceMode]}"
+            )
+
+        ticker = yf.Ticker(symbol)
+
+        if mode == FinanceMode.QUOTE.value:
+            return self._get_quote(ticker, symbol)
+        elif mode == FinanceMode.HISTORY.value:
+            return self._get_history(ticker, period, interval)
+        elif mode == FinanceMode.INFO.value:
+            return self._get_info(ticker)
+        elif mode == FinanceMode.FINANCIALS.value:
+            return self._get_financials(ticker, statement)
+
+    @retry(3, 1.0)
+    def _get_quote(self, ticker, symbol: str) -> Dict:
+        """Get current stock quote."""
+        info = ticker.info or {}
+        quote = StockQuote(
+            symbol=symbol,
+            name=info.get("longName", info.get("shortName", symbol)),
+            price=round(info.get("currentPrice", info.get("regularMarketPrice", 0)), 2),
+            currency=info.get("currency", "USD"),
+            market_cap=self._format_large_number(info.get("marketCap", 0)),
+            pe_ratio=round(info.get("trailingPE", 0), 2),
+            day_high=round(info.get("dayHigh", 0), 2),
+            day_low=round(info.get("dayLow", 0), 2),
+            volume=info.get("volume", 0),
+            change=round(
+                info.get("currentPrice", 0) - info.get("previousClose", 0), 2
+            ),
+            change_percent=round(
+                (
+                    (info.get("currentPrice", 0) - info.get("previousClose", 0))
+                    / max(info.get("previousClose", 1), 1)
+                )
+                * 100,
+                2,
+            ),
+        )
+        return {
+            "symbol": quote.symbol,
+            "name": quote.name,
+            "price": quote.price,
+            "currency": quote.currency,
+            "market_cap": quote.market_cap,
+            "pe_ratio": quote.pe_ratio,
+            "day_high": quote.day_high,
+            "day_low": quote.day_low,
+            "volume": quote.volume,
+            "change": quote.change,
+            "change_percent": f"{quote.change_percent}%",
+        }
+
+    @retry(3, 1.0)
+    def _get_history(self, ticker, period: str, interval: str) -> List[Dict]:
+        """Get historical price data."""
+        hist = ticker.history(period=period, interval=interval)
+        if hist.empty:
+            return {"error": "No historical data found for the given parameters."}
+        results = []
+        for idx, row in hist.head(self.max_results).iterrows():
+            results.append(
+                {
+                    "date": str(idx),
+                    "open": round(float(row["Open"]), 2),
+                    "high": round(float(row["High"]), 2),
+                    "low": round(float(row["Low"]), 2),
+                    "close": round(float(row["Close"]), 2),
+                    "volume": int(row["Volume"]),
+                }
+            )
+        return results
+
+    @retry(3, 1.0)
+    def _get_info(self, ticker) -> Dict:
+        """Get company information."""
+        info = ticker.info or {}
+        return {
+            "name": info.get("longName", info.get("shortName", "N/A")),
+            "sector": info.get("sector", "N/A"),
+            "industry": info.get("industry", "N/A"),
+            "country": info.get("country", "N/A"),
+            "website": info.get("website", "N/A"),
+            "employees": info.get("fullTimeEmployees", "N/A"),
+            "description": info.get("longBusinessSummary", "N/A"),
+            "currency": info.get("currency", "N/A"),
+            "exchange": info.get("exchange", "N/A"),
+        }
+
+    @retry(3, 1.0)
+    def _get_financials(self, ticker, statement: str) -> Dict:
+        """Get financial statements."""
+        if statement == "income":
+            df = ticker.financials
+            label = "Income Statement"
+        elif statement == "balance":
+            df = ticker.balance_sheet
+            label = "Balance Sheet"
+        elif statement == "cashflow":
+            df = ticker.cashflow
+            label = "Cash Flow Statement"
+        else:
+            return {"error": f"Invalid statement type: {statement}. Use income, balance, or cashflow."}
+
+        if df is None or df.empty:
+            return {"error": f"No {label} data available."}
+
+        result = {"statement_type": label, "periods": {}}
+        for col in df.columns:
+            period_key = str(col).split(" ")[0]
+            result["periods"][period_key] = {
+                str(row): self._safe_value(row_val)
+                for row, row_val in df[col].items()
+            }
+        return result
+
+    @staticmethod
+    def _format_large_number(num: int | float) -> str:
+        """Format large numbers to human-readable form."""
+        if num == 0:
+            return "N/A"
+        for unit in ["", "K", "M", "B", "T"]:
+            if abs(num) < 1000:
+                return f"{num:.2f}{unit}"
+            num /= 1000.0
+        return f"{num:.2f}T"
+
+    @staticmethod
+    def _safe_value(val: Any) -> Any:
+        """Safely convert a value for JSON serialization."""
+        if hasattr(val, "item"):
+            return val.item()
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return str(val)

--- a/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.yaml
@@ -1,0 +1,49 @@
+name: yahoo_finance_tool
+description: Yahoo Finance stock market data tool (quotes, history, company info, financials)
+class_path: agentuniverse.agent.action.tool.common_tool.yahoo_finance_tool.YahooFinanceTool
+args_model:
+  symbol:
+    type: string
+    description: Stock ticker symbol (e.g. AAPL, GOOGL, MSFT)
+    required: true
+  mode:
+    type: string
+    description: Data mode - quote (current price), history (historical prices), info (company info), financials (financial statements)
+    required: true
+  period:
+    type: string
+    description: Time period for history mode (1d,5d,1mo,3mo,6mo,1y,2y,5y,max)
+    required: false
+    default: 1mo
+  interval:
+    type: string
+    description: Data interval for history mode (1m,5m,15m,30m,60m,1h,1d,5d,1wk,1mo,3mo)
+    required: false
+    default: 1d
+  statement:
+    type: string
+    description: Financial statement type for financials mode (income, balance, cashflow)
+    required: false
+    default: income
+args_model_schema:
+  type: object
+  properties:
+    symbol:
+      type: string
+      description: Stock ticker symbol
+    mode:
+      type: string
+      enum: ["quote", "history", "info", "financials"]
+      description: Data mode
+    period:
+      type: string
+      description: Time period for history mode
+    interval:
+      type: string
+      description: Data interval for history mode
+    statement:
+      type: string
+      enum: ["income", "balance", "cashflow"]
+      default: "income"
+      description: Financial statement type
+  required: ["symbol", "mode"]

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py
@@ -1,0 +1,92 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/06
+# @FileName: test_yahoo_finance_tool.py
+
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Mock yfinance before importing the tool
+_mock_yf = MagicMock()
+sys.modules.setdefault('yfinance', _mock_yf)
+
+from agentuniverse.agent.action.tool.common_tool.yahoo_finance_tool import (
+    YahooFinanceTool,
+    FinanceMode,
+)
+
+
+def _mock_ticker():
+    """Create a mock yfinance.Ticker."""
+    ticker = MagicMock()
+    ticker.info = {
+        "longName": "Test Corp",
+        "currentPrice": 150.0,
+        "previousClose": 145.0,
+        "currency": "USD",
+        "marketCap": 2000000000000,
+        "trailingPE": 25.5,
+        "dayHigh": 152.0,
+        "dayLow": 148.0,
+        "volume": 50000000,
+        "sector": "Technology",
+        "industry": "Software",
+        "country": "US",
+        "website": "https://example.com",
+        "fullTimeEmployees": 100000,
+        "longBusinessSummary": "A test company.",
+        "exchange": "NASDAQ",
+    }
+    return ticker
+
+
+def test_yahoo_finance_quote():
+    """Test quote mode returns stock price data."""
+    ticker = _mock_ticker()
+    _mock_yf.Ticker.return_value = ticker
+
+    tool = YahooFinanceTool()
+    result = tool.execute(symbol="TEST", mode="quote")
+
+    assert result["symbol"] == "TEST"
+    assert result["price"] == 150.0
+    assert result["currency"] == "USD"
+    assert result["change"] == 5.0
+    assert "%" in result["change_percent"]
+
+
+def test_yahoo_finance_info():
+    """Test info mode returns company information."""
+    ticker = _mock_ticker()
+    _mock_yf.Ticker.return_value = ticker
+
+    tool = YahooFinanceTool()
+    result = tool.execute(symbol="TEST", mode="info")
+
+    assert result["name"] == "Test Corp"
+    assert result["sector"] == "Technology"
+    assert result["industry"] == "Software"
+
+
+def test_yahoo_finance_invalid_mode():
+    """Test that invalid mode raises ValueError."""
+    ticker = _mock_ticker()
+    _mock_yf.Ticker.return_value = ticker
+
+    tool = YahooFinanceTool()
+    with pytest.raises(ValueError):
+        tool.execute(symbol="TEST", mode="invalid_mode")
+
+
+def test_finance_mode_enum():
+    """Test FinanceMode enum values."""
+    assert FinanceMode.QUOTE.value == "quote"
+    assert FinanceMode.HISTORY.value == "history"
+    assert FinanceMode.INFO.value == "info"
+    assert FinanceMode.FINANCIALS.value == "financials"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])


### PR DESCRIPTION
## Summary
- Addresses task #252: Adds Yahoo Finance tool plugin
- Creates `YahooFinanceTool` using `yfinance` library with 4 modes:
  - **quote**: Current stock price, market cap, P/E ratio, day high/low, volume, change
  - **history**: Historical OHLCV data with configurable period and interval
  - **info**: Company sector, industry, description, employees, website
  - **financials**: Income statement, balance sheet, cash flow statement
- Includes YAML config (`yahoo_finance_tool.yaml`) with JSON schema

## Usage
```python
tool = YahooFinanceTool()
# Get current stock quote
result = tool.execute(symbol="AAPL", mode="quote")
# Get historical prices
result = tool.execute(symbol="AAPL", mode="history", period="3mo", interval="1d")
# Get company info
result = tool.execute(symbol="AAPL", mode="info")
# Get income statement
result = tool.execute(symbol="AAPL", mode="financials", statement="income")
```

## Test plan
- [x] Added 4 unit tests with mocked yfinance data
- [x] All tests pass:
```
tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py::test_yahoo_finance_quote PASSED
tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py::test_yahoo_finance_info PASSED
tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py::test_yahoo_finance_invalid_mode PASSED
tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py::test_finance_mode_enum PASSED
```