### PR TITLE
fix: add input-level sandbox to PythonREPLTool

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/python_repl.py
+++ b/agentuniverse/agent/action/tool/common_tool/python_repl.py
@@ -7,34 +7,82 @@
 # @FileName: python_repl.py
 
 import re
+from typing import List, Optional
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from langchain_community.utilities import PythonREPL
 from pydantic import Field
 
+_DEFAULT_BLOCKED_PATTERNS = [
+    r"__import__\s*\(",
+    r"\bimport\s+os\b",
+    r"\bfrom\s+os\b",
+    r"\bimport\s+subprocess\b",
+    r"\bfrom\s+subprocess\b",
+    r"\bimport\s+shutil\b",
+    r"\bfrom\s+shutil\b",
+    r"\bimport\s+socket\b",
+    r"\bfrom\s+socket\b",
+    r"\bimport\s+ctypes\b",
+    r"\bfrom\s+ctypes\b",
+    r"\bimport\s+sys\b",
+    r"\bfrom\s+sys\b",
+    r"\bopen\s*\([^)]*['\"]?[/~]",
+    r"os\.system\s*\(",
+    r"os\.popen\s*\(",
+    r"subprocess\.",
+    r"eval\s*\(",
+    r"exec\s*\(",
+    r"compile\s*\(",
+    r"globals\s*\(\s*\)",
+    r"locals\s*\(\s*\)",
+    r"getattr\s*\(",
+    r"setattr\s*\(",
+    r"delattr\s*\(",
+]
+
 
 class PythonREPLTool(Tool):
-    """The mock search tool.
+    """Python REPL tool that executes Python code.
 
-    In this tool, we mocked the search engine's answers to search for information about BYD and Warren Buffett.
+    By default, a lightweight input-level sandbox blocks dangerous
+    patterns (e.g. ``__import__``, ``os.system``, ``subprocess``).
+    Set ``sandbox_enabled=False`` to disable it.
 
