### PR TITLE
fix(tool): validate word file extension first

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/write_word_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_word_tool.py
@@ -7,6 +7,11 @@ from agentuniverse.agent.action.tool.tool import Tool
 
 class WriteWordDocumentTool(Tool):
     def execute(self, file_path: str, content: str = "", append: bool = False) -> str:
+        if not file_path.lower().endswith(".docx"):
+            return json.dumps(
+                {"error": "The target file must have a .docx extension.", "file_path": file_path, "status": "error"}
+            )
+
         directory = os.path.dirname(file_path)
         if directory and not os.path.exists(directory):
             try:
@@ -25,11 +30,6 @@ class WriteWordDocumentTool(Tool):
                     "file_path": file_path,
                     "status": "error",
                 }
-            )
-
-        if not file_path.lower().endswith(".docx"):
-            return json.dumps(
-                {"error": "The target file must have a .docx extension.", "file_path": file_path, "status": "error"}
             )
 
         document = None

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_write_word_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_write_word_tool.py
@@ -1,8 +1,11 @@
 import os
 import json
+import importlib.util
 import tempfile
 import unittest
 from agentuniverse.agent.action.tool.common_tool.write_word_tool import WriteWordDocumentTool
+
+DOCX_AVAILABLE = importlib.util.find_spec("docx") is not None
 
 
 class WriteWordDocumentToolTest(unittest.TestCase):
@@ -18,6 +21,7 @@ class WriteWordDocumentToolTest(unittest.TestCase):
                 os.rmdir(os.path.join(root, name))
         os.rmdir(self.temp_dir)
 
+    @unittest.skipUnless(DOCX_AVAILABLE, "python-docx is required")
     def test_write_new_word_file(self):
         file_path = os.path.join(self.temp_dir, "test_new.docx")
         content = "***This is a test paragraph.***"
@@ -29,6 +33,7 @@ class WriteWordDocumentToolTest(unittest.TestCase):
         self.assertEqual(result["file_path"], file_path)
         self.assertTrue(os.path.exists(file_path))
 
+    @unittest.skipUnless(DOCX_AVAILABLE, "python-docx is required")
     def test_append_to_word_file(self):
         file_path = os.path.join(self.temp_dir, "test_append.docx")
 
@@ -52,6 +57,7 @@ class WriteWordDocumentToolTest(unittest.TestCase):
         self.assertEqual(result["status"], "error")
         self.assertIn("The target file must have a .docx extension.", result["error"])
 
+    @unittest.skipUnless(DOCX_AVAILABLE, "python-docx is required")
     def test_create_directory_structure(self):
         file_path = os.path.join(self.temp_dir, "nested/dir/structure/test.docx")
         content = "Test content in nested directory."


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for duplicate work.
- [x] I accept maintainer suggestions to modify or close this PR.
- [x] I have submitted the test files and test results.
- [ ] Documentation change is not needed for this fix.
- [ ] Example change is not needed for this fix.

**Please fill in the specific details of this PR:**

This PR improves `WriteWordDocumentTool` validation order.

Previously, invalid file extensions could report a missing `python-docx` dependency before reporting that the target file was not a `.docx` file. This PR validates the file extension first, so users get the direct input error before optional dependency checks.

Changes:
- Validate `.docx` extension before importing `python-docx`.
- Keep the existing missing dependency error for valid `.docx` paths.
- Skip dependency-required tests when `python-docx` is not installed.
- Keep extension validation test runnable without `python-docx`.

**Please provide the path of test files and submit screenshots or files of the test results:**

Test file:
- `tests/test_agentuniverse/unit/agent/action/tool/test_write_word_tool.py`

Checks:
```text
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_write_word_tool.py -q
python -m py_compile agentuniverse/agent/action/tool/common_tool/write_word_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_write_word_tool.py
git diff --check