### PR TITLE
feat: add Crossref scholarly metadata tool

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/crossref_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/crossref_tool.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""A lightweight scholarly metadata tool based on the Crossref REST API."""
+
+import re
+from html.parser import HTMLParser
+from typing import Any, ClassVar, Dict, List, Optional
+from urllib.parse import quote
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.env_util import get_from_env
+
+
+class _CrossrefAPIError(Exception):
+    """Raised when Crossref returns an API-level error response."""
+
+
+class _MarkupTextExtractor(HTMLParser):
+    """Extract text from HTML or JATS-style abstract markup."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: List[str] = []
+
+    def handle_data(self, data: str) -> None:
+        self.parts.append(data)
+
+    def text(self) -> str:
+        return " ".join(" ".join(self.parts).split())
+
+
+class CrossrefTool(Tool):
+    """Search Crossref works or retrieve one work by DOI."""
+
+    MODES: ClassVar[set[str]] = {"search", "doi"}
+
+    base_url: str = "https://api.crossref.org/v1"
+    timeout: float = Field(default=15.0, description="HTTP request timeout in seconds")
+    email: Optional[str] = Field(default_factory=lambda: get_from_env("CROSSREF_EMAIL"))
+    user_agent: str = "agentUniverse-Crossref-Tool/1.0"
+
+    def execute(
+        self,
+        query: str,
+        mode: str = "search",
+        max_results: int = 5,
+    ) -> Dict[str, Any]:
+        """Search scholarly works or retrieve metadata for a Crossref DOI.
+
+        Args:
+            query: Search keywords in search mode, or a DOI/DOI URL in doi mode.
+            mode: Operation mode. Supports search and doi.
+            max_results: Maximum search results to return, from 1 to 20.
+
+        Returns:
+            A dictionary containing operation context, result counts, and a
+            list of normalized Crossref works. Network and API failures are
+            returned in a structured ``error`` field.
+
+        Raises:
+            ValueError: If query, mode, or max_results is invalid.
+        """
+        normalized_mode = self._normalize_mode(mode)
+        normalized_query = query.strip() if isinstance(query, str) else ""
+        if not normalized_query:
+            raise ValueError("query must not be empty")
+
+        if normalized_mode == "search":
+            self._validate_max_results(max_results)
+            effective_max_results = max_results
+        else:
+            normalized_query = self._normalize_doi(normalized_query)
+            effective_max_results = 1
+
+        try:
+            if normalized_mode == "search":
+                total_results, raw_works = self._search(normalized_query, effective_max_results)
+            else:
+                raw_works = [self._lookup_doi(normalized_query)]
+                total_results = 1
+
+            works = [self._parse_work(work) for work in raw_works]
+            return {
+                "mode": normalized_mode,
+                "query": normalized_query,
+                "max_results": effective_max_results,
+                "total_results": total_results,
+                "returned_results": len(works),
+                "works": works,
+            }
+        except _CrossrefAPIError as exc:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="api_error",
+                message=str(exc),
+            )
+        except requests.Timeout:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="request_timeout",
+                message="Crossref request timed out.",
+            )
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            message = (
+                f"Crossref returned HTTP status {status_code}." if status_code else "Crossref HTTP request failed."
+            )
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="http_error",
+                message=message,
+            )
+        except requests.RequestException as exc:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="request_error",
+                message=f"Crossref request failed: {exc}",
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="invalid_response",
+                message=f"Unable to parse Crossref response: {exc}",
+            )
+
+    def _search(self, query: str, max_results: int) -> tuple[int, List[Dict[str, Any]]]:
+        data = self._request(
+            "/works",
+            params={"query.bibliographic": query, "rows": max_results},
+        )
+        if data.get("message-type") != "work-list":
+            raise ValueError("unexpected message-type for Crossref search")
+
+        message = data.get("message")
+        if not isinstance(message, dict):
+            raise ValueError("missing search message")
+        items = message.get("items")
+        if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
+            raise ValueError("invalid search items")
+        return int(message.get("total-results", 0)), items
+
+    def _lookup_doi(self, doi: str) -> Dict[str, Any]:
+        data = self._request(f"/works/{quote(doi, safe='')}")
+        if data.get("message-type") != "work":
+            raise ValueError("unexpected message-type for Crossref DOI lookup")
+
+        message = data.get("message")
+        if not isinstance(message, dict):
+            raise ValueError("missing DOI message")
+        return message
+
+    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        request_params = dict(params or {})
+        if self.email:
+            request_params["mailto"] = self.email
+
+        response = requests.get(
+            f"{self.base_url}{path}",
+            params=request_params,
+            headers={"User-Agent": self._user_agent_value()},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except requests.JSONDecodeError as exc:
+            raise ValueError("invalid Crossref JSON response") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("invalid Crossref response")
+        if data.get("status") != "ok":
+            message = self._api_error_message(data.get("message"))
+            raise _CrossrefAPIError(f"Crossref API error: {message}")
+        return data
+
+    def _user_agent_value(self) -> str:
+        if self.email:
+            return f"{self.user_agent} (mailto:{self.email})"
+        return self.user_agent
+
+    @classmethod
+    def _normalize_mode(cls, mode: str) -> str:
+        normalized_mode = mode.strip().lower() if isinstance(mode, str) else ""
+        if normalized_mode not in cls.MODES:
+            raise ValueError("mode must be one of: doi, search")
+        return normalized_mode
+
+    @staticmethod
+    def _validate_max_results(max_results: int) -> None:
+        if isinstance(max_results, bool) or not isinstance(max_results, int):
+            raise ValueError("max_results must be an integer between 1 and 20")
+        if not 1 <= max_results <= 20:
+            raise ValueError("max_results must be between 1 and 20")
+
+    @staticmethod
+    def _normalize_doi(value: str) -> str:
+        doi = re.sub(r"^(?:https?://(?:dx\.)?doi\.org/|doi:\s*)", "", value, flags=re.IGNORECASE).strip()
+        if not doi.startswith("10.") or "/" not in doi or any(character.isspace() for character in doi):
+            raise ValueError("query must contain a valid DOI in doi mode")
+        return doi
+
+    @classmethod
+    def _parse_work(cls, work: Dict[str, Any]) -> Dict[str, Any]:
+        doi = cls._string_value(work.get("DOI"))
+        url = cls._string_value(work.get("URL"))
+        if not url and doi:
+            url = f"https://doi.org/{quote(doi, safe='/')}"
+
+        return {
+            "doi": doi,
+            "title": cls._first_text(work.get("title")),
+            "authors": cls._authors(work.get("author")),
+            "abstract": cls._markup_text(work.get("abstract")),
+            "container_title": cls._first_text(work.get("container-title")),
+            "published": cls._published_date(work.get("published")),
+            "publisher": cls._string_value(work.get("publisher")),
+            "type": cls._string_value(work.get("type")),
+            "url": url,
+        }
+
+    @classmethod
+    def _authors(cls, value: Any) -> List[str]:
+        if not isinstance(value, list):
+            return []
+
+        authors = []
+        for author in value:
+            if not isinstance(author, dict):
+                continue
+            given = cls._string_value(author.get("given"))
+            family = cls._string_value(author.get("family"))
+            full_name = " ".join(part for part in (given, family) if part)
+            if not full_name:
+                full_name = cls._string_value(author.get("name"))
+            if full_name:
+                authors.append(full_name)
+        return authors
+
+    @staticmethod
+    def _markup_text(value: Any) -> str:
+        if not isinstance(value, str) or not value.strip():
+            return ""
+        parser = _MarkupTextExtractor()
+        parser.feed(value)
+        parser.close()
+        return parser.text()
+
+    @staticmethod
+    def _published_date(value: Any) -> str:
+        if not isinstance(value, dict):
+            return ""
+        date_parts = value.get("date-parts")
+        if not isinstance(date_parts, list) or not date_parts or not isinstance(date_parts[0], list):
+            return ""
+
+        parts = date_parts[0][:3]
+        if not parts or not all(isinstance(part, int) and not isinstance(part, bool) for part in parts):
+            return ""
+        return "-".join(str(part).zfill(2) if index else str(part).zfill(4) for index, part in enumerate(parts))
+
+    @classmethod
+    def _first_text(cls, value: Any) -> str:
+        if isinstance(value, str):
+            return cls._markup_text(value)
+        if isinstance(value, list):
+            for item in value:
+                text = cls._markup_text(item)
+                if text:
+                    return text
+        return ""
+
+    @staticmethod
+    def _string_value(value: Any) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
+    @staticmethod
+    def _api_error_message(value: Any) -> str:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, list):
+            messages = []
+            for item in value:
+                if isinstance(item, dict) and isinstance(item.get("message"), str):
+                    messages.append(item["message"].strip())
+                elif item is not None:
+                    messages.append(str(item))
+            if messages:
+                return "; ".join(message for message in messages if message)
+        return "unknown Crossref API error"
+
+    @staticmethod
+    def _error_result(
+        mode: str,
+        query: str,
+        max_results: int,
+        error_type: str,
+        message: str,
+    ) -> Dict[str, Any]:
+        return {
+            "mode": mode,
+            "query": query,
+            "max_results": max_results,
+            "total_results": 0,
+            "returned_results": 0,
+            "works": [],
+            "error": {"type": error_type, "message": message},
+        }

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -154,6 +154,56 @@ result = tool.run(
 
 可以按需通过环境变量配置`NCBI_EMAIL`和`NCBI_API_KEY`。未配置API Key时，工具仍可正常进行基础检索。
 
+### 1.5 Crossref学术元数据查询
+
+Crossref工具通过Crossref REST API跨学科检索学术成果，或根据DOI精确查询出版元数据。公共API无需注册即可使用。
+
+工具配置：
+
+```yaml
+name: 'crossref_tool'
+description: |
+  Search Crossref for scholarly works or retrieve one work by DOI.
+tool_type: 'api'
+input_keys: ['query']
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.crossref_tool'
+  class: 'CrossrefTool'
+```
+
+关键词搜索示例：
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj('crossref_tool')
+result = tool.run(
+    query='large language models in medicine',
+    mode='search',
+    max_results=5,
+)
+```
+
+DOI查询示例：
+
+```python
+result = tool.run(
+    query='https://doi.org/10.1128/mbio.01735-25',
+    mode='doi',
+)
+```
+
+参数说明：
+
+- `query`：必填。`search`模式下为检索关键词，`doi`模式下为DOI、`doi:`前缀形式或DOI URL。
+- `mode`：可选，可选值为`search`或`doi`，默认为`search`。
+- `max_results`：可选，仅用于`search`模式，范围为1到20，默认为5。`doi`模式最多返回一条记录。
+
+返回结果包含操作模式、查询内容、结果数量和`works`列表。每条记录可包含DOI、标题、作者、摘要、期刊或会议名称、出版日期、出版商、文献类型和URL。Crossref元数据由出版机构提交，不同记录的完整度可能不同；缺失的单值字段返回空字符串，缺失的多值字段返回空列表。工具仅返回元数据，不下载或总结全文。
+
+网络超时、HTTP错误、连接失败、非法JSON和Crossref API错误会通过结构化`error`字段返回。可以通过环境变量`CROSSREF_EMAIL`提供联系邮箱，进入Crossref polite pool并在请求中携带可识别的User-Agent。
+
 
 ## 2. 代码工具
 

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/crossref_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/crossref_tool.yaml
@@ -1,0 +1,35 @@
+name: 'crossref_tool'
+description: |
+  Search Crossref for scholarly works or retrieve one work by DOI.
+
+  Input parameters:
+    - query (required): Search keywords in search mode, or a DOI/DOI URL in doi mode.
+    - mode (optional): Operation mode. Use search for keyword search or doi for an
+      exact DOI lookup. Defaults to search.
+    - max_results (optional): Number of works to return in search mode, from 1 to 20.
+      Defaults to 5. DOI mode always returns at most one work.
+
+  Search example:
+    {
+      "query": "large language models in medicine",
+      "mode": "search",
+      "max_results": 5
+    }
+
+  DOI lookup example:
+    {
+      "query": "https://doi.org/10.1128/mbio.01735-25",
+      "mode": "doi"
+    }
+
+  Each work may contain DOI, title, authors, abstract, container title, publication date,
+  publisher, work type, and URL. Missing metadata is returned as an empty string or list.
+  Network and Crossref API failures are returned in a structured error field. Set the
+  optional CROSSREF_EMAIL environment variable to use the Crossref polite pool. This tool
+  returns metadata only and does not download or summarize full text.
+tool_type: 'api'
+input_keys: ['query']
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.crossref_tool'
+  class: 'CrossrefTool'

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_crossref_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_crossref_tool.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import requests
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool.crossref_tool import CrossrefTool
+
+
+SAMPLE_WORK = {
+    "DOI": "10.1000/example",
+    "title": ["Example <i>scholarly</i> work"],
+    "author": [
+        {"given": "Alice", "family": "Smith"},
+        {"name": "Example Research Consortium"},
+    ],
+    "abstract": "<jats:p>Useful <jats:bold>abstract</jats:bold> text.</jats:p>",
+    "container-title": ["Example Journal"],
+    "published": {"date-parts": [[2025, 8, 13]]},
+    "publisher": "Example Publisher",
+    "type": "journal-article",
+    "URL": "https://doi.org/10.1000/example",
+}
+
+
+def response_mock(*, json_data=None):
+    response = Mock()
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+class CrossrefToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = CrossrefTool(email="developer@example.com")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_search_returns_structured_metadata(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {"total-results": 42, "items": [SAMPLE_WORK]},
+            }
+        )
+
+        result = self.tool.execute(query="AI medicine", max_results=3)
+
+        self.assertEqual(result["mode"], "search")
+        self.assertEqual(result["query"], "AI medicine")
+        self.assertEqual(result["max_results"], 3)
+        self.assertEqual(result["total_results"], 42)
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(
+            result["works"][0],
+            {
+                "doi": "10.1000/example",
+                "title": "Example scholarly work",
+                "authors": ["Alice Smith", "Example Research Consortium"],
+                "abstract": "Useful abstract text.",
+                "container_title": "Example Journal",
+                "published": "2025-08-13",
+                "publisher": "Example Publisher",
+                "type": "journal-article",
+                "url": "https://doi.org/10.1000/example",
+            },
+        )
+
+        request = mock_get.call_args
+        self.assertEqual(request.args[0], "https://api.crossref.org/v1/works")
+        self.assertEqual(request.kwargs["params"]["query.bibliographic"], "AI medicine")
+        self.assertEqual(request.kwargs["params"]["rows"], 3)
+        self.assertEqual(request.kwargs["params"]["mailto"], "developer@example.com")
+        self.assertIn("mailto:developer@example.com", request.kwargs["headers"]["User-Agent"])
+        self.assertEqual(request.kwargs["timeout"], 15.0)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_doi_lookup_normalizes_url_and_returns_one_work(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work",
+                "message": SAMPLE_WORK,
+            }
+        )
+
+        result = self.tool.execute(
+            query="https://doi.org/10.1000/example",
+            mode="DOI",
+            max_results=20,
+        )
+
+        self.assertEqual(result["mode"], "doi")
+        self.assertEqual(result["query"], "10.1000/example")
+        self.assertEqual(result["max_results"], 1)
+        self.assertEqual(result["total_results"], 1)
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(result["works"][0]["doi"], "10.1000/example")
+        self.assertEqual(
+            mock_get.call_args.args[0],
+            "https://api.crossref.org/v1/works/10.1000%2Fexample",
+        )
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_empty_search_returns_no_works(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {"total-results": 0, "items": []},
+            }
+        )
+
+        result = self.tool.execute(query="no matching work")
+
+        self.assertEqual(result["total_results"], 0)
+        self.assertEqual(result["returned_results"], 0)
+        self.assertEqual(result["works"], [])
+
+    def test_invalid_input(self) -> None:
+        with self.assertRaisesRegex(ValueError, "query must not be empty"):
+            self.tool.execute(query="  ")
+        with self.assertRaisesRegex(ValueError, "mode must be one of"):
+            self.tool.execute(query="AI", mode="detail")
+        with self.assertRaisesRegex(ValueError, "between 1 and 20"):
+            self.tool.execute(query="AI", max_results=0)
+        with self.assertRaisesRegex(ValueError, "integer"):
+            self.tool.execute(query="AI", max_results=True)
+        with self.assertRaisesRegex(ValueError, "valid DOI"):
+            self.tool.execute(query="not-a-doi", mode="doi")
+
+    def test_missing_metadata_returns_empty_values(self) -> None:
+        work = CrossrefTool._parse_work({"DOI": "10.1000/minimal"})
+
+        self.assertEqual(work["doi"], "10.1000/minimal")
+        self.assertEqual(work["title"], "")
+        self.assertEqual(work["authors"], [])
+        self.assertEqual(work["abstract"], "")
+        self.assertEqual(work["container_title"], "")
+        self.assertEqual(work["published"], "")
+        self.assertEqual(work["publisher"], "")
+        self.assertEqual(work["type"], "")
+        self.assertEqual(work["url"], "https://doi.org/10.1000/minimal")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_timeout_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.Timeout("timed out")
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "request_timeout")
+        self.assertEqual(result["works"], [])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_http_error_returns_structured_error(self, mock_get: Mock) -> None:
+        response = Mock(status_code=429)
+        mock_get.side_effect = requests.HTTPError(response=response)
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "http_error")
+        self.assertIn("429", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_connection_error_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.ConnectionError("connection failed")
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "request_error")
+        self.assertIn("connection failed", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_api_error_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "failed",
+                "message-type": "validation-failure",
+                "message": [{"message": "Invalid query parameter"}],
+            }
+        )
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "api_error")
+        self.assertIn("Invalid query parameter", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_invalid_json_returns_structured_error(self, mock_get: Mock) -> None:
+        response = response_mock()
+        response.json.side_effect = requests.JSONDecodeError("invalid JSON", "", 0)
+        mock_get.return_value = response
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "invalid_response")
+        self.assertIn("invalid Crossref JSON response", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_invalid_message_shape_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {"total-results": 1, "items": "not-a-list"},
+            }
+        )
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "invalid_response")
+        self.assertIn("invalid search items", result["error"]["message"])
+
+    def test_shipped_config_exposes_modes_and_metadata(self) -> None:
+        config_path = (
+            Path(__file__).resolve().parents[6]
+            / "examples"
+            / "sample_standard_app"
+            / "intelligence"
+            / "agentic"
+            / "tool"
+            / "buildin"
+            / "crossref_tool.yaml"
+        )
+        with config_path.open(encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file)
+
+        self.assertEqual(config["input_keys"], ["query"])
+        description = config["description"]
+        for parameter in ("query", "mode", "max_results"):
+            self.assertIn(parameter, description)
+        for mode in ("search", "doi"):
+            self.assertIn(mode, description)
+        for metadata_field in (
+            "DOI",
+            "title",
+            "authors",
+            "abstract",
+            "container title",
+            "publication date",
+            "publisher",
+            "work type",
+            "URL",
+        ):
+            self.assertIn(metadata_field, description)
+        self.assertIn("CROSSREF_EMAIL", description)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [x] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Refs #252. This PR adds a Crossref scholarly metadata tool for cross-disciplinary academic work discovery and DOI-based metadata lookup.
- Added `search` mode for keyword-based scholarly work searches and `doi` mode for exact DOI lookup, including support for DOI strings, `doi:` prefixes, and DOI URLs.
- Added normalized metadata parsing for DOI, title, authors, abstract, container title, publication date, publisher, work type, and URL, with safe handling for missing metadata and JATS/HTML markup.
- Added optional `CROSSREF_EMAIL` support for the Crossref polite pool and an identifiable User-Agent.
- Added structured handling for request timeouts, HTTP failures, connection failures, malformed JSON, invalid response structures, and Crossref API errors.
- Added shipped YAML configuration, keyword search and DOI lookup examples, Chinese usage documentation, and focused unit coverage.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- Test file:
  `tests/test_agentuniverse/unit/agent/action/tool/test_crossref_tool.py`
- Test command:
  `.\.venv\Scripts\python.exe -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_crossref_tool -v`
- Test result:
  `Ran 12 tests`
  `OK`
- The tests cover keyword search, DOI lookup and normalization, metadata parsing, missing fields, input validation, timeout, HTTP and connection errors, Crossref API errors, malformed JSON, invalid response structures, and the shipped YAML contract.
- Manual verification was also completed against the live Crossref API for both keyword search and DOI lookup.
- Test result screenshot:

<img width="794" height="552" alt="image" src="https://github.com/user-attachments/assets/9f315e9c-4694-4d26-ad62-7c055d78687b" />
<img width="800" height="811" alt="image" src="https://github.com/user-attachments/assets/785b5347-f104-43cc-a5fb-f65dc736b584" />
<img width="787" height="872" alt="image" src="https://github.com/user-attachments/assets/fbfd85b2-18fc-4b74-ac35-1118a94c36be" />


**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md`
- `examples/sample_standard_app/intelligence/agentic/tool/buildin/crossref_tool.yaml`