-    Note:
-        The tool is only suitable for users searching for Buffett or BYD related queries.
-        We recommend that you configure your `SERPER_API_KEY` and use google_search_tool to get information.
+    Warning:
+        Even with the sandbox enabled, this tool still uses ``exec()``
+        and is not safe for untrusted input.  Consider running it in a
+        separate subprocess or container with restricted permissions.
     """
+
     client: PythonREPL = Field(default_factory=lambda: PythonREPL())
+    sandbox_enabled: bool = True
+    blocked_patterns: List[str] = Field(
+        default_factory=lambda: list(_DEFAULT_BLOCKED_PATTERNS)
+    )
+
+    def _check_safety(self, code: str) -> Optional[str]:
+        """Return a reason string if the code is blocked, else None."""
+        for pattern in self.blocked_patterns:
+            if re.search(pattern, code):
+                return f"Blocked by sandbox pattern: {pattern}"
+        return None
 
     def execute(self, input: str):
-        """Demonstrates the execute method of the Tool class."""
+        """Execute Python code extracted from the input string."""
         pattern = re.compile(r"```python(.*?)``", re.DOTALL)
         matches = pattern.findall(input)
         if len(matches) == 0:
             pattern = re.compile(r"```py(.*?)``", re.DOTALL)
             matches = pattern.findall(input)
-        if len(matches) == 0:
-            return self.client.run(input)
-        res = self.client.run(matches[0])
+        code = matches[0] if matches else input
+
+        if self.sandbox_enabled:
+            reason = self._check_safety(code)
+            if reason:
+                return f"ERROR: Code execution blocked by sandbox. {reason}"
+
+        res = self.client.run(code)
         if res == "" or res is None:
             return "ERROR: 你的python代码中没有使用print输出任何内容，请参考工具示例"
-        else:
-            return res
+        return res

--- a/tests/test_agentuniverse/unit/agent/action/tool/common_tool/test_python_repl_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/common_tool/test_python_repl_tool.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from agentuniverse.agent.action.tool.common_tool.python_repl import (
+    PythonREPLTool,
+)
+from agentuniverse.base.config.application_configer.application_config_manager import (
+    ApplicationConfigManager,
+)
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+
+
+class TestPythonREPLTool(unittest.TestCase):
+    def setUp(self):
+        app_configer = AppConfiger()
+        ApplicationConfigManager().app_configer = app_configer
+        self.tool = PythonREPLTool()
+        self.tool.client = MagicMock()
+        self.tool.client.run = MagicMock(side_effect=lambda x: x)
+
+    def test_normal_execution(self):
+        """Test that normal Python code executes fine."""
+        result = self.tool.execute("print('hello')")
+        self.assertNotIn("ERROR", result)
+
+    def test_code_block_extraction(self):
+        """Test that code is extracted from markdown code blocks."""
+        self.tool.client.run = MagicMock(return_value="42")
+        result = self.tool.execute("```python\nprint(42)\n```")
+        self.tool.client.run.assert_called_once()
+        self.assertEqual(result, "42")
+
+    def test_py_block_extraction(self):
+        """Test that ```py blocks are also supported."""
+        self.tool.client.run = MagicMock(return_value="42")
+        result = self.tool.execute("```py\nprint(42)\n```")
+        self.tool.client.run.assert_called_once()
+        self.assertEqual(result, "42")
+
+    def test_empty_output(self):
+        """Test that empty output gives a helpful error."""
+        self.tool.client.run = MagicMock(return_value="")
+        result = self.tool.execute("x = 1")
+        self.assertIn("ERROR", result)
+
+    def test_blocks_import_os(self):
+        """Test that 'import os' is blocked by sandbox."""
+        result = self.tool.execute("import os\nos.system('id')")
+        self.assertIn("ERROR", result)
+        self.assertIn("Blocked", result)
+        self.tool.client.run.assert_not_called()
+
+    def test_blocks_subprocess(self):
+        """Test that subprocess usage is blocked."""
+        result = self.tool.execute("import subprocess\nsubprocess.run(['id'])")
+        self.assertIn("ERROR", result)
+        self.assertIn("Blocked", result)
+
+    def test_blocks_dunder_import(self):
+        """Test that __import__ is blocked."""
+        result = self.tool.execute("__import__('os').system('id')")
+        self.assertIn("ERROR", result)
+        self.assertIn("Blocked", result)
+
+    def test_blocks_open_absolute_path(self):
+        """Test that opening absolute paths is blocked."""
+        result = self.tool.execute("open('/etc/passwd').read()")
+        self.assertIn("ERROR", result)
+        self.assertIn("Blocked", result)
+
+    def test_blocks_eval(self):
+        """Test that eval() is blocked."""
+        result = self.tool.execute("eval('1+1')")
+        self.assertIn("ERROR", result)
+
+    def test_sandbox_disabled_allows_dangerous(self):
+        """Test that disabling sandbox allows dangerous code."""
+        self.tool.sandbox_enabled = False
+        self.tool.client.run = MagicMock(return_value="ok")
+        result = self.tool.execute("import os\nos.system('echo hi')")
+        self.tool.client.run.assert_called_once()
+        self.assertNotIn("ERROR", result)
+
+    def test_safe_code_passes_sandbox(self):
+        """Test that safe code passes the sandbox check."""
+        self.tool.client.run = MagicMock(return_value="4")
+        result = self.tool.execute("print(2+2)")
+        self.assertEqual(result, "4")
+        self.tool.client.run.assert_called_once()
+
+    def test_custom_blocked_patterns(self):
+        """Test that custom patterns can be added."""
+        self.tool.blocked_patterns = [r"for\s+.*\s+in\s+"]
+        result = self.tool.execute("for i in range(10):\n    print(i)")
+        self.assertIn("ERROR", result)
+        self.assertIn("Blocked", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #570

Adds a lightweight input-level sandbox to `PythonREPLTool` that blocks dangerous patterns (e.g. `__import__`, `os.system`, `subprocess`, `eval`) before code execution.

### Changes

| File | Description |
|------|-------------|
| `python_repl.py` | Add `sandbox_enabled` and `blocked_patterns` fields, `_check_safety()` method |
| `test_python_repl_tool.py` | 12 unit tests covering blocking behavior and safe code execution |

### Blocked Patterns (default)
- `__import__()`, `import os/subprocess/shutil/socket/ctypes/sys`
- `os.system()`, `os.popen()`, `subprocess.*`
- `eval()`, `exec()`, `compile()`
- `open()` with absolute or `~` paths
- `getattr()`, `setattr()`, `delattr()`
- `globals()`, `locals()`

### Configuration
```yaml
sandbox_enabled: true  # default: true, set false to disable
blocked_patterns: []   # default: built-in list, can extend with custom regex
```

### Note
This is input-level filtering only. For production use with untrusted input, consider running the tool in a separate subprocess or container with restricted permissions.

### Checklist
- [x] DCO signed
- [x] Unit tests pass (12/12)
- [x] Backward compatible (sandbox is opt-out)