### PR TITLE
feat(knowledge): LengthFilter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/length_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/length_filter.py
@@ -1,0 +1,107 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/13
+# @FileName: length_filter.py
+
+"""
+Length-based document filter.
+
+Drops input :class:`Document` objects whose text length falls outside a
+configured ``[min_length, max_length]`` range. This is a *pre-processing*
+hygiene step for issue #258: a splitter (character, token, or the
+:class:`MarkdownHeaderTextSplitter`) frequently emits near-empty fragments —
+a header line whose body was on the next line, a stray blank section — and
+those fragments embed to noise and pollute retrieval. Chaining a length filter
+right after the splitter removes them before they reach the store.
+
+The existing ``threshold_filter`` filters by *relevance score* after recall;
+this filter operates by *content length* before insert, so the two are
+complementary and never overlap.
+
+Pure-Python and dependency-free. Length is measured in characters by default;
+set ``length_unit: 'token'`` to count whitespace-separated tokens instead.
+"""
+
+from typing import List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+
+class LengthFilter(DocProcessor):
+    """Filter documents by text length, keeping only those within range.
+
+    Attributes:
+        min_length (Optional[int]): Minimum inclusive length; shorter documents
+            are dropped. Defaults to 1 so empty / whitespace-only documents are
+            removed out of the box. Set to ``None`` to disable the lower bound.
+        max_length (Optional[int]): Maximum inclusive length; longer documents
+            are dropped. Defaults to ``None`` (no upper bound).
+        length_unit (str): ``'char'`` (default) counts characters, ``'token'``
+            counts whitespace-separated tokens (an approximate, dependency-free
+            token count).
+        trim (bool): When True (default), leading/trailing whitespace is
+            stripped before measuring, so a whitespace-only document is treated
+            as length 0.
+    """
+
+    min_length: Optional[int] = 1
+    max_length: Optional[int] = None
+    length_unit: str = "char"
+    trim: bool = True
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Return only the documents whose length is within range.
+
+        Documents are passed through unchanged (this is a filter, not a
+        transformer), so their ids and metadata are preserved.
+
+        Args:
+            origin_docs (List[Document]): Documents to filter.
+            query (Query, optional): Unused; kept for interface compatibility.
+
+        Returns:
+            List[Document]: The subset of ``origin_docs`` whose measured text
+            length satisfies ``min_length <= length <= max_length``.
+        """
+        kept: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            if self.trim:
+                text = text.strip()
+            length = self._length(text)
+            if self.min_length is not None and length < self.min_length:
+                continue
+            if self.max_length is not None and length > self.max_length:
+                continue
+            kept.append(doc)
+        return kept
+
+    def _length(self, text: str) -> int:
+        """Measure ``text`` according to ``length_unit``."""
+        if self.length_unit == "token":
+            # Whitespace tokenization: deterministic and dependency-free. Good
+            # enough for a coarse length filter; not a model tokenizer.
+            return len(text.split())
+        return len(text)
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> 'LengthFilter':
+        """Initialize the filter from its component config."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "min_length"):
+            self.min_length = doc_processor_configer.min_length
+        if hasattr(doc_processor_configer, "max_length"):
+            self.max_length = doc_processor_configer.max_length
+        if hasattr(doc_processor_configer, "length_unit"):
+            self.length_unit = doc_processor_configer.length_unit
+        if hasattr(doc_processor_configer, "trim"):
+            self.trim = doc_processor_configer.trim
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml
@@ -1,0 +1,22 @@
+name: 'length_filter'
+description: 'Pre-insert document filter that drops chunks whose text length (chars or tokens) falls outside a configured range. Useful after a splitter to remove empty / tiny fragments.'
+
+# Minimum inclusive length; documents shorter than this are dropped.
+# Default 1 removes empty / whitespace-only documents.
+min_length: 1
+
+# Maximum inclusive length; documents longer than this are dropped.
+# null disables the upper bound.
+max_length: null
+
+# 'char' counts characters, 'token' counts whitespace-separated tokens.
+length_unit: 'char'
+
+# When true, leading/trailing whitespace is stripped before measuring so a
+# whitespace-only document counts as length 0.
+trim: true
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.length_filter'
+  class: 'LengthFilter'

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_length_filter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_length_filter.py
@@ -1,0 +1,111 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/13
+# @FileName: test_length_filter.py
+
+"""Tests for the LengthFilter doc processor."""
+
+import os
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.length_filter import \
+    LengthFilter
+import agentuniverse.agent.action.knowledge.doc_processor.length_filter as \
+    _filter_module
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+_YAML_PATH = os.path.join(os.path.dirname(_filter_module.__file__),
+                          "length_filter.yaml")
+
+
+def _texts(docs):
+    return [d.text for d in docs]
+
+
+class TestLengthFilter(unittest.TestCase):
+    """Filtering logic."""
+
+    def test_default_drops_empty_and_whitespace_only(self) -> None:
+        # Default min_length=1 removes empty / whitespace-only documents.
+        docs = [Document(text=""), Document(text="   \n\t  "),
+                Document(text="keep me")]
+        out = LengthFilter().process_docs(docs)
+        self.assertEqual(_texts(out), ["keep me"])
+
+    def test_min_length_threshold(self) -> None:
+        f = LengthFilter(min_length=5)
+        docs = [Document(text="abc"), Document(text="abcdef"),
+                Document(text="exactly five")]
+        out = f.process_docs(docs)
+        self.assertEqual(_texts(out), ["abcdef", "exactly five"])
+
+    def test_max_length_threshold(self) -> None:
+        f = LengthFilter(min_length=None, max_length=4)
+        docs = [Document(text="ab"), Document(text="abcde"),
+                Document(text="abcd")]
+        out = f.process_docs(docs)
+        self.assertEqual(_texts(out), ["ab", "abcd"])
+
+    def test_combined_min_and_max_bounds(self) -> None:
+        f = LengthFilter(min_length=2, max_length=4)
+        docs = [Document(text="a"), Document(text="ab"), Document(text="abcd"),
+                Document(text="abcde")]
+        out = f.process_docs(docs)
+        self.assertEqual(_texts(out), ["ab", "abcd"])
+
+    def test_token_unit(self) -> None:
+        # Whitespace-separated token count, not characters.
+        f = LengthFilter(length_unit="token", min_length=2)
+        docs = [Document(text="oneword"), Document(text="two words"),
+                Document(text="a b c")]
+        out = f.process_docs(docs)
+        self.assertEqual(_texts(out), ["two words", "a b c"])
+
+    def test_trim_false_counts_raw_whitespace(self) -> None:
+        # Without trim, "   " has length 3 and survives min_length=1.
+        f = LengthFilter(trim=False, min_length=1)
+        out = f.process_docs([Document(text="   "), Document(text="")])
+        self.assertEqual(_texts(out), ["   "])
+
+    def test_preserves_ids_and_metadata(self) -> None:
+        # A filter passes documents through untouched.
+        doc = Document(text="payload", metadata={"source": "x"})
+        out = LengthFilter().process_docs([doc])
+        self.assertIs(out[0], doc)
+        self.assertEqual(out[0].metadata["source"], "x")
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(LengthFilter().process_docs([]), [])
+
+    def test_none_min_and_max_keeps_everything(self) -> None:
+        f = LengthFilter(min_length=None, max_length=None)
+        docs = [Document(text=""), Document(text="anything")]
+        self.assertEqual(_texts(f.process_docs(docs)), ["", "anything"])
+
+
+class TestLengthFilterRegistration(unittest.TestCase):
+    """The shipped yaml resolves through the real framework loader."""
+
+    def test_yaml_resolves_to_doc_processor_type(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.get_component_config_type(),
+            ComponentEnum.DOC_PROCESSOR.value)
+
+    def test_yaml_exposes_module_and_class(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.metadata_module,
+            "agentuniverse.agent.action.knowledge.doc_processor.length_filter")
+        self.assertEqual(component_configer.metadata_class, "LengthFilter")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

