### PR TITLE
Fix/pubmed api boundaries

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/pubmed_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/pubmed_tool.py
@@ -3,8 +3,9 @@
 
 """A lightweight PubMed search tool based on NCBI E-utilities."""
 
-from datetime import date
 import re
+from calendar import monthrange
+from datetime import date
 from typing import Any, ClassVar, Dict, List, Optional
 from xml.etree import ElementTree
 
@@ -15,6 +16,10 @@ from agentuniverse.agent.action.tool.tool import Tool
 from agentuniverse.base.util.env_util import get_from_env
 
 
+class _PubMedAPIError(Exception):
+    """Raised when NCBI returns an E-utilities error response."""
+
+
 class PubMedTool(Tool):
     """Search PubMed and return structured article metadata."""
 
@@ -22,6 +27,12 @@ class PubMedTool(Tool):
         "relevance": "relevance",
         "pub_date": "pub_date",
         "publication_date": "pub_date",
+        "author": "author",
+        "journal": "journal",
+    }
+    SORT_API_VALUES: ClassVar[Dict[str, str]] = {
+        "relevance": "relevance",
+        "pub_date": "pub_date",
         "author": "Author",
         "journal": "JournalName",
     }
@@ -36,6 +47,7 @@ class PubMedTool(Tool):
         "crdt": "crdt",
         "create_date": "crdt",
     }
+    MAX_RETSTART: ClassVar[int] = 9998
 
     base_url: str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
     timeout: float = Field(default=15.0, description="HTTP request timeout in seconds")
@@ -70,7 +82,7 @@ class PubMedTool(Tool):
             a structured ``error`` field.
 
         Raises:
-            ValueError: If the query, max_results, page, or sort is invalid.
+            ValueError: If any input parameter is invalid.
         """
         query = query.strip() if isinstance(query, str) else ""
         if not query:
@@ -88,9 +100,13 @@ class PubMedTool(Tool):
         normalized_datetype = self._normalize_datetype(datetype)
         normalized_mindate = self._normalize_date(mindate, "mindate")
         normalized_maxdate = self._normalize_date(maxdate, "maxdate")
+        if bool(normalized_mindate) != bool(normalized_maxdate):
+            raise ValueError("mindate and maxdate must be provided together")
         if self._date_sort_value(normalized_maxdate, upper_bound=True) < self._date_sort_value(normalized_mindate):
             raise ValueError("maxdate must be greater than or equal to mindate")
         retstart = (page - 1) * max_results
+        if retstart > self.MAX_RETSTART:
+            raise ValueError("page and max_results cannot address records beyond PubMed's first 9,999 results")
 
         try:
             search_data = self._search(
@@ -120,6 +136,19 @@ class PubMedTool(Tool):
                 "returned_results": len(papers),
                 "papers": papers,
             }
+        except _PubMedAPIError as exc:
+            return self._error_result(
+                query=query,
+                error_type="api_error",
+                message=str(exc),
+                max_results=max_results,
+                page=page,
+                retstart=retstart,
+                sort=normalized_sort,
+                mindate=normalized_mindate,
+                maxdate=normalized_maxdate,
+                datetype=normalized_datetype,
+            )
         except requests.Timeout:
             return self._error_result(
                 query=query,
@@ -192,7 +221,7 @@ class PubMedTool(Tool):
             "retmode": "json",
             "retmax": max_results,
             "retstart": retstart,
-            "sort": sort,
+            "sort": self.SORT_API_VALUES[sort],
         }
         if mindate or maxdate:
             params["datetype"] = datetype
@@ -207,9 +236,19 @@ class PubMedTool(Tool):
             timeout=self.timeout,
         )
         response.raise_for_status()
-        data = response.json()
-        if not isinstance(data, dict) or not isinstance(data.get("esearchresult"), dict):
+        try:
+            data = response.json(strict=False)
+        except requests.JSONDecodeError as exc:
+            raise ValueError("invalid ESearch JSON response") from exc
+        if not isinstance(data, dict):
+            raise ValueError("invalid ESearch response")
+        if data.get("error"):
+            raise _PubMedAPIError(f"PubMed ESearch error: {data['error']}")
+        search_result = data.get("esearchresult")
+        if not isinstance(search_result, dict):
             raise ValueError("missing esearchresult")
+        if search_result.get("ERROR"):
+            raise _PubMedAPIError(f"PubMed ESearch error: {search_result['ERROR']}")
         return data
 
     @classmethod
@@ -261,8 +300,7 @@ class PubMedTool(Tool):
         if len(parts) > 2:
             day = parts[2]
         elif upper_bound:
-            next_month = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
-            day = (next_month.toordinal() - date(year, month, 1).toordinal())
+            day = monthrange(year, month)[1]
         else:
             day = 1
         return date(year, month, day)
@@ -280,6 +318,10 @@ class PubMedTool(Tool):
         )
         response.raise_for_status()
         root = ElementTree.fromstring(response.content)
+        error = root if root.tag == "ERROR" else root.find(".//ERROR")
+        error_message = self._element_text(error)
+        if error_message:
+            raise _PubMedAPIError(f"PubMed EFetch error: {error_message}")
         return [self._parse_article(article) for article in root.findall(".//PubmedArticle")]
 
     def _common_params(self) -> Dict[str, str]:

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -145,12 +145,14 @@ result = tool.run(
 
 - `query`：必填，PubMed关键词或检索表达式。
 - `max_results`：可选，每页返回的论文数量，范围为1到20，默认为5。
-- `page`：可选，从1开始的页码，默认为1。
+- `page`：可选，从1开始的页码，默认为1。`page`与`max_results`计算得到的范围只能访问PubMed搜索结果的前9,999条，超出范围时工具会在请求前返回参数错误。
 - `sort`：可选，排序方式，可选值为`relevance`、`pub_date`、`author`或`journal`，默认为`relevance`。
-- `mindate`、`maxdate`：可选，日期范围边界，支持`YYYY`、`YYYY-MM`或`YYYY-MM-DD`格式。
+- `mindate`、`maxdate`：可选，日期范围边界，支持`YYYY`、`YYYY-MM`或`YYYY-MM-DD`格式。两个参数必须同时提供；仅提供其中一个时，NCBI不会应用预期的日期范围，因此工具会直接返回参数错误。
 - `datetype`：可选，日期范围所使用的PubMed日期字段，可选值为`pdat`（发表日期）、`edat`（Entrez日期）、`mdat`（修改日期）或`crdt`（创建日期），默认为`pdat`。
 
 返回结果包含查询条件、分页与结果数量信息，以及论文列表。每篇论文可包含PMID、标题、作者、摘要、期刊、期刊ISSN、发布日期、出版物类型、关键词、MeSH主题词、语言、DOI和PubMed页面地址。其中，MeSH主题词同时包含描述词、限定词、唯一标识和主要主题标记。为兼容缺少部分字段的PubMed记录，未提供的单值字段返回空字符串，未提供的多值字段返回空列表。工具仅返回论文元信息，不下载或总结论文全文。
+
+网络超时、HTTP错误和响应解析失败会继续使用结构化`error`字段返回。NCBI在ESearch JSON或EFetch XML中明确报告的服务端错误使用`api_error`类型，并在`message`中保留NCBI返回的错误信息，便于调用方区分“没有搜索结果”和“搜索请求失败”。
 
 可以按需通过环境变量配置`NCBI_EMAIL`和`NCBI_API_KEY`。未配置API Key时，工具仍可正常进行基础检索。
 

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/pubmed_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/pubmed_tool.yaml
@@ -5,12 +5,15 @@ description: |
   Input parameters:
     - query (required): PubMed keywords or a PubMed search expression.
     - max_results (optional): Number of papers to return, from 1 to 20. Defaults to 5.
-    - page (optional): One-based result page. Defaults to 1.
+    - page (optional): One-based result page. Defaults to 1. The page and
+      max_results combination can only address PubMed's first 9,999 results.
     - sort (optional): Result order. One of relevance, pub_date, author, or journal.
       Defaults to relevance.
     - mindate (optional): Earliest date in YYYY, YYYY-MM, or YYYY-MM-DD format.
+      Must be provided together with maxdate.
     - maxdate (optional): Latest date in YYYY, YYYY-MM, or YYYY-MM-DD format.
-    - datetype (optional): Date field used with mindate or maxdate. One of pdat
+      Must be provided together with mindate.
+    - datetype (optional): Date field used with the date range. One of pdat
       (publication), edat (Entrez), mdat (modification), or crdt (creation).
       Defaults to pdat.
 
@@ -27,7 +30,9 @@ description: |
 
   Each result may contain PMID, title, authors, abstract, journal, publication date,
   journal ISSN, publication types, keywords, MeSH terms, languages, DOI, and a
-  PubMed entry URL. This tool does not download or summarize full text.
+  PubMed entry URL. NCBI API failures are returned in a structured error field;
+  errors reported by ESearch or EFetch use the api_error type. This tool does not
+  download or summarize full text.
 tool_type: 'api'
 input_keys: ['query']
 metadata:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_pubmed_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_pubmed_tool.py
@@ -161,6 +161,19 @@ class PubMedToolTest(unittest.TestCase):
         self.assertEqual(mock_get.call_args.kwargs["params"]["sort"], "pub_date")
 
     @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_search_keeps_canonical_sort_values_in_result(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={"esearchresult": {"count": "0", "idlist": []}}
+        )
+
+        for sort, api_value in (("author", "Author"), ("journal", "JournalName")):
+            with self.subTest(sort=sort):
+                result = self.tool.execute(query="AI medicine", sort=sort)
+
+                self.assertEqual(result["sort"], sort)
+                self.assertEqual(mock_get.call_args.kwargs["params"]["sort"], api_value)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
     def test_search_supports_date_range_filters(self, mock_get: Mock) -> None:
         mock_get.return_value = response_mock(
             json_data={"esearchresult": {"count": "0", "idlist": []}}
@@ -182,22 +195,25 @@ class PubMedToolTest(unittest.TestCase):
         self.assertEqual(params["maxdate"], "2024/12/31")
         self.assertEqual(params["datetype"], "pdat")
 
+    def test_search_rejects_incomplete_date_range(self) -> None:
+        for date_filter in ({"mindate": "2024"}, {"maxdate": "2024"}):
+            with self.subTest(date_filter=date_filter):
+                with self.assertRaisesRegex(ValueError, "must be provided together"):
+                    self.tool.execute(query="AI medicine", **date_filter)
+
     @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
-    def test_search_supports_single_date_bound(self, mock_get: Mock) -> None:
+    def test_search_enforces_pubmed_paging_limit(self, mock_get: Mock) -> None:
         mock_get.return_value = response_mock(
-            json_data={"esearchresult": {"count": "0", "idlist": []}}
+            json_data={"esearchresult": {"count": "100000", "idlist": []}}
         )
 
-        result = self.tool.execute(query="AI medicine", mindate="2024", datetype="entrez date")
+        result = self.tool.execute(query="AI medicine", max_results=1, page=9999)
 
-        self.assertEqual(result["mindate"], "2024")
-        self.assertEqual(result["maxdate"], "")
-        self.assertEqual(result["datetype"], "edat")
-
-        params = mock_get.call_args.kwargs["params"]
-        self.assertEqual(params["mindate"], "2024")
-        self.assertNotIn("maxdate", params)
-        self.assertEqual(params["datetype"], "edat")
+        self.assertEqual(result["retstart"], 9998)
+        self.assertEqual(mock_get.call_args.kwargs["params"]["retstart"], 9998)
+        with self.assertRaisesRegex(ValueError, "first 9,999 results"):
+            self.tool.execute(query="AI medicine", max_results=1, page=10000)
+        mock_get.assert_called_once()
 
     @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
     def test_empty_search_does_not_fetch_articles(self, mock_get: Mock) -> None:
@@ -253,6 +269,66 @@ class PubMedToolTest(unittest.TestCase):
 
         self.assertEqual(result["error"]["type"], "request_timeout")
         self.assertEqual(result["papers"], [])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_http_error_returns_structured_error(self, mock_get: Mock) -> None:
+        response = Mock(status_code=429)
+        mock_get.side_effect = requests.HTTPError(response=response)
+
+        result = self.tool.execute(query="cancer")
+
+        self.assertEqual(result["error"]["type"], "http_error")
+        self.assertIn("429", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_connection_error_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.ConnectionError("connection failed")
+
+        result = self.tool.execute(query="cancer")
+
+        self.assertEqual(result["error"]["type"], "request_error")
+        self.assertIn("connection failed", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_esearch_api_errors_return_structured_error(self, mock_get: Mock) -> None:
+        responses = (
+            ({"error": "API rate limit exceeded", "count": "11"}, "API rate limit exceeded"),
+            ({"esearchresult": {"ERROR": "Search backend failed"}}, "Search backend failed"),
+        )
+
+        for response_data, expected_message in responses:
+            with self.subTest(response_data=response_data):
+                mock_get.reset_mock()
+                mock_get.return_value = response_mock(json_data=response_data)
+
+                result = self.tool.execute(query="cancer")
+
+                self.assertEqual(result["error"]["type"], "api_error")
+                self.assertIn(expected_message, result["error"]["message"])
+                mock_get.assert_called_once()
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_efetch_api_error_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = [
+            response_mock(json_data={"esearchresult": {"count": "1", "idlist": ["1"]}}),
+            response_mock(content=b"<eFetchResult><ERROR>Unable to obtain query</ERROR></eFetchResult>"),
+        ]
+
+        result = self.tool.execute(query="cancer")
+
+        self.assertEqual(result["error"]["type"], "api_error")
+        self.assertIn("Unable to obtain query", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
+    def test_invalid_esearch_json_returns_structured_error(self, mock_get: Mock) -> None:
+        response = response_mock()
+        response.json.side_effect = requests.JSONDecodeError("invalid JSON", "", 0)
+        mock_get.return_value = response
+
+        result = self.tool.execute(query="cancer")
+
+        self.assertEqual(result["error"]["type"], "invalid_response")
+        self.assertIn("invalid ESearch JSON response", result["error"]["message"])
 
     def test_missing_extended_metadata_returns_empty_values(self) -> None:
         article = ElementTree.fromstring(
@@ -317,6 +393,13 @@ class PubMedToolTest(unittest.TestCase):
             '"datetype": "pdat"',
         ):
             self.assertIn(example_entry, description)
+        for boundary_contract in (
+            "first 9,999 results",
+            "Must be provided together with maxdate",
+            "Must be provided together with mindate",
+            "api_error",
+        ):
+            self.assertIn(boundary_contract, description)
 
     @patch("agentuniverse.agent.action.tool.common_tool.pubmed_tool.requests.get")
     def test_invalid_xml_returns_structured_error(self, mock_get: Mock) -> None:


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Follow-up to #604. This PR hardens the PubMed tool's boundary handling and aligns its public behavior with the actual NCBI E-utilities API constraints.
- Required `mindate` and `maxdate` to be provided together, preventing incomplete date filters from being silently ignored by NCBI. Added validation to prevent pagination beyond PubMed's first 9,999 accessible search results.
- Kept public sort values canonical as `author` and `journal`, while mapping them to the NCBI request values `Author` and `JournalName`.
- Added structured handling for top-level ESearch errors, `esearchresult.ERROR`, EFetch XML errors, malformed JSON responses, HTTP failures, connection failures, and API rate-limit errors.
- Updated the shipped PubMed tool description and guide to document the date-range requirements, pagination limit, and structured `api_error` responses.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- Test file:
  `tests/test_agentuniverse/unit/agent/action/tool/test_pubmed_tool.py`
- Test command:
  `.\.venv\Scripts\python.exe -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_pubmed_tool -v`
- Test result:
  `Ran 19 tests`
  `OK`
- The tests cover date-range validation, the PubMed paging boundary, canonical sort values, HTTP and connection failures, ESearch API errors, EFetch XML errors, malformed JSON responses, and the shipped YAML contract.
- Test result screenshot:

<img width="788" height="805" alt="image" src="https://github.com/user-attachments/assets/13bacfe6-54a7-4b53-9656-c85db2c792cc" />
<img width="817" height="759" alt="image" src="https://github.com/user-attachments/assets/044e1606-9156-4b3e-b7f7-4adb71c9ee2f" />
<img width="788" height="755" alt="image" src="https://github.com/user-attachments/assets/21ede67d-334e-462d-9cfd-bc58bfbcab54" />


**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md`
- `examples/sample_standard_app/intelligence/agentic/tool/buildin/pubmed_tool.yaml`