### PR TITLE
fix(tool): accept ToolInput in command tools

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/command_status_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/command_status_tool.py
@@ -12,7 +12,9 @@ from agentuniverse.agent.action.tool.common_tool.run_command_tool import get_com
 
 
 class CommandStatusTool(Tool):
-    def execute(self, thread_id: int) -> str:
+    def execute(self, thread_id: int | ToolInput) -> str:
+        if isinstance(thread_id, ToolInput):
+            thread_id = thread_id.get_data("thread_id")
         if isinstance(thread_id, str) and thread_id.isdigit():
             thread_id = int(thread_id)
 

--- a/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
@@ -75,7 +75,13 @@ class RunCommandTool(Tool):
     Tool for executing shell commands either synchronously or asynchronously.
     """
 
-    def execute(self, command: str, cwd: str, blocking: bool = True) -> str:
+    def execute(self, command: str | ToolInput, cwd: str = None, blocking: bool = True) -> str:
+        if isinstance(command, ToolInput):
+            params = command.to_dict()
+            cwd = params.get("cwd", cwd)
+            blocking = params.get("blocking", blocking)
+            command = params.get("command")
+        cwd = cwd or os.getcwd()
         return self._run_command(command, cwd, blocking)
 
     def _run_command(self, command: str, cwd: str, blocking: bool = True) -> str:
@@ -87,7 +93,12 @@ class RunCommandTool(Tool):
             start_time=time.time(),
         )
 
+        thread_started = threading.Event()
+
         def __run() -> None:
+            result.thread_id = threading.get_ident()
+            _command_results[result.thread_id] = result
+            thread_started.set()
             try:
                 process = subprocess.Popen(
                     command,
@@ -119,8 +130,7 @@ class RunCommandTool(Tool):
         else:
             thread = threading.Thread(target=__run)
             thread.start()
-            result.thread_id = thread.ident
-            _command_results[result.thread_id] = result
+            thread_started.wait()
 
         return result.message
 

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
@@ -8,6 +8,7 @@
 
 import os
 import json
+import sys
 import time
 import unittest
 
@@ -47,7 +48,7 @@ class CommandStatusToolTest(unittest.TestCase):
 
     def test_running_command_status(self):
         tool_input = ToolInput({
-            'command': 'sleep 2 && echo "Long running command finished"',
+            'command': f'"{sys.executable}" -c "import time; time.sleep(2); print(\'Long running command finished\')"',
             'cwd': os.getcwd(),
             'blocking': False
         })

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
@@ -10,6 +10,7 @@ import unittest
 import time
 import json
 import os
+import sys
 from agentuniverse.agent.action.tool.common_tool.run_command_tool import (
     RunCommandTool,
     CommandStatus,
@@ -50,7 +51,7 @@ class RunCommandToolTest(unittest.TestCase):
     def test_nonblocking_command_execution(self) -> None:
         """Test asynchronous command execution"""
         tool_input = ToolInput({
-            'command': 'sleep 1 && echo "Async Test"',
+            'command': f'"{sys.executable}" -c "import time; time.sleep(1); print(\'Async Test\')"',
             'cwd': os.getcwd(),
             'blocking': False
         })
@@ -91,7 +92,7 @@ class RunCommandToolTest(unittest.TestCase):
     def test_command_output_escaping(self) -> None:
         """Test that special characters in command output are properly escaped"""
         tool_input = ToolInput({
-            'command': 'echo "Line 1\nLine 2\tTabbed\r\nWindows\\"Quote\\""',
+            'command': f'"{sys.executable}" -c "import sys; sys.stdout.write(\'Line 1\\\\nLine 2\\\\tTabbed\\\\r\\\\nWindows\' + chr(34) + \'Quote\' + chr(34))"',
             'cwd': os.getcwd(),
             'blocking': True
         })


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 非必要，本次未修改文档。
- [ ] I have added examples and notes if needed. | 非必要，本次未新增示例。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

This PR makes `RunCommandTool` and `CommandStatusTool` accept `ToolInput` when invoked directly.

Changes:
- Parse `ToolInput` in `RunCommandTool.execute()`.
- Parse `ToolInput` in `CommandStatusTool.execute()`.
- Default command `cwd` to the current working directory when omitted.
- Register non-blocking command status under the worker thread id before returning.
- Make command-tool tests use portable Python commands instead of shell-specific `sleep`.

**Please provide the path of test files and submit screenshots or files of the test results:** | **请填写测试文件路径并提供测试结果截图或文件:**

Test files:
- `tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py`
- `tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py`

Checks:
```text
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py -q
python -m py_compile agentuniverse/agent/action/tool/common_tool/run_command_tool.py agentuniverse/agent/action/tool/common_tool/command_status_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
git diff --check