### PR TITLE
fix(agent): use canonical langchain.tools import in agent.py (#190)

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -252,7 +252,7 @@ class Agent(ComponentBase, ABC):
 
     def as_langchain_tool(self):
         """Convert to LangChain tool."""
-        from langchain.agents.tools import Tool
+        from langchain.tools import Tool as LangchainTool
         format_dict = {}
         for key in self.input_keys():
             format_dict.setdefault(key, "input val")
@@ -263,7 +263,7 @@ class Agent(ComponentBase, ABC):
         and the value of the key must be a json string,the format of the json string is as follows:
         ```{format_str}```
         """
-        return Tool(
+        return LangchainTool(
             name=self.agent_model.info.get("name"),
             func=self.langchain_run,
             description=self.agent_model.info.get("description") + args_description
@@ -271,7 +271,7 @@ class Agent(ComponentBase, ABC):
 
     async def async_as_langchain_tool(self):
         """Convert to LangChain tool."""
-        from langchain.agents.tools import Tool
+        from langchain.tools import Tool as LangchainTool
         format_dict = {}
         for key in self.input_keys():
             format_dict.setdefault(key, "input val")
@@ -282,7 +282,7 @@ class Agent(ComponentBase, ABC):
         and the value of the key must be a json string,the format of the json string is as follows:
         ```{format_str}```
         """
-        return Tool(
+        return LangchainTool(
             name=self.agent_model.info.get("name"),
             func=self.async_langchain_run,
             description=self.agent_model.info.get("description") + args_description


### PR DESCRIPTION
## What

Fixes #190. Replaces the two deprecated `from langchain.agents.tools import Tool` imports in `agentuniverse/agent/agent.py` with the canonical `from langchain.tools import Tool as LangchainTool`.

## Why

- **`langchain.agents.tools` is the legacy re-export location.** It still resolves on the currently pinned langchain, but it has been removed in newer langchain releases. Importing from `langchain.tools` is the supported path.
- **Consistency.** The rest of the codebase already imports the langchain Tool from the canonical path under the `LangchainTool` alias:

  ```
  agentuniverse/agent/plan/planner/react_planner/react_planner.py
  agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
  agentuniverse/agent/template/react_agent_template.py
  agentuniverse/agent/action/knowledge/knowledge.py
  agentuniverse/agent/action/tool/tool.py
  ```

  `agent.py` was the only outlier.

- **Why the alias & local import.** `agent.py` already imports the agentUniverse `Tool` at module top (`from agentuniverse.agent.action.tool.tool import Tool`). Keeping the langchain import local to the two methods that use it — and aliasing it as `LangchainTool` — avoids shadowing that class, matching the convention used elsewhere.

## Changes

`as_langchain_tool` and `async_as_langchain_tool`:

```diff
-        from langchain.agents.tools import Tool
+        from langchain.tools import Tool as LangchainTool
         ...
-        return Tool(
+        return LangchainTool(
```

No behavior change — `langchain.tools.Tool` and `langchain.agents.tools.Tool` resolve to the same class (`langchain_core.tools.Tool`) on supported langchain versions.

## Verification

- `python -m py_compile agentuniverse/agent/agent.py` — clean.
- Confirmed the canonical import resolves: `from langchain.tools import Tool` → `<class 'langchain_core.tools.Tool'>`.
- No remaining `from langchain.agents.tools import` references in the repo.

Closes #190.
