### PR TITLE
Feat/crossref tool enhancements

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/crossref_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/crossref_tool.py
@@ -4,6 +4,8 @@
 """A lightweight scholarly metadata tool based on the Crossref REST API."""
 
 import re
+from calendar import monthrange
+from datetime import date
 from html.parser import HTMLParser
 from typing import Any, ClassVar, Dict, List, Optional
 from urllib.parse import quote
@@ -37,6 +39,27 @@ class CrossrefTool(Tool):
     """Search Crossref works or retrieve one work by DOI."""
 
     MODES: ClassVar[set[str]] = {"search", "doi"}
+    SORT_FIELDS: ClassVar[set[str]] = {
+        "created",
+        "deposited",
+        "indexed",
+        "is-referenced-by-count",
+        "issued",
+        "published",
+        "published-online",
+        "published-print",
+        "references-count",
+        "relevance",
+        "score",
+        "updated",
+    }
+    SORT_ALIASES: ClassVar[Dict[str, str]] = {
+        "citation-count": "is-referenced-by-count",
+        "publication-date": "published",
+        "reference-count": "references-count",
+    }
+    ORDERS: ClassVar[set[str]] = {"asc", "desc"}
+    MAX_OFFSET: ClassVar[int] = 9999
 
     base_url: str = "https://api.crossref.org/v1"
     timeout: float = Field(default=15.0, description="HTTP request timeout in seconds")
@@ -48,6 +71,12 @@ class CrossrefTool(Tool):
         query: str,
         mode: str = "search",
         max_results: int = 5,
+        page: int = 1,
+        cursor: Optional[str] = None,
+        sort: str = "relevance",
+        order: str = "desc",
+        from_pub_date: Optional[str] = None,
+        until_pub_date: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Search scholarly works or retrieve metadata for a Crossref DOI.
 
@@ -55,6 +84,12 @@ class CrossrefTool(Tool):
             query: Search keywords in search mode, or a DOI/DOI URL in doi mode.
             mode: Operation mode. Supports search and doi.
             max_results: Maximum search results to return, from 1 to 20.
+            page: One-based search result page.
+            cursor: Crossref cursor for deep pagination. Use * for the first cursor page.
+            sort: Crossref field used to sort search results.
+            order: Search sort order, either asc or desc.
+            from_pub_date: Inclusive publication date lower bound.
+            until_pub_date: Inclusive publication date upper bound.
 
         Returns:
             A dictionary containing operation context, result counts, and a
@@ -71,40 +106,76 @@ class CrossrefTool(Tool):
 
         if normalized_mode == "search":
             self._validate_max_results(max_results)
+            self._validate_page(page, max_results)
+            normalized_cursor = self._normalize_cursor(cursor)
+            if normalized_cursor and page != 1:
+                raise ValueError("page must be 1 when cursor is provided")
             effective_max_results = max_results
+            effective_page = page
+            offset = 0 if normalized_cursor else (page - 1) * max_results
+            normalized_sort = self._normalize_sort(sort)
+            normalized_order = self._normalize_order(order)
+            normalized_from_date = self._normalize_date(from_pub_date, "from_pub_date")
+            normalized_until_date = self._normalize_date(until_pub_date, "until_pub_date")
+            self._validate_date_range(normalized_from_date, normalized_until_date)
         else:
             normalized_query = self._normalize_doi(normalized_query)
             effective_max_results = 1
+            effective_page = 1
+            offset = 0
+            normalized_cursor = ""
+            normalized_sort = ""
+            normalized_order = ""
+            normalized_from_date = ""
+            normalized_until_date = ""
+
+        context = {
+            "mode": normalized_mode,
+            "query": normalized_query,
+            "max_results": effective_max_results,
+            "page": effective_page,
+            "offset": offset,
+            "cursor": normalized_cursor,
+            "sort": normalized_sort,
+            "order": normalized_order,
+            "from_pub_date": normalized_from_date,
+            "until_pub_date": normalized_until_date,
+        }
 
         try:
             if normalized_mode == "search":
-                total_results, raw_works = self._search(normalized_query, effective_max_results)
+                total_results, raw_works, next_cursor = self._search(
+                    query=normalized_query,
+                    max_results=effective_max_results,
+                    offset=offset,
+                    cursor=normalized_cursor,
+                    sort=normalized_sort,
+                    order=normalized_order,
+                    from_pub_date=normalized_from_date,
+                    until_pub_date=normalized_until_date,
+                )
             else:
                 raw_works = [self._lookup_doi(normalized_query)]
                 total_results = 1
