### PR TITLE
feat(knowledge): MarkdownHeaderTextSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
@@ -22,6 +22,10 @@ fully unit-testable without a network connection or optional install.
 It only separates on headers; a section that is still larger than desired
 should be chained with a character / token splitter afterwards (splitter
 processors compose — the output list is a valid input to the next one).
+
+Fenced code blocks (backtick or tilde fences) are respected: a '#'-prefixed
+line inside one is treated as code rather than a header, so code samples in a
+README are not mistaken for section titles.
 """
 
 import re
@@ -38,6 +42,16 @@ from agentuniverse.base.config.component_configer.component_configer import \
 # trailing run of '#' (closed ATX syntax) and surrounding whitespace are
 # stripped. A line such as "#no-space" or "####### seven" is not a header.
 _HEADER_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
+
+# Fenced code blocks (CommonMark). An opening fence is up to three leading
+# spaces followed by three or more backticks or tildes; a backtick fence may
+# not carry a backtick in its info string. A closing fence is up to three
+# leading spaces, the same fence character repeated at least as many times as
+# the opening fence, then only trailing whitespace. While inside a fence, ATX
+# header detection is suppressed so a '# Example' line inside a ```python
+# block is treated as code instead of a header.
+_FENCE_OPEN_RE = re.compile(r"^( {0,3})(`{3,}|~{3,})(.*)$")
+_FENCE_CLOSE_RE = re.compile(r"^( {0,3})(`{3,}|~{3,})[ \t]*$")
 
 
 class MarkdownHeaderTextSplitter(DocProcessor):
@@ -108,7 +122,28 @@ class MarkdownHeaderTextSplitter(DocProcessor):
                 return
             sections.append((body, self._header_path(headers)))
 
+        fence_char: Optional[str] = None  # current fence char, or None if outside
+        fence_len: int = 0                # length of the opening fence run
+
         for raw_line in text.splitlines():
+            if fence_char is not None:
+                # Inside a fenced code block: every line is content, but watch
+                # for the matching closing fence.
+                buffer.append(raw_line)
+                close = self._match_fence(raw_line, closing=True)
+                if close is not None and close[0] == fence_char \
+                        and close[1] >= fence_len:
+                    fence_char = None
+                    fence_len = 0
+                continue
+            open_fence = self._match_fence(raw_line, closing=False)
+            if open_fence is not None:
+                # Entering a fenced code block: the fence line is content, and
+                # header detection stays off until the block closes.
+                buffer.append(raw_line)
+                fence_char = open_fence[0]
+                fence_len = open_fence[1]
+                continue
             header = self._match_header(raw_line)
             if header is not None:
                 # Lines accumulated so far belong to the *previous* context.
@@ -129,6 +164,24 @@ class MarkdownHeaderTextSplitter(DocProcessor):
         if level > self.max_header_level:
             return None
         return level, match.group(2).strip()
+
+    @staticmethod
+    def _match_fence(line: str, closing: bool) -> Optional[Tuple[str, int]]:
+        """Return ``(fence_char, run_length)`` if ``line`` is a code fence.
+
+        ``closing`` selects the closing-fence rule, which forbids any trailing
+        content. The caller verifies that the character matches the opening
+        fence and that the run is at least as long. A backtick fence whose
+        info string itself contains a backtick is not an opening fence.
+        """
+        match = (_FENCE_CLOSE_RE if closing else _FENCE_OPEN_RE).match(line)
+        if not match:
+            return None
+        fence = match.group(2)
+        char = fence[0]
+        if not closing and char == '`' and '`' in match.group(3):
+            return None
+        return char, len(fence)
 
     @staticmethod
     def _push_header(headers: Dict[int, str], level: int, title: str) -> None:

--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
@@ -1,0 +1,159 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/13
+# @FileName: markdown_header_text_splitter.py
+
+"""
+Markdown header text splitter.
+
+Splits each input :class:`Document` into one section per markdown header (ATX
+headings ``#`` … ``######``), recording the section's header hierarchy as
+metadata so a retrieved chunk can be traced back to the part of the document
+it came from. This is the *pre-processing* direction of issue #258 (knowledge
+pre-processing components): a long markdown source — read from a ``.md`` file,
+a crawled web page, a README — is broken into header-delimited chunks *before*
+it is embedded and stored.
+
+The component is pure-Python, deterministic, and dependency-free: unlike the
+framework's other splitters it does not wrap a third-party library, so it is
+fully unit-testable without a network connection or optional install.
+
+It only separates on headers; a section that is still larger than desired
+should be chained with a character / token splitter afterwards (splitter
+processors compose — the output list is a valid input to the next one).
+"""
+
+import re
+from typing import Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+# ATX header: 1-6 leading '#', mandatory whitespace, then the title text. A
+# trailing run of '#' (closed ATX syntax) and surrounding whitespace are
+# stripped. A line such as "#no-space" or "####### seven" is not a header.
+_HEADER_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
+
+
+class MarkdownHeaderTextSplitter(DocProcessor):
+    """Split markdown documents by their ATX header structure.
+
+    Attributes:
+        max_header_level (int): Deepest ATX header level to split on (1–6).
+            Headers deeper than this are treated as ordinary content lines,
+            so ``max_header_level=1`` splits only on top-level (``#``) headers.
+        header_path_key (Optional[str]): Metadata key under which the splitter
+            records the joined header hierarchy of each section (e.g.
+            ``"Installation > macOS"``). Set to ``None`` to omit the field.
+        keep_preamble (bool): When True, content before the first header is
+            emitted as its own section (with an empty header path); when False
+            it is dropped.
+        path_separator (str): Joiner used to compose the header path.
+    """
+
+    max_header_level: int = 6
+    header_path_key: Optional[str] = "header_path"
+    keep_preamble: bool = True
+    path_separator: str = " > "
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Split each document into header-delimited sections.
+
+        Args:
+            origin_docs (List[Document]): Documents whose ``text`` is parsed as
+                markdown. Each document's existing metadata is preserved on the
+                emitted sections.
+            query (Query, optional): Unused; kept for interface compatibility.
+
+        Returns:
+            List[Document]: One document per non-empty section, each carrying
+            its header hierarchy under ``header_path_key`` (when configured).
+            An empty input yields an empty list.
+        """
+        if not origin_docs:
+            return []
+        sections: List[Document] = []
+        for doc in origin_docs:
+            base_meta = dict(doc.metadata or {})
+            for text, header_path in self._split_text(doc.text or ""):
+                metadata = dict(base_meta)
+                if self.header_path_key:
+                    metadata[self.header_path_key] = header_path
+                sections.append(Document(text=text, metadata=metadata))
+        return sections
+
+    # ------------------------------------------------------------------ #
+    # Splitting (pure) — fully testable without a network
+    # ------------------------------------------------------------------ #
+
+    def _split_text(self, text: str) -> List[Tuple[str, str]]:
+        """Return ``(section_text, header_path)`` pairs for one document."""
+        headers: Dict[int, str] = {}  # current open header title per level
+        buffer: List[str] = []
+        sections: List[Tuple[str, str]] = []
+
+        def flush() -> None:
+            body = "\n".join(buffer).strip("\n")
+            buffer.clear()
+            if not body:
+                return
+            if not self.keep_preamble and not headers:
+                # Preamble (no header seen yet) is dropped when configured so.
+                return
+            sections.append((body, self._header_path(headers)))
+
+        for raw_line in text.splitlines():
+            header = self._match_header(raw_line)
+            if header is not None:
+                # Lines accumulated so far belong to the *previous* context.
+                flush()
+                level, title = header
+                self._push_header(headers, level, title)
+            else:
+                buffer.append(raw_line)
+        flush()
+        return sections
+
+    def _match_header(self, line: str) -> Optional[Tuple[int, str]]:
+        """Return ``(level, title)`` if ``line`` is a split-able header."""
+        match = _HEADER_RE.match(line)
+        if not match:
+            return None
+        level = len(match.group(1))
+        if level > self.max_header_level:
+            return None
+        return level, match.group(2).strip()
+
+    @staticmethod
+    def _push_header(headers: Dict[int, str], level: int, title: str) -> None:
+        """Open the header at ``level`` and close any deeper open headers."""
+        for deeper in [lvl for lvl in headers if lvl >= level]:
+            del headers[deeper]
+        headers[level] = title
+
+    def _header_path(self, headers: Dict[int, str]) -> str:
+        """Join the open headers from shallowest to deepest."""
+        if not headers:
+            return ""
+        return self.path_separator.join(headers[lvl] for lvl in sorted(headers))
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> 'MarkdownHeaderTextSplitter':
+        """Initialize the splitter from its component config."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "max_header_level"):
+            self.max_header_level = doc_processor_configer.max_header_level
+        if hasattr(doc_processor_configer, "header_path_key"):
+            self.header_path_key = doc_processor_configer.header_path_key
+        if hasattr(doc_processor_configer, "keep_preamble"):
+            self.keep_preamble = doc_processor_configer.keep_preamble
+        if hasattr(doc_processor_configer, "path_separator"):
+            self.path_separator = doc_processor_configer.path_separator
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.yaml
@@ -1,0 +1,22 @@
+name: 'markdown_header_text_splitter'
+description: 'Split markdown documents into one chunk per ATX header (# to ######), preserving each section header hierarchy as metadata. Pure-Python, no external dependency.'
+
+# Deepest ATX header level to split on (1-6). Headers deeper than this are kept
+# as ordinary content; e.g. max_header_level=2 splits only on '#' and '##'.
+max_header_level: 6
+
+# Metadata key under which the joined header hierarchy of a section is recorded
+# (e.g. "Installation > macOS"). Set to null to omit the field.
+header_path_key: 'header_path'
+
+# When true, content before the first header is emitted as its own section
+# (with an empty header path); when false it is dropped.
+keep_preamble: true
+
+# Joiner used to compose the header path.
+path_separator: ' > '
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.markdown_header_text_splitter'
+  class: 'MarkdownHeaderTextSplitter'

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_markdown_header_text_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_markdown_header_text_splitter.py
@@ -1,0 +1,140 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/13
+# @FileName: test_markdown_header_text_splitter.py
+
+"""Tests for the MarkdownHeaderTextSplitter doc processor."""
+
+import os
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.\
+    markdown_header_text_splitter import MarkdownHeaderTextSplitter
+import agentuniverse.agent.action.knowledge.doc_processor.\
+    markdown_header_text_splitter as _splitter_module
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+# The shipped yaml lives next to the processor module.
+_YAML_PATH = os.path.join(
+    os.path.dirname(_splitter_module.__file__),
+    "markdown_header_text_splitter.yaml")
+
+
+class TestMarkdownHeaderSplit(unittest.TestCase):
+    """Pure splitting logic."""
+
+    def setUp(self) -> None:
+        self.splitter = MarkdownHeaderTextSplitter()
+
+    def _run(self, text: str):
+        return self.splitter.process_docs([Document(text=text)])
+
+    def test_splits_by_headers_with_hierarchy(self) -> None:
+        out = self._run("# Title\nintro\n## Section\nbody\n")
+        paths = [(d.metadata["header_path"], d.text) for d in out]
+        self.assertEqual(paths, [
+            ("Title", "intro"),
+            ("Title > Section", "body"),
+        ])
+
+    def test_header_level_reset(self) -> None:
+        out = self._run("# A\na\n## B\nb\n# C\nc\n")
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("A", "a"),
+            ("A > B", "b"),
+            ("C", "c"),
+        ])
+
+    def test_sibling_header_replaces_same_level(self) -> None:
+        out = self._run("# A\n## B\nb\n## C\nc\n")
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("A > B", "b"),
+            ("A > C", "c"),
+        ])
+
+    def test_preamble_kept_by_default(self) -> None:
+        out = self._run("preamble line\n# A\nbody\n")
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("", "preamble line"),
+            ("A", "body"),
+        ])
+
+    def test_preamble_dropped_when_configured(self) -> None:
+        splitter = MarkdownHeaderTextSplitter(keep_preamble=False)
+        out = splitter.process_docs([Document(text="preamble\n# A\nbody\n")])
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("A", "body"),
+        ])
+
+    def test_max_header_level_limits_splitting(self) -> None:
+        # With max_header_level=1, '## Sub' is content, not a header.
+        splitter = MarkdownHeaderTextSplitter(max_header_level=1)
+        out = splitter.process_docs([Document(text="# A\na\n## Sub\nsub\n")])
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("A", "a\n## Sub\nsub"),
+        ])
+
+    def test_closed_atx_headers_recognized(self) -> None:
+        out = self._run("## Title ##\nbody\n")
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("Title", "body"),
+        ])
+
+    def test_non_header_hash_lines_are_content(self) -> None:
+        # No space after '#', or 7+ hashes → not an ATX header.
+        out = self._run("#NoSpace\n####### seven hashes\n# Real\nbody\n")
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("", "#NoSpace\n####### seven hashes"),
+            ("Real", "body"),
+        ])
+
+    def test_empty_and_no_header_input(self) -> None:
+        self.assertEqual(self.splitter.process_docs([Document(text="")]), [])
+        # Content but no headers → a single preamble section.
+        out = self._run("just plain text\nno headers here")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["header_path"], "")
+
+    def test_existing_metadata_preserved(self) -> None:
+        out = self.splitter.process_docs([
+            Document(text="# A\nbody", metadata={"source": "readme.md"})])
+        self.assertEqual(out[0].metadata["source"], "readme.md")
+        self.assertEqual(out[0].metadata["header_path"], "A")
+
+    def test_header_path_key_omitted_when_none(self) -> None:
+        splitter = MarkdownHeaderTextSplitter(header_path_key=None)
+        out = splitter.process_docs([Document(text="# A\nbody")])
+        self.assertNotIn("header_path", out[0].metadata)
+        # Only the original (empty) metadata remains.
+        self.assertEqual(out[0].metadata, {})
+
+
+class TestMarkdownHeaderSplitterRegistration(unittest.TestCase):
+    """The shipped yaml resolves through the real framework loader."""
+
+    def test_yaml_resolves_to_doc_processor_type(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.get_component_config_type(),
+            ComponentEnum.DOC_PROCESSOR.value,
+        )
+
+    def test_yaml_exposes_module_and_class(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.metadata_module,
+            "agentuniverse.agent.action.knowledge.doc_processor."
+            "markdown_header_text_splitter")
+        self.assertEqual(
+            component_configer.metadata_class, "MarkdownHeaderTextSplitter")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_markdown_header_text_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_markdown_header_text_splitter.py
@@ -114,6 +114,53 @@ class TestMarkdownHeaderSplit(unittest.TestCase):
         self.assertEqual(out[0].metadata, {})
 
 
+class TestMarkdownHeaderSplitCodeFences(unittest.TestCase):
+    """Fenced code blocks must not be mistaken for header structure."""
+
+    def setUp(self) -> None:
+        self.splitter = MarkdownHeaderTextSplitter()
+
+    def _run(self, text: str):
+        return self.splitter.process_docs([Document(text=text)])
+
+    def test_backtick_fence_hides_hash_line(self) -> None:
+        out = self._run("# Real\nintro\n```python\n# Not a header\nprint(1)\n```\n")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["header_path"], "Real")
+        self.assertIn("# Not a header", out[0].text)
+
+    def test_tilde_fence_hides_hash_line(self) -> None:
+        out = self._run("# Real\nintro\n~~~\n# Not a header\nprint(1)\n~~~\n")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["header_path"], "Real")
+        self.assertIn("# Not a header", out[0].text)
+
+    def test_header_recognized_after_closed_fence(self) -> None:
+        out = self._run("```python\n# code comment\n```\n# After\nbody\n")
+        self.assertEqual([(d.metadata["header_path"], d.text) for d in out], [
+            ("", "```python\n# code comment\n```"),
+            ("After", "body"),
+        ])
+
+    def test_tilde_does_not_close_backtick_fence(self) -> None:
+        out = self._run("# Real\n```\n# x\n~~~\n# y\n```\n")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["header_path"], "Real")
+        self.assertIn("# y", out[0].text)
+
+    def test_shorter_fence_run_does_not_close(self) -> None:
+        # A four-backtick fence is closed only by four or more backticks.
+        out = self._run("# Real\n````\n# a\n```\n# b\n````\n")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["header_path"], "Real")
+        self.assertIn("# b", out[0].text)
+
+    def test_unclosed_fence_suppresses_headers_to_end(self) -> None:
+        out = self._run("# Real\n```python\n# still code\n# more code\n")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].metadata["header_path"], "Real")
+
+
 class TestMarkdownHeaderSplitterRegistration(unittest.TestCase):
     """The shipped yaml resolves through the real framework loader."""
 


### PR DESCRIPTION
## What

A new knowledge **pre-processing** `DocProcessor` — `MarkdownHeaderTextSplitter` — for the *knowledge pre-processing components* direction of #258. (Sibling of the post-processing `ReciprocalRankFusionProcessor` in #609: that one fuses recall *after* retrieval, this one shapes docs *before* embedding.)

It splits each input `Document` into one section per markdown ATX header (`#` … `######`), and records each section header hierarchy as metadata so a retrieved chunk can be traced back to where it came from:

```
# Installation
## macOS
brew install ...
```
→ two chunks, the second carrying `metadata["header_path"] = "Installation > macOS"`.

## Why

Long markdown sources (`.md` files, crawled web pages, READMEs) embed poorly as a single blob. Header-based chunking is a standard RAG preprocessing step and was missing from the framework. Unlike the existing splitters (`character` / `recursive_character` / `token` / `hierarchical_regex`), this one is **pure-Python with no third-party dependency** — it does not wrap a langchain splitter — so it is fully unit-testable without a network connection or optional install, and is safe to use even where `langchain` is not installed.

It only separates on headers (its single responsibility); a section that is still too large should be chained with a character/token splitter afterwards — splitter processors compose, the output list is a valid input to the next one.

## How it works

- ATX headers matched by `^(#{1,6})[ \t]+(.+?)[ \t]*#*$` (recognizes closed-ATX `## Title ##`; `#NoSpace` and 7+ hashes are content, not headers).
- An open-header stack is maintained; a header at level `L` closes any deeper open headers, mirroring markdown outline semantics (sibling headers replace, parent headers reset children).
- Preamble (text before the first header) is emitted as its own section by default, or droppable via `keep_preamble: false`.
- Each section preserves the source document existing metadata and adds the header path under a configurable key.

Configurable via the shipped yaml: `max_header_level` (1–6), `header_path_key`, `keep_preamble`, `path_separator`.

The yaml lives next to the module and is auto-registered through the default scanned package `agentuniverse.agent.action.knowledge.doc_processor` (same convention as the other built-in processors).

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py`
- `agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.yaml`
- `tests/.../doc_processor/test_markdown_header_text_splitter.py`

## Tests

13 tests, all deterministic, no network / no optional deps:
- 11 splitting-logic cases: header hierarchy, level reset, sibling replacement, preamble keep/drop, `max_header_level` limiting, closed-ATX, non-header hash lines, empty / no-header input, existing-metadata preservation, `header_path_key=None`.
- 2 config/registration cases through the real framework loader (`Configer → ComponentConfiger`): the shipped yaml resolves to `DOC_PROCESSOR` with the correct module/class — the component-schema contract.

`pytest test_markdown_header_text_splitter.py` → **13 passed**.

Relates to #258.