### PR TITLE
fix(tool): parse view file line bounds

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
@@ -16,6 +16,17 @@ from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_
 class ViewFileTool(Tool):
     base_dir: str = "."
 
+    @staticmethod
+    def _normalize_line_number(value, field_name: str, allow_none: bool = False):
+        if value is None and allow_none:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{field_name} must be an integer")
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field_name} must be an integer") from exc
+
     def execute(self,
                 file_path: str | ToolInput,
                 start_line: int = 0,
@@ -26,6 +37,16 @@ class ViewFileTool(Tool):
             start_line = params.get('start_line', start_line)
             end_line = params.get('end_line', end_line)
             file_path = params.get('file_path')
+
+        try:
+            start_line = self._normalize_line_number(start_line, "start_line")
+            end_line = self._normalize_line_number(end_line, "end_line", allow_none=True)
+        except ValueError as e:
+            return json.dumps({
+                "error": str(e),
+                "file_path": file_path,
+                "status": "error"
+            })
 
         try:
             safe_file_path = resolve_safe_path(file_path, self.base_dir)

--- a/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
@@ -22,10 +22,17 @@ class ViewFileTool(Tool):
             return None
         if isinstance(value, bool):
             raise ValueError(f"{field_name} must be an integer")
-        try:
-            return int(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"{field_name} must be an integer") from exc
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed_value = int(value)
+            except ValueError as exc:
+                raise ValueError(f"{field_name} must be an integer") from exc
+            if str(parsed_value) != value:
+                raise ValueError(f"{field_name} must be a canonical integer string")
+            return parsed_value
+        raise ValueError(f"{field_name} must be an integer")
 
     def execute(self,
                 file_path: str | ToolInput,

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
@@ -83,6 +83,46 @@ class ViewFileToolTest(unittest.TestCase):
         self.assertEqual(result['status'], 'error')
         self.assertIn('start_line must be an integer', result['error'])
 
+    def test_fractional_line_number_returns_error(self):
+        result_json = self.tool.execute(
+            file_path=self.temp_file_path,
+            start_line=1.9
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('start_line must be an integer', result['error'])
+
+    def test_fractional_line_number_string_returns_error(self):
+        result_json = self.tool.execute(
+            file_path=self.temp_file_path,
+            start_line='1.9'
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('start_line must be an integer', result['error'])
+
+    def test_boolean_line_number_returns_error(self):
+        result_json = self.tool.execute(
+            file_path=self.temp_file_path,
+            start_line=True
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('start_line must be an integer', result['error'])
+
+    def test_non_canonical_integer_string_returns_error(self):
+        result_json = self.tool.execute(
+            file_path=self.temp_file_path,
+            start_line='01'
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('start_line must be a canonical integer string', result['error'])
+
     def test_invalid_file_path(self):
         tool_input = ToolInput({
             'file_path': 'nonexistent/file.txt'

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py
@@ -58,6 +58,31 @@ class ViewFileToolTest(unittest.TestCase):
         self.assertEqual(result['start_line'], 1)
         self.assertEqual(result['end_line'], 2)
 
+    def test_view_specific_lines_with_string_numbers(self):
+        tool_input = ToolInput({
+            'file_path': self.temp_file_path,
+            'start_line': '1',
+            'end_line': '3'
+        })
+
+        result_json = self.tool.execute(tool_input)
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['content'], "Line 2\nLine 3\n")
+        self.assertEqual(result['start_line'], 1)
+        self.assertEqual(result['end_line'], 2)
+
+    def test_invalid_line_number_returns_error(self):
+        result_json = self.tool.execute(
+            file_path=self.temp_file_path,
+            start_line='first'
+        )
+        result = json.loads(result_json)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('start_line must be an integer', result['error'])
+
     def test_invalid_file_path(self):
         tool_input = ToolInput({
             'file_path': 'nonexistent/file.txt'


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `ViewFileTool` handling of `start_line` and `end_line` values passed through `ToolInput`.
- Previously, numeric strings such as `"1"` and `"3"` could cause type errors when compared with integer line indexes.
- This PR converts valid string line bounds to integers and returns a clear structured error for invalid values.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/view_file_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_view_file.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.