+                next_cursor = ""
 
             works = [self._parse_work(work) for work in raw_works]
             return {
-                "mode": normalized_mode,
-                "query": normalized_query,
-                "max_results": effective_max_results,
+                **context,
                 "total_results": total_results,
                 "returned_results": len(works),
+                "next_cursor": next_cursor,
                 "works": works,
             }
         except _CrossrefAPIError as exc:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                **context,
                 error_type="api_error",
                 message=str(exc),
             )
         except requests.Timeout:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                **context,
                 error_type="request_timeout",
                 message="Crossref request timed out.",
             )
@@ -114,34 +185,53 @@ class CrossrefTool(Tool):
                 f"Crossref returned HTTP status {status_code}." if status_code else "Crossref HTTP request failed."
             )
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                **context,
                 error_type="http_error",
                 message=message,
             )
         except requests.RequestException as exc:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                **context,
                 error_type="request_error",
                 message=f"Crossref request failed: {exc}",
             )
         except (KeyError, TypeError, ValueError) as exc:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                **context,
                 error_type="invalid_response",
                 message=f"Unable to parse Crossref response: {exc}",
             )
 
-    def _search(self, query: str, max_results: int) -> tuple[int, List[Dict[str, Any]]]:
-        data = self._request(
-            "/works",
-            params={"query.bibliographic": query, "rows": max_results},
-        )
+    def _search(
+        self,
+        query: str,
+        max_results: int,
+        offset: int,
+        cursor: str,
+        sort: str,
+        order: str,
+        from_pub_date: str,
+        until_pub_date: str,
+    ) -> tuple[int, List[Dict[str, Any]], str]:
+        params: Dict[str, Any] = {
+            "query.bibliographic": query,
+            "rows": max_results,
+            "sort": sort,
+            "order": order,
+        }
+        if cursor:
+            params["cursor"] = cursor
+        else:
+            params["offset"] = offset
+        filters = []
+        if from_pub_date:
+            filters.append(f"from-pub-date:{from_pub_date}")
+        if until_pub_date:
+            filters.append(f"until-pub-date:{until_pub_date}")
+        if filters:
+            params["filter"] = ",".join(filters)
+
+        data = self._request("/works", params=params)
         if data.get("message-type") != "work-list":
             raise ValueError("unexpected message-type for Crossref search")
 
@@ -151,7 +241,8 @@ class CrossrefTool(Tool):
         items = message.get("items")
         if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
             raise ValueError("invalid search items")
-        return int(message.get("total-results", 0)), items
+        next_cursor = self._string_value(message.get("next-cursor")) if cursor else ""
+        return int(message.get("total-results", 0)), items, next_cursor
 
     def _lookup_doi(self, doi: str) -> Dict[str, Any]:
         data = self._request(f"/works/{quote(doi, safe='')}")
@@ -206,6 +297,68 @@ class CrossrefTool(Tool):
         if not 1 <= max_results <= 20:
             raise ValueError("max_results must be between 1 and 20")
 
