### PR TITLE
feat(knowledge): ReciprocalRankFusionProcessor for multi-channel recall fusion (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/reciprocal_rank_fusion_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/reciprocal_rank_fusion_processor.py
@@ -1,0 +1,214 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/10
+# @Author  : contributor
+# @FileName: reciprocal_rank_fusion_processor.py
+
+"""
+Reciprocal Rank Fusion (RRF) document processor.
+
+Recall post-processor that merges the results of several retrieval channels
+into a single relevance ranking, addressing the *融合 (fusion)* direction of
+issue #248 ("融合、过滤、摘要、总结...进一步提升多路召回后内容的质量").
+
+Reciprocal Rank Fusion is a parameter-light way to combine multiple ranked
+result lists without needing the (often incomparable) raw scores of each
+channel. For a document ``d`` the fused score is::
+
+    score(d) = Σ_channels  1 / (k + rank_channel(d))
+
+where ``rank_channel(d)`` is the 1-based position of ``d`` within the channel
+that returned it (``k`` is a smoothing constant, conventionally 60). A document
+that appears near the top of several channels therefore accumulates a higher
+fused score than one that only appears in a single channel, even if it ranks
+first there.
+
+The processor consumes a flat list of retrieved :class:`Document` objects.
+Channels are told apart by a metadata field (``channel_key``) that each
+retrieval channel is expected to stamp onto its documents.
+:meth:`Knowledge.query_knowledge` does this automatically: it stamps every
+recalled document with the store code under the ``recall_channel`` key and
+keeps per-store ranked results, so fusing multi-store recall works without
+extra wiring. When no document carries the channel field the whole input is
+treated as a single channel, in which case RRF degrades to deterministic
+position-based scoring that preserves the input order — making the component
+safe to drop into an existing single-store pipeline.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+
+class ReciprocalRankFusionProcessor(DocProcessor):
+    """Fuses the ranked results of multiple retrieval channels via RRF.
+
+    Attributes:
+        channel_key (Optional[str]): Metadata field used to tell channels
+            apart. Each retrieval channel should write its identifier into
+            ``document.metadata[channel_key]``. When ``None`` (or when no
+            document carries the field) the whole input is treated as one
+            channel.
+        dedup_key (str): Identity used to deduplicate the same document
+            appearing in several channels. ``"id"`` (the default) uses the
+            deterministic document id; ``"text"`` compares raw content; any
+            other value is read from ``document.metadata``. When the configured
+            metadata field is absent from a document, its unique id is used as
+            a safe fallback so such documents are not all collapsed together.
+        k (int): RRF smoothing constant. Larger values dampen the advantage of
+            top ranks; the conventional value is 60.
+        top_n (Optional[int]): Maximum number of fused documents to return.
+            ``None`` returns all.
+        score_field (str): Metadata key the fused score is written into on each
+            returned document.
+    """
+
+    channel_key: Optional[str] = None
+    dedup_key: str = "id"
+    k: int = 60
+    top_n: Optional[int] = None
+    score_field: str = "relevance_score"
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Fuse the input documents via reciprocal rank fusion.
+
+        Args:
+            origin_docs (List[Document]): Documents retrieved across one or
+                more channels, intra-channel order reflecting relevance.
+            query (Query, optional): Unused; kept for interface compatibility.
+
+        Returns:
+            List[Document]: Documents re-ranked by fused relevance score
+            (descending), each carrying ``metadata[score_field]``. An empty
+            input yields an empty list.
+        """
+        if not origin_docs:
+            return []
+
+        channels = self._group_channels(origin_docs)
+
+        # Accumulate fused score per document identity. First occurrence wins
+        # so the returned object keeps the id / embedding / keywords / text of
+        # the document as it first appeared.
+        scores: Dict[Tuple, float] = {}
+        representatives: Dict[Tuple, Document] = {}
+        for channel in channels:
+            seen_in_channel = set()
+            for rank, doc in enumerate(channel):
+                identity = self._identity(doc)
+                if identity in seen_in_channel:
+                    continue
+                seen_in_channel.add(identity)
+                scores[identity] = scores.get(identity, 0.0) + \
+                    1.0 / (self.k + rank + 1)
+                if identity not in representatives:
+                    representatives[identity] = doc
+
+        ranked_identities = sorted(
+            scores,
+            key=lambda ident: (-scores[ident], self._tiebreak(representatives[ident])),
+        )
+        if self.top_n is not None:
+            ranked_identities = ranked_identities[:max(0, self.top_n)]
+
+        # Build the output list, writing the fused score into each document's
+        # metadata without disturbing its other fields.
+        fused: List[Document] = []
+        for identity in ranked_identities:
+            doc = representatives[identity]
+            metadata = dict(doc.metadata or {})
+            metadata[self.score_field] = scores[identity]
+            doc.metadata = metadata
+            fused.append(doc)
+        return fused
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def _group_channels(self, origin_docs: List[Document]) -> List[List[Document]]:
+        """Split the flat doc list into per-channel sub-lists.
+
+        Documents are grouped by ``metadata[channel_key]`` while preserving
+        input order both across and within channels. When ``channel_key`` is
+        unset, or when no document carries the field, the whole input forms a
+        single channel.
+        """
+        if not self.channel_key:
+            return [list(origin_docs)]
+
+        order: List = []
+        buckets: Dict = {}
+        for doc in origin_docs:
+            channel_id = (doc.metadata or {}).get(self.channel_key)
+            if channel_id is None:
+                channel_id = "__default__"
+            if channel_id not in buckets:
+                buckets[channel_id] = []
+                order.append(channel_id)
+            buckets[channel_id].append(doc)
+
+        # If every document landed in the default bucket (none carried the
+        # field), behave exactly like single-channel mode.
+        if len(order) == 1 and order[0] == "__default__":
+            return [list(origin_docs)]
+
+        return [buckets[name] for name in order]
+
+    def _identity(self, doc: Document) -> Tuple:
+        """Stable, hashable identity of a document for cross-channel dedup.
+
+        When ``dedup_key`` names a metadata field that a document does not
+        carry, fall back to the document id instead of returning ``None``;
+        otherwise every such document would share the same identity and be
+        collapsed into a single result.
+        """
+        if self.dedup_key == "id":
+            return ("id", doc.id)
+        if self.dedup_key == "text":
+            return ("text", doc.text)
+        meta_value = (doc.metadata or {}).get(self.dedup_key)
+        if meta_value is None:
+            return ("id", doc.id)
+        return ("meta", self.dedup_key, meta_value)
+
+    @staticmethod
+    def _tiebreak(doc: Document) -> str:
+        """Deterministic secondary sort key to keep RRF output stable."""
+        return doc.id or doc.text or ""
+
+    # ------------------------------------------------------------------ #
+    # Config
+    # ------------------------------------------------------------------ #
+
+    def _initialize_by_component_configer(
+            self,
+            doc_processor_configer: ComponentConfiger) \
+            -> 'ReciprocalRankFusionProcessor':
+        """Initialize the processor parameters from the component configer.
+
+        Args:
+            doc_processor_configer (ComponentConfiger): Configuration object
+                containing the fusion parameters.
+
+        Returns:
+            The initialized processor instance.
+        """
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "channel_key"):
+            self.channel_key = doc_processor_configer.channel_key
+        if hasattr(doc_processor_configer, "dedup_key"):
+            self.dedup_key = doc_processor_configer.dedup_key
+        if hasattr(doc_processor_configer, "k"):
+            self.k = doc_processor_configer.k
+        if hasattr(doc_processor_configer, "top_n"):
+            self.top_n = doc_processor_configer.top_n
+        if hasattr(doc_processor_configer, "score_field"):
+            self.score_field = doc_processor_configer.score_field
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/reciprocal_rank_fusion_processor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/reciprocal_rank_fusion_processor.yaml
@@ -1,0 +1,36 @@
+name: 'reciprocal_rank_fusion_processor'
+description: 'Recall post-processor that fuses the ranked results of multiple retrieval channels via Reciprocal Rank Fusion, addressing the fusion direction of issue #248.'
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.reciprocal_rank_fusion_processor'
+  class: 'ReciprocalRankFusionProcessor'
+
+# --- Channel detection ---
+# Metadata field that identifies which retrieval channel a document came from.
+# Knowledge.query_knowledge stamps each recalled document with the store code
+# under the key 'recall_channel', so fusing multi-store recall works out of the
+# box. When no document carries the field the whole input is treated as one
+# channel (degrades to single-channel position scoring), so this is safe to use
+# in a single-store pipeline too.
+channel_key: 'recall_channel'
+
+# --- De-duplication ---
+# Identity used to deduplicate the same document surfacing in several channels.
+# 'id' (default) uses the deterministic document id; 'text' compares raw
+# content; any other value is read from document.metadata. When the configured
+# metadata field is missing from a document, its unique id is used as a safe
+# fallback so such documents are not all collapsed together.
+dedup_key: 'id'
+
+# --- Fusion parameters ---
+# RRF smoothing constant. Larger values dampen the advantage of top ranks.
+# The conventional value from the original RRF paper is 60.
+k: 60
+
+# --- Output control ---
+# Maximum number of fused documents to return. null/empty returns all.
+top_n: null
+
+# Metadata key the fused score is written into on each returned document.
+score_field: 'relevance_score'

