### PR TITLE
fix(core): preserve async compatibility and task isolation

### DIFF
--- a/agentuniverse/agent/action/tool/tool.py
+++ b/agentuniverse/agent/action/tool/tool.py
@@ -82,6 +82,8 @@ class Tool(ComponentBase):
     async def async_run(self, **kwargs):
         """The callable method that runs the tool."""
         self.input_check(kwargs)
+        if self.check_execute_signature_deprecated():
+            return await asyncio.to_thread(self.execute, ToolInput(kwargs))
         return await self.async_execute(**kwargs)
 
     def input_check(self, kwargs: dict) -> None:
@@ -111,6 +113,12 @@ class Tool(ComponentBase):
 
     @trace_tool
     async def async_langchain_run(self, *args, callbacks=None, **kwargs):
+        if self.check_execute_signature_deprecated():
+            tool_input = ToolInput(kwargs)
+            parse_result = self.parse_react_input(args[0])
+            for key in self.input_keys:
+                tool_input.add_data(key, parse_result[key])
+            return await asyncio.to_thread(self.execute, tool_input)
         try:
             parse_result = parse_and_check_json_markdown(args[0], self.input_keys)
         except Exception as e:

--- a/agentuniverse/agent/input_object.py
+++ b/agentuniverse/agent/input_object.py
@@ -9,12 +9,12 @@ import json
 
 class InputObject(object):
     def __init__(self, params: dict):
-        self.__params = params
-        for k, v in params.items():
+        self.__params = params.copy()
+        for k, v in self.__params.items():
             self.__dict__[k] = v
 
     def to_dict(self):
-        return self.__params
+        return self.__params.copy()
 
     def to_json_str(self):
         return json.dumps(self.__params)

--- a/agentuniverse/agent/template/executing_agent_template.py
+++ b/agentuniverse/agent/template/executing_agent_template.py
@@ -83,8 +83,7 @@ class ExecutingAgentTemplate(AgentTemplate):
                 'output_stream': input_object.get_data('output_stream', None)}
 
     def _execute_subtask(self, subtask, input_object, agent_input, index, memory, llm, prompt, **kwargs) -> dict:
-        context_tokens = {}
-        FrameworkContextManager().set_all_contexts(kwargs.get('context_values', {}))
+        context_tokens = FrameworkContextManager().set_all_contexts(kwargs.get('context_values', {}))
         try:
             pair_id = uuid.uuid4().hex
             ConversationMemoryModule().add_agent_input_info(

--- a/agentuniverse/base/context/framework_context_manager.py
+++ b/agentuniverse/base/context/framework_context_manager.py
@@ -108,10 +108,12 @@ class FrameworkContextManager:
                     context_values[var_name] = self.get_context(var_name)
         return context_values
 
-    def set_all_contexts(self, context_values: Dict[str, Any]):
-        """Set all context variables using the provided dictionary."""
+    def set_all_contexts(self, context_values: Dict[str, Any]) -> Dict[str, Token]:
+        """Set all context variables and return tokens for restoring them."""
+        context_tokens = {}
         for var_name, var_value in context_values.items():
-            self.set_context(var_name, var_value)
+            context_tokens[var_name] = self.set_context(var_name, var_value)
+        return context_tokens
 
     def clear_all_contexts(self):
         self.__context_dict.set({})

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+
+
+class LegacyInputTool(Tool):
+    name: str = "legacy_input_tool"
+
+    def execute(self, tool_input: ToolInput):
+        return tool_input.get_data("value")
+
+
+def test_async_run_supports_legacy_tool_input_signature():
+    tool = LegacyInputTool(input_keys=["value"])
+
+    result = asyncio.run(Tool.async_run.__wrapped__(tool, value="from-async-run"))
+
+    assert result == "from-async-run"
+
+
+def test_async_langchain_run_supports_legacy_tool_input_signature():
+    tool = LegacyInputTool(input_keys=["value"])
+
+    result = asyncio.run(
+        Tool.async_langchain_run.__wrapped__(
+            tool,
+            "from-langchain",
+        )
+    )
+
+    assert result == "from-langchain"

--- a/tests/test_agentuniverse/unit/agent/test_input_object.py
+++ b/tests/test_agentuniverse/unit/agent/test_input_object.py
@@ -1,0 +1,19 @@
+from agentuniverse.agent.input_object import InputObject
+
+
+def test_input_object_copies_constructor_params():
+    params = {"input": "original"}
+    input_object = InputObject(params)
+
+    params["input"] = "changed externally"
+
+    assert input_object.get_data("input") == "original"
+
+
+def test_to_dict_returns_an_independent_mapping():
+    input_object = InputObject({"input": "original"})
+
+    exported = input_object.to_dict()
+    exported["input"] = "changed externally"
+
+    assert input_object.get_data("input") == "original"

--- a/tests/test_agentuniverse/unit/base/context/test_framework_context.py
+++ b/tests/test_agentuniverse/unit/base/context/test_framework_context.py
@@ -52,5 +52,29 @@ async def test_context_thread_and_async_isolation():
     assert queue4.get() == 11
 
 
+def test_set_all_contexts_returns_tokens_for_restoration():
+    context_manager.clear_all_contexts()
+    original_token = context_manager.set_context("request_id", "worker-value")
+
+    tokens = context_manager.set_all_contexts(
+        {
+            "request_id": "parent-value",
+            "temporary_key": "temporary-value",
+        }
+    )
+
+    assert context_manager.get_context("request_id") == "parent-value"
+    assert context_manager.get_context("temporary_key") == "temporary-value"
+
+    for var_name, token in tokens.items():
+        context_manager.reset_context(var_name, token)
+
+    assert context_manager.get_context("request_id") == "worker-value"
+    assert context_manager.get_context("temporary_key") is None
+
+    context_manager.reset_context("request_id", original_token)
+    context_manager.clear_all_contexts()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-s"])


### PR DESCRIPTION
## Summary

- preserve deprecated `ToolInput` execution in `async_run` without blocking the event loop
- make `async_langchain_run` match the legacy synchronous ReAct-input behavior
- return context tokens from `set_all_contexts` so executing-agent workers restore their previous context
- isolate `InputObject` from constructor and `to_dict()` mapping mutations

## Why

These fixes close three runtime state/compatibility gaps that can surface under asynchronous or parallel agent execution: legacy tools fail only on async paths, worker context leaks after subtask execution, and copied input objects can still share mutable mapping state.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py tests/test_agentuniverse/unit/agent/test_input_object.py -q` (4 passed)
- `python -m pytest tests/test_agentuniverse/unit/base/context/test_framework_context.py -k set_all_contexts_returns_tokens_for_restoration -q` (1 passed)
- `python -m py_compile agentuniverse/agent/action/tool/tool.py agentuniverse/agent/input_object.py agentuniverse/agent/template/executing_agent_template.py agentuniverse/base/context/framework_context_manager.py`
- `git diff upstream/master...HEAD --check`

No new dependencies are introduced.