+    @classmethod
+    def _validate_page(cls, page: int, max_results: int) -> None:
+        if isinstance(page, bool) or not isinstance(page, int):
+            raise ValueError("page must be a positive integer")
+        if page < 1:
+            raise ValueError("page must be a positive integer")
+        if (page - 1) * max_results > cls.MAX_OFFSET:
+            raise ValueError("page and max_results must produce an offset below 10000")
+
+    @classmethod
+    def _normalize_sort(cls, sort: str) -> str:
+        normalized_sort = sort.strip().lower().replace("_", "-") if isinstance(sort, str) else ""
+        normalized_sort = cls.SORT_ALIASES.get(normalized_sort, normalized_sort)
+        if normalized_sort not in cls.SORT_FIELDS:
+            raise ValueError(f"sort must be one of: {', '.join(sorted(cls.SORT_FIELDS))}")
+        return normalized_sort
+
+    @classmethod
+    def _normalize_order(cls, order: str) -> str:
+        normalized_order = order.strip().lower() if isinstance(order, str) else ""
+        if normalized_order not in cls.ORDERS:
+            raise ValueError("order must be one of: asc, desc")
+        return normalized_order
+
+    @staticmethod
+    def _normalize_cursor(cursor: Optional[str]) -> str:
+        if cursor is None or cursor == "":
+            return ""
+        normalized_cursor = cursor.strip() if isinstance(cursor, str) else ""
+        if not normalized_cursor:
+            raise ValueError("cursor must be a non-empty string")
+        return normalized_cursor
+
+    @staticmethod
+    def _normalize_date(value: Optional[str], parameter_name: str) -> str:
+        if value is None or value == "":
+            return ""
+        normalized_value = value.strip() if isinstance(value, str) else ""
+        if not re.fullmatch(r"\d{4}(?:-\d{2}(?:-\d{2})?)?", normalized_value):
+            raise ValueError(f"{parameter_name} must use YYYY, YYYY-MM, or YYYY-MM-DD format")
+        try:
+            parts = [int(part) for part in normalized_value.split("-")]
+            date(parts[0], parts[1] if len(parts) > 1 else 1, parts[2] if len(parts) > 2 else 1)
+        except ValueError as exc:
+            raise ValueError(f"{parameter_name} must be a valid date") from exc
+        return normalized_value
+
+    @classmethod
+    def _validate_date_range(cls, from_pub_date: str, until_pub_date: str) -> None:
+        if not from_pub_date or not until_pub_date:
+            return
+        if cls._date_bound(from_pub_date, upper=False) > cls._date_bound(until_pub_date, upper=True):
+            raise ValueError("from_pub_date must not be later than until_pub_date")
+
+    @staticmethod
+    def _date_bound(value: str, upper: bool) -> date:
+        parts = [int(part) for part in value.split("-")]
+        year = parts[0]
+        month = parts[1] if len(parts) > 1 else (12 if upper else 1)
+        day = parts[2] if len(parts) > 2 else (monthrange(year, month)[1] if upper else 1)
+        return date(year, month, day)
+
     @staticmethod
     def _normalize_doi(value: str) -> str:
         doi = re.sub(r"^(?:https?://(?:dx\.)?doi\.org/|doi:\s*)", "", value, flags=re.IGNORECASE).strip()
@@ -223,6 +376,7 @@ class CrossrefTool(Tool):
         return {
             "doi": doi,
             "title": cls._first_text(work.get("title")),
+            "subtitle": cls._first_text(work.get("subtitle")),
             "authors": cls._authors(work.get("author")),
             "abstract": cls._markup_text(work.get("abstract")),
             "container_title": cls._first_text(work.get("container-title")),
@@ -230,6 +384,17 @@ class CrossrefTool(Tool):
             "publisher": cls._string_value(work.get("publisher")),
             "type": cls._string_value(work.get("type")),
             "url": url,
+            "issn": cls._string_list(work.get("ISSN")),
+            "isbn": cls._string_list(work.get("ISBN")),
+            "subjects": cls._string_list(work.get("subject")),
+            "language": cls._string_value(work.get("language")),
+            "volume": cls._string_value(work.get("volume")),
+            "issue": cls._string_value(work.get("issue")),
+            "pages": cls._string_value(work.get("page")),
+            "citation_count": cls._integer_value(work.get("is-referenced-by-count")),
+            "reference_count": cls._integer_value(work.get("references-count")),
+            "funders": cls._funders(work.get("funder")),
+            "licenses": cls._licenses(work.get("license")),
         }
 
     @classmethod
@@ -249,6 +414,42 @@ class CrossrefTool(Tool):
             if full_name:
                 authors.append(full_name)
         return authors
+
+    @classmethod
+    def _funders(cls, value: Any) -> List[Dict[str, Any]]:
+        if not isinstance(value, list):
+            return []
+        funders = []
+        for funder in value:
+            if not isinstance(funder, dict):
+                continue
+            name = cls._string_value(funder.get("name"))
+            doi = cls._string_value(funder.get("DOI"))
+            awards = cls._string_list(funder.get("award"))
+            if name or doi or awards:
+                funders.append({"name": name, "doi": doi, "awards": awards})
+        return funders
+
+    @classmethod
+    def _licenses(cls, value: Any) -> List[Dict[str, Any]]:
+        if not isinstance(value, list):
+            return []
+        licenses = []
+        for license_item in value:
+            if not isinstance(license_item, dict):
+                continue
+            url = cls._string_value(license_item.get("URL"))
+            if not url:
+                continue
+            licenses.append(
+                {
+                    "url": url,
+                    "start_date": cls._published_date(license_item.get("start")),
+                    "content_version": cls._string_value(license_item.get("content-version")),
+                    "delay_in_days": cls._integer_value(license_item.get("delay-in-days")),
+                }
+            )
+        return licenses
 
     @staticmethod
     def _markup_text(value: Any) -> str:
