### PR TITLE
fix(knowledge): raise clear error for unregistered store/router (#207)

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -187,7 +187,7 @@ class Knowledge(ComponentBase):
         for _store_code in stores:
             futures.append(
                 self.insert_executor.submit(
-                    StoreManager().get_instance_obj(_store_code).insert_document,
+                    StoreManager().get_instance_obj(_store_code, strict=True).insert_document,
                     document_list))
         wait(futures, return_when=ALL_COMPLETED)
         for future in futures:
@@ -213,7 +213,7 @@ class Knowledge(ComponentBase):
         for _store_code in stores:
             futures.append(
                 self.insert_executor.submit(
-                    StoreManager().get_instance_obj(_store_code).update_document,
+                    StoreManager().get_instance_obj(_store_code, strict=True).update_document,
                     document_list))
         wait(futures, return_when=ALL_COMPLETED)
         for future in futures:
@@ -225,7 +225,7 @@ class Knowledge(ComponentBase):
         LOGGER.info("Knowledge update complete.")
 
     def _route_rag(self, query: Query):
-        return RagRouterManager().get_instance_obj(self.rag_router).rag_route(query, self.stores)
+        return RagRouterManager().get_instance_obj(self.rag_router, strict=True).rag_route(query, self.stores)
 
     @trace_knowledge
     def query_knowledge(self, **kwargs) -> List[Document]:
@@ -241,7 +241,7 @@ class Knowledge(ComponentBase):
         for query_task in query_tasks:
             futures.append((
                 self.query_executor.submit(
-                    StoreManager().get_instance_obj(query_task[1]).query,
+                    StoreManager().get_instance_obj(query_task[1], strict=True).query,
                     query_task[0]),
                 query_task[1],
             ))

--- a/agentuniverse/base/component/component_manager_base.py
+++ b/agentuniverse/base/component/component_manager_base.py
@@ -47,17 +47,40 @@ class ComponentManagerBase(Generic[ComponentTypeVar]):
         self._instance_obj_map.pop(component_instance_name)
 
     def get_instance_obj(self, component_instance_name: str,
-                         appname: str = None, new_instance: bool = True) -> ComponentTypeVar:
-        """Return the component instance object."""
+                         appname: str = None, new_instance: bool = True,
+                         strict: bool = False) -> ComponentTypeVar:
+        """Return the component instance object.
+
+        Args:
+            component_instance_name: Registered name of the component instance.
+            appname: Application name; defaults to the current app's name.
+            new_instance: When True, return an independent copy so callers
+                cannot mutate the shared registered instance.
+            strict: When True, raise a :class:`ValueError` with a descriptive
+                message if the component is not registered, instead of
+                returning ``None``. Use this at user-facing entry points so a
+                missing component surfaces as an actionable error rather than a
+                cryptic ``AttributeError`` on the returned ``None`` (e.g.
+                ``'NoneType' object has no attribute 'query'``).
+        """
         if component_instance_name == "__default_instance__":
             return self.get_default_instance(new_instance)
         appname = appname or ApplicationConfigManager().app_configer.base_info_appname
         instance_code = f'{appname}.{self._component_type.value.lower()}.{component_instance_name}'
+        instance = self._instance_obj_map.get(instance_code)
+        if instance is None:
+            if strict:
+                raise ValueError(
+                    f"{self._component_type.value} component "
+                    f"'{component_instance_name}' is not registered (resolved "
+                    f"instance code '{instance_code}'). Ensure the corresponding "
+                    f"configuration is loaded before use — verify the component "
+                    f"config file and the application bootstrap order."
+                )
+            return None
         if new_instance:
-            instance = self._instance_obj_map.get(instance_code)
-            if instance:
-                return instance.create_copy()
-        return self._instance_obj_map.get(instance_code)
+            return instance.create_copy()
+        return instance
 
     def get_default_instance(self, new_instance: bool = False) -> ComponentTypeVar:
         """Return the default instance of component."""

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_registration_errors.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_registration_errors.py
@@ -1,0 +1,171 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/13
+# @FileName: test_knowledge_registration_errors.py
+
+"""
+Tests for clear error reporting when a referenced component is not registered.
+
+Background: ``ComponentManagerBase.get_instance_obj`` used to return ``None``
+silently when a component (store / rag-router / ...) was not registered, so a
+later attribute access on the result crashed with a cryptic
+``AttributeError: 'NoneType' object has no attribute 'query'`` (issues #207 and
+#203). The ``strict=True`` path now raises a descriptive ``ValueError`` instead.
+
+These tests cover both the generic base-manager behaviour and the end-to-end
+``Knowledge.query_knowledge`` path that originally surfaced the bug.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import agentuniverse.base.annotation.trace as trace_module
+from agentuniverse.agent.action.knowledge import knowledge as knowledge_module
+from agentuniverse.agent.action.knowledge.knowledge import Knowledge
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.component.component_manager_base import \
+    ComponentManagerBase
+import agentuniverse.base.component.component_manager_base as cmb_module
+
+
+class TestGetInstanceObjStrict(unittest.TestCase):
+    """Unit tests for the ``strict`` flag on get_instance_obj."""
+
+    def setUp(self) -> None:
+        self.mgr = ComponentManagerBase(ComponentEnum.STORE)
+
+    def test_default_returns_none_when_unregistered(self) -> None:
+        # Default behaviour is unchanged: a missing component resolves to None.
+        self.assertIsNone(self.mgr.get_instance_obj("missing", appname="test_app"))
+
+    def test_strict_raises_value_error_naming_component(self) -> None:
+        # strict=True turns the silent None into an actionable error that names
+        # both the component code and its type, instead of letting the caller
+        # blow up later with 'NoneType' object has no attribute 'query'.
+        with self.assertRaises(ValueError) as ctx:
+            self.mgr.get_instance_obj("missing", appname="test_app", strict=True)
+        msg = str(ctx.exception)
+        self.assertIn("missing", msg)
+        self.assertIn(ComponentEnum.STORE.value, msg)
+
+    def test_strict_returns_copy_when_registered(self) -> None:
+        # strict must not change the happy path: a registered component is
+        # still returned (as an independent copy when new_instance=True).
+        copy_sentinel = object()
+        dummy = MagicMock()
+        dummy.create_copy.return_value = copy_sentinel
+        self.mgr._instance_obj_map["test_app.store.my_store"] = dummy
+        result = self.mgr.get_instance_obj(
+            "my_store", appname="test_app", strict=True)
+        self.assertIs(result, copy_sentinel)
+
+    def test_strict_returns_raw_instance_when_new_instance_false(self) -> None:
+        dummy = MagicMock()
+        self.mgr._instance_obj_map["test_app.store.my_store"] = dummy
+        result = self.mgr.get_instance_obj(
+            "my_store", appname="test_app", strict=True, new_instance=False)
+        self.assertIs(result, dummy)
+
+
+class TestKnowledgeRegistrationErrors(unittest.TestCase):
+    """End-to-end: query_knowledge surfaces a clear error for an unregistered
+    store instead of a cryptic AttributeError."""
+
+    def test_query_knowledge_raises_clear_error_for_unregistered_store(self) -> None:
+        knowledge = Knowledge(
+            name="guard_knowledge",
+            stores=["definitely_unregistered_store"],
+            rag_router="base_router",
+        )
+        # Router routes the query to a store code that no one registered.
+        router = MagicMock()
+        router.rag_route.return_value = [
+            (Query(query_str="q"), "definitely_unregistered_store")]
+
+        with patch.object(trace_module, "ConversationMemoryModule"), \
+                patch.object(trace_module, "Monitor") as monitor, \
+                patch.object(knowledge_module, "RagRouterManager") as router_mgr, \
+                patch.object(cmb_module, "ApplicationConfigManager") as acm:
+            monitor.get_invocation_chain.return_value = []
+            router_mgr.return_value.get_instance_obj.return_value = router
+            acm.return_value.app_configer.base_info_appname = "test_app"
+
+            with self.assertRaises(ValueError) as ctx:
+                knowledge.query_knowledge(query_str="q")
+
+        msg = str(ctx.exception)
+        self.assertIn("definitely_unregistered_store", msg)
+        self.assertIn(ComponentEnum.STORE.value, msg)
+
+
+class TestStrictLookupWithChannelFusion(unittest.TestCase):
+    """Strict store lookup must coexist with the opt-in channel-aware recall
+    that landed for RRF fusion: when a fusion post-processor is configured,
+    ``query_knowledge`` still resolves each store with ``strict=True`` and the
+    per-channel merge runs unchanged.
+    """
+
+    def test_strict_lookup_runs_alongside_channel_aware_fusion(self) -> None:
+        from agentuniverse.agent.action.knowledge.doc_processor.\
+            reciprocal_rank_fusion_processor import ReciprocalRankFusionProcessor
+        from agentuniverse.agent.action.knowledge.knowledge import \
+            RECALL_CHANNEL_KEY
+        from agentuniverse.agent.action.knowledge.store.document import Document
+
+        class _FakeStore:
+            def __init__(self, docs):
+                self._docs = docs
+
+            def query(self, query):
+                return [Document(text=d.text, metadata=dict(d.metadata or {}))
+                        for d in self._docs]
+
+        stores = {
+            "vector_store": _FakeStore([Document(text="shared")]),
+            "keyword_store": _FakeStore([Document(text="shared")]),
+        }
+        rrf = ReciprocalRankFusionProcessor(channel_key=RECALL_CHANNEL_KEY, k=60)
+        knowledge = Knowledge(
+            name="strict_fusion_knowledge",
+            stores=list(stores.keys()),
+            rag_router="base_router",
+            post_processors=["reciprocal_rank_fusion_processor"],
+        )
+
+        router = MagicMock()
+        router.rag_route.return_value = [
+            (Query(query_str="q"), code) for code in stores]
+        with patch.object(trace_module, "ConversationMemoryModule"), \
+                patch.object(trace_module, "Monitor") as monitor, \
+                patch.object(knowledge_module, "RagRouterManager") as router_mgr, \
+                patch.object(knowledge_module, "StoreManager") as store_mgr, \
+                patch.object(knowledge_module, "DocProcessorManager") as proc_mgr:
+            monitor.get_invocation_chain.return_value = []
+            router_mgr.return_value.get_instance_obj.return_value = router
+            # The loop passes strict=True; the stub still resolves each
+            # registered store so the channel-aware merge can run.
+            store_mgr.return_value.get_instance_obj.side_effect = \
+                lambda code, **_: stores[code]
+            proc_mgr.return_value.get_instance_obj.return_value = rrf
+
+            out = knowledge.query_knowledge(query_str="q")
+
+        # The shared document is fused across both channels (2 * 1/61),
+        # proving strict lookup did not short-circuit the channel-aware merge.
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].text, "shared")
+        self.assertAlmostEqual(out[0].metadata["relevance_score"], 2.0 / 61)
+        # And query_knowledge resolved the stores via strict=True, so the
+        # clear-error contract holds even with channel fusion enabled.
+        strict_lookup_calls = [
+            c for c in store_mgr.return_value.get_instance_obj.call_args_list
+            if c.kwargs.get("strict") is True]
+        self.assertTrue(
+            strict_lookup_calls,
+            "query_knowledge should look up stores with strict=True")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

When a store (or rag-router) referenced by a Knowledge is not registered, the call site crashed with a cryptic, low-level error (#207): `'NoneType' object has no attribute 'query'` / `'NoneType' object has no attribute 'insert_knowledge'`.

> Note on #203: that report has a different root cause — the caller requested `account_rule_knowledge` while the YAML registered `account_case_knowledge`, i.e. a name mismatch that fails *before* a `Knowledge` instance is resolved. This PR's `strict` lookup only fires inside an already-resolved `Knowledge`, so it does **not** claim to fix #203; it targets the `NoneType`-on-missing-component crash in #207.

## Root cause

`ComponentManagerBase.get_instance_obj` returns `self._instance_obj_map.get(instance_code)` — i.e. **silently `None`** when the component is not registered. Every caller then does `…get_instance_obj(code).query` / `.insert_document`, so the `None` surfaces as an `AttributeError` deep inside the query/insert path, with no hint that a component is simply missing.

## Fix

1. **`component_manager_base.py`** — add an opt-in `strict: bool = False` flag to `get_instance_obj`. When `True` and the component is missing, it raises a descriptive `ValueError` naming the **component code** and **type** (e.g. `STORE component 'my_store' is not registered (resolved instance code '…'). Ensure the corresponding configuration is loaded before use — verify the component config file and the application bootstrap order.`) instead of returning `None`. **Default behaviour is unchanged** (`strict=False` still returns `None`).

2. **`knowledge.py`** — switch the four lookups to `strict=True`: the `query_knowledge` / `insert_knowledge` / `update_knowledge` store lookups and the `_route_rag` rag-router lookup.

## Rebased onto #609's channel-aware recall

The branch is rebuilt from current master, which now carries the channel-aware recall from #609. The `strict=True` change is preserved alongside the `(future, store_code)` pairs, the `recall_channel` metadata, and the opt-in deduplication contract — strict lookup and RRF fusion compose without either changing the other's behaviour.

## Tests

`tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_registration_errors.py` (6):
- `TestGetInstanceObjStrict` (4): default still returns `None`; `strict` raises `ValueError` naming the code + type; happy path still returns a copy / raw instance under `strict`.
- `TestKnowledgeRegistrationErrors` (1): end-to-end through the real `query_knowledge` — an unregistered store raises a `ValueError` mentioning the store code and `STORE`, not an `AttributeError`.
- `TestStrictLookupWithChannelFusion` (1): with an RRF fusion processor configured, `query_knowledge` still resolves stores with `strict=True` and the per-channel merge fuses correctly — strict and channel-aware fusion coexist.

`python -m unittest test_knowledge_registration_errors` → **6 passed**, and the existing RRF integration tests (`test_knowledge_rrf_integration`) still pass.

Relates to #207. Part of #253 (error message optimization).
