### PR TITLE
fix(tool): lazy load YouTube API dependency

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/youtube_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/youtube_tool.py
@@ -11,9 +11,13 @@ from pydantic import Field
 from agentuniverse.agent.action.tool.tool import Tool
 from agentuniverse.base.annotation.retry import retry
 from agentuniverse.base.util.env_util import get_from_env
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 import re
+
+try:
+    from googleapiclient.errors import HttpError
+except ImportError:
+    class HttpError(Exception):
+        """Fallback used when google-api-python-client is not installed."""
 
 service_name = "youtube"
 api_version = "v3"
@@ -33,6 +37,13 @@ class YouTubeTool(Tool):
         if not self.api_key:
             raise ValueError("YouTube API key not provided, please set the YOUTUBE_API_KEY environment variable.")
         if self.service is None:
+            try:
+                from googleapiclient.discovery import build
+            except ImportError as e:
+                raise ImportError(
+                    "google-api-python-client is required. "
+                    "Install with: pip install google-api-python-client"
+                ) from e
             self.service = build(service_name, api_version, developerKey=self.api_key)
         return self.service
 

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
@@ -7,16 +7,111 @@
 # @FileName: test_youtube_tool.py
 
 import unittest
-import os
 from agentuniverse.agent.action.tool.common_tool.youtube_tool import YouTubeTool, Mode
 from agentuniverse.agent.action.tool.tool import ToolInput
+
+
+class FakeRequest:
+    def __init__(self, response):
+        self.response = response
+
+    def execute(self):
+        return self.response
+
+
+class FakeSearchResource:
+    def list(self, **kwargs):
+        return FakeRequest({
+            "items": [{"id": {"videoId": "video-1"}}]
+        })
+
+
+class FakeVideosResource:
+    def list(self, **kwargs):
+        if kwargs.get("chart") == "mostPopular":
+            return FakeRequest({
+                "items": [{
+                    "id": "trending-1",
+                    "snippet": {
+                        "title": "Trending video",
+                        "channelTitle": "Test channel",
+                        "publishedAt": "2026-07-12T00:00:00Z",
+                    },
+                    "statistics": {
+                        "viewCount": "100",
+                        "likeCount": "10",
+                        "commentCount": "1",
+                    },
+                    "contentDetails": {"duration": "PT1M30S"},
+                }]
+            })
+        return FakeRequest({
+            "items": [{
+                "id": "video-1",
+                "snippet": {"title": "Machine learning video"},
+                "statistics": {
+                    "viewCount": "100",
+                    "likeCount": "10",
+                    "commentCount": "1",
+                },
+                "contentDetails": {"duration": "PT2M"},
+            }]
+        })
+
+
+class FakeChannelsResource:
+    def list(self, **kwargs):
+        return FakeRequest({
+            "items": [{
+                "snippet": {
+                    "title": "Google Developers",
+                    "description": "Developer videos",
+                },
+                "statistics": {
+                    "subscriberCount": "1000",
+                    "viewCount": "2000",
+                    "videoCount": "3",
+                },
+                "contentDetails": {
+                    "relatedPlaylists": {"uploads": "uploads-playlist"}
+                },
+            }]
+        })
+
+
+class FakePlaylistItemsResource:
+    def list(self, **kwargs):
+        return FakeRequest({
+            "items": [{
+                "contentDetails": {"videoId": "upload-1"},
+                "snippet": {
+                    "title": "Latest upload",
+                    "publishedAt": "2026-07-12T00:00:00Z",
+                },
+            }]
+        })
+
+
+class FakeYouTubeService:
+    def search(self):
+        return FakeSearchResource()
+
+    def videos(self):
+        return FakeVideosResource()
+
+    def channels(self):
+        return FakeChannelsResource()
+
+    def playlistItems(self):
+        return FakePlaylistItemsResource()
+
 
 class YouTubeToolTest(unittest.TestCase):
     """
     Test cases for YouTubeTool class
     """
     def setUp(self) -> None:
-        self.tool = YouTubeTool()
+        self.tool = YouTubeTool(service=FakeYouTubeService(), api_key="test-key")
     
     def test_search_videos(self) -> None:
         tool_input = ToolInput({


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for duplicate work.
- [x] I accept maintainer suggestions to modify or close this PR.
- [x] I have submitted the test files and test results.
- [ ] Documentation change is not needed for this fix.
- [ ] Example change is not needed for this fix.

**Please fill in the specific details of this PR:**

This PR makes `YouTubeTool` import optional YouTube API dependencies lazily.

Previously, importing `youtube_tool.py` required `googleapiclient` immediately. In environments without `google-api-python-client`, the module failed during import or test collection even if the tool was not used. This PR moves the dependency import into service initialization and returns a clear dependency error only when the tool is actually used.

Changes:
- Lazy-load `googleapiclient.discovery.build` in `_initialize_service()`.
- Provide a fallback `HttpError` class when `googleapiclient` is not installed.
- Update tests to use a fake YouTube service instead of real API calls.
- Keep search, channel info, and trending video behavior covered.

**Please provide the path of test files and submit screenshots or files of the test results:**

Test file:
- `tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py`

Checks:
```text
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py -q
python -m py_compile agentuniverse/agent/action/tool/common_tool/youtube_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
git diff --check