@@ -287,6 +488,21 @@ class CrossrefTool(Tool):
     def _string_value(value: Any) -> str:
         return value.strip() if isinstance(value, str) else ""
 
+    @classmethod
+    def _string_list(cls, value: Any) -> List[str]:
+        if not isinstance(value, list):
+            return []
+        values = []
+        for item in value:
+            normalized_item = cls._string_value(item)
+            if normalized_item and normalized_item not in values:
+                values.append(normalized_item)
+        return values
+
+    @staticmethod
+    def _integer_value(value: Any) -> int:
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
     @staticmethod
     def _api_error_message(value: Any) -> str:
         if isinstance(value, str) and value.strip():
@@ -307,6 +523,13 @@ class CrossrefTool(Tool):
         mode: str,
         query: str,
         max_results: int,
+        page: int,
+        offset: int,
+        cursor: str,
+        sort: str,
+        order: str,
+        from_pub_date: str,
+        until_pub_date: str,
         error_type: str,
         message: str,
     ) -> Dict[str, Any]:
@@ -314,8 +537,16 @@ class CrossrefTool(Tool):
             "mode": mode,
             "query": query,
             "max_results": max_results,
+            "page": page,
+            "offset": offset,
+            "cursor": cursor,
+            "sort": sort,
+            "order": order,
+            "from_pub_date": from_pub_date,
+            "until_pub_date": until_pub_date,
             "total_results": 0,
             "returned_results": 0,
