### PR TITLE
feat(knowledge): MMRProcessor for diversity-aware re-ranking (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
@@ -102,6 +102,20 @@ class MMRProcessor(DocProcessor):
                 "returning documents in input order.")
             return origin_docs[:self.top_n] if self.top_n else list(origin_docs)
 
+        # Guarantee a homogeneous embedding space before ranking. Documents
+        # recalled from multiple stores can carry vectors from different models
+        # or dimensions; comparing them with cosine would silently truncate to
+        # the shortest vector and produce a plausible but meaningless ranking.
+        # Require one shared dimension, else degrade to input order.
+        dims = {len(e) for e in doc_embeddings} | {len(query_embedding)}
+        if len(dims) > 1:
+            logger.warning(
+                f"MMR: embeddings have inconsistent dimensions {sorted(dims)}; "
+                "cannot compute meaningful similarities. Returning documents in "
+                "input order. Set embedding_name to recompute all embeddings "
+                "with a single model.")
+            return origin_docs[:self.top_n] if self.top_n else list(origin_docs)
+
         order = self._select(doc_embeddings, query_embedding)
         if self.score_key:
             for i in order:
@@ -117,47 +131,58 @@ class MMRProcessor(DocProcessor):
     def _resolve_embeddings(
             self, docs: List[Document], query: Query
     ) -> Tuple[List[Optional[List[float]]], Optional[List[float]]]:
-        """Return per-document and query embeddings, computing missing ones.
+        """Return per-document and query embeddings.
 
         Returns ``(doc_embeddings, query_embedding)`` where ``doc_embeddings``
         aligns positionally with ``docs``. Entries that cannot be obtained stay
         ``None``; the caller treats any ``None`` as "MMR not runnable" and
         degrades to input order.
+
+        When ``embedding_name`` is configured, *every* embedding (all documents
+        and the query) is recomputed with that single model. This is the only
+        way to guarantee a homogeneous embedding space for documents recalled
+        from multiple stores that may carry precomputed vectors from different
+        models or dimensions; reusing those precomputed vectors would mix
+        incompatible spaces and yield meaningless similarities.
         """
-        doc_embeddings: List[Optional[List[float]]] = []
-        missing_texts: List[str] = []
-        missing_indices: List[int] = []
-        for idx, doc in enumerate(docs):
-            if doc.embedding:
-                doc_embeddings.append(doc.embedding)
-            else:
-                doc_embeddings.append(None)
-                missing_texts.append(doc.text or "")
-                missing_indices.append(idx)
+        if self.embedding_name:
+            return self._resolve_embeddings_via_model(docs, query)
 
+        # No model configured: rely on embeddings already carried by the
+        # documents and query. Any heterogeneity here is caught by the
+        # dimension check in ``_process_docs`` and degrades explicitly.
+        doc_embeddings: List[Optional[List[float]]] = [
+            doc.embedding if doc.embedding else None for doc in docs]
         query_embedding: Optional[List[float]] = None
-        query_text: Optional[str] = None
-        if query is not None:
-            if query.embeddings:
-                query_embedding = query.embeddings[0]
-            elif query.query_str:
-                query_text = query.query_str
+        if query is not None and query.embeddings:
+            query_embedding = query.embeddings[0]
+        return doc_embeddings, query_embedding
 
-        needs_model = bool(missing_texts) or query_text is not None
-        if not needs_model:
-            return doc_embeddings, query_embedding
-        if not self.embedding_name:
-            # No model configured to compute the missing embeddings.
-            return doc_embeddings, query_embedding
+    def _resolve_embeddings_via_model(
+            self, docs: List[Document], query: Optional[Query]
+    ) -> Tuple[List[Optional[List[float]]], Optional[List[float]]]:
+        """Recompute all embeddings with the configured model.
+
+        Precomputed ``Document.embedding`` / ``Query.embeddings`` are ignored on
+        purpose so the whole set lives in one embedding space. A query with a
+        ``query_str`` is embedded in that same space; a query that only carries
+        precomputed embeddings falls back to them and is left for the dimension
+        check to accept or reject.
+        """
+        doc_embeddings: List[Optional[List[float]]] = [None] * len(docs)
+        query_embedding: Optional[List[float]] = None
         try:
             model = EmbeddingManager().get_instance_obj(self.embedding_name)
-            if missing_texts:
-                computed = model.get_embeddings(missing_texts)
-                for idx, emb in zip(missing_indices, computed):
+            if docs:
+                computed = model.get_embeddings([doc.text or "" for doc in docs])
+                for idx, emb in enumerate(computed):
                     doc_embeddings[idx] = emb
                     docs[idx].embedding = emb
-            if query_text is not None:
-                query_embedding = model.get_embeddings([query_text])[0]
+            if query is not None:
+                if query.query_str:
+                    query_embedding = model.get_embeddings([query.query_str])[0]
+                elif query.embeddings:
+                    query_embedding = query.embeddings[0]
         except Exception as exc:  # noqa: BLE001 - degrade, never crash retrieval
             logger.error(f"MMR: embedding lookup failed: {exc}")
         return doc_embeddings, query_embedding
@@ -203,7 +228,18 @@ class MMRProcessor(DocProcessor):
 
     @staticmethod
     def _cosine(a: List[float], b: List[float]) -> float:
-        """Cosine similarity; zero when either vector has zero magnitude."""
+        """Cosine similarity; zero when either vector has zero magnitude.
+
+        Raises ``ValueError`` for vectors of different dimensions rather than
+        silently truncating via ``zip`` (which would rank on meaningless
+        similarities). The dimension check in ``_process_docs`` keeps this from
+        firing in normal operation; the guard is an explicit invariant.
+        """
+        if len(a) != len(b):
+            raise ValueError(
+                f"Cannot compute cosine similarity between vectors of different "
+                f"dimensions ({len(a)} vs {len(b)}); ensure all embeddings come "
+                f"from a single model, or set embedding_name to recompute them.")
         dot = 0.0
         for x, y in zip(a, b):
             dot += x * y

--- a/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
@@ -30,8 +30,13 @@ recalled set.
 
 Embeddings: query and document embeddings are taken from ``Query.embeddings``
 and ``Document.embedding`` when present (the store populates them during
-retrieval). When an ``embedding_name`` is configured, any missing embeddings are
-computed on demand via ``EmbeddingManager``. If embeddings cannot be obtained,
+retrieval). When an ``embedding_name`` is configured, *every* embedding is
+recomputed with that single model so the whole set lives in one space — this
+is the only way to obtain a meaningful ranking for documents recalled from
+multiple stores that may carry precomputed vectors from different models. A
+query is embedded from its ``query_str``; a query that only carries a
+precomputed vector is unverifiable (equal dimension does not imply same model)
+and the processor degrades to input order. If embeddings cannot be obtained,
 the processor degrades gracefully and returns the documents in their input
 order rather than crashing retrieval.
 """
