### PR TITLE
fix(tool): accept ToolInput in arxiv tool

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
@@ -34,7 +34,15 @@ class ArxivTool(Tool):
     sch_engine: Optional[Any] = None
     MAX_QUERY_LENGTH: int = Field(default=300, description="查询字符串最大长度")
 
-    def execute(self, input: str, mode: str):
+    def execute(self, input: str | ToolInput, mode: str = None):
+        if isinstance(input, ToolInput):
+            params = input.to_dict()
+            mode = params.get("mode", mode)
+            input = params.get("input")
+
+        if mode not in [m.value for m in SearchMode]:
+            raise ValueError(f"Invalid mode: {mode}. Must be one of {[m.value for m in SearchMode]}")
+
         try:
             import arxiv
         except ImportError:
@@ -42,9 +50,6 @@ class ArxivTool(Tool):
 
         if self.sch_engine is None:
             self.sch_engine = arxiv.Client()
-
-        if mode not in [m.value for m in SearchMode]:
-            raise ValueError(f"Invalid mode: {mode}. Must be one of {[m.value for m in SearchMode]}")
 
         query = input
         return (self.find_papers_by_str(query) if mode == SearchMode.SEARCH.value

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
@@ -7,8 +7,15 @@
 # @FileName: test_arxiv_tool.py
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from agentuniverse.agent.action.tool.common_tool.arxiv_tool import ArxivTool, SearchMode
 from agentuniverse.agent.action.tool.tool import ToolInput
+
+
+class FakeArxivClient:
+    pass
 
 
 class ArxivToolTest(unittest.TestCase):
@@ -24,16 +31,28 @@ class ArxivToolTest(unittest.TestCase):
             'input': 'machine learning',
             'mode': SearchMode.SEARCH.value
         })
-        result = self.tool.execute(tool_input)
+        fake_arxiv = SimpleNamespace(Client=FakeArxivClient)
+        with patch.dict("sys.modules", {"arxiv": fake_arxiv}):
+            with patch.object(ArxivTool, "find_papers_by_str",
+                              autospec=True,
+                              return_value="search results") as mock_search:
+                result = self.tool.execute(tool_input)
         self.assertTrue(result!= "")
+        mock_search.assert_called_once_with(self.tool, "machine learning")
 
     def test_get_paper_detail(self) -> None:
         tool_input = ToolInput({
             'input': '1605.08386v1',
             'mode': SearchMode.DETAIL.value
         })
-        result = self.tool.execute(tool_input)
+        fake_arxiv = SimpleNamespace(Client=FakeArxivClient)
+        with patch.dict("sys.modules", {"arxiv": fake_arxiv}):
+            with patch.object(ArxivTool, "retrieve_full_paper_text",
+                              autospec=True,
+                              return_value="paper detail") as mock_detail:
+                result = self.tool.execute(tool_input)
         self.assertTrue(result!= "")
+        mock_detail.assert_called_once_with(self.tool, "1605.08386v1")
 
     def test_invalid_mode(self) -> None:
         tool_input = ToolInput({


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for duplicate work.
- [x] I accept maintainer suggestions to modify or close this PR.
- [x] I have submitted the test files and test results.
- [ ] Documentation change is not needed for this fix.
- [ ] Example change is not needed for this fix.

**Please fill in the specific details of this PR:**

This PR makes `ArxivTool` accept `ToolInput` when invoked directly and validates the requested mode before importing the optional `arxiv` dependency.

Changes:
- Parse `input` and `mode` from `ToolInput`.
- Validate invalid mode early and raise `ValueError`.
- Keep the optional `arxiv` dependency import only for valid execution paths.
- Update tests to mock the arxiv client and avoid real network calls.

**Please provide the path of test files and submit screenshots or files of the test results:**

Test file:
- `tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py`

Checks:
```text
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py -q
python -m py_compile agentuniverse/agent/action/tool/common_tool/arxiv_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
git diff --check