+            "next_cursor": "",
             "works": [],
             "error": {"type": error_type, "message": message},
         }

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -184,6 +184,11 @@ result = tool.run(
     query='large language models in medicine',
     mode='search',
     max_results=5,
+    page=2,
+    sort='citation_count',
+    order='desc',
+    from_pub_date='2020-01-01',
+    until_pub_date='2025-12-31',
 )
 ```
 
@@ -201,8 +206,14 @@ result = tool.run(
 - `query`：必填。`search`模式下为检索关键词，`doi`模式下为DOI、`doi:`前缀形式或DOI URL。
 - `mode`：可选，可选值为`search`或`doi`，默认为`search`。
 - `max_results`：可选，仅用于`search`模式，范围为1到20，默认为5。`doi`模式最多返回一条记录。
+- `page`：可选，仅用于`search`模式，从1开始，默认为1。`page`和`max_results`计算出的Crossref `offset`必须小于10000。
+- `cursor`：可选，用于深度分页。第一次传入`*`，后续请求传入上一次结果中的`next_cursor`；使用时`page`必须为1。Crossref游标在停止使用5分钟后过期。
+- `sort`：可选，仅用于`search`模式，默认为`relevance`。支持`created`、`deposited`、`indexed`、`is-referenced-by-count`、`issued`、`published`、`published-online`、`published-print`、`references-count`、`relevance`、`score`和`updated`。连字符可以写成下划线，还支持`citation_count`、`publication_date`和`reference_count`别名。
+- `order`：可选，仅用于`search`模式，可选值为`asc`或`desc`，默认为`desc`。
+- `from_pub_date`：可选，包含边界的最早出版日期。
+- `until_pub_date`：可选，包含边界的最晚出版日期。日期支持`YYYY`、`YYYY-MM`或`YYYY-MM-DD`格式，可以只设置一侧；同时设置时，起始日期不能晚于结束日期。
 
-返回结果包含操作模式、查询内容、结果数量和`works`列表。每条记录可包含DOI、标题、作者、摘要、期刊或会议名称、出版日期、出版商、文献类型和URL。Crossref元数据由出版机构提交，不同记录的完整度可能不同；缺失的单值字段返回空字符串，缺失的多值字段返回空列表。工具仅返回元数据，不下载或总结全文。
+返回结果包含操作模式、查询内容、分页与排序上下文、日期过滤条件、结果数量和`works`列表，游标检索还会返回供下一次请求使用的`next_cursor`。每条记录除原有DOI、标题、作者、摘要、期刊或会议名称、出版日期、出版商、文献类型和URL外，还可包含副标题、ISSN、ISBN、主题、语言、卷、期、页码、引用次数、参考文献数量、资助方和许可证。Crossref元数据由出版机构提交，不同记录的完整度可能不同；缺失的单值字段返回空字符串，缺失的多值字段返回空列表，缺失的计数字段返回0。工具仅返回元数据，不下载或总结全文。
 
 网络超时、HTTP错误、连接失败、非法JSON和Crossref API错误会通过结构化`error`字段返回。可以通过环境变量`CROSSREF_EMAIL`提供联系邮箱，进入Crossref polite pool并在请求中携带可识别的User-Agent。
 

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/crossref_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/crossref_tool.yaml
@@ -8,12 +8,33 @@ description: |
       exact DOI lookup. Defaults to search.
     - max_results (optional): Number of works to return in search mode, from 1 to 20.
       Defaults to 5. DOI mode always returns at most one work.
+    - page (optional): One-based search result page. Defaults to 1. The calculated
+      Crossref offset must remain below 10000.
+    - cursor (optional): Crossref cursor for deep pagination. Use * for the first cursor
+      request, then pass the returned next_cursor value to the next call. Cursor requests
+      require page to remain 1 and Crossref cursors expire after 5 minutes.
+    - sort (optional): Sort field. Supports created, deposited, indexed,
+      is-referenced-by-count, issued, published, published-online, published-print,
+      references-count, relevance, score, or updated. Underscores may replace hyphens;
+      citation_count, publication_date, and reference_count are also accepted aliases.
+      Defaults to relevance.
+    - order (optional): Sort direction, either asc or desc. Defaults to desc.
+    - from_pub_date (optional): Inclusive publication date lower bound.
+    - until_pub_date (optional): Inclusive publication date upper bound.
+      Publication dates use YYYY, YYYY-MM, or YYYY-MM-DD format. Either date bound may
+      be used independently; when both are set, from_pub_date must not be later than
+      until_pub_date.
 
   Search example:
     {
       "query": "large language models in medicine",
       "mode": "search",
-      "max_results": 5
+      "max_results": 5,
+      "page": 2,
+      "sort": "citation_count",
+      "order": "desc",
+      "from_pub_date": "2020-01-01",
+      "until_pub_date": "2025-12-31"
     }
 
   DOI lookup example:
@@ -22,11 +43,14 @@ description: |
       "mode": "doi"
     }
 
-  Each work may contain DOI, title, authors, abstract, container title, publication date,
-  publisher, work type, and URL. Missing metadata is returned as an empty string or list.
-  Network and Crossref API failures are returned in a structured error field. Set the
-  optional CROSSREF_EMAIL environment variable to use the Crossref polite pool. This tool
-  returns metadata only and does not download or summarize full text.
+  Each work may contain DOI, title, subtitle, authors, abstract, container title,
+  publication date, publisher, work type, URL, ISSN, ISBN, subjects, language, volume,
+  issue, pages, citation count, reference count, funders, and licenses. Missing metadata
+  is returned as an empty string, empty list, or zero count. Search context including
+  page, offset, sorting, and date filters is included in successful and structured error
+  responses. Cursor searches also return next_cursor for the next request. Set the
+  optional CROSSREF_EMAIL environment variable to use the Crossref polite pool. This
+  tool returns metadata only and does not download or summarize full text.
 tool_type: 'api'
 input_keys: ['query']
 metadata:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_crossref_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_crossref_tool.py
@@ -14,6 +14,7 @@ from agentuniverse.agent.action.tool.common_tool.crossref_tool import CrossrefTo
 SAMPLE_WORK = {
     "DOI": "10.1000/example",
     "title": ["Example <i>scholarly</i> work"],
+    "subtitle": ["An extended metadata example"],
     "author": [
         {"given": "Alice", "family": "Smith"},
         {"name": "Example Research Consortium"},
@@ -24,6 +25,30 @@ SAMPLE_WORK = {
     "publisher": "Example Publisher",
     "type": "journal-article",
     "URL": "https://doi.org/10.1000/example",
+    "ISSN": ["1234-5678", "8765-4321"],
+    "ISBN": ["978-1-4028-9462-6"],
+    "subject": ["Artificial Intelligence", "Medicine"],
+    "language": "en",
+    "volume": "12",
+    "issue": "3",
+    "page": "101-110",
+    "is-referenced-by-count": 25,
+    "references-count": 40,
+    "funder": [
+        {
+            "name": "Example Research Foundation",
+            "DOI": "10.13039/100000001",
+            "award": ["GRANT-123"],
+        }
+    ],
+    "license": [
+        {
+            "URL": "https://creativecommons.org/licenses/by/4.0/",
+            "start": {"date-parts": [[2025, 8, 13]]},
+            "content-version": "vor",
+            "delay-in-days": 0,
+        }
+    ],
 }
 
 
@@ -53,13 +78,22 @@ class CrossrefToolTest(unittest.TestCase):
         self.assertEqual(result["mode"], "search")
         self.assertEqual(result["query"], "AI medicine")
         self.assertEqual(result["max_results"], 3)
+        self.assertEqual(result["page"], 1)
+        self.assertEqual(result["offset"], 0)
+        self.assertEqual(result["cursor"], "")
+        self.assertEqual(result["sort"], "relevance")
+        self.assertEqual(result["order"], "desc")
+        self.assertEqual(result["from_pub_date"], "")
+        self.assertEqual(result["until_pub_date"], "")
         self.assertEqual(result["total_results"], 42)
         self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(result["next_cursor"], "")
         self.assertEqual(
             result["works"][0],
             {
                 "doi": "10.1000/example",
                 "title": "Example scholarly work",
+                "subtitle": "An extended metadata example",
                 "authors": ["Alice Smith", "Example Research Consortium"],
                 "abstract": "Useful abstract text.",
                 "container_title": "Example Journal",
@@ -67,6 +101,30 @@ class CrossrefToolTest(unittest.TestCase):
                 "publisher": "Example Publisher",
                 "type": "journal-article",
                 "url": "https://doi.org/10.1000/example",
+                "issn": ["1234-5678", "8765-4321"],
+                "isbn": ["978-1-4028-9462-6"],
+                "subjects": ["Artificial Intelligence", "Medicine"],
+                "language": "en",
+                "volume": "12",
+                "issue": "3",
+                "pages": "101-110",
+                "citation_count": 25,
+                "reference_count": 40,
+                "funders": [
+                    {
+                        "name": "Example Research Foundation",
+                        "doi": "10.13039/100000001",
+                        "awards": ["GRANT-123"],
+                    }
+                ],
+                "licenses": [
+                    {
+                        "url": "https://creativecommons.org/licenses/by/4.0/",
+                        "start_date": "2025-08-13",
+                        "content_version": "vor",
+                        "delay_in_days": 0,
+                    }
+                ],
             },
         )
 
@@ -74,6 +132,10 @@ class CrossrefToolTest(unittest.TestCase):
         self.assertEqual(request.args[0], "https://api.crossref.org/v1/works")
         self.assertEqual(request.kwargs["params"]["query.bibliographic"], "AI medicine")
         self.assertEqual(request.kwargs["params"]["rows"], 3)
+        self.assertEqual(request.kwargs["params"]["offset"], 0)
+        self.assertEqual(request.kwargs["params"]["sort"], "relevance")
+        self.assertEqual(request.kwargs["params"]["order"], "desc")
+        self.assertNotIn("filter", request.kwargs["params"])
         self.assertEqual(request.kwargs["params"]["mailto"], "developer@example.com")
         self.assertIn("mailto:developer@example.com", request.kwargs["headers"]["User-Agent"])
         self.assertEqual(request.kwargs["timeout"], 15.0)
@@ -97,6 +159,10 @@ class CrossrefToolTest(unittest.TestCase):
         self.assertEqual(result["mode"], "doi")
         self.assertEqual(result["query"], "10.1000/example")
         self.assertEqual(result["max_results"], 1)
+        self.assertEqual(result["page"], 1)
+        self.assertEqual(result["offset"], 0)
+        self.assertEqual(result["sort"], "")
+        self.assertEqual(result["order"], "")
         self.assertEqual(result["total_results"], 1)
         self.assertEqual(result["returned_results"], 1)
         self.assertEqual(result["works"][0]["doi"], "10.1000/example")
@@ -104,6 +170,75 @@ class CrossrefToolTest(unittest.TestCase):
             mock_get.call_args.args[0],
             "https://api.crossref.org/v1/works/10.1000%2Fexample",
         )
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_search_maps_paging_sorting_and_date_filters(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {"total-results": 100, "items": []},
+            }
+        )
+
+        result = self.tool.execute(
+            query="AI medicine",
+            max_results=4,
+            page=3,
+            sort="citation_count",
+            order="ASC",
+            from_pub_date="2024-01",
+            until_pub_date="2025-06-30",
+        )
+
+        self.assertEqual(result["page"], 3)
+        self.assertEqual(result["offset"], 8)
+        self.assertEqual(result["sort"], "is-referenced-by-count")
+        self.assertEqual(result["order"], "asc")
+        self.assertEqual(result["from_pub_date"], "2024-01")
+        self.assertEqual(result["until_pub_date"], "2025-06-30")
+        params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(params["offset"], 8)
+        self.assertEqual(params["sort"], "is-referenced-by-count")
+        self.assertEqual(params["order"], "asc")
+        self.assertEqual(params["filter"], "from-pub-date:2024-01,until-pub-date:2025-06-30")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_search_supports_one_sided_date_filter(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {"total-results": 0, "items": []},
+            }
+        )
+
+        self.tool.execute(query="AI medicine", until_pub_date="2020")
+
+        self.assertEqual(mock_get.call_args.kwargs["params"]["filter"], "until-pub-date:2020")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_search_uses_cursor_for_deep_pagination(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {
+                    "total-results": 100000,
+                    "items": [],
+                    "next-cursor": "next-cursor-token",
+                },
+            }
+        )
+
+        result = self.tool.execute(query="AI medicine", max_results=20, cursor="*")
+
+        self.assertEqual(result["cursor"], "*")
+        self.assertEqual(result["offset"], 0)
+        self.assertEqual(result["next_cursor"], "next-cursor-token")
+        params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(params["cursor"], "*")
+        self.assertNotIn("offset", params)
 
     @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
     def test_empty_search_returns_no_works(self, mock_get: Mock) -> None:
@@ -130,6 +265,24 @@ class CrossrefToolTest(unittest.TestCase):
             self.tool.execute(query="AI", max_results=0)
         with self.assertRaisesRegex(ValueError, "integer"):
             self.tool.execute(query="AI", max_results=True)
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            self.tool.execute(query="AI", page=0)
+        with self.assertRaisesRegex(ValueError, "offset below 10000"):
+            self.tool.execute(query="AI", max_results=20, page=501)
+        with self.assertRaisesRegex(ValueError, "page must be 1"):
+            self.tool.execute(query="AI", page=2, cursor="*")
+        with self.assertRaisesRegex(ValueError, "non-empty string"):
+            self.tool.execute(query="AI", cursor=" ")
+        with self.assertRaisesRegex(ValueError, "sort must be one of"):
+            self.tool.execute(query="AI", sort="citations")
+        with self.assertRaisesRegex(ValueError, "order must be one of"):
+            self.tool.execute(query="AI", order="newest")
+        with self.assertRaisesRegex(ValueError, "YYYY"):
+            self.tool.execute(query="AI", from_pub_date="2025/01/01")
+        with self.assertRaisesRegex(ValueError, "valid date"):
+            self.tool.execute(query="AI", until_pub_date="2025-02-30")
+        with self.assertRaisesRegex(ValueError, "must not be later"):
+            self.tool.execute(query="AI", from_pub_date="2025-02", until_pub_date="2025-01")
         with self.assertRaisesRegex(ValueError, "valid DOI"):
             self.tool.execute(query="not-a-doi", mode="doi")
 
@@ -138,6 +291,7 @@ class CrossrefToolTest(unittest.TestCase):
 
         self.assertEqual(work["doi"], "10.1000/minimal")
         self.assertEqual(work["title"], "")
+        self.assertEqual(work["subtitle"], "")
         self.assertEqual(work["authors"], [])
         self.assertEqual(work["abstract"], "")
         self.assertEqual(work["container_title"], "")
@@ -145,6 +299,17 @@ class CrossrefToolTest(unittest.TestCase):
         self.assertEqual(work["publisher"], "")
         self.assertEqual(work["type"], "")
         self.assertEqual(work["url"], "https://doi.org/10.1000/minimal")
+        self.assertEqual(work["issn"], [])
+        self.assertEqual(work["isbn"], [])
+        self.assertEqual(work["subjects"], [])
+        self.assertEqual(work["language"], "")
+        self.assertEqual(work["volume"], "")
+        self.assertEqual(work["issue"], "")
+        self.assertEqual(work["pages"], "")
+        self.assertEqual(work["citation_count"], 0)
+        self.assertEqual(work["reference_count"], 0)
+        self.assertEqual(work["funders"], [])
+        self.assertEqual(work["licenses"], [])
 
     @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
     def test_timeout_returns_structured_error(self, mock_get: Mock) -> None:
@@ -154,6 +319,25 @@ class CrossrefToolTest(unittest.TestCase):
 
         self.assertEqual(result["error"]["type"], "request_timeout")
         self.assertEqual(result["works"], [])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
+    def test_error_response_preserves_search_context(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.Timeout("timed out")
+
+        result = self.tool.execute(
+            query="AI medicine",
+            max_results=2,
+            page=2,
+            sort="published_online",
+            order="asc",
+            from_pub_date="2024",
+        )
+
+        self.assertEqual(result["page"], 2)
+        self.assertEqual(result["offset"], 2)
+        self.assertEqual(result["sort"], "published-online")
+        self.assertEqual(result["order"], "asc")
+        self.assertEqual(result["from_pub_date"], "2024")
 
     @patch("agentuniverse.agent.action.tool.common_tool.crossref_tool.requests.get")
     def test_http_error_returns_structured_error(self, mock_get: Mock) -> None:
@@ -231,7 +415,17 @@ class CrossrefToolTest(unittest.TestCase):
 
         self.assertEqual(config["input_keys"], ["query"])
         description = config["description"]
-        for parameter in ("query", "mode", "max_results"):
+        for parameter in (
+            "query",
+            "mode",
+            "max_results",
+            "page",
+            "cursor",
+            "sort",
+            "order",
+            "from_pub_date",
+            "until_pub_date",
+        ):
             self.assertIn(parameter, description)
         for mode in ("search", "doi"):
             self.assertIn(mode, description)
@@ -245,8 +439,23 @@ class CrossrefToolTest(unittest.TestCase):
             "publisher",
             "work type",
             "URL",
+            "subtitle",
+            "ISSN",
+            "ISBN",
+            "subjects",
+            "language",
+            "volume",
+            "issue",
+            "pages",
+            "citation count",
+            "reference count",
+            "funders",
+            "licenses",
         ):
             self.assertIn(metadata_field, description)
+        self.assertIn("offset must remain below 10000", description)
+        self.assertIn("next_cursor", description)
+        self.assertIn("YYYY, YYYY-MM, or YYYY-MM-DD", description)
         self.assertIn("CROSSREF_EMAIL", description)
 
 


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Follow-up to #613. This PR enhances the Crossref scholarly metadata tool with advanced search controls and richer metadata parsing.
- Added paging, cursor-based deep pagination, sorting, ordering, and publication date filters to `CrossrefTool.execute`.
- Extended parsed Crossref work metadata with fields such as subtitle, ISSN, ISBN, subjects, language, volume, issue, pages, citation count, reference count, funders, and licenses.
- Added validation for invalid page, cursor, sort, order, date format, reversed date ranges, and Crossref offset limits.
- Updated the shipped Crossref YAML description and Chinese usage guide so agent-facing parameters, limits, examples, and returned metadata are documented.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_crossref_tool.py`
- Test command:
  `.\.venv\Scripts\python.exe -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_crossref_tool -v`
- Test result:
  `Ran 16 tests in 0.010s`
  `OK`
- Test result screenshot:
<img width="892" height="703" alt="image" src="https://github.com/user-attachments/assets/092f07bf-629d-43f1-b577-25e442e27e9b" />
<img width="885" height="573" alt="image" src="https://github.com/user-attachments/assets/712700c6-0079-4ccd-ab2f-c3f67b24925e" />
<img width="890" height="754" alt="image" src="https://github.com/user-attachments/assets/caf9d9b1-7a36-4e73-a29f-f7c7915259a0" />

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- `examples/sample_standard_app/intelligence/agentic/tool/buildin/crossref_tool.yaml`
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md`