@@ -165,9 +170,11 @@ class MMRProcessor(DocProcessor):
 
         Precomputed ``Document.embedding`` / ``Query.embeddings`` are ignored on
         purpose so the whole set lives in one embedding space. A query with a
-        ``query_str`` is embedded in that same space; a query that only carries
-        precomputed embeddings falls back to them and is left for the dimension
-        check to accept or reject.
+        ``query_str`` is embedded in that same space. A query that only carries
+        a precomputed vector has unverifiable provenance — even when its
+        dimension matches the configured model, it may come from a different
+        model and the dimension check cannot tell. The processor therefore
+        degrades to input order rather than rank on a possibly-foreign vector.
         """
         doc_embeddings: List[Optional[List[float]]] = [None] * len(docs)
         query_embedding: Optional[List[float]] = None
@@ -178,11 +185,19 @@ class MMRProcessor(DocProcessor):
                 for idx, emb in enumerate(computed):
                     doc_embeddings[idx] = emb
                     docs[idx].embedding = emb
-            if query is not None:
-                if query.query_str:
-                    query_embedding = model.get_embeddings([query.query_str])[0]
-                elif query.embeddings:
-                    query_embedding = query.embeddings[0]
+            if query is not None and query.query_str:
+                # Only a freshly computed embedding shares the configured model's
+                # space; a precomputed Query.embeddings value has no verifiable
+                # provenance (equal dimension does NOT imply same model).
+                query_embedding = model.get_embeddings([query.query_str])[0]
+            elif query is not None and not query.query_str and query.embeddings:
+                logger.warning(
+                    "MMR: embedding_name is configured but the query carries no "
+                    "query_str, only a precomputed vector. Its provenance cannot "
+                    "be verified against the configured model (equal dimensions "
+                    "do not imply the same embedding space); returning documents "
+                    "in input order. Pass query_str to embed the query with the "
+                    "configured model.")
         except Exception as exc:  # noqa: BLE001 - degrade, never crash retrieval
             logger.error(f"MMR: embedding lookup failed: {exc}")
         return doc_embeddings, query_embedding

--- a/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
@@ -1,0 +1,232 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/16
+# @FileName: mmr_processor.py
+
+"""
+Maximal Marginal Relevance (MMR) post-processor.
+
+Re-ranks the documents recalled by a RAG pipeline so the result set is both
+on-topic and non-repetitive. Classic MMR selects documents one at a time,
+maximising
+
+    score(d) = lambda * sim(d, query) - (1 - lambda) * max_{s in selected} sim(d, s)
+
+The first term keeps selected documents relevant to the query; the second
+penalises redundancy with anything already chosen. ``lambda = 1`` collapses to
+pure relevance ranking; ``lambda = 0`` maximises diversity.
+
+This is the *post-processing* direction of issue #248 (knowledge post-
+processing components): it runs over the list of documents that
+``Knowledge.query_knowledge`` already retrieved and de-duplicated, and returns a
+re-ordered (and optionally truncated) list.
+
+It is intentionally distinct from sibling components: ``semantic_deduplicator``
+*removes* near-duplicate documents above a hard threshold, and
+``ReciprocalRankFusionProcessor`` *combines* ranked lists from several stores;
+MMR instead performs diversity-aware *selection / re-ranking* of a single
+recalled set.
+
+Embeddings: query and document embeddings are taken from ``Query.embeddings``
+and ``Document.embedding`` when present (the store populates them during
+retrieval). When an ``embedding_name`` is configured, any missing embeddings are
+computed on demand via ``EmbeddingManager``. If embeddings cannot be obtained,
+the processor degrades gracefully and returns the documents in their input
+order rather than crashing retrieval.
+"""
+
+import logging
+import math
+from typing import Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import \
+    EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class MMRProcessor(DocProcessor):
+    """Re-rank recalled documents with Maximal Marginal Relevance.
+
+    Attributes:
+        lambda_coef: Relevance/diversity trade-off in [0.0, 1.0]. ``1.0`` is
+            pure relevance ranking, ``0.0`` maximises diversity, and ``0.5``
+            (the default) balances the two.
+        top_n: Number of documents to keep after re-ranking. ``None`` keeps all
+            documents, only re-ordering them.
+        embedding_name: Name of a registered embedding component used to embed
+            documents / the query on demand when they lack an embedding. When
+            ``None``, only embeddings already carried on the documents and the
+            query are used.
+        score_key: Optional metadata key under which each kept document's cosine
+            relevance to the query is stamped. ``None`` (the default) stamps
+            nothing, so the processor does not clobber scores written by earlier
+            processors such as RRF.
+    """
+
+    lambda_coef: float = 0.5
+    top_n: Optional[int] = None
+    embedding_name: Optional[str] = None
+    score_key: Optional[str] = None
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Re-rank ``origin_docs`` by maximal marginal relevance.
+
+        Args:
+            origin_docs: Documents recalled by the knowledge query.
+            query: The originating query; its embedding drives relevance.
+
+        Returns:
+            Re-ranked (and optionally truncated to ``top_n``) documents. If
+            embeddings are unavailable the input order is preserved.
+        """
+        if not origin_docs:
+            return []
+        if self.top_n is not None and self.top_n <= 0:
+            return []
+
+        doc_embeddings, query_embedding = self._resolve_embeddings(
+            origin_docs, query)
+        if query_embedding is None or any(e is None for e in doc_embeddings):
+            logger.warning(
+                "MMR: embeddings unavailable (set embedding_name or ensure the "
+                "store populates Document.embedding / Query.embeddings); "
+                "returning documents in input order.")
+            return origin_docs[:self.top_n] if self.top_n else list(origin_docs)
+
+        order = self._select(doc_embeddings, query_embedding)
+        if self.score_key:
+            for i in order:
+                meta = dict(origin_docs[i].metadata or {})
+                meta[self.score_key] = self._cosine(doc_embeddings[i],
+                                                    query_embedding)
+                origin_docs[i].metadata = meta
+        return [origin_docs[i] for i in order]
+
+    # ------------------------------------------------------------------ #
+    # Embedding resolution
+    # ------------------------------------------------------------------ #
+    def _resolve_embeddings(
+            self, docs: List[Document], query: Query
+    ) -> Tuple[List[Optional[List[float]]], Optional[List[float]]]:
+        """Return per-document and query embeddings, computing missing ones.
+
+        Returns ``(doc_embeddings, query_embedding)`` where ``doc_embeddings``
+        aligns positionally with ``docs``. Entries that cannot be obtained stay
+        ``None``; the caller treats any ``None`` as "MMR not runnable" and
+        degrades to input order.
+        """
+        doc_embeddings: List[Optional[List[float]]] = []
+        missing_texts: List[str] = []
+        missing_indices: List[int] = []
+        for idx, doc in enumerate(docs):
+            if doc.embedding:
+                doc_embeddings.append(doc.embedding)
+            else:
+                doc_embeddings.append(None)
+                missing_texts.append(doc.text or "")
+                missing_indices.append(idx)
+
+        query_embedding: Optional[List[float]] = None
+        query_text: Optional[str] = None
+        if query is not None:
+            if query.embeddings:
+                query_embedding = query.embeddings[0]
+            elif query.query_str:
+                query_text = query.query_str
+
+        needs_model = bool(missing_texts) or query_text is not None
+        if not needs_model:
+            return doc_embeddings, query_embedding
+        if not self.embedding_name:
+            # No model configured to compute the missing embeddings.
+            return doc_embeddings, query_embedding
+        try:
+            model = EmbeddingManager().get_instance_obj(self.embedding_name)
+            if missing_texts:
+                computed = model.get_embeddings(missing_texts)
+                for idx, emb in zip(missing_indices, computed):
+                    doc_embeddings[idx] = emb
+                    docs[idx].embedding = emb
+            if query_text is not None:
+                query_embedding = model.get_embeddings([query_text])[0]
+        except Exception as exc:  # noqa: BLE001 - degrade, never crash retrieval
+            logger.error(f"MMR: embedding lookup failed: {exc}")
+        return doc_embeddings, query_embedding
+
+    # ------------------------------------------------------------------ #
+    # MMR selection (pure)
+    # ------------------------------------------------------------------ #
+    def _select(self, doc_embeddings: List[List[float]],
+                query_embedding: List[float]) -> List[int]:
+        """Greedy MMR selection; returns chosen indices in selection order."""
+        n = len(doc_embeddings)
+        relevance = [self._cosine(e, query_embedding) for e in doc_embeddings]
+        sim_cache: Dict[Tuple[int, int], float] = {}
+
+        def pair_sim(i: int, j: int) -> float:
+            key = (i, j) if i < j else (j, i)
+            cached = sim_cache.get(key)
+            if cached is None:
+                cached = self._cosine(doc_embeddings[i], doc_embeddings[j])
+                sim_cache[key] = cached
+            return cached
+
+        remaining = list(range(n))
+        # First pick: the most query-relevant document.
+        first = max(remaining, key=lambda i: relevance[i])
+        selected = [first]
+        remaining.remove(first)
+
+        limit = self.top_n if self.top_n is not None else n
+        while remaining and len(selected) < limit:
+            best_i = remaining[0]
+            best_score = None
+            for i in remaining:
+                redundancy = max(pair_sim(i, s) for s in selected)
+                score = self.lambda_coef * relevance[i] \
+                    - (1.0 - self.lambda_coef) * redundancy
+                if best_score is None or score > best_score:
+                    best_score = score
+                    best_i = i
+            selected.append(best_i)
+            remaining.remove(best_i)
+        return selected
+
+    @staticmethod
+    def _cosine(a: List[float], b: List[float]) -> float:
+        """Cosine similarity; zero when either vector has zero magnitude."""
+        dot = 0.0
+        for x, y in zip(a, b):
+            dot += x * y
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(y * y for y in b))
+        if norm_a == 0.0 or norm_b == 0.0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> 'MMRProcessor':
+        """Initialize the processor from its component config."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "lambda_coef"):
+            self.lambda_coef = doc_processor_configer.lambda_coef
+        if hasattr(doc_processor_configer, "top_n"):
+            self.top_n = doc_processor_configer.top_n
+        if hasattr(doc_processor_configer, "embedding_name"):
+            self.embedding_name = doc_processor_configer.embedding_name
+        if hasattr(doc_processor_configer, "score_key"):
+            self.score_key = doc_processor_configer.score_key
+        if not 0.0 <= self.lambda_coef <= 1.0:
+            raise ValueError(
+                f"lambda_coef must be in [0.0, 1.0], got {self.lambda_coef}.")
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.yaml
@@ -1,0 +1,30 @@
+name: 'mmr_processor'
+description: 'Maximal Marginal Relevance re-ranking for recalled knowledge documents (diversity-aware selection), addressing the re-ranking direction of issue #248.'
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.mmr_processor'
+  class: 'MMRProcessor'
+
+# --- Relevance / diversity trade-off ---
+# lambda_coef in [0.0, 1.0]: 1.0 = pure relevance ranking, 0.0 = maximise
+# diversity, 0.5 = balanced (default).
+lambda_coef: 0.5
+
+# --- Output size ---
+# Number of documents to keep after re-ranking. null keeps every document and
+# only re-orders them.
+top_n: null
+
+# --- Embeddings ---
+# Query / document embeddings are read from Query.embeddings and
+# Document.embedding when present. Set embedding_name to a registered embedding
+# component so any missing embeddings are computed on demand; leave null to rely
+# only on embeddings already carried by the query / documents.
+embedding_name: ''            # e.g. 'default_openai_embedding'
+
+# --- Optional score stamping ---
+# When set, each kept document's cosine relevance to the query is written under
+# this metadata key. Leave empty to avoid clobbering scores from earlier
+# processors such as ReciprocalRankFusionProcessor.
+score_key: ''

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -229,3 +229,29 @@ metadata:
 - language: An optional output-language hint for the LLM summary, e.g. `Chinese` (ignored in extractive mode).
 
 The processor always returns a single Document whose `text` is the summary. Its `metadata` records the operating mode (`summarization_mode`: `llm` or `extractive`), the number of source documents (`source_doc_count`), and the `llm_name` used.
+
+### [MMRProcessor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.yaml)
+
+This component re-ranks the recalled documents with Maximal Marginal Relevance (MMR), balancing query relevance against inter-document redundancy so a result set is both on-topic and non-repetitive. It addresses the *re-ranking / diversity* direction of issue #248.
+
+At each step MMR selects the document maximising `lambda * sim(d, query) - (1 - lambda) * max_{selected} sim(d, selected)`. Set `lambda_coef` to `1.0` for pure relevance ranking, `0.0` to maximise diversity, or `0.5` (the default) to balance the two. It is distinct from `SemanticDeduplicator` (which removes near-duplicates above a hard threshold) and `ReciprocalRankFusionProcessor` (which fuses ranked lists from several stores): MMR performs diversity-aware selection over a single recalled set.
+
+Query and document embeddings are read from `Query.embeddings` and `Document.embedding`; set `embedding_name` to compute any missing embeddings on demand. If embeddings cannot be obtained, the documents are returned in their input order.
+
+The component definition file is as follows:
+```yaml
+name: 'mmr_processor'
+description: 'Maximal Marginal Relevance re-ranking for recalled documents'
+lambda_coef: 0.5          # 1.0 = relevance only, 0.0 = max diversity
+top_n: null               # number of documents to keep after re-ranking
+embedding_name: ''        # registered embedding component for on-demand embedding
+score_key: ''             # metadata key for the stamped cosine relevance, '' to skip
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.mmr_processor'
+  class: 'MMRProcessor'
+```
+- lambda_coef: Relevance/diversity trade-off in [0.0, 1.0].
+- top_n: Number of documents to keep after re-ranking; `null` keeps all documents and only re-orders them.
+- embedding_name: Registered embedding component used to embed documents / the query on demand when they lack an embedding. When empty, only embeddings already carried by the query/documents are used.
+- score_key: Metadata key under which each kept document's cosine relevance is stamped; empty stamps nothing (so earlier scores such as RRF's are preserved).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -230,3 +230,29 @@ metadata:
 - language: LLM 摘要的可选输出语言提示，如 `Chinese`（抽取式模式下忽略）。
 
 该组件始终返回单个 Document，其 `text` 为摘要内容。其 `metadata` 记录工作模式（`summarization_mode`：`llm` 或 `extractive`）、参与摘要的源文档数（`source_doc_count`）以及使用的 `llm_name`。
+
+### [MMRProcessor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.yaml)
+
+该组件使用最大边际相关性（Maximal Marginal Relevance，MMR）对召回文档重排，在"与查询相关"和"彼此不重复"之间取得平衡，使结果既切题又无冗余。对应 issue #248 的*重排 / 多样性*方向。
+
+MMR 每一步选择使 `lambda * sim(d, query) - (1 - lambda) * max_{已选} sim(d, 已选)` 最大的文档。`lambda_coef` 设为 `1.0` 即纯相关性排序、`0.0` 即最大化多样性、`0.5`（默认）为二者折中。它与 `SemanticDeduplicator`（按硬阈值删除近似重复）和 `ReciprocalRankFusionProcessor`（融合多路召回的排序列表）不同：MMR 是对单个召回集做"兼顾多样性的选择 / 重排"。
+
+查询与文档向量优先取自 `Query.embeddings` 和 `Document.embedding`；设置 `embedding_name` 可按需补算缺失向量。若无法获得向量，则按输入顺序原样返回。
+
+组件定义文件如下：
+```yaml
+name: 'mmr_processor'
+description: '对召回文档做最大边际相关性重排'
+lambda_coef: 0.5          # 1.0 = 仅相关性，0.0 = 最大化多样性
+top_n: null               # 重排后保留的文档数量
+embedding_name: ''        # 用于按需计算向量的注册 embedding 组件
+score_key: ''             # 写入余弦相关性的 metadata 键，'' 表示不写入
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.mmr_processor'
+  class: 'MMRProcessor'
+```
+- lambda_coef: 相关性/多样性权衡，取值 [0.0, 1.0]。
+- top_n: 重排后保留的文档数量；`null` 表示保留全部，仅重排顺序。
+- embedding_name: 当文档/查询缺少向量时，用于按需计算向量的注册 embedding 组件。为空时只使用查询/文档已携带的向量。
+- score_key: 写入每个保留文档与查询余弦相关性的 metadata 键；为空则不写入（从而保留前置处理器如 RRF 写入的分数）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_mmr_processor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_mmr_processor.py
@@ -153,6 +153,64 @@ class TestMMREmbeddingResolution(unittest.TestCase):
         self.assertEqual([d.text for d in out], ["a"])
 
 
+class TestMMREmbeddingHomogeneity(unittest.TestCase):
+    """A meaningful ranking requires one embedding space.
+
+    Guards the regression where ``_cosine`` zipped vectors of different lengths
+    (silently truncating) and where a configured ``embedding_name`` still reused
+    precomputed vectors, so multi-store retrieval could rank on garbage.
+    """
+
+    def test_cosine_rejects_mismatched_dimensions(self) -> None:
+        with self.assertRaises(ValueError):
+            MMRProcessor._cosine([1.0, 0.0], [1.0, 0.0, 0.0])
+
+    def test_mixed_document_dimensions_degrade_to_input_order(self) -> None:
+        # Documents carry vectors of different dimensions (e.g. from stores
+        # backed by different models). Without a model to homogenise them, MMR
+        # must not silently truncate and rank; it degrades to input order.
+        docs = [_doc("d1", [1.0, 0.0, 0.0]), _doc("d2", [1.0, 1.0])]
+        query = Query(query_str="q", embeddings=[[1.0, 0.0, 0.0]])
+        out = MMRProcessor(lambda_coef=1.0).process_docs(docs, query)
+        self.assertEqual([d.text for d in out], ["d1", "d2"])
+
+    def test_query_document_dimension_mismatch_degrades_to_input_order(self) -> None:
+        # Even with equal document dimensions, a query vector of a different
+        # dimension cannot be compared meaningfully.
+        docs = [_doc("d1", _D1), _doc("d2", _D2)]            # dim 2
+        query = Query(query_str="q", embeddings=[[1.0, 0.0, 0.0]])  # dim 3
+        out = MMRProcessor(lambda_coef=1.0).process_docs(docs, query)
+        self.assertEqual([d.text for d in out], ["d1", "d2"])
+
+    def test_embedding_name_recomputes_all_ignoring_precomputed(self) -> None:
+        # Docs carry precomputed vectors from DIFFERENT models/dimensions. With
+        # embedding_name set, every embedding is recomputed with that one model,
+        # the heterogeneous precomputed vectors are ignored, and MMR produces a
+        # meaningful ranking in a homogeneous space.
+        docs = [
+            Document(text="d1", embedding=[9.0, 9.0, 9.0]),   # bogus precomputed
+            Document(text="d2", embedding=[1.0]),              # different dim
+            Document(text="d3", embedding=[0.0, 0.0]),         # different dim
+        ]
+        model = MagicMock()
+        model.get_embeddings.side_effect = [
+            [_D1, _D2, _D3],   # recomputed documents (homogeneous, dim 2)
+            [_Q],              # recomputed query
+        ]
+        with patch.object(mmr_module, "EmbeddingManager") as emb_mgr:
+            emb_mgr.return_value.get_instance_obj.return_value = model
+            out = MMRProcessor(embedding_name="fake_emb", lambda_coef=1.0)\
+                .process_docs(docs, Query(query_str="q"))
+
+        # d1's bogus precomputed vector is gone; ranking follows the recomputed
+        # homogeneous vectors -> relevance order d1 > d2 > d3.
+        self.assertEqual([d.text for d in out], ["d1", "d2", "d3"])
+        # The documents now carry the recomputed (homogeneous) embeddings.
+        self.assertEqual(list(docs[0].embedding), _D1)
+        self.assertEqual(list(docs[1].embedding), _D2)
+        self.assertEqual(list(docs[2].embedding), _D3)
+
+
 class TestMMRConfig(unittest.TestCase):
     """Initialization and configuration."""
 

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_mmr_processor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_mmr_processor.py
@@ -210,6 +210,34 @@ class TestMMREmbeddingHomogeneity(unittest.TestCase):
         self.assertEqual(list(docs[1].embedding), _D2)
         self.assertEqual(list(docs[2].embedding), _D3)
 
+    def test_embedding_name_rejects_precomputed_query_without_query_str(self) -> None:
+        # Regression: when embedding_name is configured but the query carries
+        # only a precomputed vector (no query_str), the query's provenance is
+        # unverifiable. Even if the precomputed vector has the SAME dimension as
+        # the configured model (so the dimension check cannot catch it), it may
+        # come from a different model and must not be ranked against. MMR must
+        # degrade to input order rather than silently rank on a foreign vector.
+        docs = [Document(text="d1"), Document(text="d2"), Document(text="d3")]
+        # Foreign precomputed query vector with the SAME dimension (2) as the
+        # configured model would emit — exactly the hole the dimension check
+        # cannot detect.
+        foreign_query = Query(embeddings=[[0.7, 0.7]])
+        model = MagicMock()
+        # The model is only called for the documents; it must NOT be asked to
+        # embed a query string (there is none), and the foreign vector must not
+        # reach _cosine.
+        model.get_embeddings.return_value = [_D1, _D2, _D3]
+        with patch.object(mmr_module, "EmbeddingManager") as emb_mgr:
+            emb_mgr.return_value.get_instance_obj.return_value = model
+            out = MMRProcessor(embedding_name="fake_emb", lambda_coef=1.0)\
+                .process_docs(docs, foreign_query)
+
+        # Degrades to input order; the foreign precomputed query is NOT used.
+        self.assertEqual([d.text for d in out], ["d1", "d2", "d3"])
+        # The query-embedding call never happened: only one get_embeddings call
+        # (the documents), not the two-call pattern of a recomputed query.
+        self.assertEqual(model.get_embeddings.call_count, 1)
+
 
 class TestMMRConfig(unittest.TestCase):
     """Initialization and configuration."""

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_mmr_processor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_mmr_processor.py
@@ -1,0 +1,245 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/16
+# @FileName: test_mmr_processor.py
+
+"""Tests for the MMRProcessor doc processor."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agentuniverse.agent.action.knowledge.doc_processor.mmr_processor as \
+    mmr_module
+from agentuniverse.agent.action.knowledge.doc_processor.mmr_processor import \
+    MMRProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+_YAML_PATH = os.path.join(os.path.dirname(mmr_module.__file__),
+                          "mmr_processor.yaml")
+
+
+def _doc(name: str, embedding) -> Document:
+    return Document(text=name, embedding=list(embedding))
+
+
+# Fixture: query along the x-axis.
+#   d1 = [1, 0]  rel = 1.0
+#   d2 = [1, 1]  rel = 1/sqrt2 ~ 0.7071   (also similar to d1: sim 0.7071)
+#   d3 = [0, 1]  rel = 0.0                (orthogonal to d1, sim 0.0)
+_Q = [1.0, 0.0]
+_D1 = [1.0, 0.0]
+_D2 = [1.0, 1.0]
+_D3 = [0.0, 1.0]
+
+
+class TestMMRSelection(unittest.TestCase):
+    """Greedy MMR selection over pre-supplied embeddings."""
+
+    def setUp(self) -> None:
+        self.query = Query(query_str="q", embeddings=[_Q])
+
+    def _run(self, docs, **kwargs):
+        proc = MMRProcessor(**kwargs)
+        return proc.process_docs(docs, self.query)
+
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(self._run([]), [])
+
+    def test_non_positive_top_n_returns_empty(self) -> None:
+        docs = [_doc("d1", _D1)]
+        self.assertEqual(self._run(docs, top_n=0), [])
+        self.assertEqual(self._run(docs, top_n=-3), [])
+
+    def test_pure_relevance_when_lambda_is_one(self) -> None:
+        # lambda=1 ignores diversity: output is relevance order d1 > d2 > d3.
+        out = self._run([_doc("d1", _D1), _doc("d2", _D2), _doc("d3", _D3)],
+                        lambda_coef=1.0)
+        self.assertEqual([d.text for d in out], ["d1", "d2", "d3"])
+
+    def test_diversity_when_lambda_is_zero(self) -> None:
+        # lambda=0 maximises diversity: after the most relevant d1, the
+        # orthogonal d3 is preferred over the redundant d2.
+        out = self._run([_doc("d1", _D1), _doc("d2", _D2), _doc("d3", _D3)],
+                        lambda_coef=0.0)
+        self.assertEqual([d.text for d in out], ["d1", "d3", "d2"])
+
+    def test_top_n_truncates_after_reranking(self) -> None:
+        out = self._run([_doc("d1", _D1), _doc("d2", _D2), _doc("d3", _D3)],
+                        lambda_coef=1.0, top_n=2)
+        self.assertEqual([d.text for d in out], ["d1", "d2"])
+
+    def test_most_relevant_first_regardless_of_lambda(self) -> None:
+        # The first MMR pick is always the most query-relevant document.
+        for lam in (0.0, 0.25, 0.5, 0.75, 1.0):
+            out = self._run([_doc("d2", _D2), _doc("d1", _D1), _doc("d3", _D3)],
+                            lambda_coef=lam)
+            self.assertEqual(out[0].text, "d1", f"lambda={lam}")
+
+    def test_top_n_larger_than_input_keeps_all(self) -> None:
+        out = self._run([_doc("d1", _D1), _doc("d2", _D2)],
+                        lambda_coef=1.0, top_n=10)
+        self.assertEqual(len(out), 2)
+
+    def test_score_key_stamps_cosine_relevance(self) -> None:
+        out = self._run([_doc("d1", _D1), _doc("d2", _D2), _doc("d3", _D3)],
+                        lambda_coef=1.0, score_key="mmr_score")
+        scores = {d.text: d.metadata["mmr_score"] for d in out}
+        self.assertAlmostEqual(scores["d1"], 1.0)
+        self.assertAlmostEqual(scores["d2"], 0.70710678, places=6)
+        self.assertAlmostEqual(scores["d3"], 0.0)
+
+    def test_no_score_key_leaves_metadata_clean(self) -> None:
+        out = self._run([_doc("d1", _D1)], lambda_coef=1.0)
+        self.assertNotIn("mmr_score", out[0].metadata or {})
+
+
+class TestMMREmbeddingResolution(unittest.TestCase):
+    """Embedding acquisition and graceful fallback."""
+
+    def test_uses_query_embeddings_directly(self) -> None:
+        # Query.embeddings[0] is used; no EmbeddingManager call is made.
+        query = Query(query_str="q", embeddings=[_Q])
+        with patch.object(mmr_module, "EmbeddingManager") as emb_mgr:
+            out = MMRProcessor().process_docs(
+                [_doc("d1", _D1), _doc("d2", _D2)], query)
+            emb_mgr.assert_not_called()
+        self.assertEqual([d.text for d in out], ["d1", "d2"])
+
+    def test_missing_embeddings_without_model_falls_back(self) -> None:
+        # No embeddings anywhere and no embedding_name -> input order preserved.
+        docs = [Document(text="a"), Document(text="b")]
+        out = MMRProcessor().process_docs(docs, Query(query_str="q"))
+        self.assertEqual([d.text for d in out], ["a", "b"])
+
+    def test_partial_embeddings_without_model_falls_back(self) -> None:
+        # One doc has an embedding, the other does not, and there is no model to
+        # fill the gap -> safe fallback to input order.
+        docs = [_doc("d1", _D1), Document(text="d2")]
+        out = MMRProcessor().process_docs(docs, Query(query_str="q",
+                                                      embeddings=[_Q]))
+        self.assertEqual([d.text for d in out], ["d1", "d2"])
+
+    def test_embedding_name_computes_missing_embeddings(self) -> None:
+        # Docs lack embeddings; embedding_name drives an EmbeddingManager call
+        # that supplies them, so MMR runs and ranks by relevance.
+        docs = [Document(text="d1"), Document(text="d2"), Document(text="d3")]
+        model = MagicMock()
+        # First call embeds the three doc texts, second embeds the query string.
+        model.get_embeddings.side_effect = [
+            [_D1, _D2, _D3],   # documents
+            [_Q],              # query
+        ]
+        with patch.object(mmr_module, "EmbeddingManager") as emb_mgr:
+            emb_mgr.return_value.get_instance_obj.return_value = model
+            out = MMRProcessor(embedding_name="fake_emb", lambda_coef=1.0)\
+                .process_docs(docs, Query(query_str="q"))
+        # Relevance order with the supplied vectors.
+        self.assertEqual([d.text for d in out], ["d1", "d2", "d3"])
+
+    def test_embedding_lookup_failure_falls_back(self) -> None:
+        with patch.object(mmr_module, "EmbeddingManager") as emb_mgr:
+            emb_mgr.return_value.get_instance_obj.side_effect = RuntimeError(
+                "no model")
+            out = MMRProcessor(embedding_name="bad")\
+                .process_docs([Document(text="a")], Query(query_str="q"))
+        self.assertEqual([d.text for d in out], ["a"])
+
+
+class TestMMRConfig(unittest.TestCase):
+    """Initialization and configuration."""
+
+    def test_invalid_lambda_raises(self) -> None:
+        configer = SimpleNamespace(name="mmr", description="d", lambda_coef=1.5)
+        with self.assertRaises(ValueError):
+            MMRProcessor()._initialize_by_component_configer(configer)
+
+    def test_attributes_loaded_from_configer(self) -> None:
+        configer = SimpleNamespace(
+            name="mmr", description="d",
+            lambda_coef=0.3, top_n=4, embedding_name="emb", score_key="s")
+        proc = MMRProcessor()._initialize_by_component_configer(configer)
+        self.assertEqual(proc.lambda_coef, 0.3)
+        self.assertEqual(proc.top_n, 4)
+        self.assertEqual(proc.embedding_name, "emb")
+        self.assertEqual(proc.score_key, "s")
+
+
+class TestMMRRegistration(unittest.TestCase):
+    """The shipped yaml resolves through the real framework loader."""
+
+    def test_yaml_resolves_to_doc_processor_type(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.get_component_config_type(),
+            ComponentEnum.DOC_PROCESSOR.value)
+
+    def test_yaml_exposes_module_and_class(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.metadata_module,
+            "agentuniverse.agent.action.knowledge.doc_processor.mmr_processor")
+        self.assertEqual(component_configer.metadata_class, "MMRProcessor")
+
+
+class TestMMRThroughKnowledgePipeline(unittest.TestCase):
+    """MMR runs as a real post_processor through Knowledge.query_knowledge."""
+
+    def test_mmr_reranks_in_the_pipeline(self) -> None:
+        from agentuniverse.agent.action.knowledge import knowledge as \
+            knowledge_module
+        from agentuniverse.agent.action.knowledge.knowledge import Knowledge
+        import agentuniverse.base.annotation.trace as trace_module
+
+        class _FakeStore:
+            def __init__(self, docs):
+                self._docs = docs
+
+            def query(self, query):
+                # Fresh copies, preserving the hand-crafted embeddings.
+                return [Document(text=d.text, embedding=list(d.embedding),
+                                 metadata=dict(d.metadata or {}))
+                        for d in self._docs]
+
+        # A single store returns d2 (more relevant than d3 to query [1,0]).
+        store = _FakeStore([_doc("d2", _D2), _doc("d3", _D3)])
+        mmr = MMRProcessor(lambda_coef=1.0, score_key="mmr_score")
+        knowledge = Knowledge(
+            name="mmr_knowledge",
+            stores=["only_store"],
+            rag_router="base_router",
+            post_processors=["mmr_processor"],
+        )
+        router = MagicMock()
+        router.rag_route.return_value = [(Query(query_str="q"), "only_store")]
+
+        with patch.object(trace_module, "ConversationMemoryModule"), \
+                patch.object(trace_module, "Monitor") as monitor, \
+                patch.object(knowledge_module, "RagRouterManager") as router_mgr, \
+                patch.object(knowledge_module, "StoreManager") as store_mgr, \
+                patch.object(knowledge_module, "DocProcessorManager") as proc_mgr:
+            monitor.get_invocation_chain.return_value = []
+            router_mgr.return_value.get_instance_obj.return_value = router
+            store_mgr.return_value.get_instance_obj.side_effect = \
+                lambda code, **_: store
+            proc_mgr.return_value.get_instance_obj.return_value = mmr
+            out = knowledge.query_knowledge(query_str="q",
+                                            embeddings=[_Q])
+
+        # Relevance order: d2 (rel ~0.707) before d3 (rel 0), score stamped.
+        self.assertEqual([d.text for d in out], ["d2", "d3"])
+        self.assertAlmostEqual(out[0].metadata["mmr_score"], 0.70710678,
+                               places=6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds `MMRProcessor`, a knowledge *post-processor* (#248) that re-ranks recalled documents with **Maximal Marginal Relevance (MMR)** so a result set is both on-topic and non-repetitive.

At each step it selects the document maximising:

```
score(d) = lambda * sim(d, query) - (1 - lambda) * max_{selected} sim(d, selected)
```

- `lambda_coef = 1.0` → pure relevance ranking
- `lambda_coef = 0.0` → maximise diversity
- `lambda_coef = 0.5` (default) → balance

## Why this component

Fills a gap in the current `doc_processor` set (verified: no MMR today), and is intentionally distinct from the siblings it might be compared to, to avoid redundancy:

- vs **`semantic_deduplicator`** — that *removes* near-duplicates above a hard threshold; MMR does soft, diversity-aware *selection / re-ranking* with a relevance/diversity trade-off.
- vs **`ReciprocalRankFusionProcessor`** — that *combines* ranked lists from several stores (cross-channel score fusion); MMR re-ranks a single recalled set for intra-list diversity.

Both the similarity matrix and the greedy selection make it non-trivial (not a few-line inline), complementing the existing rerank / dedup / fusion components.

## Design

- **Embeddings**: query/doc vectors are read from `Query.embeddings` / `Document.embedding` (the store populates them during retrieval). When `embedding_name` is set, missing embeddings are computed on demand via `EmbeddingManager` (same pattern as `semantic_deduplicator`).
- **Graceful fallback**: if embeddings cannot be obtained, the documents are returned in input order instead of crashing retrieval.
- **No score clobbering**: `score_key` defaults to empty, so MMR does not overwrite `relevance_score` stamped by earlier processors such as RRF; opt in by setting `score_key`.
- Pure-Python cosine (dependency-free, fully unit-testable).

## Config

```yaml
name: 'mmr_processor'
metadata:
  type: 'DOC_PROCESSOR'
  module: 'agentuniverse.agent.action.knowledge.doc_processor.mmr_processor'
  class: 'MMRProcessor'
lambda_coef: 0.5
top_n: null
embedding_name: ''
score_key: ''
```

## Tests

`tests/.../test_mmr_processor.py` — 19, all pass:
- **Selection**: `lambda=1` → relevance order; `lambda=0` → diversity order (an orthogonal document is promoted over a redundant one); `top_n` truncation; most-relevant-first regardless of lambda; `score_key` stamps cosine relevance.
- **Embeddings**: uses `Query.embeddings` directly (no model call); falls back to input order when embeddings are missing and no `embedding_name`; `embedding_name` computes missing embeddings; an embedding-lookup failure degrades safely.
- **Config**: `lambda_coef` validated to `[0, 1]`; attributes loaded from the configer.
- **Registration**: shipped yaml resolves to `DOC_PROCESSOR` with the right module/class.
- **Integration**: re-ranks through the real `Knowledge.query_knowledge` → `post_processors` path.

`python -m unittest test_mmr_processor` → 19 passed; `test_knowledge_rrf_integration` still passes (no regression).

Addresses the re-ranking / diversity direction of #248.