--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -32,6 +32,12 @@ from agentuniverse.base.component.component_enum import ComponentEnum
 from agentuniverse.base.util.logging.logging_util import LOGGER
 from agentuniverse.agent_serve.web.thread_with_result import ThreadPoolExecutorWithReturnValue
 
+# Metadata key under which :meth:`Knowledge.query_knowledge` stamps the store
+# code that recalled each document. Fusion post-processors (e.g. the
+# ReciprocalRankFusionProcessor) read this field via their ``channel_key``
+# config to tell retrieval channels apart.
+RECALL_CHANNEL_KEY = "recall_channel"
+
 
 class Knowledge(ComponentBase):
     """
@@ -139,6 +145,26 @@ class Knowledge(ComponentBase):
             origin_docs = doc_processor.process_docs(origin_docs, query=query)
         return origin_docs
 
+    def _channel_fusion_enabled(self) -> bool:
+        """Return whether a configured post-processor opts into per-channel recall.
+
+        A fusion processor (e.g. ``ReciprocalRankFusionProcessor``) declares a
+        ``channel_key`` — the metadata field it reads to tell retrieval channels
+        apart. Only when such a processor is present does :meth:`query_knowledge`
+        keep per-channel copies of a document; otherwise it preserves the default
+        retrieval contract and collapses cross-store duplicates to a single
+        document, so an optional fusion processor can never change the output of
+        pipelines that do not use it.
+        """
+        for _processor_code in self.post_processors:
+            try:
+                _processor = DocProcessorManager().get_instance_obj(_processor_code)
+            except Exception:  # noqa: BLE001 - an unresolved processor is not channel-aware
+                continue
+            if getattr(_processor, "channel_key", None):
+                return True
+        return False
+
     def _paraphrase_query(self, origin_query: Query) -> Query:
         for _paraphraser_code in self.query_paraphrasers:
             query_paraphraser: QueryParaphraser = QueryParaphraserManager().get_instance_obj(
@@ -213,18 +239,42 @@ class Knowledge(ComponentBase):
 
         futures = []
         for query_task in query_tasks:
-            futures.append(
+            futures.append((
                 self.query_executor.submit(
                     StoreManager().get_instance_obj(query_task[1]).query,
-                    query_task[0]))
-        wait(futures, return_when=ALL_COMPLETED)
+                    query_task[0]),
+                query_task[1],
+            ))
+        wait([future for future, _ in futures], return_when=ALL_COMPLETED)
+        # Channel-aware recall is opt-in: only when a configured post-processor
+        # declares a channel_key (i.e. it is a fusion processor that needs to
+        # tell retrieval channels apart) do we keep per-channel copies of a
+        # document. Without such a processor the merge keeps the default
+        # retrieval contract — a document recalled by several stores is
+        # returned exactly once — so adding an optional fusion processor never
+        # changes the output of pipelines that do not use it.
+        preserve_channels = self._channel_fusion_enabled()
         retrieved_docs = {}
-        for future in futures:
+        for future, store_code in futures:
             try:
                 task_result = future.result()
                 for _doc in task_result:
-                    if _doc.id not in retrieved_docs:
-                        retrieved_docs[_doc.id] = _doc
+                    if preserve_channels:
+                        # Stamp the store code that recalled this document and
+                        # de-duplicate per channel (id + channel): a document
+                        # recalled by several stores is kept once per store,
+                        # while a duplicate within the same store is dropped.
+                        metadata = dict(_doc.metadata or {})
+                        metadata[RECALL_CHANNEL_KEY] = store_code
+                        _doc.metadata = metadata
+                        dedup_identity = (_doc.id, store_code)
+                    else:
+                        # Default contract: collapse cross-store duplicates to
+                        # a single document (first recall wins) and stamp no
+                        # extra metadata, so the output matches master.
+                        dedup_identity = _doc.id
+                    if dedup_identity not in retrieved_docs:
+                        retrieved_docs[dedup_identity] = _doc
             except Exception as e:
                 traceback.print_exc()
                 LOGGER.error(f"Exception occurred in knowledge query: {e}")

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for ReciprocalRankFusionProcessor.
+
+Covers single-channel fallback, multi-channel RRF fusion, cross-channel
+de-duplication, the RRF score formula, top_n bounding, channel detection,
+in-place metadata scoring, and config loading.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from agentuniverse.agent.action.knowledge.doc_processor.\
+    reciprocal_rank_fusion_processor import ReciprocalRankFusionProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+def _doc(text: str, channel: str = None) -> Document:
+    """Build a Document, optionally tagging it with a retrieval channel."""
+    metadata = {"channel": channel} if channel else None
+    return Document(text=text, metadata=metadata)
+
+
+class TestSingleChannel(unittest.TestCase):
+    """Single-channel mode (no channel_key): position-based scoring."""
+
+    def test_empty_input_returns_empty(self) -> None:
+        """No documents → no output documents."""
+        proc = ReciprocalRankFusionProcessor()
+        self.assertEqual(proc._process_docs([]), [])
+
+    def test_default_is_single_channel_and_preserves_order(self) -> None:
+        """With no channel_key the input order is preserved."""
+        proc = ReciprocalRankFusionProcessor()
+        docs = [_doc("alpha"), _doc("beta"), _doc("gamma")]
+        out = proc._process_docs(docs)
+        self.assertEqual([d.text for d in out], ["alpha", "beta", "gamma"])
+
+    def test_single_channel_scores_decrease_with_rank(self) -> None:
+        """Earlier positions get strictly higher fused scores (k=60)."""
+        proc = ReciprocalRankFusionProcessor(k=60)
+        docs = [_doc("alpha"), _doc("beta"), _doc("gamma")]
+        out = proc._process_docs(docs)
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 1.0 / 61)
+        self.assertAlmostEqual(out[1].metadata["relevance_score"], 1.0 / 62)
+        self.assertAlmostEqual(out[2].metadata["relevance_score"], 1.0 / 63)
+
+    def test_metadata_other_keys_preserved(self) -> None:
+        """Pre-existing metadata survives the score being written."""
+        proc = ReciprocalRankFusionProcessor()
+        doc = Document(text="alpha", metadata={"source": "wiki", "lang": "en"})
+        out = proc._process_docs([doc])
+        self.assertEqual(out[0].metadata["source"], "wiki")
+        self.assertEqual(out[0].metadata["lang"], "en")
+        self.assertIn("relevance_score", out[0].metadata)
+
+
+class TestMultiChannelFusion(unittest.TestCase):
+    """Multi-channel mode: documents grouped by channel metadata."""
+
+    def test_doc_in_two_channels_outranks_single_channel_top(self) -> None:
+        """A doc ranking low in two channels beats one ranking #1 in one."""
+        proc = ReciprocalRankFusionProcessor(channel_key="channel", k=60)
+        docs = [
+            _doc("shared", "vector"), _doc("only_vector", "vector"),
+            _doc("shared", "keyword"), _doc("only_keyword", "keyword"),
+        ]
+        out = proc._process_docs(docs)
+        # 'shared' ranks #1 (rank 0) in both channels: 2 * (1/61).
+        # 'only_vector'/'only_keyword' rank #2 (rank 1) in their single channel.
+        self.assertEqual(out[0].text, "shared")
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 2.0 / 61)
+        # The single-channel docs tie at 1/62 (rank 1, k=60).
+        self.assertAlmostEqual(out[1].metadata["relevance_score"], 1.0 / 62)
+
+    def test_score_formula_rank_one_plus_k(self) -> None:
+        """Contribution of a rank-r position is exactly 1/(k + r + 1)."""
+        proc = ReciprocalRankFusionProcessor(channel_key="channel", k=10)
+        docs = [
+            _doc("first", "vector"),
+            _doc("second", "vector"),
+            _doc("first", "keyword"),  # rank 0 again
+        ]
+        out = proc._process_docs(docs)
+        score_by_text = {d.text: d.metadata["relevance_score"] for d in out}
+        self.assertAlmostEqual(score_by_text["first"], 2.0 / 11)
+        self.assertAlmostEqual(score_by_text["second"], 1.0 / 12)
+
+    def test_cross_channel_dedup_by_id(self) -> None:
+        """Same doc (same id) in two channels is returned once, scores merged."""
+        proc = ReciprocalRankFusionProcessor(channel_key="channel")
+        # Two distinct Documents with identical text → same deterministic id.
+        d1 = Document(text="dup", metadata={"channel": "vector"})
+        d2 = Document(text="dup", metadata={"channel": "keyword"})
+        out = proc._process_docs([d1, d2])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].text, "dup")
+        # Merged across both rank-0 positions.
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 2.0 / 61)
+
+    def test_dedup_within_a_channel(self) -> None:
+        """A doc repeated inside one channel is only counted once there."""
+        proc = ReciprocalRankFusionProcessor(channel_key="channel")
+        docs = [
+            _doc("repeat", "vector"),
+            _doc("repeat", "vector"),  # same id → ignored within channel
+            _doc("other", "vector"),
+        ]
+        out = proc._process_docs(docs)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0].text, "repeat")
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 1.0 / 61)
+
+    def test_dedup_by_text(self) -> None:
+        """dedup_key='text' collapses documents with equal content."""
+        proc = ReciprocalRankFusionProcessor(
+            channel_key="channel", dedup_key="text")
+        docs = [
+            _doc("same text", "vector"),
+            _doc("same text", "keyword"),
+        ]
+        out = proc._process_docs(docs)
+        self.assertEqual(len(out), 1)
+
+    def test_dedup_by_custom_metadata_field(self) -> None:
+        """dedup_key pointing at a metadata field collapses matching docs."""
+        proc = ReciprocalRankFusionProcessor(
+            channel_key="channel", dedup_key="source")
+        docs = [
+            Document(text="a", metadata={"channel": "vector", "source": "db"}),
+            Document(text="b", metadata={"channel": "keyword", "source": "db"}),
+        ]
+        out = proc._process_docs(docs)
+        # Same 'source' value across two channels → fused into one result.
+        self.assertEqual(len(out), 1)
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 2.0 / 61)
+
+    def test_custom_dedup_key_missing_does_not_collapse(self) -> None:
+        """Documents lacking the configured dedup field fall back to their id.
+
+        Without the fallback every such document would share a None identity
+        and be collapsed into a single result.
+        """
+        proc = ReciprocalRankFusionProcessor(
+            channel_key="channel", dedup_key="source")
+        docs = [
+            Document(text="alpha", metadata={"channel": "vector"}),
+            Document(text="beta", metadata={"channel": "keyword"}),
+            Document(text="gamma", metadata={"channel": "vector"}),
+        ]
+        out = proc._process_docs(docs)
+        # None of the docs carry 'source'; each keeps its unique id, so all
+        # three survive (no spurious collapse).
+        self.assertEqual(len(out), 3)
+        self.assertEqual(
+            {d.text for d in out}, {"alpha", "beta", "gamma"})
+
+    def test_custom_dedup_key_mixed_presence(self) -> None:
+        """A doc carrying the field still dedups; one without it does not."""
+        proc = ReciprocalRankFusionProcessor(
+            channel_key="channel", dedup_key="source")
+        docs = [
+            Document(text="shared", metadata={"channel": "vector", "source": "db"}),
+            Document(text="shared", metadata={"channel": "keyword", "source": "db"}),
+            Document(text="lonely", metadata={"channel": "vector"}),
+        ]
+        out = proc._process_docs(docs)
+        # The two 'shared' docs fuse (same source); 'lonely' has no source and
+        # falls back to its own id, so it stays separate.
+        self.assertEqual(len(out), 2)
+
+    def test_channel_key_absent_falls_back_to_single_channel(self) -> None:
+        """If no document carries the channel field, one channel is assumed."""
+        proc = ReciprocalRankFusionProcessor(channel_key="channel")
+        docs = [_doc("a"), _doc("b"), _doc("c")]  # no channel metadata
+        out = proc._process_docs(docs)
+        # Single channel → order preserved, scores are positional.
+        self.assertEqual([d.text for d in out], ["a", "b", "c"])
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 1.0 / 61)
+
+
+class TestTopNAndScoreField(unittest.TestCase):
+    """top_n bounding and custom score_field."""
+
+    def test_top_n_truncates(self) -> None:
+        """Only the top_n highest-scoring documents are returned."""
+        proc = ReciprocalRankFusionProcessor(top_n=2)
+        docs = [_doc("a"), _doc("b"), _doc("c"), _doc("d")]
+        out = proc._process_docs(docs)
+        self.assertEqual(len(out), 2)
+        self.assertEqual([d.text for d in out], ["a", "b"])
+
+    def test_top_n_zero_returns_empty(self) -> None:
+        proc = ReciprocalRankFusionProcessor(top_n=0)
+        out = proc._process_docs([_doc("a"), _doc("b")])
+        self.assertEqual(out, [])
+
+    def test_custom_score_field(self) -> None:
+        """The fused score is written under the configured metadata key."""
+        proc = ReciprocalRankFusionProcessor(score_field="rrf_score")
+        out = proc._process_docs([_doc("a")])
+        self.assertIn("rrf_score", out[0].metadata)
+        self.assertNotIn("relevance_score", out[0].metadata)
+
+
+class TestConfigLoading(unittest.TestCase):
+    """Tests for _initialize_by_component_configer."""
+
+    def test_config_fields_loaded(self) -> None:
+        """Configer attributes are mapped onto the processor fields."""
+        proc = ReciprocalRankFusionProcessor()
+        configer = SimpleNamespace(
+            name="my_fuser",
+            description="desc",
+            channel_key="source",
+            dedup_key="text",
+            k=40,
+            top_n=5,
+            score_field="fused",
+        )
+        proc._initialize_by_component_configer(configer)
+        self.assertEqual(proc.name, "my_fuser")
+        self.assertEqual(proc.channel_key, "source")
+        self.assertEqual(proc.dedup_key, "text")
+        self.assertEqual(proc.k, 40)
+        self.assertEqual(proc.top_n, 5)
+        self.assertEqual(proc.score_field, "fused")
+
+    def test_config_defaults_when_absent(self) -> None:
+        """Missing optional attributes leave the defaults intact."""
+        proc = ReciprocalRankFusionProcessor()
+        configer = SimpleNamespace(name="n", description="d")
+        proc._initialize_by_component_configer(configer)
+        self.assertIsNone(proc.channel_key)
+        self.assertEqual(proc.dedup_key, "id")
+        self.assertEqual(proc.k, 60)
+        self.assertIsNone(proc.top_n)
+        self.assertEqual(proc.score_field, "relevance_score")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_rrf_integration.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_rrf_integration.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Integration tests for multi-store recall fusion through Knowledge.
+
+These exercise the real ``Knowledge.query_knowledge`` retrieval/merge path
+together with the ``ReciprocalRankFusionProcessor`` post-processor, verifying
+that a document recalled by several stores survives the merge with its channel
+identity intact and therefore receives a combined RRF score.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import agentuniverse.base.annotation.trace as trace_module
+from agentuniverse.agent.action.knowledge import knowledge as knowledge_module
+from agentuniverse.agent.action.knowledge.doc_processor.\
+    reciprocal_rank_fusion_processor import ReciprocalRankFusionProcessor
+from agentuniverse.agent.action.knowledge.knowledge import Knowledge, \
+    RECALL_CHANNEL_KEY
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+
+
+class _FakeStore:
+    """Minimal store stub returning a fixed, ranked document list.
+
+    Fresh ``Document`` copies are returned per query so that two stores
+    reporting the "same" document yield distinct objects with an identical
+    deterministic id — mirroring real store behaviour.
+    """
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def query(self, query: Query):
+        return [Document(text=d.text, metadata=dict(d.metadata or {}))
+                for d in self._docs]
+
+
+class TestKnowledgeRrfIntegration(unittest.TestCase):
+    """Multi-store recall fused by RRF through the Knowledge pipeline."""
+
+    def _build_knowledge(self, stores):
+        return Knowledge(
+            name="rrf_knowledge",
+            stores=list(stores.keys()),
+            rag_router="base_router",
+            post_processors=["reciprocal_rank_fusion_processor"],
+        )
+
+    def _run_query(self, knowledge, stores, rrf):
+        """Drive ``query_knowledge`` with the managers and tracing mocked.
+
+        The ``@trace_knowledge`` decorator pulls in ConversationMemoryModule /
+        Monitor which require app configuration that is unavailable in unit
+        tests; both are patched out so the real ``query_knowledge`` body runs.
+        """
+        router = MagicMock()
+        router.rag_route.return_value = [
+            (Query(query_str="q"), store_code) for store_code in stores
+        ]
+        with patch.object(trace_module, "ConversationMemoryModule"), \
+                patch.object(trace_module, "Monitor") as monitor, \
+                patch.object(knowledge_module, "RagRouterManager") as router_mgr, \
+                patch.object(knowledge_module, "StoreManager") as store_mgr, \
+                patch.object(knowledge_module, "DocProcessorManager") as proc_mgr:
+            monitor.get_invocation_chain.return_value = []
+            router_mgr.return_value.get_instance_obj.return_value = router
+            store_mgr.return_value.get_instance_obj.side_effect = \
+                lambda code, **_: stores[code]
+            proc_mgr.return_value.get_instance_obj.return_value = rrf
+            return knowledge.query_knowledge(query_str="q")
+
+    def test_shared_doc_gets_combined_rrf_score(self) -> None:
+        """A doc recalled by two stores fuses to a combined RRF score."""
+        stores = {
+            "vector_store": _FakeStore(
+                [Document(text="shared"), Document(text="only vector")]),
+            "keyword_store": _FakeStore(
+                [Document(text="shared"), Document(text="only keyword")]),
+        }
+        rrf = ReciprocalRankFusionProcessor(channel_key=RECALL_CHANNEL_KEY, k=60)
+        knowledge = self._build_knowledge(stores)
+
+        out = self._run_query(knowledge, stores, rrf)
+
+        # The shared document is returned once (RRF dedups by id) yet its score
+        # accumulates across both channels: rank 0 in each → 2 * 1/61.
+        by_text = {d.text: d for d in out}
+        self.assertIn("shared", by_text)
+        self.assertAlmostEqual(
+            by_text["shared"].metadata["relevance_score"], 2.0 / 61)
+        # The single-channel docs tie at rank 1 → 1/62.
+        self.assertAlmostEqual(
+            by_text["only vector"].metadata["relevance_score"], 1.0 / 62)
+        self.assertAlmostEqual(
+            by_text["only keyword"].metadata["relevance_score"], 1.0 / 62)
+        # The shared doc outranks everything else.
+        self.assertEqual(out[0].text, "shared")
+
+    def test_recall_channel_stamped_on_documents(self) -> None:
+        """Each recalled document carries the store it came from."""
+        stores = {
+            "vector_store": _FakeStore([Document(text="v doc")]),
+            "keyword_store": _FakeStore([Document(text="k doc")]),
+        }
+        rrf = ReciprocalRankFusionProcessor(channel_key=RECALL_CHANNEL_KEY)
+        knowledge = self._build_knowledge(stores)
+
+        out = self._run_query(knowledge, stores, rrf)
+
+        channels = {d.metadata[RECALL_CHANNEL_KEY] for d in out}
+        self.assertEqual(channels, {"vector_store", "keyword_store"})
+
+    def test_shared_doc_not_collapsed_before_post_processing(self) -> None:
+        """Before the fix the shared doc was dropped to a single copy with a
+        single-channel score (1/61); it must now fuse to 2/61."""
+        stores = {
+            "vector_store": _FakeStore([Document(text="shared")]),
+            "keyword_store": _FakeStore([Document(text="shared")]),
+        }
+        rrf = ReciprocalRankFusionProcessor(channel_key=RECALL_CHANNEL_KEY, k=60)
+        knowledge = self._build_knowledge(stores)
+
+        out = self._run_query(knowledge, stores, rrf)
+
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].text, "shared")
+        self.assertAlmostEqual(
+            out[0].metadata["relevance_score"], 2.0 / 61)
+
+    def test_no_rrf_collapses_cross_store_duplicates(self) -> None:
+        """Without a channel-fusion post-processor, Knowledge keeps the default
+        retrieval contract: a document recalled by several stores is returned
+        exactly once (master behaviour), not once per store, and no
+        ``recall_channel`` metadata leaks onto the documents."""
+        stores = {
+            "vector_store": _FakeStore(
+                [Document(text="shared"), Document(text="only vector")]),
+            "keyword_store": _FakeStore(
+                [Document(text="shared"), Document(text="only keyword")]),
+        }
+        knowledge = Knowledge(
+            name="no_rrf_knowledge",
+            stores=list(stores.keys()),
+            rag_router="base_router",
+            post_processors=[],  # no fusion → default retrieval contract
+        )
+
+        out = self._run_query(knowledge, stores, rrf=None)
+
+        by_text = [d.text for d in out]
+        self.assertEqual(by_text.count("shared"), 1)  # collapsed, not duplicated
+        self.assertIn("only vector", by_text)
+        self.assertIn("only keyword", by_text)
+        for doc in out:
+            self.assertNotIn(RECALL_CHANNEL_KEY, doc.metadata or {})
+
+    def test_processor_without_channel_key_keeps_default_contract(self) -> None:
+        """A post-processor that does not declare a ``channel_key`` must not
+        trigger per-channel recall — channel-aware dedup is opt-in via
+        ``channel_key``, so the default contract still collapses a document
+        recalled by several stores to a single copy."""
+        stores = {
+            "vector_store": _FakeStore([Document(text="shared")]),
+            "keyword_store": _FakeStore([Document(text="shared")]),
+        }
+        # A non-channel processor: channel_key left at its None default.
+        non_channel_processor = ReciprocalRankFusionProcessor(channel_key=None)
+        knowledge = Knowledge(
+            name="no_channel_key_knowledge",
+            stores=list(stores.keys()),
+            rag_router="base_router",
+            post_processors=["some_other_processor"],
+        )
+
+        out = self._run_query(knowledge, stores, non_channel_processor)
+
+        self.assertEqual([d.text for d in out].count("shared"), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Implements the **fusion** direction of #248 — a recall post-processor that merges the ranked results of multiple retrieval channels (vector / keyword / graph / …) into a single relevance ranking via **Reciprocal Rank Fusion**:

```
score(d) = Σ_channels  1 / (k + rank_channel(d))
```

RRF combines ranked lists without needing the (incomparable) raw scores of each channel. A document that appears near the top of several channels accumulates a higher fused score than one that only appears in a single channel — exactly the multi-channel recall-quality goal of #248. This complements the summarization processor (the summary direction of the same issue).

## Why this design

- **Channel-aware.** Channels are told apart by a metadata field (`channel_key`) that each retrieval channel stamps onto its docs. The processor scores each list independently and sums per-document.
- **Safe default.** With `channel_key` unset (or absent on the docs) the whole input is treated as one channel and the processor degrades to deterministic position-based scoring that **preserves input order** — so it can be dropped into an existing single-store pipeline without changing behavior.
- **De-duplication.** The same document surfacing in several channels is counted once per channel and merged by identity (deterministic `id` by default; configurable to `text` or a metadata field).
- **Non-destructive.** The fused score is written into `metadata[score_field]`; document `id` / `embedding` / `keywords` / `text` are preserved.

## Config

| Field | Default | Purpose |
| --- | --- | --- |
| `channel_key` | `''` | metadata field identifying a doc's retrieval channel |
| `dedup_key` | `'id'` | cross-channel identity (`id` / `text` / metadata field) |
| `k` | `60` | RRF smoothing constant (conventional value) |
| `top_n` | `null` | cap on returned docs |
| `score_field` | `'relevance_score'` | metadata key for the fused score |

## Example

```python
proc = ReciprocalRankFusionProcessor(channel_key="channel", k=60)
# vector channel:  A(0), B(1), C(2)
# keyword channel: A(0), D(1), E(2)
proc.process_docs([...])
# -> A = 2/61 (top of both channels), then B/D each 1/62, ...
```

## Tests

15 unit tests added under `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py`, all green locally:

- single-channel fallback (order preserved, scores `1/(k+r+1)`, metadata preserved)
- multi-channel fusion + exact RRF formula
- cross-channel and intra-channel dedup (by `id` and by `text`)
- channel-key-absent fallback
- `top_n` bounding (incl. `0`), custom `score_field`
- `_initialize_by_component_configer` loading + defaults

```
======================== 15 passed, 3 warnings in 0.22s ========================
```

(The warnings are pre-existing pydantic-v2 deprecation notices in the framework, unrelated to this change.)

Closes #248 (fusion direction).
