### PR TITLE
fix(config): preserve explicit component configuration values

### DIFF
--- a/agentuniverse/base/config/component_configer/configers/knowledge_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/knowledge_configer.py
@@ -45,7 +45,7 @@ class KnowledgeConfiger(ComponentConfiger):
         Returns:
             KnowledgeConfiger: the KnowledgeConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'KnowledgeConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/llm_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/llm_configer.py
@@ -80,7 +80,7 @@ class LLMConfiger(ComponentConfiger):
         Returns:
             LLMConfiger: the LLMConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'LLMConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/memory_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/memory_configer.py
@@ -83,7 +83,7 @@ class MemoryConfiger(ComponentConfiger):
         Returns:
             MemoryConfiger: the MemoryConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'MemoryConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/planner_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/planner_configer.py
@@ -66,6 +66,9 @@ class PlannerConfiger(ComponentConfiger):
         try:
             self.__name = configer.value.get('name')
             self.__description = configer.value.get('description')
+            self.__input_key = configer.value.get('input_key')
+            self.__output_key = configer.value.get('output_key')
+            self.__memory_key = configer.value.get('memory_key')
         except Exception as e:
             raise Exception(f"Failed to parse the Planner configuration: {e}")
         return self

--- a/agentuniverse/base/config/component_configer/configers/planner_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/planner_configer.py
@@ -52,7 +52,7 @@ class PlannerConfiger(ComponentConfiger):
         Returns:
             PlannerConfiger: the PlannerConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'PlannerConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/prompt_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/prompt_configer.py
@@ -30,7 +30,7 @@ class PromptConfiger(ComponentConfiger):
         Returns:
             PromptConfiger: the PromptConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'PromptConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/tool_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/tool_configer.py
@@ -44,7 +44,7 @@ class ToolConfiger(ComponentConfiger):
         Returns:
             ToolConfiger: the ToolConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'ToolConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/work_pattern_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/work_pattern_configer.py
@@ -35,7 +35,7 @@ class WorkPatternConfiger(ComponentConfiger):
         Returns:
             WorkPatternConfiger: the WorkPatternConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'WorkPatternConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/base/config/component_configer/configers/workflow_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/workflow_configer.py
@@ -45,7 +45,7 @@ class WorkflowConfiger(ComponentConfiger):
         Returns:
             WorkflowConfiger: the WorkflowConfiger object
         """
-        return self.load_by_configer(self.__configer)
+        return self.load_by_configer(self.configer)
 
     def load_by_configer(self, configer: Configer) -> 'WorkflowConfiger':
         """Load the configuration by the Configer object.

--- a/agentuniverse/llm/llm.py
+++ b/agentuniverse/llm/llm.py
@@ -125,17 +125,17 @@ class LLM(ComponentBase):
             self.description = component_configer.description
         if component_configer.model_name:
             self.model_name = component_configer.model_name
-        if component_configer.temperature:
+        if component_configer.temperature is not None:
             self.temperature = component_configer.temperature
         if component_configer.request_timeout:
             self.request_timeout = component_configer.request_timeout
         if component_configer.max_tokens:
             self.max_tokens = component_configer.max_tokens
-        if component_configer.max_retries:
+        if component_configer.max_retries is not None:
             self.max_retries = component_configer.max_retries
-        if component_configer.streaming:
+        if component_configer.streaming is not None:
             self.streaming = component_configer.streaming
-        if component_configer.ext_info:
+        if component_configer.ext_info is not None:
             self.ext_info = component_configer.ext_info
         self.tracing = component_configer.tracing
         if 'max_context_length' in component_configer.configer.value:
@@ -150,15 +150,15 @@ class LLM(ComponentBase):
         copied_obj = self.model_copy()
         if 'model_name' in kwargs and kwargs['model_name']:
             copied_obj.model_name = kwargs['model_name']
