### PR TITLE
fix(tool): parse write file append flag

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/tool_input_utils.py
+++ b/agentuniverse/agent/action/tool/common_tool/tool_input_utils.py
@@ -1,0 +1,28 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+
+def parse_strict_bool(value, field_name: str, default: bool = False) -> bool:
+    """Parse a boolean-like tool input value without unsafe truthy fallback."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off"}:
+            return False
+        raise ValueError(
+            f"{field_name} must be a boolean value: true/false, 1/0, yes/no, or on/off"
+        )
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+        raise ValueError(f"{field_name} numeric value must be 0 or 1")
+    raise ValueError(
+        f"{field_name} must be a boolean value: true/false, 1/0, yes/no, or on/off"
+    )

--- a/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
@@ -11,24 +11,11 @@ import json
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.agent.action.tool.common_tool.tool_input_utils import parse_strict_bool
 
 
 class WriteFileTool(Tool):
     base_dir: str = "."
-
-    @staticmethod
-    def _normalize_bool(value, default: bool = False) -> bool:
-        if value is None:
-            return default
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized in {"true", "1", "yes", "y", "on"}:
-                return True
-            if normalized in {"false", "0", "no", "n", "off"}:
-                return False
-        return bool(value)
 
     def execute(self,
                 file_path: str | ToolInput,
@@ -39,7 +26,14 @@ class WriteFileTool(Tool):
             content = params.get('content', content)
             append = params.get('append', append)
             file_path = params.get('file_path')
-        append = self._normalize_bool(append)
+        try:
+            append = parse_strict_bool(append, "append", default=False)
+        except ValueError as e:
+            return json.dumps({
+                "error": str(e),
+                "file_path": file_path,
+                "status": "error"
+            })
 
         try:
             safe_file_path = resolve_safe_path(file_path, self.base_dir)

--- a/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
@@ -16,6 +16,20 @@ from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_
 class WriteFileTool(Tool):
     base_dir: str = "."
 
+    @staticmethod
+    def _normalize_bool(value, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off"}:
+                return False
+        return bool(value)
+
     def execute(self,
                 file_path: str | ToolInput,
                 content: str = '',
@@ -25,6 +39,7 @@ class WriteFileTool(Tool):
             content = params.get('content', content)
             append = params.get('append', append)
             file_path = params.get('file_path')
+        append = self._normalize_bool(append)
 
         try:
             safe_file_path = resolve_safe_path(file_path, self.base_dir)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
@@ -68,6 +68,25 @@ class WriteFileToolTest(unittest.TestCase):
         
         with open(file_path, 'r') as f:
             self.assertEqual(f.read(), initial_content + append_content)
+
+    def test_string_false_append_value_overwrites_file(self):
+        file_path = os.path.join(self.temp_dir, 'test_append_string_false.txt')
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write('old content')
+
+        tool_input = ToolInput({
+            'file_path': file_path,
+            'content': 'new content',
+            'append': 'false'
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['append_mode'], False)
+        with open(file_path, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'new content')
     
     def test_create_directory_structure(self):
         file_path = os.path.join(self.temp_dir, 'nested/dir/structure/test.txt')

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py
@@ -87,6 +87,44 @@ class WriteFileToolTest(unittest.TestCase):
         self.assertEqual(result['append_mode'], False)
         with open(file_path, 'r', encoding='utf-8') as f:
             self.assertEqual(f.read(), 'new content')
+
+    def test_typo_append_value_returns_error_without_writing(self):
+        file_path = os.path.join(self.temp_dir, 'test_append_typo.txt')
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write('old content')
+
+        tool_input = ToolInput({
+            'file_path': file_path,
+            'content': 'new content',
+            'append': 'flase'
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('append must be a boolean value', result['error'])
+        with open(file_path, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'old content')
+
+    def test_non_binary_numeric_append_value_returns_error_without_writing(self):
+        file_path = os.path.join(self.temp_dir, 'test_append_numeric.txt')
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write('old content')
+
+        tool_input = ToolInput({
+            'file_path': file_path,
+            'content': 'new content',
+            'append': 2
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('append numeric value must be 0 or 1', result['error'])
+        with open(file_path, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'old content')
     
     def test_create_directory_structure(self):
         file_path = os.path.join(self.temp_dir, 'nested/dir/structure/test.txt')


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `WriteFileTool` parsing for the `append` option when it is passed through `ToolInput`.
- Previously, a string value such as `"false"` was treated as truthy, causing the tool to append content instead of overwriting the file.
- This PR normalizes common boolean strings before choosing append or write mode.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/write_file_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_write_file.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.