### PR TITLE
Feat/semantic scholar tool enhancements

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/semantic_scholar_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/semantic_scholar_tool.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
-"""A scholarly paper search and metadata tool based on Semantic Scholar."""
+"""A scholarly paper discovery tool based on the Semantic Scholar Graph API."""
 
+import calendar
 import re
+from datetime import date
 from typing import Any, ClassVar, Dict, List, Optional
 from urllib.parse import quote
 
@@ -19,9 +21,49 @@ class _SemanticScholarAPIError(Exception):
 
 
 class SemanticScholarTool(Tool):
-    """Search Semantic Scholar or retrieve one paper by a supported identifier."""
+    """Search papers, retrieve metadata, and explore citation relationships."""
 
-    MODES: ClassVar[set[str]] = {"search", "paper"}
+    MODES: ClassVar[set[str]] = {"search", "paper", "citations", "references", "batch"}
+    PUBLICATION_TYPES: ClassVar[tuple[str, ...]] = (
+        "Review",
+        "JournalArticle",
+        "CaseReport",
+        "ClinicalTrial",
+        "Conference",
+        "Dataset",
+        "Editorial",
+        "LettersAndComments",
+        "MetaAnalysis",
+        "News",
+        "Study",
+        "Book",
+        "BookSection",
+    )
+    FIELDS_OF_STUDY: ClassVar[tuple[str, ...]] = (
+        "Computer Science",
+        "Medicine",
+        "Chemistry",
+        "Biology",
+        "Materials Science",
+        "Physics",
+        "Geology",
+        "Psychology",
+        "Art",
+        "History",
+        "Geography",
+        "Sociology",
+        "Business",
+        "Political Science",
+        "Economics",
+        "Philosophy",
+        "Mathematics",
+        "Engineering",
+        "Environmental Science",
+        "Agricultural and Food Sciences",
+        "Education",
+        "Law",
+        "Linguistics",
+    )
     PAPER_FIELDS: ClassVar[str] = ",".join(
         (
             "paperId",
@@ -42,6 +84,7 @@ class SemanticScholarTool(Tool):
             "fieldsOfStudy",
         )
     )
+    RELATION_FIELDS: ClassVar[str] = ",".join(("contexts", "intents", "isInfluential", PAPER_FIELDS))
 
     base_url: str = "https://api.semanticscholar.org/graph/v1"
     timeout: float = Field(default=15.0, description="HTTP request timeout in seconds")
@@ -50,150 +93,312 @@ class SemanticScholarTool(Tool):
 
     def execute(
         self,
-        query: str,
+        query: str | List[str],
         mode: str = "search",
         max_results: int = 5,
+        page: int = 1,
+        year: Optional[str] = None,
+        publication_date_or_year: Optional[str] = None,
+        publication_types: Optional[str | List[str]] = None,
+        fields_of_study: Optional[str | List[str]] = None,
+        venue: Optional[str | List[str]] = None,
+        min_citation_count: Optional[int] = None,
+        open_access_only: bool = False,
     ) -> Dict[str, Any]:
-        """Search papers or retrieve one paper by a supported identifier.
+        """Run a Semantic Scholar paper operation.
 
         Args:
-            query: Search keywords in search mode, or a paper identifier in
-                paper mode. DOI, PMID, PMCID, ArXiv, CorpusId, and Semantic
-                Scholar paper IDs are supported.
-            mode: Operation mode. Supports search and paper.
-            max_results: Maximum search results to return, from 1 to 20.
+            query: Search text, one paper identifier, or a list of identifiers
+                in batch mode. Supported identifiers include DOI, PMID, PMCID,
+                ArXiv, CorpusId, and Semantic Scholar paper IDs.
+            mode: One of search, paper, citations, references, or batch.
+            max_results: Results per page for search, citations, and references,
+                from 1 to 20. Paper and batch modes determine this value.
+            page: One-based page for search, citations, and references.
+            year: Search year filter such as 2024, 2020-2024, 2020-, or -2024.
+            publication_date_or_year: Search date filter using YYYY, YYYY-MM,
+                YYYY-MM-DD, or a colon-delimited inclusive range.
+            publication_types: Search publication type or list of types.
+            fields_of_study: Search field of study or list of fields.
+            venue: Search venue or list of venues.
+            min_citation_count: Minimum citation count for search results.
+            open_access_only: Whether search results must have a public PDF.
 
         Returns:
-            A dictionary containing operation context, result counts, and a
-            list of normalized papers. Network and API failures are returned
-            in a structured ``error`` field.
+            A dictionary containing operation context and normalized papers.
+            Network and API failures use a structured ``error`` field.
 
         Raises:
