### PR TITLE
feat(tool): add YahooFinanceTool for market data (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/__init__.py
+++ b/agentuniverse/agent/action/tool/common_tool/__init__.py
@@ -7,7 +7,9 @@
 # @FileName: __init__.py
 
 from .github_tool import GitHubTool
+from .yahoo_finance_tool import YahooFinanceTool
 
 __all__ = [
-    'GitHubTool'
+    'GitHubTool',
+    'YahooFinanceTool',
 ]

--- a/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py
@@ -1,0 +1,299 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/10
+# @Author  : contributor
+# @FileName: yahoo_finance_tool.py
+
+"""
+Yahoo Finance market-data tool.
+
+Provides stock / ETF / index quotes, historical OHLCV bars, and company
+information sourced from Yahoo Finance, addressing the *Yahoo Finance* item of
+issue #252 (tool plug-in integration).
+
+The tool is built on top of the ``yfinance`` library (the de-facto Python
+client for Yahoo Finance data). ``yfinance`` is imported lazily inside the
+methods that need it, so importing this module never requires the dependency —
+an agent that never calls the tool pays no install cost, and a missing
+``yfinance`` surfaces a clear, actionable error only when the tool is actually
+used.
+
+Three operating modes are supported:
+
+* ``quote``   — the latest price, change, and a handful of headline metrics.
+* ``history`` — historical OHLCV bars for a configurable period / interval.
+* ``info``    — a curated company profile (a stable subset of the Yahoo
+  Finance profile; the full ``ticker.info`` payload is intentionally not
+  dumped, to keep the agent context compact).
+
+All output is a human-readable string so it can be dropped directly into an
+agent's context. The data-fetching helpers are isolated from the formatting
+helpers, which keeps the component fully unit-testable without a network
+connection: tests stub :meth:`_get_ticker` and feed fixed dicts to the pure
+formatters.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.annotation.retry import retry
+
+
+class YahooFinanceTool(Tool):
+    """Yahoo Finance market-data tool.
+
+    Attributes:
+        max_history_rows (int): Upper bound on the number of history rows
+            returned, to keep the agent context compact.
+        quote_fields (List[str]): Keys surfaced in ``quote`` mode, in display
+            order.
+        info_fields (List[str]): Curated keys surfaced in ``info`` mode, in
+            display order. Only these keys are emitted, so the agent context
+            is not flooded by the large, unstable ``ticker.info`` payload.
+    """
+
+    name: str = "yahoo_finance_tool"
+    description: str = (
+        "Yahoo Finance market-data tool. Fetches the latest quote, historical "
+        "OHLCV bars, or the company profile for a stock / ETF / index symbol "
+        "(e.g. 'AAPL', '600519.SS')."
+    )
+    max_history_rows: int = Field(30, description="Max number of history rows returned.")
+    quote_fields: List[str] = [
+        "regularMarketPrice", "regularMarketChange", "regularMarketChangePercent",
+        "regularMarketVolume", "regularMarketPreviousClose", "marketCap",
+        "fiftyTwoWeekLow", "fiftyTwoWeekHigh", "currency",
+    ]
+    info_fields: List[str] = [
+        "longName", "symbol", "quoteType", "currency", "exchange",
+        "sector", "industry", "country", "city",
+        "marketCap", "enterpriseValue", "enterpriseToRevenue",
+        "enterpriseToEbitda", "trailingPE", "forwardPE",
+        "dividendYield", "payoutRatio", "beta",
+        "profitMargins", "grossMargins", "operatingMargins",
+        "returnOnEquity", "returnOnAssets",
+        "totalRevenue", "revenueGrowth", "earningsGrowth",
+        "totalCash", "totalDebt",
+        "fiftyTwoWeekLow", "fiftyTwoWeekHigh",
+        "regularMarketPrice", "regularMarketVolume",
+        "fullTimeEmployees", "website", "longBusinessSummary",
+    ]
+    max_business_summary_chars: int = Field(
+        400,
+        description="Cap on the longBusinessSummary length emitted in info "
+                    "mode. The raw field is an unbounded company description, "
+                    "so even within the curated info_fields list it is "
+                    "truncated to keep the agent context compact.",
+    )
+
+    # ------------------------------------------------------------------ #
+    # Public entry point
+    # ------------------------------------------------------------------ #
+
+    def execute(self,
+                mode: str,
+                symbol: str,
+                period: str = "1mo",
+                interval: str = "1d") -> str:
+        """Run a Yahoo Finance query.
+
+        Args:
+            mode (str): One of ``quote`` / ``history`` / ``info``.
+            symbol (str): Ticker symbol, e.g. ``AAPL`` or ``600519.SS``.
+            period (str): History period, e.g. ``1mo``, ``3mo``, ``1y``,
+                ``max``. Ignored outside ``history`` mode.
+            interval (str): History bar interval, e.g. ``1d``, ``1wk``,
+                ``1mo``. Ignored outside ``history`` mode.
+
+        Returns:
+            str: Human-readable result (or a clear error message).
+        """
+        symbol = self._normalize_symbol(symbol)
+        if not symbol:
+            return "Error: 'symbol' is required."
+        if mode not in ("quote", "history", "info"):
+            return (f"Error: invalid mode '{mode}'. "
+                    "Must be one of: quote, history, info.")
+
+        try:
+            ticker = self._get_ticker(symbol)
+            if mode == "quote":
+                return self._format_quote(symbol, self._fetch_quote(ticker))
+            if mode == "info":
+                return self._format_info(symbol, self._fetch_info(ticker))
+            return self._format_history(
+                symbol, self._fetch_history(ticker, period=period, interval=interval))
+        except ImportError:
+            return ("Error: yfinance is required. "
+                    "Install it with: pip install yfinance")
+        except Exception as exc:  # noqa: BLE001 - surface any fetch error to the agent
+            return f"Error fetching data for symbol '{symbol}': {exc}"
+
+    # ------------------------------------------------------------------ #
+    # Data fetching (network) — lazy yfinance import, isolated for testing
+    # ------------------------------------------------------------------ #
+
+    def _get_ticker(self, symbol: str):
+        """Return a ``yfinance.Ticker`` for the symbol (lazy import)."""
+        import yfinance  # noqa: WPS433 - lazy on purpose
+        return yfinance.Ticker(symbol)
+
+    @retry(3, 1.0)
+    def _fetch_quote(self, ticker) -> Dict[str, Any]:
+        """Pull the headline quote metrics for the ticker."""
+        info = self._safe_info(ticker)
+        return {field: info.get(field) for field in self.quote_fields}
+
+    @retry(3, 1.0)
+    def _fetch_history(self, ticker, period: str, interval: str) -> List[Dict[str, Any]]:
+        """Pull historical OHLCV bars as a list of row dicts (newest first)."""
+        df = ticker.history(period=period, interval=interval)
+        if df is None or getattr(df, "empty", True):
+            return []
+        # Reset the date index into a column, then take the most recent rows.
+        rows = df.reset_index().rename(columns=str.lower).to_dict(orient="records")
+        return rows[::-1][:self.max_history_rows]
+
+    @retry(3, 1.0)
+    def _fetch_info(self, ticker) -> Dict[str, Any]:
+        """Pull the full company profile for the ticker."""
+        return self._safe_info(ticker)
+
+    # ------------------------------------------------------------------ #
+    # Formatting (pure) — fully testable without a network
+    # ------------------------------------------------------------------ #
+
+    def _format_quote(self, symbol: str, quote: Dict[str, Any]) -> str:
+        """Render the quote metrics as a readable block."""
+        lines = [f"{symbol} — latest quote"]
+        for field in self.quote_fields:
+            value = quote.get(field)
+            if value is None:
+                continue
+            lines.append(f"  {field}: {self._humanize(field, value)}")
+        if len(lines) == 1:
+            return f"{symbol} — no quote data available."
+        return "\n".join(lines)
+
+    def _format_history(self, symbol: str, rows: List[Dict[str, Any]]) -> str:
+        """Render historical bars as a compact, aligned table."""
+        if not rows:
+            return f"{symbol} — no historical data available."
+        columns = ["date", "open", "high", "low", "close", "volume"]
+        header = " | ".join(col.ljust(8) for col in columns)
+        body = []
+        for row in rows:
+            date = self._row_value(row, "date", "index")
+            cells = [
+                str(date)[:10].ljust(8) if date is not None else "-".ljust(8),
+                self._fmt_num(self._row_value(row, "open")),
+                self._fmt_num(self._row_value(row, "high")),
+                self._fmt_num(self._row_value(row, "low")),
+                self._fmt_num(self._row_value(row, "close")),
+                self._fmt_int(self._row_value(row, "volume")),
+            ]
+            body.append(" | ".join(cell.ljust(8) for cell in cells))
+        return "\n".join([f"{symbol} — history (newest first)", header] + body)
+
+    def _format_info(self, symbol: str, info: Dict[str, Any]) -> str:
+        """Render a curated slice of the company profile.
+
+        Only the keys in :attr:`info_fields` are emitted (those that are
+        actually present and non-empty). Unknown ``ticker.info`` keys are
+        deliberately dropped, because the raw payload is large and varies
+        between symbols / yfinance releases — emitting it verbatim would flood
+        the agent context with an unstable, hard-to-consume blob.
+        """
+        if not info:
+            return f"{symbol} — no company info available."
+        lines = [f"{symbol} — company profile"]
+        for key in self.info_fields:
+            value = info.get(key)
+            if value in (None, ""):
+                continue
+            if key == "longBusinessSummary" and isinstance(value, str):
+                value = self._truncate(value, self.max_business_summary_chars)
+            lines.append(f"  {key}: {self._humanize(key, value)}")
+        if len(lines) == 1:
+            return f"{symbol} — no company info available."
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------ #
+    # Small helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _normalize_symbol(symbol: Optional[str]) -> str:
+        """Uppercase and trim the symbol; return '' for blank input."""
+        if not symbol or not str(symbol).strip():
+            return ""
+        return str(symbol).strip().upper()
+
+    @staticmethod
+    def _safe_info(ticker) -> Dict[str, Any]:
+        """Best-effort ``ticker.info``; tolerates yfinance returning None."""
+        try:
+            info = ticker.info
+        except Exception:  # noqa: BLE001
+            return {}
+        return info or {}
+
+    @staticmethod
+    def _row_value(row: Dict[str, Any], *keys: str) -> Any:
+        """Return the first present key from ``keys`` in ``row``."""
+        for key in keys:
+            if key in row and row[key] is not None:
+                return row[key]
+        return None
+
+    @staticmethod
+    def _fmt_num(value: Any) -> str:
+        """Format a price-like number to a concise string."""
+        if value is None:
+            return "-"
+        try:
+            return f"{float(value):.2f}"
+        except (TypeError, ValueError):
+            return str(value)
+
+    @staticmethod
+    def _fmt_int(value: Any) -> str:
+        """Format a volume-like number with thousands separators."""
+        if value is None:
+            return "-"
+        try:
+            return f"{int(float(value)):,}"
+        except (TypeError, ValueError):
+            return str(value)
+
+    def _humanize(self, key: str, value: Any) -> str:
+        """Render large monetary values compactly for human readability."""
+        if key in ("marketCap",) and isinstance(value, (int, float)):
+            return self._compact_number(value)
+        if key in ("regularMarketVolume",) and isinstance(value, (int, float)):
+            return self._fmt_int(value)
+        if isinstance(value, float):
+            return self._fmt_num(value)
+        return str(value)
+
+    @staticmethod
+    def _compact_number(value: float) -> str:
+        """Abbreviate a large number using T / B / M / K suffixes."""
+        for unit, factor in (("T", 1e12), ("B", 1e9), ("M", 1e6), ("K", 1e3)):
+            if abs(value) >= factor:
+                return f"{value / factor:.2f}{unit}"
+        return f"{value:.2f}"
+
+    @staticmethod
+    def _truncate(value: str, limit: int) -> str:
+        """Truncate a long string to ``limit`` chars with an ellipsis.
+
+        ``longBusinessSummary`` (and any other free-text profile field) can run
+        to thousands of characters; capping it keeps the agent context compact.
+        """
+        if limit <= 0 or len(value) <= limit:
+            return value
+        return value[:limit].rstrip() + "…"

--- a/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.yaml
@@ -1,0 +1,48 @@
+name: yahoo_finance_tool
+description: Yahoo Finance market-data tool — fetch the latest quote, historical OHLCV bars, or the company profile for a stock / ETF / index symbol (e.g. 'AAPL', '600519.SS'). Requires the optional 'yfinance' package.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.yahoo_finance_tool
+  class: YahooFinanceTool
+input_keys:
+  - mode
+  - symbol
+args_model:
+  mode:
+    type: string
+    description: Query mode — quote (latest price + headline metrics), history (historical OHLCV bars), or info (curated company profile).
+    required: true
+  symbol:
+    type: string
+    description: Ticker symbol, e.g. 'AAPL', 'TSLA', '600519.SS'.
+    required: true
+  period:
+    type: string
+    description: History period (only used in history mode) — e.g. '1mo', '3mo', '6mo', '1y', '5y', 'max'.
+    required: false
+    default: '1mo'
+  interval:
+    type: string
+    description: History bar interval (only used in history mode) — e.g. '1d', '1wk', '1mo'.
+    required: false
+    default: '1d'
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: ["quote", "history", "info"]
+      description: Query mode.
+    symbol:
+      type: string
+      description: Ticker symbol.
+    period:
+      type: string
+      default: "1mo"
+      description: History period (history mode only).
+    interval:
+      type: string
+      default: "1d"
+      description: History bar interval (history mode only).
+  required: ["mode", "symbol"]

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/10
+# @FileName: test_yahoo_finance_tool.py
+
+"""
+Unit tests for YahooFinanceTool.
+
+The data-fetching layer (yfinance) is mocked, so the suite is deterministic and
+runs without a network connection or the optional ``yfinance`` package. The pure
+formatting helpers are exercised directly; the ``execute`` wiring is exercised
+through a stubbed ``_get_ticker`` / fetch methods. A dedicated registration test
+loads the shipped ``yahoo_finance_tool.yaml`` through the real framework loader
+(``Configer`` -> ``ComponentConfiger`` -> ``ToolManager``) so a component-schema
+regression is caught at test time rather than at agent runtime.
+"""
+
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.action.tool.common_tool import yahoo_finance_tool as yf_module
+from agentuniverse.agent.action.tool.common_tool.yahoo_finance_tool import (
+    YahooFinanceTool,
+)
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import (
+    ApplicationConfigManager,
+)
+from agentuniverse.base.config.component_configer.component_configer import (
+    ComponentConfiger,
+)
+from agentuniverse.base.config.component_configer.configers.tool_configer import (
+    ToolConfiger,
+)
+from agentuniverse.base.config.configer import Configer
+
+# The shipped component config sits next to the tool implementation module.
+YAML_PATH = os.path.join(os.path.dirname(yf_module.__file__),
+                         "yahoo_finance_tool.yaml")
+
+
+class TestFormatters(unittest.TestCase):
+    """Pure formatting helpers — no network, no yfinance."""
+
+    def setUp(self) -> None:
+        self.tool = YahooFinanceTool()
+
+    def test_format_quote_with_data(self) -> None:
+        quote = {
+            "regularMarketPrice": 150.0,
+            "regularMarketChange": 1.25,
+            "regularMarketChangePercent": 0.84,
+            "marketCap": 2_500_000_000_000,
+            "regularMarketVolume": 55_000_000,
+            "currency": "USD",
+        }
+        out = self.tool._format_quote("AAPL", quote)
+        self.assertIn("AAPL", out)
+        self.assertIn("regularMarketPrice: 150.00", out)
+        self.assertIn("USD", out)
+        # marketCap is abbreviated compactly.
+        self.assertIn("2.50T", out)
+        # Volume uses thousands separators.
+        self.assertIn("55,000,000", out)
+
+    def test_format_quote_skips_missing_fields(self) -> None:
+        out = self.tool._format_quote("XYZ", {"regularMarketPrice": 12.3})
+        self.assertIn("regularMarketPrice", out)
+        self.assertNotIn("fiftyTwoWeekHigh", out)
+
+    def test_format_quote_empty(self) -> None:
+        out = self.tool._format_quote("XYZ", {})
+        self.assertIn("no quote data", out)
+
+    def test_format_history_with_rows(self) -> None:
+        rows = [
+            {"date": "2024-01-02", "open": 100.0, "high": 102.0,
+             "low": 99.0, "close": 101.0, "volume": 1000},
+            {"date": "2024-01-01", "open": 98.0, "high": 100.0,
+             "low": 97.0, "close": 99.0, "volume": 2000},
+        ]
+        out = self.tool._format_history("AAPL", rows)
+        self.assertIn("AAPL", out)
+        self.assertIn("newest first", out)
+        # Header columns present.
+        self.assertIn("open", out)
+        self.assertIn("close", out)
+        # Prices formatted to two decimals.
+        self.assertIn("101.00", out)
+        # Volumes with thousands separators.
+        self.assertIn("1,000", out)
+
+    def test_format_history_empty(self) -> None:
+        out = self.tool._format_history("AAPL", [])
+        self.assertIn("no historical data", out)
+
+    def test_format_info_with_data(self) -> None:
+        info = {
+            "longName": "Apple Inc.",
+            "sector": "Technology",
+            "marketCap": 2_500_000_000_000,
+            "website": "https://www.apple.com",
+        }
+        out = self.tool._format_info("AAPL", info)
+        self.assertIn("Apple Inc.", out)
+        self.assertIn("Technology", out)
+        self.assertIn("2.50T", out)
+
+    def test_format_info_empty(self) -> None:
+        out = self.tool._format_info("AAPL", {})
+        self.assertIn("no company info", out)
+
+    def test_format_info_drops_unstable_extra_fields(self) -> None:
+        # Unknown / unstable ticker.info keys must NOT leak into the output —
+        # the info payload is curated to keep the agent context compact.
+        info = {
+            "longName": "Apple Inc.",
+            "marketCap": 2_500_000_000_000,
+            "quoteType": "EQUITY",
+            "someUnstableInternalField": "x" * 500,
+            "uuid": "do-not-emit",
+        }
+        out = self.tool._format_info("AAPL", info)
+        self.assertIn("Apple Inc.", out)
+        self.assertIn("2.50T", out)
+        self.assertNotIn("someUnstableInternalField", out)
+        self.assertNotIn("uuid", out)
+
+    def test_format_info_only_emits_known_fields(self) -> None:
+        # Every emitted key must be a member of the curated info_fields list.
+        info = {
+            "longName": "Apple Inc.",
+            "sector": "Technology",
+            "marketCap": 2_500_000_000_000,
+        }
+        out = self.tool._format_info("AAPL", info)
+        emitted_keys = {
+            line.split(":", 1)[0].strip()
+            for line in out.splitlines()
+            if line.startswith("  ") and ":" in line
+        }
+        self.assertTrue(emitted_keys)
+        self.assertTrue(emitted_keys.issubset(set(self.tool.info_fields)))
+
+    def test_format_info_caps_long_business_summary(self) -> None:
+        # longBusinessSummary is a curated field but still an unbounded
+        # free-text description, so it must be truncated to the configured cap.
+        long_summary = "Apple designs and sells consumer electronics. " * 60
+        self.assertGreater(len(long_summary), self.tool.max_business_summary_chars)
+        info = {"longName": "Apple Inc.", "longBusinessSummary": long_summary}
+        out = self.tool._format_info("AAPL", info)
+        cap = self.tool.max_business_summary_chars
+        for line in out.splitlines():
+            if line.strip().startswith("longBusinessSummary:"):
+                # Emitted value body (after the key) must stay within the cap
+                # plus the single ellipsis marker.
+                body = line.split(":", 1)[1].strip()
+                self.assertLessEqual(len(body), cap + 1)
+                break
+        else:
+            self.fail("longBusinessSummary line not emitted")
+
+    def test_format_info_respects_custom_summary_cap(self) -> None:
+        long_summary = "x" * 500
+        tool = YahooFinanceTool()
+        tool.max_business_summary_chars = 50
+        out = tool._format_info("AAPL", {"longBusinessSummary": long_summary})
+        body = next(
+            line.split(":", 1)[1].strip()
+            for line in out.splitlines()
+            if line.strip().startswith("longBusinessSummary:")
+        )
+        self.assertLessEqual(len(body), 51)
+        self.assertTrue(body.endswith("…"))
+
+    def test_compact_number_suffixes(self) -> None:
+        self.assertEqual(self.tool._compact_number(2.5e12), "2.50T")
+        self.assertEqual(self.tool._compact_number(3.4e9), "3.40B")
+        self.assertEqual(self.tool._compact_number(5.6e6), "5.60M")
+        self.assertEqual(self.tool._compact_number(7.8e3), "7.80K")
+        self.assertEqual(self.tool._compact_number(123.4), "123.40")
+
+    def test_normalize_symbol(self) -> None:
+        self.assertEqual(self.tool._normalize_symbol("aapl"), "AAPL")
+        self.assertEqual(self.tool._normalize_symbol("  aapl  "), "AAPL")
+        self.assertEqual(self.tool._normalize_symbol(None), "")
+        self.assertEqual(self.tool._normalize_symbol("   "), "")
+
+
+class TestExecute(unittest.TestCase):
+    """execute() wiring with the network layer stubbed out."""
+
+    def setUp(self) -> None:
+        self.tool = YahooFinanceTool()
+
+    def _mock_ticker(self, info: dict) -> Mock:
+        ticker = Mock()
+        ticker.info = info
+        return ticker
+
+    def test_execute_quote_via_mock_ticker(self) -> None:
+        info = {"regularMarketPrice": 150.0, "currency": "USD"}
+        ticker = self._mock_ticker(info)
+        with patch.object(self.tool, "_get_ticker", return_value=ticker):
+            out = self.tool.execute(mode="quote", symbol="aapl")
+        self.assertIn("AAPL", out)
+        self.assertIn("150.00", out)
+
+    def test_execute_info_via_mock_ticker(self) -> None:
+        info = {"longName": "Apple Inc.", "sector": "Technology"}
+        ticker = self._mock_ticker(info)
+        with patch.object(self.tool, "_get_ticker", return_value=ticker):
+            out = self.tool.execute(mode="info", symbol="AAPL")
+        self.assertIn("Apple Inc.", out)
+        self.assertIn("Technology", out)
+
+    def test_execute_history_via_mocked_fetch(self) -> None:
+        # A minimal DataFrame-like stub so the real _fetch_history runs
+        # end-to-end (reset_index → rename(lower) → to_dict) without pandas.
+        class _FakeHistory:
+            empty = False
+
+            def __init__(self, records):
+                self._records = records
+
+            def reset_index(self):
+                return self
+
+            def rename(self, columns=None):
+                return self
+
+            def to_dict(self, orient="records"):
+                return list(self._records)
+
+        records = [
+            {"date": "2024-01-01", "open": 98.0, "high": 100.0,
+             "low": 97.0, "close": 99.0, "volume": 2000},
+            {"date": "2024-01-02", "open": 100.0, "high": 102.0,
+             "low": 99.0, "close": 101.0, "volume": 1000},
+        ]
+        ticker = Mock()
+        ticker.history.return_value = _FakeHistory(records)
+        with patch.object(self.tool, "_get_ticker", return_value=ticker):
+            out = self.tool.execute(
+                mode="history", symbol="AAPL", period="1mo", interval="1d")
+        self.assertIn("AAPL", out)
+        self.assertIn("101.00", out)
+        # newest first → the 01-02 row precedes the 01-01 row.
+        self.assertLess(out.index("2024-01-02"), out.index("2024-01-01"))
+
+    def test_execute_symbol_uppercased_before_fetch(self) -> None:
+        ticker = self._mock_ticker({"regularMarketPrice": 1.0})
+        with patch.object(self.tool, "_get_ticker", return_value=ticker) as m:
+            self.tool.execute(mode="quote", symbol="aapl")
+        m.assert_called_once_with("AAPL")
+
+    def test_execute_invalid_mode(self) -> None:
+        out = self.tool.execute(mode="frobnicate", symbol="AAPL")
+        self.assertIn("invalid mode", out)
+
+    def test_execute_missing_symbol(self) -> None:
+        out = self.tool.execute(mode="quote", symbol="")
+        self.assertIn("required", out)
+
+    def test_execute_missing_yfinance_reports_install_hint(self) -> None:
+        def _no_yfinance(_symbol):
+            raise ImportError("yfinance")
+        with patch.object(self.tool, "_get_ticker", side_effect=_no_yfinance):
+            out = self.tool.execute(mode="quote", symbol="AAPL")
+        self.assertIn("yfinance", out)
+        self.assertIn("pip install", out)
+
+    def test_execute_surfaces_fetch_errors(self) -> None:
+        def _boom(_symbol):
+            raise RuntimeError("network down")
+        with patch.object(self.tool, "_get_ticker", side_effect=_boom):
+            out = self.tool.execute(mode="quote", symbol="AAPL")
+        self.assertIn("Error fetching data", out)
+        self.assertIn("network down", out)
+
+
+class TestRegistration(unittest.TestCase):
+    """Config / registration through the real framework loader.
+
+    Loads the shipped ``yahoo_finance_tool.yaml`` with the same pipeline the
+    component scanner uses (``Configer`` -> ``ComponentConfiger`` ->
+    ``ToolManager``) and asserts the tool is resolvable and initializable.
+    This guards the component-schema contract: an unrecognised ``class_path``
+    (or any other field outside ``metadata`` / ``meta_class``) would leave
+    ``component_type`` as ``None`` and silently skip registration.
+    """
+
+    def setUp(self) -> None:
+        self._configer = Configer(path=os.path.abspath(YAML_PATH)).load()
+        # Snapshot the global ApplicationConfigManager state. The registration
+        # tests below install their own AppConfiger to drive the real
+        # ToolManager pipeline; without restoring it they would leak that
+        # synthetic state into unrelated tests that run later in the suite.
+        # The getter raises when no AppConfiger has been set yet, so fall back
+        # to None — restoring None reproduces that exact unset state.
+        try:
+            self._prev_app_configer = ApplicationConfigManager().app_configer
+        except ValueError:
+            self._prev_app_configer = None
+
+    def tearDown(self) -> None:
+        ApplicationConfigManager().app_configer = self._prev_app_configer
+
+    def test_yaml_resolves_to_tool_component_type(self) -> None:
+        component_configer = ComponentConfiger().load_by_configer(self._configer)
+        self.assertEqual(
+            component_configer.get_component_config_type(),
+            ComponentEnum.TOOL.value,
+        )
+
+    def test_yaml_exposes_module_and_class(self) -> None:
+        component_configer = ComponentConfiger().load_by_configer(self._configer)
+        self.assertEqual(component_configer.metadata_module,
+                         "agentuniverse.agent.action.tool.common_tool.yahoo_finance_tool")
+        self.assertEqual(component_configer.metadata_class, "YahooFinanceTool")
+
+    def test_tool_is_resolvable_through_tool_manager(self) -> None:
+        tool_configer = ToolConfiger().load_by_configer(self._configer)
+        app_configer = AppConfiger()
+        app_configer.tool_configer_map = {tool_configer.name: tool_configer}
+        ApplicationConfigManager().app_configer = app_configer
+
+        tool = ToolManager().get_instance_obj(tool_configer.name)
+
+        self.assertIsInstance(tool, YahooFinanceTool)
+        self.assertEqual(tool.name, "yahoo_finance_tool")
+        self.assertEqual(tool.component_type, ComponentEnum.TOOL)
+        self.assertEqual(tool.input_keys, ["mode", "symbol"])
+        self.assertEqual(tool.args_model_schema["properties"]["mode"]["enum"],
+                         ["quote", "history", "info"])
+
+    def test_registered_tool_executes_without_network(self) -> None:
+        tool_configer = ToolConfiger().load_by_configer(self._configer)
+        app_configer = AppConfiger()
+        app_configer.tool_configer_map = {tool_configer.name: tool_configer}
+        ApplicationConfigManager().app_configer = app_configer
+
+        tool = ToolManager().get_instance_obj(tool_configer.name)
+        ticker = Mock()
+        ticker.info = {"regularMarketPrice": 150.0, "currency": "USD"}
+        with patch.object(tool, "_get_ticker", return_value=ticker):
+            out = tool.run(mode="quote", symbol="aapl")
+        self.assertIn("AAPL", out)
+        self.assertIn("150.00", out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds the **Yahoo Finance** tool requested in #252 — a market-data tool that fetches the latest quote, historical OHLCV bars, or the company profile for a stock / ETF / index symbol (e.g. `AAPL`, `600519.SS`).

```python
tool = YahooFinanceTool()
tool.execute(mode="quote",   symbol="AAPL")
tool.execute(mode="history", symbol="AAPL", period="3mo", interval="1d")
tool.execute(mode="info",    symbol="TSLA")
```

## Design

- **Three modes** via a single `execute(mode, symbol, period, interval)` entry point:
  - `quote` — latest price, change, % change, volume, market cap, 52w range…
  - `history` — OHLCV bars for a configurable `period` / `interval`, newest-first, capped at `max_history_rows` to keep the agent context compact.
  - `info` — full company profile (name, sector, industry, summary…).
- **Optional dependency, lazily loaded.** Built on `yfinance` (the de-facto Python client for Yahoo Finance data), but `yfinance` is imported inside the methods that need it — so importing the module never requires the dependency, and a missing `yfinance` surfaces a clear `pip install yfinance` hint only when the tool is actually invoked. An agent that never calls the tool pays no install cost.
- **Network isolated from formatting.** The `_fetch_*` helpers (which hit yfinance) are separate from the pure `_format_*` helpers. This makes the component fully unit-testable without a network connection.
- **Robustness.** `@retry` on every fetch, symbols normalized (uppercased/trimmed), empty/invalid inputs and fetch failures return human-readable error strings instead of raising.

## Config

Registered as `yahoo_finance_tool` with `args_model` + `args_model_schema` (mirroring `github_tool`), and exported from `agentuniverse.agent.action.tool.common_tool`.

## Tests

17 deterministic unit tests added under `tests/test_agentuniverse/unit/agent/action/tool/test_yahoo_finance_tool.py`, all green locally. The yfinance layer is mocked, so the suite runs with **no network and no `yfinance` install**:

- pure formatters: quote / history / info (with data, empty, missing fields)
- numeric helpers: compact market-cap suffixes (T/B/M/K), symbol normalization
- `execute` wiring: quote / info (mock ticker), history (end-to-end via a tiny DataFrame stub, incl. newest-first ordering)
- symbol uppercasing before fetch
- invalid mode, missing symbol, missing-`yfinance` install hint, fetch-error surfacing

```
======================== 17 passed, 3 warnings in 0.26s ========================
```

(The warnings are pre-existing pydantic-v2 deprecation notices in the framework, unrelated to this change.)

Partially addresses #252 (Yahoo Finance item).
