### PR TITLE
Feat/semantic scholar tool

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/semantic_scholar_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/semantic_scholar_tool.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""A scholarly paper search and metadata tool based on Semantic Scholar."""
+
+import re
+from typing import Any, ClassVar, Dict, List, Optional
+from urllib.parse import quote
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.env_util import get_from_env
+
+
+class _SemanticScholarAPIError(Exception):
+    """Raised when Semantic Scholar returns an API-level error response."""
+
+
+class SemanticScholarTool(Tool):
+    """Search Semantic Scholar or retrieve one paper by a supported identifier."""
+
+    MODES: ClassVar[set[str]] = {"search", "paper"}
+    PAPER_FIELDS: ClassVar[str] = ",".join(
+        (
+            "paperId",
+            "corpusId",
+            "externalIds",
+            "url",
+            "title",
+            "abstract",
+            "venue",
+            "year",
+            "publicationDate",
+            "publicationTypes",
+            "authors",
+            "citationCount",
+            "referenceCount",
+            "isOpenAccess",
+            "openAccessPdf",
+            "fieldsOfStudy",
+        )
+    )
+
+    base_url: str = "https://api.semanticscholar.org/graph/v1"
+    timeout: float = Field(default=15.0, description="HTTP request timeout in seconds")
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("S2_API_KEY"))
+    user_agent: str = "agentUniverse-Semantic-Scholar-Tool/1.0"
+
+    def execute(
+        self,
+        query: str,
+        mode: str = "search",
+        max_results: int = 5,
+    ) -> Dict[str, Any]:
+        """Search papers or retrieve one paper by a supported identifier.
+
+        Args:
+            query: Search keywords in search mode, or a paper identifier in
+                paper mode. DOI, PMID, PMCID, ArXiv, CorpusId, and Semantic
+                Scholar paper IDs are supported.
+            mode: Operation mode. Supports search and paper.
+            max_results: Maximum search results to return, from 1 to 20.
+
+        Returns:
+            A dictionary containing operation context, result counts, and a
+            list of normalized papers. Network and API failures are returned
+            in a structured ``error`` field.
+
+        Raises:
+            ValueError: If query, mode, or max_results is invalid.
+        """
+        normalized_mode = self._normalize_mode(mode)
+        normalized_query = query.strip() if isinstance(query, str) else ""
+        if not normalized_query:
+            raise ValueError("query must not be empty")
+
+        if normalized_mode == "search":
+            self._validate_max_results(max_results)
+            effective_max_results = max_results
+        else:
+            normalized_query = self._normalize_paper_id(normalized_query)
+            effective_max_results = 1
+
+        try:
+            if normalized_mode == "search":
+                total_results, raw_papers = self._search(normalized_query, effective_max_results)
+            else:
+                raw_papers = [self._lookup_paper(normalized_query)]
+                total_results = 1
+
+            papers = [self._parse_paper(paper) for paper in raw_papers]
+            return {
+                "mode": normalized_mode,
+                "query": normalized_query,
+                "max_results": effective_max_results,
+                "total_results": total_results,
+                "returned_results": len(papers),
+                "papers": papers,
+            }
+        except _SemanticScholarAPIError as exc:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="api_error",
+                message=str(exc),
+            )
+        except requests.Timeout:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="request_timeout",
+                message="Semantic Scholar request timed out.",
+            )
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            message = self._http_error_message(status_code)
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="http_error",
+                message=message,
+            )
+        except requests.RequestException as exc:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="request_error",
+                message=f"Semantic Scholar request failed: {exc}",
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            return self._error_result(
+                mode=normalized_mode,
+                query=normalized_query,
+                max_results=effective_max_results,
+                error_type="invalid_response",
+                message=f"Unable to parse Semantic Scholar response: {exc}",
+            )
+
+    def _search(self, query: str, max_results: int) -> tuple[int, List[Dict[str, Any]]]:
+        data = self._request(
+            "/paper/search",
+            params={"query": query, "limit": max_results, "fields": self.PAPER_FIELDS},
+        )
+        papers = data.get("data")
+        if not isinstance(papers, list) or not all(isinstance(paper, dict) for paper in papers):
+            raise ValueError("invalid search data")
+        total = data.get("total", 0)
+        if isinstance(total, bool) or not isinstance(total, int):
+            raise ValueError("invalid total result count")
+        return total, papers
+
+    def _lookup_paper(self, paper_id: str) -> Dict[str, Any]:
+        data = self._request(
+            f"/paper/{quote(paper_id, safe='')}",
+            params={"fields": self.PAPER_FIELDS},
+        )
+        if not isinstance(data.get("paperId"), str):
+            raise ValueError("missing Semantic Scholar paperId")
+        return data
+
+    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        headers = {"User-Agent": self.user_agent}
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+
+        response = requests.get(
+            f"{self.base_url}{path}",
+            params=dict(params or {}),
+            headers=headers,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except requests.JSONDecodeError as exc:
+            raise ValueError("invalid Semantic Scholar JSON response") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("invalid Semantic Scholar response")
+        api_error = data.get("error")
+        if api_error:
+            raise _SemanticScholarAPIError(f"Semantic Scholar API error: {api_error}")
+        return data
+
+    @classmethod
+    def _normalize_mode(cls, mode: str) -> str:
+        normalized_mode = mode.strip().lower() if isinstance(mode, str) else ""
+        if normalized_mode not in cls.MODES:
+            raise ValueError("mode must be one of: paper, search")
+        return normalized_mode
+
+    @staticmethod
+    def _validate_max_results(max_results: int) -> None:
+        if isinstance(max_results, bool) or not isinstance(max_results, int):
+            raise ValueError("max_results must be an integer between 1 and 20")
+        if not 1 <= max_results <= 20:
+            raise ValueError("max_results must be between 1 and 20")
+
+    @classmethod
+    def _normalize_paper_id(cls, value: str) -> str:
+        paper_id = value.strip()
+        paper_id = re.sub(r"^https?://(?:www\.)?semanticscholar\.org/paper/(?:[^/]+/)?", "", paper_id, flags=re.I)
+        paper_id = re.sub(r"^https?://(?:dx\.)?doi\.org/", "DOI:", paper_id, flags=re.I)
+        paper_id = re.sub(r"^https?://arxiv\.org/(?:abs|pdf)/", "ARXIV:", paper_id, flags=re.I)
+        paper_id = re.sub(r"\.pdf$", "", paper_id, flags=re.I)
+
+        prefix_match = re.match(r"^(doi|arxiv|pmid|pmcid|corpusid)\s*:\s*(.+)$", paper_id, flags=re.I)
+        if prefix_match:
+            prefix = {
+                "doi": "DOI",
+                "arxiv": "ARXIV",
+                "pmid": "PMID",
+                "pmcid": "PMCID",
+                "corpusid": "CorpusId",
+            }[prefix_match.group(1).lower()]
+            identifier = prefix_match.group(2).strip()
+            if not identifier or any(character.isspace() for character in identifier):
+                raise ValueError("query must contain a valid paper identifier in paper mode")
+            if prefix == "DOI" and not cls._is_doi(identifier):
+                raise ValueError("query must contain a valid DOI in paper mode")
+            return f"{prefix}:{identifier}"
+
+        if cls._is_doi(paper_id):
+            return f"DOI:{paper_id}"
+        if re.fullmatch(r"[0-9a-fA-F]{40}", paper_id):
+            return paper_id.lower()
+        raise ValueError(
+            "query must contain a valid paper identifier in paper mode: DOI, PMID, "
+            "PMCID, ArXiv ID, CorpusId, or Semantic Scholar paper ID"
+        )
+
+    @staticmethod
+    def _is_doi(value: str) -> bool:
+        return value.startswith("10.") and "/" in value and not any(character.isspace() for character in value)
+
+    @classmethod
+    def _parse_paper(cls, paper: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "paper_id": cls._string_value(paper.get("paperId")),
+            "corpus_id": cls._integer_value(paper.get("corpusId")),
+            "external_ids": cls._external_ids(paper.get("externalIds")),
+            "title": cls._string_value(paper.get("title")),
+            "authors": cls._authors(paper.get("authors")),
+            "abstract": cls._string_value(paper.get("abstract")),
+            "venue": cls._string_value(paper.get("venue")),
+            "publication_date": cls._string_value(paper.get("publicationDate")),
+            "year": cls._integer_value(paper.get("year")),
+            "publication_types": cls._string_list(paper.get("publicationTypes")),
+            "fields_of_study": cls._string_list(paper.get("fieldsOfStudy")),
+            "citation_count": cls._integer_value(paper.get("citationCount")),
+            "reference_count": cls._integer_value(paper.get("referenceCount")),
+            "is_open_access": paper.get("isOpenAccess") is True,
+            "open_access_pdf": cls._open_access_pdf(paper.get("openAccessPdf")),
+            "url": cls._string_value(paper.get("url")),
+        }
+
+    @classmethod
+    def _authors(cls, value: Any) -> List[str]:
+        if not isinstance(value, list):
+            return []
+        return [name for author in value if isinstance(author, dict) if (name := cls._string_value(author.get("name")))]
+
+    @classmethod
+    def _external_ids(cls, value: Any) -> Dict[str, str]:
+        if not isinstance(value, dict):
+            return {}
+        return {str(key): normalized for key, item in value.items() if (normalized := cls._scalar_string(item))}
+
+    @classmethod
+    def _open_access_pdf(cls, value: Any) -> Dict[str, str]:
+        if not isinstance(value, dict):
+            return {}
+        return {
+            field: normalized
+            for field in ("url", "status", "license")
+            if (normalized := cls._string_value(value.get(field)))
+        }
+
+    @classmethod
+    def _string_list(cls, value: Any) -> List[str]:
+        if not isinstance(value, list):
+            return []
+        return [normalized for item in value if (normalized := cls._string_value(item))]
+
+    @staticmethod
+    def _string_value(value: Any) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
+    @staticmethod
+    def _scalar_string(value: Any) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+        return ""
+
+    @staticmethod
+    def _integer_value(value: Any) -> int:
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    @staticmethod
+    def _http_error_message(status_code: Optional[int]) -> str:
+        if status_code == 429:
+            return (
+                "Semantic Scholar returned HTTP status 429 (rate limited). "
+                "Retry later, or configure S2_API_KEY if Semantic Scholar has issued one to you."
+            )
+        if status_code:
+            return f"Semantic Scholar returned HTTP status {status_code}."
+        return "Semantic Scholar HTTP request failed."
+
+    @staticmethod
+    def _error_result(
+        mode: str,
+        query: str,
+        max_results: int,
+        error_type: str,
+        message: str,
+    ) -> Dict[str, Any]:
+        return {
+            "mode": mode,
+            "query": query,
+            "max_results": max_results,
+            "total_results": 0,
+            "returned_results": 0,
+            "papers": [],
+            "error": {"type": error_type, "message": message},
+        }

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -206,6 +206,56 @@ result = tool.run(
 
 网络超时、HTTP错误、连接失败、非法JSON和Crossref API错误会通过结构化`error`字段返回。可以通过环境变量`CROSSREF_EMAIL`提供联系邮箱，进入Crossref polite pool并在请求中携带可识别的User-Agent。
 
+### 1.6 Semantic Scholar论文搜索
+
+Semantic Scholar工具通过Semantic Scholar Academic Graph API检索跨学科学术论文，或根据论文标识符精确查询元数据。大多数端点支持不配置API Key进行基础调用。如果Semantic Scholar已经向你发放API Key，可以通过环境变量`S2_API_KEY`进行配置；基础使用不要求个人必须申请API Key。
+
+工具配置：
+
+```yaml
+name: 'semantic_scholar_tool'
+description: |
+  Search Semantic Scholar for scholarly papers or retrieve one paper by identifier.
+tool_type: 'api'
+input_keys: ['query']
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool'
+  class: 'SemanticScholarTool'
+```
+
+关键词搜索示例：
+
+```python
+from agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool import SemanticScholarTool
+
+tool = SemanticScholarTool()
+result = tool.execute(
+    query="large language models in medicine",
+    mode="search",
+    max_results=5,
+)
+```
+
+论文精确查询示例：
+
+```python
+result = tool.execute(
+    query="DOI:10.18653/v1/2020.acl-main.447",
+    mode="paper",
+)
+```
+
+参数说明：
+
+- `query`：必填。`search`模式下为检索关键词；`paper`模式下为DOI、PMID、PMCID、ArXiv ID、CorpusId或Semantic Scholar paper ID，也支持DOI URL和ArXiv URL。
+- `mode`：可选，可选值为`search`或`paper`，默认为`search`。
+- `max_results`：可选，仅用于`search`模式，范围为1到20，默认为5。`paper`模式最多返回一条记录。
+
+返回结果包含操作模式、查询内容、结果数量和`papers`列表。每篇论文可包含Semantic Scholar paper ID、CorpusId、外部标识符、标题、作者、摘要、期刊或会议名称、发表日期和年份、出版物类型、研究领域、引用数、参考文献数、开放获取状态、开放获取PDF地址和Semantic Scholar页面地址。缺失字段会根据字段类型返回空字符串、空列表、空对象、`0`或`false`。工具仅返回元数据，不下载或总结论文全文。
+
+网络超时、HTTP错误、连接失败、非法JSON、响应结构异常和Semantic Scholar API错误会通过结构化`error`字段返回。匿名用户共用Semantic Scholar的调用额度，并可能在繁忙时段受到额外限制；遇到HTTP 429时应稍后重试。仅当Semantic Scholar已经向你发放API Key时才需要配置`S2_API_KEY`，配置后工具会通过`x-api-key`请求头发送该Key。
+
 
 ## 2. 代码工具
 

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml
@@ -1,0 +1,46 @@
+name: 'semantic_scholar_tool'
+description: |
+  Search Semantic Scholar for scholarly papers or retrieve one paper by identifier.
+
+  Input parameters:
+    - query (required): Search keywords in search mode, or a paper identifier in paper
+      mode. Paper mode supports DOI, PMID, PMCID, ArXiv, CorpusId, and Semantic Scholar
+      paper ID values, including DOI and ArXiv URLs.
+    - mode (optional): Operation mode. Use search for keyword search or paper for an
+      exact paper lookup. Defaults to search.
+    - max_results (optional): Number of papers to return in search mode, from 1 to 20.
+      Defaults to 5. Paper mode always returns at most one paper.
+
+  Search example:
+    {
+      "query": "large language models in medicine",
+      "mode": "search",
+      "max_results": 5
+    }
+
+  Paper lookup examples:
+    {
+      "query": "DOI:10.18653/v1/2020.acl-main.447",
+      "mode": "paper"
+    }
+    {
+      "query": "PMID:19872477",
+      "mode": "paper"
+    }
+
+  Each paper may contain its Semantic Scholar paper ID, CorpusId, external identifiers,
+  title, authors, abstract, venue, publication date and year, publication types, fields
+  of study, citation count, reference count, open access status, open access PDF, and
+  Semantic Scholar URL. Missing metadata is returned as an empty string, list, object,
+  zero, or false value. Network and Semantic Scholar API failures are returned in a
+  structured error field. Most endpoints support anonymous access, but anonymous users
+  share a rate limit and may receive HTTP 429 during busy periods. If Semantic Scholar
+  has issued an API key to you, set the optional S2_API_KEY environment variable to send
+  it with requests. An API key is not required for basic use. This tool returns metadata
+  only and does not download or summarize full text.
+tool_type: 'api'
+input_keys: ['query']
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool'
+  class: 'SemanticScholarTool'

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import requests
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool import SemanticScholarTool
+
+
+SAMPLE_PAPER = {
+    "paperId": "649def34f8be52c8b66281af98ae884c09aef38b",
+    "corpusId": 215416146,
+    "externalIds": {
+        "DOI": "10.18653/v1/2020.acl-main.447",
+        "ArXiv": "2004.12345",
+        "CorpusId": 215416146,
+    },
+    "url": "https://www.semanticscholar.org/paper/649def34f8be52c8b66281af98ae884c09aef38b",
+    "title": "Construction of the Literature Graph in Semantic Scholar",
+    "abstract": "A useful scholarly graph abstract.",
+    "venue": "ACL",
+    "year": 2020,
+    "publicationDate": "2020-07-01",
+    "publicationTypes": ["JournalArticle", "Review"],
+    "authors": [
+        {"authorId": "1", "name": "Alice Smith"},
+        {"authorId": "2", "name": "Bob Jones"},
+    ],
+    "citationCount": 299,
+    "referenceCount": 27,
+    "isOpenAccess": True,
+    "openAccessPdf": {
+        "url": "https://example.org/paper.pdf",
+        "status": "GREEN",
+        "license": "CCBY",
+    },
+    "fieldsOfStudy": ["Computer Science", "Medicine"],
+}
+
+
+def response_mock(*, json_data=None):
+    response = Mock()
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+class SemanticScholarToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = SemanticScholarTool(api_key="test-api-key")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_search_returns_structured_metadata(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(json_data={"total": 42, "offset": 0, "next": 1, "data": [SAMPLE_PAPER]})
+
+        result = self.tool.execute(query="AI medicine", max_results=3)
+
+        self.assertEqual(result["mode"], "search")
+        self.assertEqual(result["query"], "AI medicine")
+        self.assertEqual(result["max_results"], 3)
+        self.assertEqual(result["total_results"], 42)
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(
+            result["papers"][0],
+            {
+                "paper_id": "649def34f8be52c8b66281af98ae884c09aef38b",
+                "corpus_id": 215416146,
+                "external_ids": {
+                    "DOI": "10.18653/v1/2020.acl-main.447",
+                    "ArXiv": "2004.12345",
+                    "CorpusId": "215416146",
+                },
+                "title": "Construction of the Literature Graph in Semantic Scholar",
+                "authors": ["Alice Smith", "Bob Jones"],
+                "abstract": "A useful scholarly graph abstract.",
+                "venue": "ACL",
+                "publication_date": "2020-07-01",
+                "year": 2020,
+                "publication_types": ["JournalArticle", "Review"],
+                "fields_of_study": ["Computer Science", "Medicine"],
+                "citation_count": 299,
+                "reference_count": 27,
+                "is_open_access": True,
+                "open_access_pdf": {
+                    "url": "https://example.org/paper.pdf",
+                    "status": "GREEN",
+                    "license": "CCBY",
+                },
+                "url": "https://www.semanticscholar.org/paper/649def34f8be52c8b66281af98ae884c09aef38b",
+            },
+        )
+
+        request = mock_get.call_args
+        self.assertEqual(request.args[0], "https://api.semanticscholar.org/graph/v1/paper/search")
+        self.assertEqual(request.kwargs["params"]["query"], "AI medicine")
+        self.assertEqual(request.kwargs["params"]["limit"], 3)
+        self.assertIn("citationCount", request.kwargs["params"]["fields"])
+        self.assertEqual(request.kwargs["headers"]["x-api-key"], "test-api-key")
+        self.assertEqual(request.kwargs["timeout"], 15.0)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_paper_lookup_normalizes_doi_url(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(json_data=SAMPLE_PAPER)
+
+        result = self.tool.execute(
+            query="https://doi.org/10.18653/v1/2020.acl-main.447",
+            mode="PAPER",
+            max_results=20,
+        )
+
+        self.assertEqual(result["mode"], "paper")
+        self.assertEqual(result["query"], "DOI:10.18653/v1/2020.acl-main.447")
+        self.assertEqual(result["max_results"], 1)
+        self.assertEqual(result["total_results"], 1)
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(
+            mock_get.call_args.args[0],
+            "https://api.semanticscholar.org/graph/v1/paper/DOI%3A10.18653%2Fv1%2F2020.acl-main.447",
+        )
+
+    def test_paper_identifier_normalization(self) -> None:
+        self.assertEqual(
+            self.tool._normalize_paper_id("https://arxiv.org/abs/2106.15928"),
+            "ARXIV:2106.15928",
+        )
+        self.assertEqual(self.tool._normalize_paper_id("pmid:19872477"), "PMID:19872477")
+        self.assertEqual(self.tool._normalize_paper_id("pmcid:2323736"), "PMCID:2323736")
+        self.assertEqual(self.tool._normalize_paper_id("corpusid:215416146"), "CorpusId:215416146")
+        paper_id = "649def34f8be52c8b66281af98ae884c09aef38b"
+        self.assertEqual(self.tool._normalize_paper_id(paper_id.upper()), paper_id)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_request_without_api_key_omits_header(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(json_data={"total": 0, "data": []})
+        tool = SemanticScholarTool(api_key=None)
+
+        tool.execute(query="no matching paper")
+
+        self.assertNotIn("x-api-key", mock_get.call_args.kwargs["headers"])
+
+    def test_invalid_input(self) -> None:
+        with self.assertRaisesRegex(ValueError, "query must not be empty"):
+            self.tool.execute(query="  ")
+        with self.assertRaisesRegex(ValueError, "mode must be one of"):
+            self.tool.execute(query="AI", mode="detail")
+        with self.assertRaisesRegex(ValueError, "between 1 and 20"):
+            self.tool.execute(query="AI", max_results=0)
+        with self.assertRaisesRegex(ValueError, "integer"):
+            self.tool.execute(query="AI", max_results=True)
+        with self.assertRaisesRegex(ValueError, "paper identifier"):
+            self.tool.execute(query="not-an-identifier", mode="paper")
+        with self.assertRaisesRegex(ValueError, "valid DOI"):
+            self.tool.execute(query="doi:not-a-doi", mode="paper")
+
+    def test_missing_metadata_returns_empty_values(self) -> None:
+        paper = SemanticScholarTool._parse_paper({"paperId": "abc"})
+
+        self.assertEqual(paper["paper_id"], "abc")
+        self.assertEqual(paper["corpus_id"], 0)
+        self.assertEqual(paper["external_ids"], {})
+        self.assertEqual(paper["title"], "")
+        self.assertEqual(paper["authors"], [])
+        self.assertEqual(paper["abstract"], "")
+        self.assertEqual(paper["publication_types"], [])
+        self.assertEqual(paper["fields_of_study"], [])
+        self.assertFalse(paper["is_open_access"])
+        self.assertEqual(paper["open_access_pdf"], {})
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_timeout_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.Timeout("timed out")
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "request_timeout")
+        self.assertEqual(result["papers"], [])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_http_error_returns_structured_error(self, mock_get: Mock) -> None:
+        response = Mock(status_code=429)
+        mock_get.side_effect = requests.HTTPError(response=response)
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "http_error")
+        self.assertIn("429", result["error"]["message"])
+        self.assertIn("S2_API_KEY", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_connection_error_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.ConnectionError("connection failed")
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "request_error")
+        self.assertIn("connection failed", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_api_error_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(json_data={"error": "Unknown paper id"})
+
+        result = self.tool.execute(query="PMID:19872477", mode="paper")
+
+        self.assertEqual(result["error"]["type"], "api_error")
+        self.assertIn("Unknown paper id", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_invalid_json_returns_structured_error(self, mock_get: Mock) -> None:
+        response = response_mock()
+        response.json.side_effect = requests.JSONDecodeError("invalid JSON", "", 0)
+        mock_get.return_value = response
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "invalid_response")
+        self.assertIn("invalid Semantic Scholar JSON response", result["error"]["message"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_invalid_search_shape_returns_structured_error(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(json_data={"total": 1, "data": "not-a-list"})
+
+        result = self.tool.execute(query="AI medicine")
+
+        self.assertEqual(result["error"]["type"], "invalid_response")
+        self.assertIn("invalid search data", result["error"]["message"])
+
+    def test_shipped_config_exposes_modes_identifiers_and_metadata(self) -> None:
+        config_path = (
+            Path(__file__).resolve().parents[6]
+            / "examples"
+            / "sample_standard_app"
+            / "intelligence"
+            / "agentic"
+            / "tool"
+            / "buildin"
+            / "semantic_scholar_tool.yaml"
+        )
+        with config_path.open(encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file)
+
+        self.assertEqual(config["input_keys"], ["query"])
+        description = config["description"]
+        for parameter in ("query", "mode", "max_results"):
+            self.assertIn(parameter, description)
+        for mode in ("search", "paper"):
+            self.assertIn(mode, description)
+        for identifier in ("DOI", "PMID", "PMCID", "ArXiv", "CorpusId", "Semantic Scholar paper ID"):
+            self.assertIn(identifier, description)
+        for metadata_field in (
+            "title",
+            "authors",
+            "abstract",
+            "venue",
+            "publication date",
+            "citation count",
+            "reference count",
+            "open access PDF",
+        ):
+            self.assertIn(metadata_field, description)
+        self.assertIn("S2_API_KEY", description)
+        self.assertIn("rate", description.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [x] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Related to #252. This PR adds a Semantic Scholar scholarly metadata tool with keyword search and exact paper lookup capabilities.
- Added `search` mode for keyword-based paper discovery and `paper` mode for exact lookup using DOI, PMID, PMCID, ArXiv ID, CorpusId, Semantic Scholar paper ID, DOI URL, or ArXiv URL.
- Added normalized paper metadata including paper ID, CorpusId, external identifiers, title, authors, abstract, venue, publication date, publication types, fields of study, citation count, reference count, open-access status, PDF information, and Semantic Scholar URL.
- Added validation for invalid modes, result limits, and paper identifiers, together with structured handling for timeouts, HTTP errors, connection failures, invalid JSON, malformed responses, and Semantic Scholar API errors.
- Added optional `S2_API_KEY` support through the `x-api-key` request header. An API key is not required for basic use and is only used when Semantic Scholar has issued one to the user.
- Added the shipped YAML configuration, usage examples, anonymous rate-limit notes, and Chinese documentation.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- Test file:
  `tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py`
- Test command:
  `.\.venv\Scripts\python.exe -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_semantic_scholar_tool -v`
- Test result:
  `Ran 13 tests in 0.010s`
  `OK`
- Manual verification:
  - Exact PMID lookup successfully returned one paper with normalized metadata, including authors, abstract, publication information, citation/reference counts, fields of study, and open-access PDF information.
  - Anonymous requests may temporarily return:
    `Semantic Scholar returned HTTP status 429 (rate limited). Retry later, or configure S2_API_KEY if Semantic Scholar has issued one to you.`
  - HTTP 429 is an upstream Semantic Scholar anonymous rate-limit response. Anonymous users share a common request quota and may be throttled during busy periods. The tool converts this response into a structured `http_error`; retrying later may succeed.
  - A direct request to the official Semantic Scholar endpoint returned the same HTTP 429 response, confirming that the rate limit was imposed by the upstream API rather than by the tool implementation.




<img width="899" height="757" alt="image" src="https://github.com/user-attachments/assets/132d8d79-247f-4930-9cb0-3838373a15ee" />
<img width="878" height="331" alt="image" src="https://github.com/user-attachments/assets/a9e7e8b1-0227-4041-a3ee-6dcbf591fe39" />
<img width="897" height="768" alt="image" src="https://github.com/user-attachments/assets/852f36c3-d30b-45bb-90d5-d7b65fe5a020" />
<img width="894" height="611" alt="image" src="https://github.com/user-attachments/assets/52e13251-6059-4012-82e9-03dd085200c4" />



**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- `examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml`
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md`