-        if 'temperature' in kwargs and kwargs['temperature']:
+        if 'temperature' in kwargs and kwargs['temperature'] is not None:
             copied_obj.temperature = kwargs['temperature']
         if 'request_timeout' in kwargs and kwargs['request_timeout']:
             copied_obj.request_timeout = kwargs['request_timeout']
         if 'max_tokens' in kwargs and kwargs['max_tokens']:
             copied_obj.max_tokens = kwargs['max_tokens']
-        if 'max_retries' in kwargs and kwargs['max_retries']:
+        if 'max_retries' in kwargs and kwargs['max_retries'] is not None:
             copied_obj.max_retries = kwargs['max_retries']
-        if 'streaming' in kwargs and kwargs['streaming']:
+        if 'streaming' in kwargs and kwargs['streaming'] is not None:
             copied_obj.streaming = kwargs['streaming']
         if 'max_context_length' in kwargs and kwargs['max_context_length']:
             copied_obj._max_context_length = kwargs['max_context_length']

--- a/tests/test_agentuniverse/unit/base/config/test_component_configer_load.py
+++ b/tests/test_agentuniverse/unit/base/config/test_component_configer_load.py
@@ -1,0 +1,33 @@
+import pytest
+
+from agentuniverse.base.config.component_configer.configers.knowledge_configer import KnowledgeConfiger
+from agentuniverse.base.config.component_configer.configers.llm_configer import LLMConfiger
+from agentuniverse.base.config.component_configer.configers.memory_configer import MemoryConfiger
+from agentuniverse.base.config.component_configer.configers.planner_configer import PlannerConfiger
+from agentuniverse.base.config.component_configer.configers.prompt_configer import PromptConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.component_configer.configers.work_pattern_configer import WorkPatternConfiger
+from agentuniverse.base.config.component_configer.configers.workflow_configer import WorkflowConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+@pytest.mark.parametrize(
+    ("configer_class", "value"),
+    [
+        (KnowledgeConfiger, {"name": "knowledge"}),
+        (LLMConfiger, {"name": "llm"}),
+        (MemoryConfiger, {"name": "memory"}),
+        (PlannerConfiger, {"name": "planner"}),
+        (PromptConfiger, {"metadata": {"version": "1.0"}}),
+        (ToolConfiger, {"name": "tool"}),
+        (WorkflowConfiger, {"name": "workflow"}),
+        (WorkPatternConfiger, {"name": "work_pattern"}),
+    ],
+)
+def test_load_uses_configer_passed_to_constructor(configer_class, value):
+    configer = Configer()
+    configer.value = value
+
+    loaded = configer_class(configer).load()
+
+    assert loaded.configer is configer

--- a/tests/test_agentuniverse/unit/base/config/test_planner_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/test_planner_configer.py
@@ -1,0 +1,21 @@
+from agentuniverse.base.config.component_configer.configers.planner_configer import (
+    PlannerConfiger,
+)
+from agentuniverse.base.config.configer import Configer
+
+
+def test_load_by_configer_preserves_planner_keys():
+    configer = Configer()
+    configer.value = {
+        "name": "custom_planner",
+        "description": "planner with custom data keys",
+        "input_key": "question",
+        "output_key": "answer",
+        "memory_key": "history",
+    }
+
+    planner_configer = PlannerConfiger().load_by_configer(configer)
+
+    assert planner_configer.input_key == "question"
+    assert planner_configer.output_key == "answer"
+    assert planner_configer.memory_key == "history"