-            ValueError: If query, mode, or max_results is invalid.
+            ValueError: If an operation or parameter is invalid.
         """
         normalized_mode = self._normalize_mode(mode)
-        normalized_query = query.strip() if isinstance(query, str) else ""
-        if not normalized_query:
-            raise ValueError("query must not be empty")
+        normalized_query = self._normalize_query(query, normalized_mode)
+        self._validate_page(page)
+        self._validate_mode_options(
+            mode=normalized_mode,
+            page=page,
+            year=year,
+            publication_date_or_year=publication_date_or_year,
+            publication_types=publication_types,
+            fields_of_study=fields_of_study,
+            venue=venue,
+            min_citation_count=min_citation_count,
+            open_access_only=open_access_only,
+        )
 
-        if normalized_mode == "search":
+        if normalized_mode == "paper":
+            effective_max_results = 1
+            offset = 0
+        elif normalized_mode == "batch":
+            effective_max_results = len(normalized_query)
+            offset = 0
+        else:
             self._validate_max_results(max_results)
             effective_max_results = max_results
-        else:
-            normalized_query = self._normalize_paper_id(normalized_query)
-            effective_max_results = 1
+            offset = (page - 1) * max_results
+            self._validate_result_window(normalized_mode, offset, max_results)
+
+        search_filters = self._normalize_search_filters(
+            year=year,
+            publication_date_or_year=publication_date_or_year,
+            publication_types=publication_types,
+            fields_of_study=fields_of_study,
+            venue=venue,
+            min_citation_count=min_citation_count,
+            open_access_only=open_access_only,
+        )
+        context = self._operation_context(
+            mode=normalized_mode,
+            query=normalized_query,
+            max_results=effective_max_results,
+            page=page,
+            offset=offset,
+            search_filters=search_filters,
+        )
 
         try:
             if normalized_mode == "search":
-                total_results, raw_papers = self._search(normalized_query, effective_max_results)
-            else:
-                raw_papers = [self._lookup_paper(normalized_query)]
-                total_results = 1
+                result = self._search(
+                    query=normalized_query,
+                    max_results=effective_max_results,
+                    offset=offset,
+                    filters=search_filters,
+                )
+                papers = [self._parse_paper(paper) for paper in result["papers"]]
+                return {
+                    **context,
+                    "total_results": result["total"],
+                    "returned_results": len(papers),
+                    "next_offset": result["next_offset"],
+                    "papers": papers,
+                }
 
-            papers = [self._parse_paper(paper) for paper in raw_papers]
+            if normalized_mode == "paper":
+                paper = self._parse_paper(self._lookup_paper(normalized_query))
+                return {
+                    **context,
+                    "total_results": 1,
+                    "returned_results": 1,
+                    "papers": [paper],
+                }
+
+            if normalized_mode in {"citations", "references"}:
+                result = self._related_papers(
+                    paper_id=normalized_query,
+                    relation=normalized_mode,
+                    max_results=effective_max_results,
+                    offset=offset,
+                    publication_date_or_year=search_filters["publication_date_or_year"],
+                )
+                papers = [self._parse_relation(item, normalized_mode) for item in result["relations"]]
+                return {
+                    **context,
+                    "total_results": None,
+                    "returned_results": len(papers),
+                    "next_offset": result["next_offset"],
+                    "papers": papers,
+                }
+
+            result = self._batch_lookup(normalized_query)
+            papers = [self._parse_paper(paper) for paper in result["papers"]]
             return {
-                "mode": normalized_mode,
-                "query": normalized_query,
-                "max_results": effective_max_results,
-                "total_results": total_results,
+                **context,
+                "requested_results": len(normalized_query),
+                "total_results": len(papers),
                 "returned_results": len(papers),
+                "not_found_ids": result["not_found_ids"],
                 "papers": papers,
             }
         except _SemanticScholarAPIError as exc:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                context=context,
                 error_type="api_error",
                 message=str(exc),
             )
         except requests.Timeout:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                context=context,
                 error_type="request_timeout",
                 message="Semantic Scholar request timed out.",
             )
         except requests.HTTPError as exc:
             status_code = exc.response.status_code if exc.response is not None else None
-            message = self._http_error_message(status_code)
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                context=context,
                 error_type="http_error",
-                message=message,
+                message=self._http_error_message(status_code),
             )
         except requests.RequestException as exc:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                context=context,
                 error_type="request_error",
                 message=f"Semantic Scholar request failed: {exc}",
             )
         except (KeyError, TypeError, ValueError) as exc:
             return self._error_result(
-                mode=normalized_mode,
-                query=normalized_query,
-                max_results=effective_max_results,
+                context=context,
                 error_type="invalid_response",
                 message=f"Unable to parse Semantic Scholar response: {exc}",
             )
 
-    def _search(self, query: str, max_results: int) -> tuple[int, List[Dict[str, Any]]]:
-        data = self._request(
-            "/paper/search",
-            params={"query": query, "limit": max_results, "fields": self.PAPER_FIELDS},
-        )
+    def _search(
+        self,
+        query: str,
+        max_results: int,
+        offset: int,
+        filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        params = {
+            "query": query,
+            "limit": max_results,
+            "offset": offset,
+            "fields": self.PAPER_FIELDS,
+            **self._search_request_filters(filters),
+        }
+        data = self._request("/paper/search", params=params)
+        if not isinstance(data, dict):
+            raise ValueError("invalid search response")
         papers = data.get("data")
         if not isinstance(papers, list) or not all(isinstance(paper, dict) for paper in papers):
             raise ValueError("invalid search data")
-        total = data.get("total", 0)
-        if isinstance(total, bool) or not isinstance(total, int):
-            raise ValueError("invalid total result count")
-        return total, papers
+        total = self._required_nonnegative_integer(data.get("total"), "total result count")
+        next_offset = self._optional_nonnegative_integer(data.get("next"), "next offset")
+        return {"total": total, "next_offset": next_offset, "papers": papers}
 
     def _lookup_paper(self, paper_id: str) -> Dict[str, Any]:
         data = self._request(
             f"/paper/{quote(paper_id, safe='')}",
             params={"fields": self.PAPER_FIELDS},
         )
-        if not isinstance(data.get("paperId"), str):
+        if not isinstance(data, dict) or not isinstance(data.get("paperId"), str):
             raise ValueError("missing Semantic Scholar paperId")
         return data
 
-    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def _related_papers(
+        self,
+        paper_id: str,
+        relation: str,
+        max_results: int,
+        offset: int,
+        publication_date_or_year: str,
+    ) -> Dict[str, Any]:
+        params = {"offset": offset, "limit": max_results, "fields": self.RELATION_FIELDS}
+        if relation == "citations" and publication_date_or_year:
+            params["publicationDateOrYear"] = publication_date_or_year
+        data = self._request(
+            f"/paper/{quote(paper_id, safe='')}/{relation}",
+            params=params,
+        )
+        if not isinstance(data, dict):
+            raise ValueError(f"invalid {relation} response")
+        relations = data.get("data")
+        if not isinstance(relations, list) or not all(isinstance(item, dict) for item in relations):
+            raise ValueError(f"invalid {relation} data")
+        next_offset = self._optional_nonnegative_integer(data.get("next"), "next offset")
+        return {"next_offset": next_offset, "relations": relations}
+
+    def _batch_lookup(self, paper_ids: List[str]) -> Dict[str, Any]:
+        data = self._request(
+            "/paper/batch",
+            params={"fields": self.PAPER_FIELDS},
+            json_body={"ids": paper_ids},
+        )
+        if not isinstance(data, list) or len(data) != len(paper_ids):
+            raise ValueError("invalid batch response")
+        if not all(item is None or isinstance(item, dict) for item in data):
+            raise ValueError("invalid batch paper data")
+
+        papers = []
+        not_found_ids = []
+        for paper_id, paper in zip(paper_ids, data):
+            if paper is None:
+                not_found_ids.append(paper_id)
+            else:
+                papers.append(paper)
+        return {"papers": papers, "not_found_ids": not_found_ids}
+
+    def _request(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> Any:
         headers = {"User-Agent": self.user_agent}
         if self.api_key:
             headers["x-api-key"] = self.api_key
 
-        response = requests.get(
-            f"{self.base_url}{path}",
-            params=dict(params or {}),
-            headers=headers,
-            timeout=self.timeout,
-        )
+        request_kwargs = {
+            "params": dict(params or {}),
+            "headers": headers,
+            "timeout": self.timeout,
+        }
+        url = f"{self.base_url}{path}"
+        if json_body is None:
+            response = requests.get(url, **request_kwargs)
+        else:
+            response = requests.post(url, json=json_body, **request_kwargs)
         response.raise_for_status()
         try:
             data = response.json()
         except requests.JSONDecodeError as exc:
             raise ValueError("invalid Semantic Scholar JSON response") from exc
 
-        if not isinstance(data, dict):
+        if not isinstance(data, (dict, list)):
             raise ValueError("invalid Semantic Scholar response")
-        api_error = data.get("error")
-        if api_error:
-            raise _SemanticScholarAPIError(f"Semantic Scholar API error: {api_error}")
+        if isinstance(data, dict) and data.get("error"):
+            raise _SemanticScholarAPIError(f"Semantic Scholar API error: {data['error']}")
         return data
 
     @classmethod
     def _normalize_mode(cls, mode: str) -> str:
         normalized_mode = mode.strip().lower() if isinstance(mode, str) else ""
         if normalized_mode not in cls.MODES:
-            raise ValueError("mode must be one of: paper, search")
+            raise ValueError("mode must be one of: batch, citations, paper, references, search")
         return normalized_mode
+
+    @classmethod
+    def _normalize_query(cls, query: str | List[str], mode: str) -> str | List[str]:
+        if mode == "batch":
+            return cls._normalize_batch_ids(query)
+        normalized_query = query.strip() if isinstance(query, str) else ""
+        if not normalized_query:
+            raise ValueError("query must not be empty")
+        if mode in {"paper", "citations", "references"}:
+            return cls._normalize_paper_id(normalized_query)
+        return normalized_query
+
+    @classmethod
+    def _normalize_batch_ids(cls, value: Any) -> List[str]:
+        if not isinstance(value, list):
+            raise ValueError("query must be a list of paper identifiers in batch mode")
+        if not 1 <= len(value) <= 500:
+            raise ValueError("batch query must contain between 1 and 500 paper identifiers")
+        paper_ids = [cls._normalize_paper_id(item) if isinstance(item, str) else "" for item in value]
+        if any(not paper_id for paper_id in paper_ids):
+            raise ValueError("batch query must contain only string paper identifiers")
+        if len(set(paper_ids)) != len(paper_ids):
+            raise ValueError("batch query must not contain duplicate paper identifiers")
+        return paper_ids
 
     @staticmethod
     def _validate_max_results(max_results: int) -> None:
@@ -202,15 +407,196 @@ class SemanticScholarTool(Tool):
         if not 1 <= max_results <= 20:
             raise ValueError("max_results must be between 1 and 20")
 
+    @staticmethod
+    def _validate_page(page: int) -> None:
+        if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+            raise ValueError("page must be an integer greater than or equal to 1")
+
+    @staticmethod
+    def _validate_result_window(mode: str, offset: int, max_results: int) -> None:
+        if mode == "search" and offset + max_results > 1000:
+            raise ValueError("search can access only the first 1,000 results")
+
+    @staticmethod
+    def _validate_mode_options(
+        mode: str,
+        page: int,
+        year: Optional[str],
+        publication_date_or_year: Optional[str],
+        publication_types: Optional[str | List[str]],
+        fields_of_study: Optional[str | List[str]],
+        venue: Optional[str | List[str]],
+        min_citation_count: Optional[int],
+        open_access_only: bool,
+    ) -> None:
+        if not isinstance(open_access_only, bool):
+            raise ValueError("open_access_only must be a boolean")
+        search_only_filters = (year, publication_types, fields_of_study, venue, min_citation_count)
+        if mode == "citations":
+            if any(value is not None for value in search_only_filters) or open_access_only:
+                raise ValueError("citations mode supports only publication_date_or_year filtering")
+        elif mode != "search" and (
+            any(value is not None for value in search_only_filters)
+            or publication_date_or_year is not None
+            or open_access_only
+        ):
+            raise ValueError("search filters can be used only in search mode")
+        if mode in {"paper", "batch"} and page != 1:
+            raise ValueError(f"page must be 1 in {mode} mode")
+
+    @classmethod
+    def _normalize_search_filters(
+        cls,
+        year: Optional[str],
+        publication_date_or_year: Optional[str],
+        publication_types: Optional[str | List[str]],
+        fields_of_study: Optional[str | List[str]],
+        venue: Optional[str | List[str]],
+        min_citation_count: Optional[int],
+        open_access_only: bool,
+    ) -> Dict[str, Any]:
+        normalized_year = cls._normalize_year_filter(year)
+        normalized_date = cls._normalize_date_filter(publication_date_or_year)
+        if normalized_year and normalized_date:
+            raise ValueError("year and publication_date_or_year cannot be used together")
+        if min_citation_count is not None and (
+            isinstance(min_citation_count, bool) or not isinstance(min_citation_count, int) or min_citation_count < 0
+        ):
+            raise ValueError("min_citation_count must be a non-negative integer")
+
+        return {
+            "year": normalized_year,
+            "publication_date_or_year": normalized_date,
+            "publication_types": cls._normalize_values(publication_types, "publication_types", cls.PUBLICATION_TYPES),
+            "fields_of_study": cls._normalize_values(fields_of_study, "fields_of_study", cls.FIELDS_OF_STUDY),
+            "venue": cls._normalize_values(venue, "venue"),
+            "min_citation_count": min_citation_count,
+            "open_access_only": open_access_only,
+        }
+
+    @staticmethod
+    def _search_request_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
+        params = {}
+        mappings = (
+            ("year", "year"),
+            ("publication_date_or_year", "publicationDateOrYear"),
+            ("publication_types", "publicationTypes"),
+            ("fields_of_study", "fieldsOfStudy"),
+            ("venue", "venue"),
+            ("min_citation_count", "minCitationCount"),
+        )
+        for context_name, api_name in mappings:
+            value = filters[context_name]
+            if isinstance(value, list):
+                if value:
+                    params[api_name] = ",".join(value)
+            elif value is not None and value != "":
+                params[api_name] = value
+        if filters["open_access_only"]:
+            params["openAccessPdf"] = ""
+        return params
+
+    @classmethod
+    def _normalize_values(
+        cls,
+        value: Optional[str | List[str]],
+        parameter_name: str,
+        allowed: Optional[tuple[str, ...]] = None,
+    ) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            items = value.split(",")
+        elif isinstance(value, list) and all(isinstance(item, str) for item in value):
+            items = value
+        else:
+            raise ValueError(f"{parameter_name} must be a string or list of strings")
+
+        normalized = []
+        canonical = {item.lower(): item for item in allowed or ()}
+        for item in items:
+            text = item.strip()
+            if not text:
+                raise ValueError(f"{parameter_name} must not contain empty values")
+            if allowed:
+                match = canonical.get(text.lower())
+                if not match:
+                    raise ValueError(f"{parameter_name} contains an unsupported value: {text}")
+                text = match
+            if text not in normalized:
+                normalized.append(text)
+        return normalized
+
+    @staticmethod
+    def _normalize_year_filter(value: Optional[str]) -> str:
+        if value is None:
+            return ""
+        normalized = value.strip() if isinstance(value, str) else ""
+        match = re.fullmatch(r"(?:(\d{4})-(\d{4})|(\d{4})-|-(\d{4})|(\d{4}))", normalized)
+        if not match:
+            raise ValueError("year must use YYYY, YYYY-YYYY, YYYY-, or -YYYY format")
+        years = [int(item) for item in match.groups() if item is not None]
+        if any(year < 1 for year in years):
+            raise ValueError("year values must be greater than zero")
+        if match.group(1) and int(match.group(1)) > int(match.group(2)):
+            raise ValueError("year range start must not be after its end")
+        return normalized
+
+    @classmethod
+    def _normalize_date_filter(cls, value: Optional[str]) -> str:
+        if value is None:
+            return ""
+        normalized = value.strip() if isinstance(value, str) else ""
+        if not normalized or normalized.count(":") > 1:
+            raise ValueError("publication_date_or_year must contain a valid date or range")
+        if ":" not in normalized:
+            cls._date_boundary(normalized, end=False)
+            return normalized
+
+        start, end = normalized.split(":", 1)
+        if not start and not end:
+            raise ValueError("publication_date_or_year range must include a boundary")
+        start_date = cls._date_boundary(start, end=False) if start else None
+        end_date = cls._date_boundary(end, end=True) if end else None
+        if start_date and end_date and start_date > end_date:
+            raise ValueError("publication date range start must not be after its end")
+        return normalized
+
+    @staticmethod
+    def _date_boundary(value: str, end: bool) -> date:
+        match = re.fullmatch(r"(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?", value)
+        if not match:
+            raise ValueError("publication dates must use YYYY, YYYY-MM, or YYYY-MM-DD")
+        year = int(match.group(1))
+        month_text = match.group(2)
+        day_text = match.group(3)
+        if year < 1:
+            raise ValueError("publication date years must be greater than zero")
+        try:
+            month = int(month_text) if month_text else (12 if end else 1)
+            day = int(day_text) if day_text else (calendar.monthrange(year, month)[1] if end else 1)
+            return date(year, month, day)
+        except ValueError as exc:
+            raise ValueError(f"invalid publication date: {value}") from exc
+
     @classmethod
     def _normalize_paper_id(cls, value: str) -> str:
         paper_id = value.strip()
-        paper_id = re.sub(r"^https?://(?:www\.)?semanticscholar\.org/paper/(?:[^/]+/)?", "", paper_id, flags=re.I)
+        paper_id = re.sub(
+            r"^https?://(?:www\.)?semanticscholar\.org/paper/(?:[^/]+/)?",
+            "",
+            paper_id,
+            flags=re.I,
+        )
         paper_id = re.sub(r"^https?://(?:dx\.)?doi\.org/", "DOI:", paper_id, flags=re.I)
         paper_id = re.sub(r"^https?://arxiv\.org/(?:abs|pdf)/", "ARXIV:", paper_id, flags=re.I)
         paper_id = re.sub(r"\.pdf$", "", paper_id, flags=re.I)
 
-        prefix_match = re.match(r"^(doi|arxiv|pmid|pmcid|corpusid)\s*:\s*(.+)$", paper_id, flags=re.I)
+        prefix_match = re.match(
+            r"^(doi|arxiv|pmid|pmcid|corpusid|mag|acl|url)\s*:\s*(.+)$",
+            paper_id,
+            flags=re.I,
+        )
         if prefix_match:
             prefix = {
                 "doi": "DOI",
@@ -218,12 +604,17 @@ class SemanticScholarTool(Tool):
                 "pmid": "PMID",
                 "pmcid": "PMCID",
                 "corpusid": "CorpusId",
+                "mag": "MAG",
+                "acl": "ACL",
+                "url": "URL",
             }[prefix_match.group(1).lower()]
             identifier = prefix_match.group(2).strip()
             if not identifier or any(character.isspace() for character in identifier):
-                raise ValueError("query must contain a valid paper identifier in paper mode")
+                raise ValueError("query must contain a valid paper identifier")
             if prefix == "DOI" and not cls._is_doi(identifier):
-                raise ValueError("query must contain a valid DOI in paper mode")
+                raise ValueError("query must contain a valid DOI")
+            if prefix == "URL" and not re.match(r"^https?://", identifier, flags=re.I):
+                raise ValueError("query must contain a valid URL")
             return f"{prefix}:{identifier}"
 
         if cls._is_doi(paper_id):
@@ -231,8 +622,8 @@ class SemanticScholarTool(Tool):
         if re.fullmatch(r"[0-9a-fA-F]{40}", paper_id):
             return paper_id.lower()
         raise ValueError(
-            "query must contain a valid paper identifier in paper mode: DOI, PMID, "
-            "PMCID, ArXiv ID, CorpusId, or Semantic Scholar paper ID"
+            "query must contain a valid paper identifier: DOI, PMID, PMCID, ArXiv ID, "
+            "CorpusId, MAG, ACL, URL, or Semantic Scholar paper ID"
         )
 
     @staticmethod
@@ -259,6 +650,20 @@ class SemanticScholarTool(Tool):
             "open_access_pdf": cls._open_access_pdf(paper.get("openAccessPdf")),
             "url": cls._string_value(paper.get("url")),
         }
+
+    @classmethod
+    def _parse_relation(cls, item: Dict[str, Any], relation: str) -> Dict[str, Any]:
+        paper_key = "citingPaper" if relation == "citations" else "citedPaper"
+        raw_paper = item.get(paper_key)
+        paper = cls._parse_paper(raw_paper if isinstance(raw_paper, dict) else {})
+        paper.update(
+            {
+                "contexts": cls._string_list(item.get("contexts")),
+                "intents": cls._string_list(item.get("intents")),
+                "is_influential": item.get("isInfluential") is True,
+            }
+        )
+        return paper
 
     @classmethod
     def _authors(cls, value: Any) -> List[str]:
@@ -305,6 +710,40 @@ class SemanticScholarTool(Tool):
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
     @staticmethod
+    def _required_nonnegative_integer(value: Any, field_name: str) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"invalid {field_name}")
+        return value
+
+    @classmethod
+    def _optional_nonnegative_integer(cls, value: Any, field_name: str) -> Optional[int]:
+        if value is None:
+            return None
+        return cls._required_nonnegative_integer(value, field_name)
+
+    @staticmethod
+    def _operation_context(
+        mode: str,
+        query: str | List[str],
+        max_results: int,
+        page: int,
+        offset: int,
+        search_filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        context = {
+            "mode": mode,
+            "query": query,
+            "max_results": max_results,
+        }
+        if mode in {"search", "citations", "references"}:
+            context.update({"page": page, "offset": offset})
+        if mode == "search":
+            context.update(search_filters)
+        elif mode == "citations" and search_filters["publication_date_or_year"]:
+            context["publication_date_or_year"] = search_filters["publication_date_or_year"]
+        return context
+
+    @staticmethod
     def _http_error_message(status_code: Optional[int]) -> str:
         if status_code == 429:
             return (
@@ -317,18 +756,22 @@ class SemanticScholarTool(Tool):
 
     @staticmethod
     def _error_result(
-        mode: str,
-        query: str,
-        max_results: int,
+        context: Dict[str, Any],
         error_type: str,
         message: str,
     ) -> Dict[str, Any]:
-        return {
-            "mode": mode,
-            "query": query,
-            "max_results": max_results,
+        result = {
+            **context,
             "total_results": 0,
             "returned_results": 0,
             "papers": [],
             "error": {"type": error_type, "message": message},
         }
+        if context["mode"] == "batch":
+            result.update(
+                {
+                    "requested_results": len(context["query"]),
+                    "not_found_ids": [],
+                }
+            )
+        return result

--- a/agentuniverse/agent/action/tool/common_tool/semantic_scholar_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/semantic_scholar_tool.py
@@ -4,6 +4,7 @@
 """A scholarly paper discovery tool based on the Semantic Scholar Graph API."""
 
 import calendar
+import json
 import re
 from datetime import date
 from typing import Any, ClassVar, Dict, List, Optional
@@ -24,6 +25,11 @@ class SemanticScholarTool(Tool):
     """Search papers, retrieve metadata, and explore citation relationships."""
 
     MODES: ClassVar[set[str]] = {"search", "paper", "citations", "references", "batch"}
+    MAX_BATCH_RESULTS: ClassVar[int] = 20
+    MAX_BATCH_OUTPUT_BYTES: ClassVar[int] = 32 * 1024
+    MAX_PAPER_IDENTIFIER_LENGTH: ClassVar[int] = 256
+    MAX_BATCH_TITLE_LENGTH: ClassVar[int] = 500
+    MAX_BATCH_VENUE_LENGTH: ClassVar[int] = 200
     PUBLICATION_TYPES: ClassVar[tuple[str, ...]] = (
         "Review",
         "JournalArticle",
@@ -82,6 +88,16 @@ class SemanticScholarTool(Tool):
             "isOpenAccess",
             "openAccessPdf",
             "fieldsOfStudy",
+        )
+    )
+    BATCH_FIELDS: ClassVar[str] = ",".join(
+        (
+            "paperId",
+            "title",
+            "venue",
+            "year",
+            "citationCount",
+            "isOpenAccess",
         )
     )
     RELATION_FIELDS: ClassVar[str] = ",".join(("contexts", "intents", "isInfluential", PAPER_FIELDS))
@@ -220,8 +236,8 @@ class SemanticScholarTool(Tool):
                 }
 
             result = self._batch_lookup(normalized_query)
-            papers = [self._parse_paper(paper) for paper in result["papers"]]
-            return {
+            papers = [self._parse_batch_paper(paper) for paper in result["papers"]]
+            batch_result = {
                 **context,
                 "requested_results": len(normalized_query),
                 "total_results": len(papers),
@@ -229,6 +245,13 @@ class SemanticScholarTool(Tool):
                 "not_found_ids": result["not_found_ids"],
                 "papers": papers,
             }
+            if self._serialized_size(batch_result) > self.MAX_BATCH_OUTPUT_BYTES:
+                return self._error_result(
+                    context=context,
+                    error_type="output_limit_exceeded",
+                    message="Semantic Scholar batch result exceeded the agent output limit.",
+                )
+            return batch_result
         except _SemanticScholarAPIError as exc:
             return self._error_result(
                 context=context,
@@ -320,7 +343,7 @@ class SemanticScholarTool(Tool):
     def _batch_lookup(self, paper_ids: List[str]) -> Dict[str, Any]:
         data = self._request(
             "/paper/batch",
-            params={"fields": self.PAPER_FIELDS},
+            params={"fields": self.BATCH_FIELDS},
             json_body={"ids": paper_ids},
         )
         if not isinstance(data, list) or len(data) != len(paper_ids):
@@ -391,8 +414,8 @@ class SemanticScholarTool(Tool):
     def _normalize_batch_ids(cls, value: Any) -> List[str]:
         if not isinstance(value, list):
             raise ValueError("query must be a list of paper identifiers in batch mode")
-        if not 1 <= len(value) <= 500:
-            raise ValueError("batch query must contain between 1 and 500 paper identifiers")
+        if not 1 <= len(value) <= cls.MAX_BATCH_RESULTS:
+            raise ValueError(f"batch query must contain between 1 and {cls.MAX_BATCH_RESULTS} paper identifiers")
         paper_ids = [cls._normalize_paper_id(item) if isinstance(item, str) else "" for item in value]
         if any(not paper_id for paper_id in paper_ids):
             raise ValueError("batch query must contain only string paper identifiers")
@@ -615,16 +638,25 @@ class SemanticScholarTool(Tool):
                 raise ValueError("query must contain a valid DOI")
             if prefix == "URL" and not re.match(r"^https?://", identifier, flags=re.I):
                 raise ValueError("query must contain a valid URL")
-            return f"{prefix}:{identifier}"
+            normalized = f"{prefix}:{identifier}"
+            cls._validate_identifier_length(normalized)
+            return normalized
 
         if cls._is_doi(paper_id):
-            return f"DOI:{paper_id}"
+            normalized = f"DOI:{paper_id}"
+            cls._validate_identifier_length(normalized)
+            return normalized
         if re.fullmatch(r"[0-9a-fA-F]{40}", paper_id):
             return paper_id.lower()
         raise ValueError(
             "query must contain a valid paper identifier: DOI, PMID, PMCID, ArXiv ID, "
             "CorpusId, MAG, ACL, URL, or Semantic Scholar paper ID"
         )
+
+    @classmethod
+    def _validate_identifier_length(cls, paper_id: str) -> None:
+        if len(paper_id) > cls.MAX_PAPER_IDENTIFIER_LENGTH:
+            raise ValueError(f"paper identifier must not exceed {cls.MAX_PAPER_IDENTIFIER_LENGTH} characters")
 
     @staticmethod
     def _is_doi(value: str) -> bool:
@@ -649,6 +681,17 @@ class SemanticScholarTool(Tool):
             "is_open_access": paper.get("isOpenAccess") is True,
             "open_access_pdf": cls._open_access_pdf(paper.get("openAccessPdf")),
             "url": cls._string_value(paper.get("url")),
+        }
+
+    @classmethod
+    def _parse_batch_paper(cls, paper: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "paper_id": cls._bounded_string(paper.get("paperId"), 64),
+            "title": cls._bounded_string(paper.get("title"), cls.MAX_BATCH_TITLE_LENGTH),
+            "venue": cls._bounded_string(paper.get("venue"), cls.MAX_BATCH_VENUE_LENGTH),
+            "year": cls._integer_value(paper.get("year")),
+            "citation_count": cls._integer_value(paper.get("citationCount")),
+            "is_open_access": paper.get("isOpenAccess") is True,
         }
 
     @classmethod
@@ -696,6 +739,14 @@ class SemanticScholarTool(Tool):
     @staticmethod
     def _string_value(value: Any) -> str:
         return value.strip() if isinstance(value, str) else ""
+
+    @classmethod
+    def _bounded_string(cls, value: Any, max_length: int) -> str:
+        return cls._string_value(value)[:max_length]
+
+    @staticmethod
+    def _serialized_size(value: Dict[str, Any]) -> int:
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
 
     @staticmethod
     def _scalar_string(value: Any) -> str:

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -281,7 +281,7 @@ result = tool.execute(
 参数说明：
 
 - `query`：必填。`search`模式下为检索文本；`paper`、`citations`和`references`模式下为单个论文标识符；`batch`模式下为标识符列表。支持DOI、PMID、PMCID、ArXiv ID、CorpusId、MAG、ACL、`URL:`和Semantic Scholar paper ID，也支持DOI、ArXiv和Semantic Scholar论文URL。
-- `mode`：可选，可选值为`search`、`paper`、`citations`、`references`或`batch`，默认为`search`。`citations`返回引用目标论文的论文，`references`返回目标论文引用的论文；`batch`一次接收1到500个不重复标识符。Semantic Scholar同时限制批量响应不得超过10 MB，因此元数据较多时需要拆分大型批次。
+- `mode`：可选，可选值为`search`、`paper`、`citations`、`references`或`batch`，默认为`search`。`citations`返回引用目标论文的论文，`references`返回目标论文引用的论文；为避免Agent上下文被大型响应占满，`batch`一次只接收1到20个不重复标识符，并具有32 KiB的序列化输出硬上限。
 - `max_results`：可选，用于`search`、`citations`和`references`模式，范围为1到20，默认为5。`paper`固定返回至多一条，`batch`由标识符数量决定。
 - `page`：可选，从1开始，用于`search`、`citations`和`references`。Semantic Scholar相关性搜索只允许访问前1,000条结果。
 - `year`：可选，仅用于搜索。支持`YYYY`、`YYYY-YYYY`、`YYYY-`和`-YYYY`。
@@ -292,9 +292,9 @@ result = tool.execute(
 - `min_citation_count`：可选，仅用于搜索，必须为非负整数。
 - `open_access_only`：可选，仅用于搜索。设为`true`时仅返回带公开PDF的论文。
 
-所有模式统一使用`papers`列表返回标准化论文元数据。每篇论文可包含Semantic Scholar paper ID、CorpusId、外部标识符、标题、作者、摘要、期刊或会议名称、发表日期和年份、出版物类型、研究领域、引用数、参考文献数、开放获取状态、开放获取PDF地址和Semantic Scholar页面地址。`citations`和`references`结果还包含引用上下文`contexts`、引用意图`intents`和高影响关系标记`is_influential`。
+所有模式统一使用`papers`列表返回标准化论文元数据。`search`、`paper`、`citations`和`references`中的每篇论文可包含Semantic Scholar paper ID、CorpusId、外部标识符、标题、作者、摘要、期刊或会议名称、发表日期和年份、出版物类型、研究领域、引用数、参考文献数、开放获取状态、开放获取PDF地址和Semantic Scholar页面地址。`citations`和`references`结果还包含引用上下文`contexts`、引用意图`intents`和高影响关系标记`is_influential`。
 
-搜索和关系模式返回`page`、`offset`与`next_offset`。引用关系端点不返回总数，因此这两种模式的`total_results`为`null`。批量模式返回`requested_results`和`not_found_ids`。缺失字段会根据字段类型返回空字符串、空列表、空对象、`0`或`false`。工具仅返回元数据，不下载或总结论文全文。
+搜索和关系模式返回`page`、`offset`与`next_offset`。引用关系端点不返回总数，因此这两种模式的`total_results`为`null`。批量模式返回`requested_results`、`not_found_ids`以及精简的`paper_id`、`title`、`venue`、`year`、`citation_count`和`is_open_access`字段，不返回摘要、作者列表、外部标识符或链接；批量结果中的标题最多保留500个字符，期刊或会议名称最多保留200个字符。需要完整元数据时应对目标论文使用`paper`模式。缺失字段会根据字段类型返回空字符串、空列表、空对象、`0`或`false`。工具仅返回元数据，不下载或总结论文全文。
 
 Semantic Scholar的相关性搜索端点不提供服务端排序参数，因此工具不对搜索结果做误导性的局部排序。需要大量离线数据时，应使用Semantic Scholar bulk search或数据集API，而不是扩大Agent工具的单次返回量。
 

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -217,16 +217,17 @@ result = tool.run(
 
 网络超时、HTTP错误、连接失败、非法JSON和Crossref API错误会通过结构化`error`字段返回。可以通过环境变量`CROSSREF_EMAIL`提供联系邮箱，进入Crossref polite pool并在请求中携带可识别的User-Agent。
 
-### 1.6 Semantic Scholar论文搜索
+### 1.6 Semantic Scholar论文发现与引用关系
 
-Semantic Scholar工具通过Semantic Scholar Academic Graph API检索跨学科学术论文，或根据论文标识符精确查询元数据。大多数端点支持不配置API Key进行基础调用。如果Semantic Scholar已经向你发放API Key，可以通过环境变量`S2_API_KEY`进行配置；基础使用不要求个人必须申请API Key。
+Semantic Scholar工具通过Semantic Scholar Academic Graph API检索跨学科学术论文、精确查询论文元数据、浏览引用与参考文献关系，或批量查询多篇论文。大多数端点支持不配置API Key进行基础调用。如果Semantic Scholar已经向你发放API Key，可以通过环境变量`S2_API_KEY`进行配置；基础使用不要求个人必须申请API Key。
 
 工具配置：
 
 ```yaml
 name: 'semantic_scholar_tool'
 description: |
-  Search Semantic Scholar for scholarly papers or retrieve one paper by identifier.
+  Search Semantic Scholar, retrieve paper metadata, explore citation relationships,
+  or look up multiple papers in one request.
 tool_type: 'api'
 input_keys: ['query']
 metadata:
@@ -235,7 +236,7 @@ metadata:
   class: 'SemanticScholarTool'
 ```
 
-关键词搜索示例：
+高级搜索示例：
 
 ```python
 from agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool import SemanticScholarTool
@@ -245,27 +246,59 @@ result = tool.execute(
     query="large language models in medicine",
     mode="search",
     max_results=5,
+    page=1,
+    year="2020-",
+    fields_of_study=["Medicine", "Computer Science"],
+    min_citation_count=10,
+    open_access_only=True,
 )
 ```
 
-论文精确查询示例：
+引用关系查询示例：
 
 ```python
 result = tool.execute(
     query="DOI:10.18653/v1/2020.acl-main.447",
-    mode="paper",
+    mode="citations",
+    max_results=5,
+    page=1,
+    publication_date_or_year="2020:",
+)
+```
+
+批量查询示例：
+
+```python
+result = tool.execute(
+    query=[
+        "DOI:10.18653/v1/2020.acl-main.447",
+        "PMID:19872477",
+    ],
+    mode="batch",
 )
 ```
 
 参数说明：
 
-- `query`：必填。`search`模式下为检索关键词；`paper`模式下为DOI、PMID、PMCID、ArXiv ID、CorpusId或Semantic Scholar paper ID，也支持DOI URL和ArXiv URL。
-- `mode`：可选，可选值为`search`或`paper`，默认为`search`。
-- `max_results`：可选，仅用于`search`模式，范围为1到20，默认为5。`paper`模式最多返回一条记录。
+- `query`：必填。`search`模式下为检索文本；`paper`、`citations`和`references`模式下为单个论文标识符；`batch`模式下为标识符列表。支持DOI、PMID、PMCID、ArXiv ID、CorpusId、MAG、ACL、`URL:`和Semantic Scholar paper ID，也支持DOI、ArXiv和Semantic Scholar论文URL。
+- `mode`：可选，可选值为`search`、`paper`、`citations`、`references`或`batch`，默认为`search`。`citations`返回引用目标论文的论文，`references`返回目标论文引用的论文；`batch`一次接收1到500个不重复标识符。Semantic Scholar同时限制批量响应不得超过10 MB，因此元数据较多时需要拆分大型批次。
+- `max_results`：可选，用于`search`、`citations`和`references`模式，范围为1到20，默认为5。`paper`固定返回至多一条，`batch`由标识符数量决定。
+- `page`：可选，从1开始，用于`search`、`citations`和`references`。Semantic Scholar相关性搜索只允许访问前1,000条结果。
+- `year`：可选，仅用于搜索。支持`YYYY`、`YYYY-YYYY`、`YYYY-`和`-YYYY`。
+- `publication_date_or_year`：可选，用于`search`和`citations`。支持`YYYY`、`YYYY-MM`、`YYYY-MM-DD`及以冒号分隔的闭区间或开放区间，例如`2020-01:2024-06-30`、`2020:`和`:2024-06`。搜索模式下不能与`year`同时使用；引用模式下该参数过滤引用目标论文的论文，`references`端点不支持此过滤条件。
+- `publication_types`：可选，仅用于搜索。支持单个类型、逗号分隔字符串或字符串列表，例如`Review`、`JournalArticle`、`ClinicalTrial`、`Conference`和`Dataset`。
+- `fields_of_study`：可选，仅用于搜索。支持单个研究领域、逗号分隔字符串或字符串列表，例如`Medicine`、`Computer Science`、`Biology`和`Physics`。
+- `venue`：可选，仅用于搜索。期刊、会议等发表场所名称或名称列表。
+- `min_citation_count`：可选，仅用于搜索，必须为非负整数。
+- `open_access_only`：可选，仅用于搜索。设为`true`时仅返回带公开PDF的论文。
 
-返回结果包含操作模式、查询内容、结果数量和`papers`列表。每篇论文可包含Semantic Scholar paper ID、CorpusId、外部标识符、标题、作者、摘要、期刊或会议名称、发表日期和年份、出版物类型、研究领域、引用数、参考文献数、开放获取状态、开放获取PDF地址和Semantic Scholar页面地址。缺失字段会根据字段类型返回空字符串、空列表、空对象、`0`或`false`。工具仅返回元数据，不下载或总结论文全文。
+所有模式统一使用`papers`列表返回标准化论文元数据。每篇论文可包含Semantic Scholar paper ID、CorpusId、外部标识符、标题、作者、摘要、期刊或会议名称、发表日期和年份、出版物类型、研究领域、引用数、参考文献数、开放获取状态、开放获取PDF地址和Semantic Scholar页面地址。`citations`和`references`结果还包含引用上下文`contexts`、引用意图`intents`和高影响关系标记`is_influential`。
 
-网络超时、HTTP错误、连接失败、非法JSON、响应结构异常和Semantic Scholar API错误会通过结构化`error`字段返回。匿名用户共用Semantic Scholar的调用额度，并可能在繁忙时段受到额外限制；遇到HTTP 429时应稍后重试。仅当Semantic Scholar已经向你发放API Key时才需要配置`S2_API_KEY`，配置后工具会通过`x-api-key`请求头发送该Key。
+搜索和关系模式返回`page`、`offset`与`next_offset`。引用关系端点不返回总数，因此这两种模式的`total_results`为`null`。批量模式返回`requested_results`和`not_found_ids`。缺失字段会根据字段类型返回空字符串、空列表、空对象、`0`或`false`。工具仅返回元数据，不下载或总结论文全文。
+
+Semantic Scholar的相关性搜索端点不提供服务端排序参数，因此工具不对搜索结果做误导性的局部排序。需要大量离线数据时，应使用Semantic Scholar bulk search或数据集API，而不是扩大Agent工具的单次返回量。
+
+网络超时、HTTP错误、连接失败、非法JSON、响应结构异常和Semantic Scholar API错误会通过结构化`error`字段返回，并保留操作、分页和过滤条件。匿名用户共用Semantic Scholar的调用额度，并可能在繁忙时段受到额外限制；遇到HTTP 429时应稍后重试。仅当Semantic Scholar已经向你发放API Key时才需要配置`S2_API_KEY`，配置后工具会通过`x-api-key`请求头发送该Key。
 
 
 ## 2. 代码工具

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml
@@ -1,43 +1,78 @@
 name: 'semantic_scholar_tool'
 description: |
-  Search Semantic Scholar for scholarly papers or retrieve one paper by identifier.
+  Search Semantic Scholar, retrieve paper metadata, explore citation relationships,
+  or look up multiple papers in one request.
 
   Input parameters:
-    - query (required): Search keywords in search mode, or a paper identifier in paper
-      mode. Paper mode supports DOI, PMID, PMCID, ArXiv, CorpusId, and Semantic Scholar
-      paper ID values, including DOI and ArXiv URLs.
-    - mode (optional): Operation mode. Use search for keyword search or paper for an
-      exact paper lookup. Defaults to search.
-    - max_results (optional): Number of papers to return in search mode, from 1 to 20.
-      Defaults to 5. Paper mode always returns at most one paper.
+    - query (required): Search text in search mode; one paper identifier in paper,
+      citations, or references mode; or a JSON list of identifiers in batch mode.
+      Identifiers may be DOI, PMID, PMCID, ArXiv, CorpusId, MAG, ACL, URL, or Semantic
+      Scholar paper ID values. DOI URLs, ArXiv URLs, and Semantic Scholar paper URLs
+      are accepted.
+    - mode (optional): One of search, paper, citations, references, or batch. Defaults
+      to search. Citations returns papers that cite query; references returns papers
+      cited by query. Batch accepts between 1 and 500 unique identifiers. Semantic
+      Scholar also applies a 10 MB response limit, so large batches may need splitting.
+    - max_results (optional): Results per page for search, citations, and references,
+      from 1 to 20. Defaults to 5. Paper returns one result; batch uses the list size.
+    - page (optional): One-based page for search, citations, and references. Defaults
+      to 1. Relevance search exposes only the first 1,000 results.
+    - year (optional, search only): YYYY, YYYY-YYYY, YYYY-, or -YYYY year filter.
+    - publication_date_or_year (optional, search and citations): YYYY, YYYY-MM,
+      YYYY-MM-DD, or an inclusive colon-delimited range such as 2020-01:2024-06-30.
+      Do not combine it with year in search mode. It filters citing papers in citations
+      mode; the references endpoint does not support this filter.
+    - publication_types (optional, search only): A publication type or list. Supported
+      values include Review, JournalArticle, CaseReport, ClinicalTrial, Conference,
+      Dataset, Editorial, LettersAndComments, MetaAnalysis, News, Study, Book, and
+      BookSection.
+    - fields_of_study (optional, search only): A Semantic Scholar field or list, such
+      as Computer Science, Medicine, Biology, Physics, or Mathematics.
+    - venue (optional, search only): A venue name or list of venue names.
+    - min_citation_count (optional, search only): Non-negative minimum citation count.
+    - open_access_only (optional, search only): Set true to require a public PDF.
 
-  Search example:
+  Filtered search example:
     {
       "query": "large language models in medicine",
       "mode": "search",
-      "max_results": 5
+      "max_results": 5,
+      "page": 1,
+      "year": "2020-",
+      "fields_of_study": ["Medicine", "Computer Science"],
+      "min_citation_count": 10,
+      "open_access_only": true
     }
 
-  Paper lookup examples:
+  Citation example:
     {
       "query": "DOI:10.18653/v1/2020.acl-main.447",
-      "mode": "paper"
-    }
-    {
-      "query": "PMID:19872477",
-      "mode": "paper"
+      "mode": "citations",
+      "max_results": 5,
+      "page": 1,
+      "publication_date_or_year": "2020:"
     }
 
-  Each paper may contain its Semantic Scholar paper ID, CorpusId, external identifiers,
-  title, authors, abstract, venue, publication date and year, publication types, fields
-  of study, citation count, reference count, open access status, open access PDF, and
-  Semantic Scholar URL. Missing metadata is returned as an empty string, list, object,
-  zero, or false value. Network and Semantic Scholar API failures are returned in a
-  structured error field. Most endpoints support anonymous access, but anonymous users
-  share a rate limit and may receive HTTP 429 during busy periods. If Semantic Scholar
-  has issued an API key to you, set the optional S2_API_KEY environment variable to send
-  it with requests. An API key is not required for basic use. This tool returns metadata
-  only and does not download or summarize full text.
+  Batch example:
+    {
+      "query": ["DOI:10.18653/v1/2020.acl-main.447", "PMID:19872477"],
+      "mode": "batch"
+    }
+
+  Every response uses a normalized papers list. Citation and reference papers also
+  contain contexts, intents, and is_influential relationship metadata. Search and
+  relationship modes return page, offset, and next_offset; relation total_results is
+  null because those endpoints do not provide a total. Batch returns requested_results
+  and not_found_ids. Paper metadata may include Semantic Scholar paper ID, CorpusId,
+  external identifiers, title, authors, abstract, venue, publication date and year,
+  publication types, fields of study, citation and reference counts, open access status,
+  open access PDF, and URL. Missing metadata uses empty values.
+
+  Network and Semantic Scholar API failures use a structured error field and preserve
+  operation context. Most endpoints allow anonymous access, but anonymous users share a
+  rate limit and may receive HTTP 429. Retry later when limited. If Semantic Scholar has
+  issued an API key to you, set S2_API_KEY to send it with requests. This tool returns
+  metadata only and does not download or summarize full text.
 tool_type: 'api'
 input_keys: ['query']
 metadata:

--- a/examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml
@@ -11,10 +11,11 @@ description: |
       are accepted.
     - mode (optional): One of search, paper, citations, references, or batch. Defaults
       to search. Citations returns papers that cite query; references returns papers
-      cited by query. Batch accepts between 1 and 500 unique identifiers. Semantic
-      Scholar also applies a 10 MB response limit, so large batches may need splitting.
+      cited by query. Batch accepts between 1 and 20 unique identifiers and returns
+      compact metadata with a hard 32 KiB serialized output limit.
     - max_results (optional): Results per page for search, citations, and references,
-      from 1 to 20. Defaults to 5. Paper returns one result; batch uses the list size.
+      from 1 to 20. Defaults to 5. Paper returns one result; batch uses the list size
+      and is capped separately at 20 identifiers.
     - page (optional): One-based page for search, citations, and references. Defaults
       to 1. Relevance search exposes only the first 1,000 results.
     - year (optional, search only): YYYY, YYYY-YYYY, YYYY-, or -YYYY year filter.
@@ -63,7 +64,10 @@ description: |
   contain contexts, intents, and is_influential relationship metadata. Search and
   relationship modes return page, offset, and next_offset; relation total_results is
   null because those endpoints do not provide a total. Batch returns requested_results
-  and not_found_ids. Paper metadata may include Semantic Scholar paper ID, CorpusId,
+  and not_found_ids plus compact paper_id, title, venue, year, citation_count, and
+  is_open_access fields; batch titles are capped at 500 characters and venues at 200.
+  Use paper mode for full metadata. Full paper metadata may
+  include Semantic Scholar paper ID, CorpusId,
   external identifiers, title, authors, abstract, venue, publication date and year,
   publication types, fields of study, citation and reference counts, open access status,
   open access PDF, and URL. Missing metadata uses empty values.

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -308,7 +309,54 @@ class SemanticScholarToolTest(unittest.TestCase):
             "https://api.semanticscholar.org/graph/v1/paper/batch",
         )
         self.assertEqual(mock_post.call_args.kwargs["json"], {"ids": expected_ids})
-        self.assertIn("fields", mock_post.call_args.kwargs["params"])
+        self.assertEqual(mock_post.call_args.kwargs["params"]["fields"], self.tool.BATCH_FIELDS)
+        self.assertEqual(
+            set(result["papers"][0]),
+            {"paper_id", "title", "venue", "year", "citation_count", "is_open_access"},
+        )
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.post")
+    def test_maximum_batch_output_is_compact_and_bounded(self, mock_post: Mock) -> None:
+        paper_ids = [f"CorpusId:{index}" for index in range(1, self.tool.MAX_BATCH_RESULTS + 1)]
+        oversized_paper = {
+            **SAMPLE_PAPER,
+            "title": "T" * 10_000,
+            "venue": "V" * 10_000,
+            "abstract": "A" * 100_000,
+            "authors": [{"name": "An Author"}] * 1_000,
+        }
+        mock_post.return_value = response_mock(json_data=[dict(oversized_paper) for _ in paper_ids])
+
+        result = self.tool.execute(query=paper_ids, mode="batch")
+
+        self.assertEqual(result["returned_results"], self.tool.MAX_BATCH_RESULTS)
+        self.assertTrue(all(len(paper["title"]) <= self.tool.MAX_BATCH_TITLE_LENGTH for paper in result["papers"]))
+        self.assertTrue(all(len(paper["venue"]) <= self.tool.MAX_BATCH_VENUE_LENGTH for paper in result["papers"]))
+        self.assertNotIn("abstract", result["papers"][0])
+        self.assertNotIn("authors", result["papers"][0])
+        serialized = json.dumps(result, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        self.assertLessEqual(len(serialized), self.tool.MAX_BATCH_OUTPUT_BYTES)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.post")
+    def test_oversized_utf8_batch_returns_bounded_error(self, mock_post: Mock) -> None:
+        paper_ids = [f"CorpusId:{index}" for index in range(1, self.tool.MAX_BATCH_RESULTS + 1)]
+        mock_post.return_value = response_mock(
+            json_data=[
+                {
+                    **SAMPLE_PAPER,
+                    "title": "\U0001f4da" * self.tool.MAX_BATCH_TITLE_LENGTH,
+                    "venue": "\U0001f4da" * self.tool.MAX_BATCH_VENUE_LENGTH,
+                }
+                for _ in paper_ids
+            ]
+        )
+
+        result = self.tool.execute(query=paper_ids, mode="batch")
+
+        self.assertEqual(result["error"]["type"], "output_limit_exceeded")
+        self.assertEqual(result["papers"], [])
+        serialized = json.dumps(result, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        self.assertLessEqual(len(serialized), self.tool.MAX_BATCH_OUTPUT_BYTES)
 
     @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.post")
     def test_invalid_batch_shape_returns_structured_error(self, mock_post: Mock) -> None:
@@ -373,10 +421,17 @@ class SemanticScholarToolTest(unittest.TestCase):
             self.tool.execute(query="AI", min_citation_count=-1)
         with self.assertRaisesRegex(ValueError, "must be a list"):
             self.tool.execute(query="PMID:19872477", mode="batch")
-        with self.assertRaisesRegex(ValueError, "between 1 and 500"):
+        with self.assertRaisesRegex(ValueError, "between 1 and 20"):
             self.tool.execute(query=[], mode="batch")
+        with self.assertRaisesRegex(ValueError, "between 1 and 20"):
+            self.tool.execute(
+                query=[f"CorpusId:{index}" for index in range(21)],
+                mode="batch",
+            )
         with self.assertRaisesRegex(ValueError, "duplicate"):
             self.tool.execute(query=["PMID:19872477", "pmid:19872477"], mode="batch")
+        with self.assertRaisesRegex(ValueError, "must not exceed 256"):
+            self.tool.execute(query=[f"URL:https://example.com/{'x' * 300}"], mode="batch")
 
     def test_missing_metadata_returns_empty_values(self) -> None:
         paper = SemanticScholarTool._parse_paper({"paperId": "abc"})
@@ -528,8 +583,9 @@ class SemanticScholarToolTest(unittest.TestCase):
         self.assertIn("S2_API_KEY", description)
         self.assertIn("rate", description.lower())
         self.assertIn("1,000", description)
-        self.assertIn("500", description)
-        self.assertIn("10 MB", description)
+        self.assertIn("1 and 20", description)
+        self.assertIn("32 KiB", description)
+        self.assertIn("compact", description)
         for relationship_field in ("contexts", "intents", "is_influential"):
             self.assertIn(relationship_field, description)
         for batch_field in ("requested_results", "not_found_ids"):

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py
@@ -9,6 +9,8 @@ import requests
 import yaml
 
 from agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool import SemanticScholarTool
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
 
 
 SAMPLE_PAPER = {
@@ -103,6 +105,59 @@ class SemanticScholarToolTest(unittest.TestCase):
         self.assertEqual(request.kwargs["timeout"], 15.0)
 
     @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_search_maps_paging_and_filters(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={"total": 200, "offset": 10, "next": 12, "data": [SAMPLE_PAPER]}
+        )
+
+        result = self.tool.execute(
+            query="language models",
+            max_results=2,
+            page=6,
+            year="2020-2024",
+            publication_types=["Review", "journalarticle"],
+            fields_of_study="medicine,Computer Science",
+            venue=["Nature", "NEJM"],
+            min_citation_count=100,
+            open_access_only=True,
+        )
+
+        self.assertEqual(result["page"], 6)
+        self.assertEqual(result["offset"], 10)
+        self.assertEqual(result["next_offset"], 12)
+        self.assertEqual(result["year"], "2020-2024")
+        self.assertEqual(result["publication_types"], ["Review", "JournalArticle"])
+        self.assertEqual(result["fields_of_study"], ["Medicine", "Computer Science"])
+        self.assertEqual(result["venue"], ["Nature", "NEJM"])
+        self.assertEqual(result["min_citation_count"], 100)
+        self.assertTrue(result["open_access_only"])
+
+        params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(params["offset"], 10)
+        self.assertEqual(params["limit"], 2)
+        self.assertEqual(params["year"], "2020-2024")
+        self.assertEqual(params["publicationTypes"], "Review,JournalArticle")
+        self.assertEqual(params["fieldsOfStudy"], "Medicine,Computer Science")
+        self.assertEqual(params["venue"], "Nature,NEJM")
+        self.assertEqual(params["minCitationCount"], 100)
+        self.assertEqual(params["openAccessPdf"], "")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_search_maps_publication_date_filter(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(json_data={"total": 0, "data": []})
+
+        result = self.tool.execute(
+            query="AI medicine",
+            publication_date_or_year="2020-02:2024-06-30",
+        )
+
+        self.assertEqual(result["publication_date_or_year"], "2020-02:2024-06-30")
+        self.assertEqual(
+            mock_get.call_args.kwargs["params"]["publicationDateOrYear"],
+            "2020-02:2024-06-30",
+        )
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
     def test_paper_lookup_normalizes_doi_url(self, mock_get: Mock) -> None:
         mock_get.return_value = response_mock(json_data=SAMPLE_PAPER)
 
@@ -130,8 +185,145 @@ class SemanticScholarToolTest(unittest.TestCase):
         self.assertEqual(self.tool._normalize_paper_id("pmid:19872477"), "PMID:19872477")
         self.assertEqual(self.tool._normalize_paper_id("pmcid:2323736"), "PMCID:2323736")
         self.assertEqual(self.tool._normalize_paper_id("corpusid:215416146"), "CorpusId:215416146")
+        self.assertEqual(self.tool._normalize_paper_id("mag:112218234"), "MAG:112218234")
+        self.assertEqual(self.tool._normalize_paper_id("acl:W12-3903"), "ACL:W12-3903")
+        self.assertEqual(
+            self.tool._normalize_paper_id("URL:https://acm.org/example"),
+            "URL:https://acm.org/example",
+        )
         paper_id = "649def34f8be52c8b66281af98ae884c09aef38b"
         self.assertEqual(self.tool._normalize_paper_id(paper_id.upper()), paper_id)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_citations_returns_relationship_metadata(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "offset": 2,
+                "next": 4,
+                "data": [
+                    {
+                        "contexts": ["This work extends the graph approach."],
+                        "intents": ["background"],
+                        "isInfluential": True,
+                        "citingPaper": SAMPLE_PAPER,
+                    }
+                ],
+            }
+        )
+
+        result = self.tool.execute(
+            query="DOI:10.18653/v1/2020.acl-main.447",
+            mode="citations",
+            max_results=2,
+            page=2,
+            publication_date_or_year="2020:",
+        )
+
+        self.assertEqual(result["mode"], "citations")
+        self.assertEqual(result["offset"], 2)
+        self.assertIsNone(result["total_results"])
+        self.assertEqual(result["next_offset"], 4)
+        self.assertEqual(result["publication_date_or_year"], "2020:")
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(result["papers"][0]["paper_id"], SAMPLE_PAPER["paperId"])
+        self.assertEqual(result["papers"][0]["contexts"], ["This work extends the graph approach."])
+        self.assertEqual(result["papers"][0]["intents"], ["background"])
+        self.assertTrue(result["papers"][0]["is_influential"])
+
+        request = mock_get.call_args
+        self.assertEqual(
+            request.args[0],
+            "https://api.semanticscholar.org/graph/v1/paper/" "DOI%3A10.18653%2Fv1%2F2020.acl-main.447/citations",
+        )
+        self.assertEqual(request.kwargs["params"]["offset"], 2)
+        self.assertEqual(request.kwargs["params"]["limit"], 2)
+        self.assertEqual(request.kwargs["params"]["publicationDateOrYear"], "2020:")
+        self.assertIn("contexts", request.kwargs["params"]["fields"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_references_uses_cited_paper(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "offset": 0,
+                "data": [
+                    {
+                        "contexts": [],
+                        "intents": [],
+                        "isInfluential": False,
+                        "citedPaper": SAMPLE_PAPER,
+                    }
+                ],
+            }
+        )
+
+        result = self.tool.execute(query="PMID:19872477", mode="references")
+
+        self.assertEqual(result["mode"], "references")
+        self.assertIsNone(result["next_offset"])
+        self.assertEqual(result["papers"][0]["title"], SAMPLE_PAPER["title"])
+        self.assertFalse(result["papers"][0]["is_influential"])
+        self.assertTrue(mock_get.call_args.args[0].endswith("/PMID%3A19872477/references"))
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_relation_without_paper_keeps_relationship_metadata(self, mock_get: Mock) -> None:
+        mock_get.return_value = response_mock(
+            json_data={
+                "data": [
+                    {
+                        "contexts": ["A retained citation context."],
+                        "intents": ["methodology"],
+                        "isInfluential": True,
+                        "citingPaper": None,
+                    }
+                ]
+            }
+        )
+
+        result = self.tool.execute(query="PMID:19872477", mode="citations")
+
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(result["papers"][0]["paper_id"], "")
+        self.assertEqual(result["papers"][0]["contexts"], ["A retained citation context."])
+        self.assertEqual(result["papers"][0]["intents"], ["methodology"])
+        self.assertTrue(result["papers"][0]["is_influential"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.post")
+    def test_batch_lookup_normalizes_ids_and_reports_missing_papers(self, mock_post: Mock) -> None:
+        mock_post.return_value = response_mock(json_data=[SAMPLE_PAPER, None])
+
+        result = self.tool.execute(
+            query=["https://doi.org/10.18653/v1/2020.acl-main.447", "pmid:19872477"],
+            mode="batch",
+        )
+
+        expected_ids = ["DOI:10.18653/v1/2020.acl-main.447", "PMID:19872477"]
+        self.assertEqual(result["query"], expected_ids)
+        self.assertEqual(result["max_results"], 2)
+        self.assertEqual(result["requested_results"], 2)
+        self.assertEqual(result["returned_results"], 1)
+        self.assertEqual(result["not_found_ids"], ["PMID:19872477"])
+        self.assertEqual(result["papers"][0]["paper_id"], SAMPLE_PAPER["paperId"])
+        self.assertEqual(
+            mock_post.call_args.args[0],
+            "https://api.semanticscholar.org/graph/v1/paper/batch",
+        )
+        self.assertEqual(mock_post.call_args.kwargs["json"], {"ids": expected_ids})
+        self.assertIn("fields", mock_post.call_args.kwargs["params"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.post")
+    def test_invalid_batch_shape_returns_structured_error(self, mock_post: Mock) -> None:
+        mock_post.return_value = response_mock(json_data=[SAMPLE_PAPER])
+
+        result = self.tool.execute(
+            query=["PMID:19872477", "DOI:10.18653/v1/2020.acl-main.447"],
+            mode="batch",
+        )
+
+        self.assertEqual(result["requested_results"], 2)
+        self.assertEqual(result["returned_results"], 0)
+        self.assertEqual(result["not_found_ids"], [])
+        self.assertEqual(result["error"]["type"], "invalid_response")
+        self.assertIn("invalid batch response", result["error"]["message"])
 
     @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
     def test_request_without_api_key_omits_header(self, mock_get: Mock) -> None:
@@ -156,6 +348,36 @@ class SemanticScholarToolTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "valid DOI"):
             self.tool.execute(query="doi:not-a-doi", mode="paper")
 
+    def test_invalid_paging_filters_and_batch_input(self) -> None:
+        with self.assertRaisesRegex(ValueError, "page must be an integer"):
+            self.tool.execute(query="AI", page=0)
+        with self.assertRaisesRegex(ValueError, "page must be an integer"):
+            self.tool.execute(query="PMID:19872477", mode="paper", page=True)
+        with self.assertRaisesRegex(ValueError, "first 1,000"):
+            self.tool.execute(query="AI", max_results=20, page=51)
+        with self.assertRaisesRegex(ValueError, "only in search mode"):
+            self.tool.execute(query="PMID:19872477", mode="paper", year="2024")
+        with self.assertRaisesRegex(ValueError, "supports only publication_date_or_year"):
+            self.tool.execute(query="PMID:19872477", mode="citations", year="2024")
+        with self.assertRaisesRegex(ValueError, "cannot be used together"):
+            self.tool.execute(query="AI", year="2024", publication_date_or_year="2024")
+        with self.assertRaisesRegex(ValueError, "year range start"):
+            self.tool.execute(query="AI", year="2025-2020")
+        with self.assertRaisesRegex(ValueError, "publication date range start"):
+            self.tool.execute(query="AI", publication_date_or_year="2025:2020")
+        with self.assertRaisesRegex(ValueError, "invalid publication date"):
+            self.tool.execute(query="AI", publication_date_or_year="2024-02-30")
+        with self.assertRaisesRegex(ValueError, "unsupported value"):
+            self.tool.execute(query="AI", publication_types="UnsupportedType")
+        with self.assertRaisesRegex(ValueError, "non-negative integer"):
+            self.tool.execute(query="AI", min_citation_count=-1)
+        with self.assertRaisesRegex(ValueError, "must be a list"):
+            self.tool.execute(query="PMID:19872477", mode="batch")
+        with self.assertRaisesRegex(ValueError, "between 1 and 500"):
+            self.tool.execute(query=[], mode="batch")
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            self.tool.execute(query=["PMID:19872477", "pmid:19872477"], mode="batch")
+
     def test_missing_metadata_returns_empty_values(self) -> None:
         paper = SemanticScholarTool._parse_paper({"paperId": "abc"})
 
@@ -178,6 +400,26 @@ class SemanticScholarToolTest(unittest.TestCase):
 
         self.assertEqual(result["error"]["type"], "request_timeout")
         self.assertEqual(result["papers"], [])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_error_response_preserves_search_context(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.Timeout("timed out")
+
+        result = self.tool.execute(
+            query="AI medicine",
+            max_results=2,
+            page=3,
+            year="2020-",
+            fields_of_study="Medicine",
+            open_access_only=True,
+        )
+
+        self.assertEqual(result["page"], 3)
+        self.assertEqual(result["offset"], 4)
+        self.assertEqual(result["year"], "2020-")
+        self.assertEqual(result["fields_of_study"], ["Medicine"])
+        self.assertTrue(result["open_access_only"])
+        self.assertEqual(result["error"]["type"], "request_timeout")
 
     @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
     def test_http_error_returns_structured_error(self, mock_get: Mock) -> None:
@@ -244,11 +486,33 @@ class SemanticScholarToolTest(unittest.TestCase):
 
         self.assertEqual(config["input_keys"], ["query"])
         description = config["description"]
-        for parameter in ("query", "mode", "max_results"):
+        for parameter in (
+            "query",
+            "mode",
+            "max_results",
+            "page",
+            "year",
+            "publication_date_or_year",
+            "publication_types",
+            "fields_of_study",
+            "venue",
+            "min_citation_count",
+            "open_access_only",
+        ):
             self.assertIn(parameter, description)
-        for mode in ("search", "paper"):
+        for mode in ("search", "paper", "citations", "references", "batch"):
             self.assertIn(mode, description)
-        for identifier in ("DOI", "PMID", "PMCID", "ArXiv", "CorpusId", "Semantic Scholar paper ID"):
+        for identifier in (
+            "DOI",
+            "PMID",
+            "PMCID",
+            "ArXiv",
+            "CorpusId",
+            "MAG",
+            "ACL",
+            "URL",
+            "Semantic Scholar paper ID",
+        ):
             self.assertIn(identifier, description)
         for metadata_field in (
             "title",
@@ -263,6 +527,38 @@ class SemanticScholarToolTest(unittest.TestCase):
             self.assertIn(metadata_field, description)
         self.assertIn("S2_API_KEY", description)
         self.assertIn("rate", description.lower())
+        self.assertIn("1,000", description)
+        self.assertIn("500", description)
+        self.assertIn("10 MB", description)
+        for relationship_field in ("contexts", "intents", "is_influential"):
+            self.assertIn(relationship_field, description)
+        for batch_field in ("requested_results", "not_found_ids"):
+            self.assertIn(batch_field, description)
+
+    @patch("agentuniverse.agent.action.tool.common_tool.semantic_scholar_tool.requests.get")
+    def test_shipped_config_initializes_tool(self, mock_get: Mock) -> None:
+        config_path = (
+            Path(__file__).resolve().parents[6]
+            / "examples"
+            / "sample_standard_app"
+            / "intelligence"
+            / "agentic"
+            / "tool"
+            / "buildin"
+            / "semantic_scholar_tool.yaml"
+        )
+        configer = Configer(str(config_path)).load()
+        tool_configer = ToolConfiger(configer).load_by_configer(configer)
+        tool = SemanticScholarTool(api_key=None).initialize_by_component_configer(tool_configer)
+        mock_get.return_value = response_mock(json_data={"total": 0, "data": []})
+
+        result = tool.execute(query="configuration pipeline")
+
+        self.assertEqual(tool.name, "semantic_scholar_tool")
+        self.assertEqual(tool.input_keys, ["query"])
+        self.assertEqual(result["mode"], "search")
+        self.assertEqual(result["query"], "configuration pipeline")
+        self.assertEqual(result["papers"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [x] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Follow-up to #623 under #252. This PR completes the Semantic Scholar tool by extending the previously merged basic search and paper lookup capabilities.
- Added citation, reference, and batch paper lookup modes, including citation contexts, intents, influential citation indicators, missing paper reporting, and support for DOI, PMID, PMCID, ArXiv, CorpusId, MAG, ACL, URL, and Semantic Scholar identifiers.
- Added search pagination and filters for year, publication date, publication type, field of study, venue, minimum citation count, and open-access status, with strict input validation and structured error responses.
- Preserved backward compatibility with the existing `search` and `paper` modes, including optional `S2_API_KEY` support and explicit handling for anonymous API rate limits.
- Updated the shipped YAML configuration and Chinese guide with the complete parameter contract, response fields, usage examples, API limits, and rate-limit guidance.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- Test file:
  `tests/test_agentuniverse/unit/agent/action/tool/test_semantic_scholar_tool.py`
- Focused test command:
  `.\.venv\Scripts\python.exe -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_semantic_scholar_tool -v`
- Focused test result:
  `Ran 23 tests`
  `OK`
- Tool regression test command:
  `.\.venv\Scripts\python.exe -m unittest discover -s tests/test_agentuniverse/unit/agent/action/tool -p "test_*.py" -v`
- Tool regression test result:
  `Ran 128 tests`
  `OK (skipped=3)`
- The skipped tests require optional dependencies and are unrelated to the Semantic Scholar tool.
- Anonymous Semantic Scholar API requests may return HTTP 429 due to upstream rate limiting. The tool returns a structured `http_error` response and recommends configuring `S2_API_KEY` or retrying later.

<img width="635" height="177" alt="image" src="https://github.com/user-attachments/assets/d6b385e9-222b-4318-b818-c1bcbc2aaa06" />

<img width="815" height="781" alt="image" src="https://github.com/user-attachments/assets/cbd3534a-ce0b-4cee-b1e9-94d4facab53e" />

<img width="824" height="772" alt="image" src="https://github.com/user-attachments/assets/901c551a-3e9d-46d2-bf38-23de7422f989" />

<img width="805" height="755" alt="image" src="https://github.com/user-attachments/assets/da706029-9772-476e-acdf-00dc5a8c184e" />

<img width="809" height="704" alt="image" src="https://github.com/user-attachments/assets/b04ec519-dcfb-4bfe-88a3-21be8ad393af" />

<img width="810" height="688" alt="image" src="https://github.com/user-attachments/assets/a4719af6-028d-4c08-8e80-6baec460556e" />


**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md`
- `examples/sample_standard_app/intelligence/agentic/tool/buildin/semantic_scholar_tool.yaml`