### PR TITLE
fix(tool): guard readimage optional dependencies

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/readimage_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/readimage_tool.py
@@ -6,18 +6,44 @@
 # @Email   : zhangdongxu0852@163.com
 # @FileName: readimage_tool.py
 
-import cv2
-import pytesseract
-from PIL import Image
-import numpy as np
 import re
 import os
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
+try:
+    import pytesseract
+except ImportError:
+    pytesseract = None
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+
+def _require_dependency(dependency, package_name: str):
+    if dependency is None:
+        raise ImportError(
+            f"{package_name} is required for readimage_tool. "
+            f"Install it before using image OCR features."
+        )
+
 
 def enhance_image(image):
     """
     Enhance the image: convert to grayscale, apply CLAHE for contrast enhancement,
     then apply bilateral filtering to reduce noise while preserving edges.
     """
+    _require_dependency(cv2, "opencv-python")
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
     enhanced = clahe.apply(gray)
@@ -30,6 +56,8 @@ def detect_text_regions(image, east_model='frozen_east_text_detection.pb', min_c
     Detect text regions in the image using the EAST text detection model.
     Returns a list of image regions (as numpy arrays) corresponding to text areas.
     """
+    _require_dependency(cv2, "opencv-python")
+    _require_dependency(np, "numpy")
     # Load the EAST model
     net = cv2.dnn.readNet(east_model)
     orig = image.copy()
@@ -102,6 +130,8 @@ def ocr_on_regions(regions, lang='chi_sim+eng'):
     """
     Perform OCR on each text region separately and concatenate the results.
     """
+    _require_dependency(Image, "Pillow")
+    _require_dependency(pytesseract, "pytesseract")
     texts = []
     config = "--oem 3 --psm 6"
     for region in regions:
@@ -132,6 +162,9 @@ def extract_text_from_image(image_path, use_east=True, lang='chi_sim+eng'):
       - If use_east is True, use the EAST model to detect text regions and perform OCR on each region.
       - Otherwise, perform OCR on the enhanced whole image.
     """
+    _require_dependency(cv2, "opencv-python")
+    _require_dependency(Image, "Pillow")
+    _require_dependency(pytesseract, "pytesseract")
     # Read image using IMREAD_UNCHANGED to support any image format
     image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
     if image is None:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
@@ -6,20 +6,44 @@
 # @Email   : zhangdongxu0852@163.com
 # @FileName: test_readimage_tool.py
 import os
-import cv2
-import numpy as np
+import importlib.util
 import unittest
-from readimage_tool import (enhance_image, detect_text_regions, ocr_on_regions,
-                            clean_extracted_text, save_text_to_file, extract_text_from_image)
+
+HAS_CV_DEPS = (
+    importlib.util.find_spec("cv2") is not None
+    and importlib.util.find_spec("numpy") is not None
+)
+HAS_OCR_DEPS = (
+    HAS_CV_DEPS
+    and importlib.util.find_spec("PIL") is not None
+    and importlib.util.find_spec("pytesseract") is not None
+)
+
+if HAS_CV_DEPS:
+    import cv2
+    import numpy as np
+else:
+    cv2 = None
+    np = None
+
+from agentuniverse.agent.action.tool.common_tool.readimage_tool import (
+    clean_extracted_text,
+    detect_text_regions,
+    enhance_image,
+    extract_text_from_image,
+    save_text_to_file,
+)
 
 class TestReadImageTool(unittest.TestCase):
     def setUp(self):
-        # Create a simple color test image (100x100 pixels, random content)
-        self.test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        # Create an image with black text on a white background for OCR testing
-        self.test_ocr_image = np.full((100, 300, 3), 255, dtype=np.uint8)
-        cv2.putText(self.test_ocr_image, 'Test', (5, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (0,0,0), 2)
+        if HAS_CV_DEPS:
+            # Create a simple color test image (100x100 pixels, random content)
+            self.test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+            # Create an image with black text on a white background for OCR testing
+            self.test_ocr_image = np.full((100, 300, 3), 255, dtype=np.uint8)
+            cv2.putText(self.test_ocr_image, 'Test', (5, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (0,0,0), 2)
 
+    @unittest.skipUnless(HAS_CV_DEPS, "opencv-python and numpy are required")
     def test_enhance_image(self):
         enhanced = enhance_image(self.test_image)
         # The enhanced image is a grayscale image, and the shape should be two-dimensional
@@ -45,7 +69,7 @@ class TestReadImageTool(unittest.TestCase):
             if os.path.exists(test_filename): 
                 os.remove(test_filename)
 
-
+    @unittest.skipUnless(HAS_OCR_DEPS, "OCR dependencies are required")
     def test_extract_text_from_image_without_east(self):
         # Save the test OCR image as a temporary file
         temp_image = "temp_test_ocr.png"
@@ -59,6 +83,7 @@ class TestReadImageTool(unittest.TestCase):
             if os.path.exists(temp_image):
                 os.remove(temp_image)
 
+    @unittest.skipUnless(HAS_CV_DEPS, "opencv-python and numpy are required")
     def test_detect_text_regions_no_text(self):
         # Text areas are usually not detected using random images
         regions = detect_text_regions(self.test_image)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
@@ -5,91 +5,219 @@
 # @Author  : zhangdongxu
 # @Email   : zhangdongxu0852@163.com
 # @FileName: test_readimage_tool.py
+import builtins
+import importlib
+import math
 import os
-import importlib.util
+import sys
+import tempfile
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
-HAS_CV_DEPS = (
-    importlib.util.find_spec("cv2") is not None
-    and importlib.util.find_spec("numpy") is not None
-)
-HAS_OCR_DEPS = (
-    HAS_CV_DEPS
-    and importlib.util.find_spec("PIL") is not None
-    and importlib.util.find_spec("pytesseract") is not None
+
+READIMAGE_TOOL_MODULE = "agentuniverse.agent.action.tool.common_tool.readimage_tool"
+READIMAGE_TOOL_FILE = (
+    Path(__file__).resolve().parents[6]
+    / "agentuniverse"
+    / "agent"
+    / "action"
+    / "tool"
+    / "common_tool"
+    / "readimage_tool.py"
 )
 
-if HAS_CV_DEPS:
-    import cv2
-    import numpy as np
-else:
-    cv2 = None
-    np = None
 
-from agentuniverse.agent.action.tool.common_tool.readimage_tool import (
-    clean_extracted_text,
-    detect_text_regions,
-    enhance_image,
-    extract_text_from_image,
-    save_text_to_file,
-)
+class FakeImageArray:
+    def __init__(self, shape=(100, 100, 3), size=1):
+        self.shape = shape
+        self.size = size
+
+    def copy(self):
+        return FakeImageArray(self.shape, self.size)
+
+    def __getitem__(self, _):
+        return FakeImageArray((1, 1, 3), self.size)
+
+
+class FakeScores:
+    shape = (1, 1, 1, 1)
+
+    def __getitem__(self, _):
+        return [0.0]
+
+
+class FakeGeometry:
+    shape = (1, 5, 1, 1)
+
+    def __getitem__(self, _):
+        return [0.0]
+
+
+class FakeNet:
+    def __init__(self):
+        self.setInput = Mock()
+        self.forward = Mock(return_value=(FakeScores(), FakeGeometry()))
+
+
+class FakeDnn:
+    def __init__(self):
+        self.net = FakeNet()
+        self.readNet = Mock(return_value=self.net)
+        self.blobFromImage = Mock(return_value="blob")
+        self.NMSBoxes = Mock(return_value=[])
+
+
+class FakeClahe:
+    def apply(self, _):
+        return FakeImageArray((100, 100))
+
+
+class FakeCv2:
+    COLOR_BGR2GRAY = 1
+    COLOR_GRAY2BGR = 2
+    COLOR_BGRA2BGR = 3
+    COLOR_BGR2RGB = 4
+    FONT_HERSHEY_SIMPLEX = 5
+    IMREAD_UNCHANGED = -1
+
+    def __init__(self):
+        self.dnn = FakeDnn()
+        self.imread = Mock(return_value=FakeImageArray())
+        self.imwrite = Mock(return_value=True)
+        self.putText = Mock()
+        self.resize = Mock(side_effect=lambda image, _: image)
+        self.cvtColor = Mock(side_effect=self._cvt_color)
+        self.createCLAHE = Mock(return_value=FakeClahe())
+        self.bilateralFilter = Mock(side_effect=lambda image, *_: image)
+
+    def _cvt_color(self, image, code):
+        if code == self.COLOR_BGR2GRAY:
+            return FakeImageArray((100, 100), image.size)
+        return image
+
+
+class FakePillowImage:
+    @staticmethod
+    def fromarray(image):
+        return SimpleNamespace(source=image)
+
+
+def unload_readimage_tool():
+    sys.modules.pop(READIMAGE_TOOL_MODULE, None)
+    parent_name, _, module_name = READIMAGE_TOOL_MODULE.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and hasattr(parent, module_name):
+        delattr(parent, module_name)
+
+
+def import_readimage_tool_without(blocked=()):
+    blocked = set(blocked)
+    fake_modules = {
+        "cv2": FakeCv2(),
+        "pytesseract": SimpleNamespace(image_to_string=Mock(return_value="Mocked OCR\ntext")),
+        "PIL": SimpleNamespace(Image=FakePillowImage),
+        "numpy": SimpleNamespace(cos=math.cos, sin=math.sin),
+    }
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        root_name = name.split(".", 1)[0]
+        if name in blocked or root_name in blocked:
+            raise ImportError(f"No module named {name}")
+        if name in fake_modules:
+            return fake_modules[name]
+        return original_import(name, globals, locals, fromlist, level)
+
+    unload_readimage_tool()
+    with patch("builtins.__import__", side_effect=guarded_import):
+        spec = importlib.util.spec_from_file_location(READIMAGE_TOOL_MODULE, READIMAGE_TOOL_FILE)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[READIMAGE_TOOL_MODULE] = module
+        spec.loader.exec_module(module)
+    return module, fake_modules
+
 
 class TestReadImageTool(unittest.TestCase):
-    def setUp(self):
-        if HAS_CV_DEPS:
-            # Create a simple color test image (100x100 pixels, random content)
-            self.test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-            # Create an image with black text on a white background for OCR testing
-            self.test_ocr_image = np.full((100, 300, 3), 255, dtype=np.uint8)
-            cv2.putText(self.test_ocr_image, 'Test', (5, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (0,0,0), 2)
+    def tearDown(self):
+        unload_readimage_tool()
 
-    @unittest.skipUnless(HAS_CV_DEPS, "opencv-python and numpy are required")
     def test_enhance_image(self):
-        enhanced = enhance_image(self.test_image)
-        # The enhanced image is a grayscale image, and the shape should be two-dimensional
+        readimage_tool, _ = import_readimage_tool_without()
+
+        enhanced = readimage_tool.enhance_image(FakeImageArray())
+
         self.assertEqual(len(enhanced.shape), 2)
 
     def test_clean_extracted_text(self):
+        readimage_tool, _ = import_readimage_tool_without()
+
         dirty_text = "This   is   a   test.\nNew    line."
-        clean_text = clean_extracted_text(dirty_text)
+        clean_text = readimage_tool.clean_extracted_text(dirty_text)
+
         self.assertNotIn("\n", clean_text)
         self.assertNotIn("  ", clean_text)
         self.assertEqual(clean_text, "This is a test. New line.")
 
     def test_save_text_to_file(self):
+        readimage_tool, _ = import_readimage_tool_without()
         test_text = "Sample text for testing."
-        test_filename = "test_extracted_text.txt"
-        save_text_to_file(test_text, test_filename)
-        try:
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_filename = os.path.join(temp_dir, "test_extracted_text.txt")
+            readimage_tool.save_text_to_file(test_text, test_filename)
+
             self.assertTrue(os.path.exists(test_filename))
-            with open(test_filename, 'r', encoding='utf-8') as f:
+            with open(test_filename, "r", encoding="utf-8") as f:
                 content = f.read()
             self.assertEqual(content, test_text)
-        finally:
-            if os.path.exists(test_filename): 
-                os.remove(test_filename)
 
-    @unittest.skipUnless(HAS_OCR_DEPS, "OCR dependencies are required")
     def test_extract_text_from_image_without_east(self):
-        # Save the test OCR image as a temporary file
-        temp_image = "temp_test_ocr.png"
-        cv2.imwrite(temp_image, self.test_ocr_image)
-        try:
-            # Use simple OCR, no EAST detection
-            text = extract_text_from_image(temp_image, use_east=False, lang='eng')
-            self.assertIsInstance(text, str)
-            self.assertGreater(len(text), 0)
-        finally:
-            if os.path.exists(temp_image):
-                os.remove(temp_image)
+        readimage_tool, fake_modules = import_readimage_tool_without()
 
-    @unittest.skipUnless(HAS_CV_DEPS, "opencv-python and numpy are required")
+        text = readimage_tool.extract_text_from_image("input.png", use_east=False, lang="eng")
+
+        self.assertEqual(text, "Mocked OCR text")
+        fake_modules["pytesseract"].image_to_string.assert_called_once()
+        self.assertEqual(fake_modules["pytesseract"].image_to_string.call_args.kwargs["lang"], "eng")
+
     def test_detect_text_regions_no_text(self):
-        # Text areas are usually not detected using random images
-        regions = detect_text_regions(self.test_image)
-        # The test result may be an empty list
-        self.assertIsInstance(regions, list)
+        readimage_tool, fake_modules = import_readimage_tool_without()
 
-if __name__ == '__main__':
+        regions = readimage_tool.detect_text_regions(FakeImageArray())
+
+        self.assertEqual(regions, [])
+        fake_cv2 = fake_modules["cv2"]
+        fake_cv2.dnn.readNet.assert_called_once_with("frozen_east_text_detection.pb")
+        fake_cv2.dnn.blobFromImage.assert_called_once()
+        fake_cv2.dnn.net.setInput.assert_called_once_with("blob")
+        fake_cv2.dnn.net.forward.assert_called_once_with(
+            ["feature_fusion/Conv_7/Sigmoid", "feature_fusion/concat_3"]
+        )
+
+    def test_import_succeeds_and_runtime_error_is_clear_when_optional_dependency_is_absent(self):
+        cases = [
+            ("cv2", "cv2", "enhance_image", (FakeImageArray(),), "opencv-python is required"),
+            ("numpy", "np", "detect_text_regions", (FakeImageArray(),), "numpy is required"),
+            ("PIL", "Image", "ocr_on_regions", ([FakeImageArray()],), "Pillow is required"),
+            (
+                "pytesseract",
+                "pytesseract",
+                "ocr_on_regions",
+                ([FakeImageArray()],),
+                "pytesseract is required",
+            ),
+        ]
+
+        for missing_module, attribute_name, function_name, args, message in cases:
+            with self.subTest(missing_module=missing_module):
+                readimage_tool, _ = import_readimage_tool_without(blocked={missing_module})
+
+                self.assertIsNone(getattr(readimage_tool, attribute_name))
+                with self.assertRaisesRegex(ImportError, message):
+                    getattr(readimage_tool, function_name)(*args)
+
+
+if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for duplicate work.
- [x] I accept maintainer suggestions to modify or close this PR.
- [x] I have submitted the test files and test results.
- [ ] Documentation change is not needed for this fix.
- [ ] Example change is not needed for this fix.

**Please fill in the specific details of this PR:**

This PR makes `readimage_tool` handle optional OCR dependencies more safely.

Previously, importing `readimage_tool.py` required packages such as `cv2`, `pytesseract`, `PIL`, and `numpy` at module import time. If any optional dependency was missing, test collection or module import failed immediately. This PR guards those imports and raises a clear dependency error only when image/OCR functionality is actually used.

Changes:
- Guard optional imports for `cv2`, `pytesseract`, `PIL`, and `numpy`.
- Add a shared dependency check helper with clear error messages.
- Keep non-OCR utility functions importable without image dependencies.
- Update tests to use the correct package import path.
- Skip only dependency-required tests when optional packages are missing.

**Please provide the path of test files and submit screenshots or files of the test results:**

Test file:
- `tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py`

Checks:
```text
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py -q
python -m py_compile agentuniverse/agent/action/tool/common_tool/readimage_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_readimage_tool.py
git diff --check