--- a/tests/test_agentuniverse/unit/llm/test_llm_configuration.py
+++ b/tests/test_agentuniverse/unit/llm/test_llm_configuration.py
@@ -1,0 +1,89 @@
+from agentuniverse.base.config.component_configer.configers.llm_configer import LLMConfiger
+from agentuniverse.base.config.configer import Configer
+from agentuniverse.llm.llm import LLM
+
+
+class ConfigurableLLM(LLM):
+    def _call(self, *args, **kwargs):
+        return None
+
+    async def _acall(self, *args, **kwargs):
+        return None
+
+    def get_num_tokens(self, text: str) -> int:
+        return len(text)
+
+
+def _llm_configer(**overrides) -> LLMConfiger:
+    configer = Configer()
+    configer.value = {
+        "name": "configured_llm",
+        "model_name": "gpt-4o",
+        **overrides,
+    }
+    return LLMConfiger().load_by_configer(configer)
+
+
+def test_initialize_preserves_explicit_falsy_values():
+    llm = ConfigurableLLM(
+        model_name="initial-model",
+        temperature=0.8,
+        max_retries=3,
+        streaming=True,
+        ext_info={"initial": True},
+    )
+
+    llm.initialize_by_component_configer(
+        _llm_configer(
+            temperature=0.0,
+            max_retries=0,
+            streaming=False,
+            ext_info={},
+        )
+    )
+
+    assert llm.temperature == 0.0
+    assert llm.max_retries == 0
+    assert llm.streaming is False
+    assert llm.ext_info == {}
+
+
+def test_agent_model_overrides_preserve_explicit_falsy_values():
+    llm = ConfigurableLLM(
+        model_name="gpt-4o",
+        temperature=0.8,
+        max_retries=3,
+        streaming=True,
+    )
+
+    configured = llm.set_by_agent_model(
+        temperature=0.0,
+        max_retries=0,
+        streaming=False,
+    )
+
+    assert configured.temperature == 0.0
+    assert configured.max_retries == 0
+    assert configured.streaming is False
+    assert llm.temperature == 0.8
+    assert llm.max_retries == 3
+    assert llm.streaming is True
+
+
+def test_agent_model_none_values_do_not_override_defaults():
+    llm = ConfigurableLLM(
+        model_name="gpt-4o",
+        temperature=0.8,
+        max_retries=3,
+        streaming=True,
+    )
+
+    configured = llm.set_by_agent_model(
+        temperature=None,
+        max_retries=None,
+        streaming=None,
+    )
+
+    assert configured.temperature == 0.8
+    assert configured.max_retries == 3
+    assert configured.streaming is True


### PR DESCRIPTION
**Checklist | 检查项**

- [x] I have read and understood the contributor guidelines.
- [x] I checked open issues and pull requests for duplicate work; no matching work was found.
- [x] I accept maintainer suggestions to change or close this PR.
- [x] I have submitted regression tests for these bug fixes.
- [ ] Documentation changed (not needed; internal configuration behavior only).
- [ ] Examples added (not needed for these regression fixes).

## Summary

- Use the inherited public `configer` property in eight component configurer `load()` methods, avoiding Python name-mangling `AttributeError` failures.
- Preserve explicit falsy LLM settings: `temperature=0.0`, `max_retries=0`, `streaming=False`, and empty `ext_info`.
- Load Planner `input_key`, `output_key`, and `memory_key` instead of silently leaving them unset.

## Motivation

Subclass loaders accessed `self.__configer` even though that private attribute belongs to `ComponentConfiger`, so direct `load()` calls fail due to Python name mangling. Truthiness checks also discarded valid falsy LLM settings, while PlannerConfiger declared data-key fields without loading them.

## Tests

- `tests/test_agentuniverse/unit/llm/test_llm_configuration.py`
- `tests/test_agentuniverse/unit/base/config/test_component_configer_load.py`
- `tests/test_agentuniverse/unit/base/config/test_planner_configer.py`

```text
python -m pytest tests/test_agentuniverse/unit/llm/test_llm_configuration.py tests/test_agentuniverse/unit/base/config/test_component_configer_load.py tests/test_agentuniverse/unit/base/config/test_planner_configer.py -q
# 12 passed

ruff check --no-fix <the three test files>
# All checks passed

black --check <the three test files>
# 3 files would be left unchanged
```

## Compatibility

No new dependencies or public API changes. `None` continues to mean “do not override”; explicit falsy values are now respected.
