### PR TITLE
fix(tool): normalize request methods

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/request_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/request_tool.py
@@ -28,6 +28,11 @@ class RequestTool(Tool):
         """Strips quotes from the url."""
         return url.strip("\"'")
 
+    def _normalized_method(self) -> str:
+        if not isinstance(self.method, str):
+            return ""
+        return self.method.strip().upper()
+
     def execute(self, input: str):
         input_params: str = input
         if self.json_parser:
@@ -54,29 +59,31 @@ class RequestTool(Tool):
 
     async def async_execute_by_method(self, url: str, data: dict = None, **kwargs):
         url = self._clean_url(url)
-        if self.method == 'GET':
+        method = self._normalized_method()
+        if method == 'GET':
             return await self.requests_wrapper.aget(url)
-        elif self.method == 'POST':
+        elif method == 'POST':
             return await self.requests_wrapper.apost(url, data=data)
-        elif self.method == 'PUT':
+        elif method == 'PUT':
             return await self.requests_wrapper.aput(url, data=data)
-        elif self.method == 'DELETE':
+        elif method == 'DELETE':
             return await self.requests_wrapper.adelete(url)
         else:
-            raise ValueError(f"Unsupported method: {self.method}")
+            raise ValueError(f"Unsupported method: {method or self.method}")
 
     def execute_by_method(self, url: str, data: dict = None, **kwargs):
         url = self._clean_url(url)
-        if self.method == 'GET':
+        method = self._normalized_method()
+        if method == 'GET':
             return self.requests_wrapper.get(url)
-        elif self.method == 'POST':
+        elif method == 'POST':
             return self.requests_wrapper.post(url, data=data)
-        elif self.method == 'PUT':
+        elif method == 'PUT':
             return self.requests_wrapper.put(url, data=data)
-        elif self.method == 'DELETE':
+        elif method == 'DELETE':
             return self.requests_wrapper.delete(url)
         else:
-            raise ValueError(f"Unsupported method: {self.method}")
+            raise ValueError(f"Unsupported method: {method or self.method}")
 
     def initialize_by_component_configer(self, component_configer: ToolConfiger) -> 'Tool':
         """

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py
@@ -1,8 +1,29 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from agentuniverse.agent.action.tool.common_tool.request_tool import RequestTool
+
+
+class RequestToolTest(unittest.TestCase):
+    """Test cases for RequestTool synchronous execution."""
+
+    def test_execute_accepts_lowercase_method(self) -> None:
+        requests_wrapper = SimpleNamespace(
+            get=Mock(return_value='response body')
+        )
+        tool = RequestTool(
+            method='get',
+            json_parser=False
+        )
+        tool.requests_wrapper = requests_wrapper
+
+        result = tool.execute('"https://example.com/resource"')
+
+        self.assertEqual(result, 'response body')
+        requests_wrapper.get.assert_called_once_with(
+            'https://example.com/resource'
+        )
 
 
 class RequestToolAsyncTest(unittest.IsolatedAsyncioTestCase):
@@ -55,6 +76,27 @@ class RequestToolAsyncTest(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaisesRegex(ValueError, 'Unsupported method: PATCH'):
             await tool.async_execute('https://example.com/resource')
+
+    async def test_async_execute_accepts_lowercase_method(self) -> None:
+        requests_wrapper = SimpleNamespace(
+            apost=AsyncMock(return_value={'created': True})
+        )
+        tool = RequestTool(
+            method='post',
+            json_parser=True
+        )
+        tool.requests_wrapper = requests_wrapper
+
+        result = await tool.async_execute(
+            '{"url": "https://example.com/items", '
+            '"data": {"name": "agentUniverse"}}'
+        )
+
+        self.assertEqual(result, {'created': True})
+        requests_wrapper.apost.assert_awaited_once_with(
+            'https://example.com/items',
+            data={'name': 'agentUniverse'}
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `RequestTool` method dispatch so configured HTTP methods are handled case-insensitively.
- Previously, values such as `"get"` or `"post"` were rejected because the tool compared them directly with uppercase method names.
- This PR normalizes the configured method with `strip().upper()` for both sync and async execution paths.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/request_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_request_tool.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.