### PR TITLE
fix(tool): parse run command blocking flag

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional
 from dataclasses import dataclass
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from agentuniverse.agent.action.tool.common_tool.tool_input_utils import parse_strict_bool
 
 
 class CommandStatus(Enum):
@@ -75,20 +76,6 @@ class RunCommandTool(Tool):
     Tool for executing shell commands either synchronously or asynchronously.
     """
 
-    @staticmethod
-    def _normalize_bool(value, default: bool = True) -> bool:
-        if value is None:
-            return default
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized in {"true", "1", "yes", "y", "on"}:
-                return True
-            if normalized in {"false", "0", "no", "n", "off"}:
-                return False
-        return bool(value)
-
     def execute(self, command: str | ToolInput, cwd: str = None, blocking: bool = True) -> str:
         if isinstance(command, ToolInput):
             params = command.to_dict()
@@ -96,7 +83,13 @@ class RunCommandTool(Tool):
             blocking = params.get("blocking", blocking)
             command = params.get("command")
         cwd = cwd or os.getcwd()
-        blocking = self._normalize_bool(blocking)
+        try:
+            blocking = parse_strict_bool(blocking, "blocking", default=True)
+        except ValueError as e:
+            return json.dumps({
+                "error": str(e),
+                "status": CommandStatus.ERROR.value
+            })
         return self._run_command(command, cwd, blocking)
 
     def _run_command(self, command: str, cwd: str, blocking: bool = True) -> str:

--- a/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
@@ -75,6 +75,20 @@ class RunCommandTool(Tool):
     Tool for executing shell commands either synchronously or asynchronously.
     """
 
+    @staticmethod
+    def _normalize_bool(value, default: bool = True) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off"}:
+                return False
+        return bool(value)
+
     def execute(self, command: str | ToolInput, cwd: str = None, blocking: bool = True) -> str:
         if isinstance(command, ToolInput):
             params = command.to_dict()
@@ -82,6 +96,7 @@ class RunCommandTool(Tool):
             blocking = params.get("blocking", blocking)
             command = params.get("command")
         cwd = cwd or os.getcwd()
+        blocking = self._normalize_bool(blocking)
         return self._run_command(command, cwd, blocking)
 
     def _run_command(self, command: str, cwd: str, blocking: bool = True) -> str:

--- a/agentuniverse/agent/action/tool/common_tool/tool_input_utils.py
+++ b/agentuniverse/agent/action/tool/common_tool/tool_input_utils.py
@@ -1,0 +1,28 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+
+def parse_strict_bool(value, field_name: str, default: bool = False) -> bool:
+    """Parse a boolean-like tool input value without unsafe truthy fallback."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off"}:
+            return False
+        raise ValueError(
+            f"{field_name} must be a boolean value: true/false, 1/0, yes/no, or on/off"
+        )
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+        raise ValueError(f"{field_name} numeric value must be 0 or 1")
+    raise ValueError(
+        f"{field_name} must be a boolean value: true/false, 1/0, yes/no, or on/off"
+    )

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
@@ -74,6 +74,21 @@ class RunCommandToolTest(unittest.TestCase):
         self.assertIn('Async Test', cmd_result.stdout)
         self.assertEqual(cmd_result.exit_code, 0)
 
+    def test_string_false_blocking_value_runs_nonblocking(self) -> None:
+        tool_input = ToolInput({
+            'command': f'"{sys.executable}" -c "import time; time.sleep(0.5); print(\'String False\')"',
+            'cwd': os.getcwd(),
+            'blocking': 'false'
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], CommandStatus.RUNNING.value)
+        cmd_result = get_command_result(result['thread_id'])
+        self.assertIsNotNone(cmd_result)
+        self.assertEqual(cmd_result.status, CommandStatus.RUNNING)
+
     def test_command_error(self) -> None:
         """Test handling of commands that result in errors"""
         tool_input = ToolInput({

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
@@ -89,6 +89,32 @@ class RunCommandToolTest(unittest.TestCase):
         self.assertIsNotNone(cmd_result)
         self.assertEqual(cmd_result.status, CommandStatus.RUNNING)
 
+    def test_typo_blocking_value_returns_input_error(self) -> None:
+        tool_input = ToolInput({
+            'command': 'echo "should not run"',
+            'cwd': os.getcwd(),
+            'blocking': 'flase'
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], CommandStatus.ERROR.value)
+        self.assertIn('blocking must be a boolean value', result['error'])
+
+    def test_non_binary_numeric_blocking_value_returns_input_error(self) -> None:
+        tool_input = ToolInput({
+            'command': 'echo "should not run"',
+            'cwd': os.getcwd(),
+            'blocking': 2
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], CommandStatus.ERROR.value)
+        self.assertIn('blocking numeric value must be 0 or 1', result['error'])
+
     def test_command_error(self) -> None:
         """Test handling of commands that result in errors"""
         tool_input = ToolInput({


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `RunCommandTool` parsing for the `blocking` option when it is passed through `ToolInput`.
- Previously, a string value such as `"false"` was treated as truthy by Python, so the command still ran in blocking mode.
- This PR normalizes common boolean strings such as `true/false`, `1/0`, `yes/no`, and `on/off` before command execution.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/run_command_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.