A new knowledge **pre-processing** `DocProcessor` — `LengthFilter` — for #258. It drops documents whose text length falls outside a configurable `[min_length, max_length]` range. This is the standard RAG hygiene step to chain right after a splitter: splitters (`character` / `token` / the `MarkdownHeaderTextSplitter` in #625) frequently emit near-empty fragments — a header whose body wrapped to the next line, a stray blank section — and those fragments embed to noise and pollute retrieval.

## Why it does not overlap with existing components

The framework already has `threshold_filter`, but that filters by **relevance score *after* recall**. `LengthFilter` filters by **content length *before* insert**. Different axis, different stage — they compose cleanly:

```
reader → markdown_header_text_splitter → length_filter → store
```

## How

Pure-Python, dependency-free. Length is measured in **characters** by default, or in **whitespace-separated tokens** when `length_unit: token` (an approximate, dependency-free token count — not a model tokenizer). `trim: true` (default) strips leading/trailing whitespace before measuring so a whitespace-only document counts as length 0.

It is a **filter, not a transformer**: kept documents are passed through unchanged, so their ids and metadata are preserved.

Configurable via the shipped yaml: `min_length` (default 1 — removes empty / whitespace-only out of the box), `max_length` (default null = no upper bound), `length_unit`, `trim`.

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/length_filter.py`
- `agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml`
- `tests/.../doc_processor/test_length_filter.py`

## Tests

11 deterministic tests, no network / no optional deps:
- 9 logic cases: default drops empty/whitespace-only, min threshold, max threshold, combined bounds, token unit, `trim=false` counts raw whitespace, ids/metadata preserved (same object), empty input, `min=max=None` keeps everything.
- 2 config/registration cases through the real loader (`Configer → ComponentConfiger`): the shipped yaml resolves to `DOC_PROCESSOR` with the correct module/class.

`pytest test_length_filter.py` → **11 passed**.

Relates to #258.