### PR TITLE
feat(knowledge): ContextBudgetCompressor for context-window fitting (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.py
@@ -36,7 +36,7 @@ never "tokens" while silently counting words.
 """
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
     DocProcessor
@@ -49,9 +49,11 @@ logger = logging.getLogger(__name__)
 
 _VALID_COUNTERS = {"estimate", "tiktoken", "char", "word"}
 
-# Module-level tiktoken cache so repeated processing does not reload it.
-_TIKTOKEN_ENCODER = None
-_TIKTOKEN_TRIED = False
+# Cache of tiktoken encoders keyed by encoding name. Keying by name (rather
+# than a single module-global slot) means multiple compressor instances can use
+# different encodings, and a failed lookup for one encoding never poisons
+# another. A value of None means "tiktoken not installed" for that name.
+_TIKTOKEN_ENCODERS: Dict[str, Optional[object]] = {}
 
 
 class ContextBudgetCompressor(DocProcessor):
@@ -167,14 +169,35 @@ class ContextBudgetCompressor(DocProcessor):
 
 
 def _tiktoken_encoder(encoding: str):
-    """Return a cached tiktoken encoder for ``encoding``, or None if unavailable."""
-    global _TIKTOKEN_ENCODER, _TIKTOKEN_TRIED
-    if not _TIKTOKEN_TRIED:
-        _TIKTOKEN_TRIED = True
-        try:
-            import tiktoken
-            _TIKTOKEN_ENCODER = tiktoken.get_encoding(encoding)
-        except Exception as exc:  # noqa: BLE001 - optional dependency
-            logger.debug(f"tiktoken unavailable: {exc}")
-            _TIKTOKEN_ENCODER = None
-    return _TIKTOKEN_ENCODER
+    """Return a cached tiktoken encoder for ``encoding``.
+
+    Two distinct failure modes are handled differently:
+
+    * tiktoken is not installed (an optional dependency) -> return None so the
+      caller degrades to the estimate counter with a warning. This is a
+      legitimate graceful fallback for a missing dependency.
+    * tiktoken is installed but ``encoding`` is not a known encoding name ->
+      raise ValueError. A bad configuration must fail loudly rather than
+      silently switching the counting unit from tokens to the chars/4 estimate.
+
+    Results are cached per encoding name, so one instance's encoder is never
+    handed to another instance that configured a different encoding, and an
+    invalid name does not poison subsequent lookups.
+    """
+    if encoding in _TIKTOKEN_ENCODERS:
+        return _TIKTOKEN_ENCODERS[encoding]
+
+    try:
+        import tiktoken
+    except ImportError as exc:
+        logger.debug("tiktoken is not installed; degrading to the estimate counter: %s", exc)
+        _TIKTOKEN_ENCODERS[encoding] = None
+        return None
+
+    try:
+        encoder = tiktoken.get_encoding(encoding)
+    except Exception as exc:
+        raise ValueError(f"Invalid tiktoken encoding {encoding!r}: {exc}") from exc
+
+    _TIKTOKEN_ENCODERS[encoding] = encoder
+    return encoder

--- a/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.py
@@ -1,0 +1,180 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/16
+# @FileName: context_budget_compressor.py
+
+"""
+Context-budget compressor post-processor.
+
+Fits the documents recalled by a RAG pipeline into a fixed budget (typically
+the LLM's context window). It walks the recalled list — already ranked by the
+store / an earlier reranker or fusion processor — and keeps documents in order
+while their cumulative size stays within ``budget``; the boundary document that
+would overflow is optionally truncated so the result uses the budget as fully as
+possible without exceeding it.
+
+This is the *post-processing* direction of issue #248 (knowledge post-
+processing components). It operates on a different axis from
+``ThresholdFilter``: ``ThresholdFilter`` applies per-document predicates (a
+score / length range) or a fixed top-k, whereas this component manages the
+**cumulative** size of the kept set and can split the last document to fit —
+i.e. "how much context can I afford", not "does this one doc pass".
+
+Counting is explicit and honestly named via ``counter``:
+
+* ``"estimate"`` (default) — ``max(1, len(text) // 4)``, a fast, dependency-free
+  approximation of tokens suitable for budgeting.
+* ``"tiktoken"`` — real BPE token count via ``tiktoken`` (encoding configurable)
+  when that package is installed; falls back to the estimate with a warning if
+  it is not.
+* ``"char"`` — exact character count.
+* ``"word"`` — exact whitespace word count.
+
+The budget is interpreted in the unit of the chosen counter, so the contract is
+never "tokens" while silently counting words.
+"""
+
+import logging
+from typing import List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_VALID_COUNTERS = {"estimate", "tiktoken", "char", "word"}
+
+# Module-level tiktoken cache so repeated processing does not reload it.
+_TIKTOKEN_ENCODER = None
+_TIKTOKEN_TRIED = False
+
+
+class ContextBudgetCompressor(DocProcessor):
+    """Trim the recalled set to a cumulative size budget.
+
+    Attributes:
+        budget: Maximum cumulative size of the kept documents, in the unit of
+            ``counter``.
+        counter: How each document's size is measured: ``"estimate"``
+            (chars/4, default), ``"tiktoken"`` (BPE tokens), ``"char"``, or
+            ``"word"``.
+        truncate: When True, the first document that would exceed the budget is
+            shortened so its size equals the remaining budget and included as
+            the last result; when False, processing stops at that document.
+        tiktoken_encoding: Encoding passed to ``tiktoken`` when
+            ``counter == "tiktoken"``.
+    """
+
+    budget: int = 4096
+    counter: str = "estimate"
+    truncate: bool = True
+    tiktoken_encoding: str = "cl100k_base"
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Keep documents in order until their cumulative size reaches budget.
+
+        Args:
+            origin_docs: Documents recalled by the knowledge query, assumed to
+                be in relevance order (place this processor after a reranker or
+                fusion processor when that is not the case).
+            query: Unused; kept for interface compatibility.
+
+        Returns:
+            Documents fitting within ``budget``; the last one may be truncated
+            when ``truncate`` is set.
+        """
+        if not origin_docs or self.budget <= 0:
+            return []
+
+        kept: List[Document] = []
+        used = 0
+        for doc in origin_docs:
+            size = self._count(doc.text or "")
+            if used + size <= self.budget:
+                kept.append(doc)
+                used += size
+                continue
+            if not self.truncate:
+                break
+            remaining = self.budget - used
+            truncated_text = self._truncate(doc.text or "", remaining)
+            if truncated_text:
+                metadata = dict(doc.metadata or {})
+                metadata["truncated"] = True
+                kept.append(Document(text=truncated_text, metadata=metadata,
+                                     id=doc.id))
+            break  # budget exhausted after the (possibly truncated) boundary doc
+        return kept
+
+    # ------------------------------------------------------------------ #
+    # Counting / truncation
+    # ------------------------------------------------------------------ #
+    def _count(self, text: str) -> int:
+        if self.counter == "char":
+            return len(text)
+        if self.counter == "word":
+            return len(text.split())
+        if self.counter == "tiktoken":
+            encoder = _tiktoken_encoder(self.tiktoken_encoding)
+            if encoder is not None:
+                return len(encoder.encode(text))
+            logger.warning(
+                "tiktoken is not available; counting with the chars/4 estimate "
+                "instead. Install tiktoken or set counter to 'estimate'/'char'/"
+                "'word' to silence this.")
+        # "estimate" (also the tiktoken-unavailable fallback).
+        return max(1, len(text) // 4)
+
+    def _truncate(self, text: str, remaining: int) -> str:
+        """Return a prefix of ``text`` whose size is at most ``remaining``."""
+        if remaining <= 0:
+            return ""
+        if self.counter == "char":
+            return text[:remaining]
+        if self.counter == "word":
+            return " ".join(text.split()[:remaining])
+        if self.counter == "tiktoken":
+            encoder = _tiktoken_encoder(self.tiktoken_encoding)
+            if encoder is not None:
+                return encoder.decode(encoder.encode(text)[:remaining])
+        # "estimate" (and the tiktoken-unavailable fallback): ~4 chars per unit.
+        return text[:remaining * 4]
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> 'ContextBudgetCompressor':
+        """Initialize the compressor from its component config."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "budget"):
+            self.budget = doc_processor_configer.budget
+        if hasattr(doc_processor_configer, "counter"):
+            self.counter = doc_processor_configer.counter
+        if hasattr(doc_processor_configer, "truncate"):
+            self.truncate = doc_processor_configer.truncate
+        if hasattr(doc_processor_configer, "tiktoken_encoding"):
+            self.tiktoken_encoding = doc_processor_configer.tiktoken_encoding
+        if self.counter not in _VALID_COUNTERS:
+            raise ValueError(
+                f"counter must be one of {sorted(_VALID_COUNTERS)}, "
+                f"got '{self.counter}'.")
+        return self
+
+
+def _tiktoken_encoder(encoding: str):
+    """Return a cached tiktoken encoder for ``encoding``, or None if unavailable."""
+    global _TIKTOKEN_ENCODER, _TIKTOKEN_TRIED
+    if not _TIKTOKEN_TRIED:
+        _TIKTOKEN_TRIED = True
+        try:
+            import tiktoken
+            _TIKTOKEN_ENCODER = tiktoken.get_encoding(encoding)
+        except Exception as exc:  # noqa: BLE001 - optional dependency
+            logger.debug(f"tiktoken unavailable: {exc}")
+            _TIKTOKEN_ENCODER = None
+    return _TIKTOKEN_ENCODER

--- a/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.yaml
@@ -1,0 +1,30 @@
+name: 'context_budget_compressor'
+description: 'Fit recalled knowledge documents into a cumulative size budget (optionally truncating the boundary document), addressing the context-window-management direction of issue #248.'
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.context_budget_compressor'
+  class: 'ContextBudgetCompressor'
+
+# --- Budget ---
+# Maximum cumulative size of the kept documents, measured in the unit of
+# `counter`. Walk the recalled list (already relevance-ordered) and keep
+# documents in order until the budget is reached.
+budget: 4096
+
+# --- Counter (how each document's size is measured) ---
+# 'estimate' (default): max(1, len(text)//4), a dependency-free token estimate.
+# 'tiktoken': real BPE tokens via tiktoken (see tiktoken_encoding).
+# 'char': exact character count.
+# 'word': exact whitespace word count.
+counter: 'estimate'
+
+# --- Boundary handling ---
+# When true, the first document that would exceed the budget is shortened to the
+# remaining budget and kept as the last result; when false, processing stops at
+# that document (whole documents only).
+truncate: true
+
+# --- tiktoken ---
+# Encoding used when counter is 'tiktoken'.
+tiktoken_encoding: 'cl100k_base'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -229,3 +229,29 @@ metadata:
 - language: An optional output-language hint for the LLM summary, e.g. `Chinese` (ignored in extractive mode).
 
 The processor always returns a single Document whose `text` is the summary. Its `metadata` records the operating mode (`summarization_mode`: `llm` or `extractive`), the number of source documents (`source_doc_count`), and the `llm_name` used.
+
+### [ContextBudgetCompressor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.yaml)
+
+This component fits the recalled documents into a fixed cumulative size budget (typically the LLM context window). It walks the recalled list — already ranked by the store or an earlier reranker / fusion processor — keeping documents in order while their total size stays within `budget`; the boundary document that would overflow is optionally truncated so the budget is used as fully as possible without exceeding it. It addresses the *context-window management* direction of issue #248.
+
+It operates on a different axis from `ThresholdFilter`: `ThresholdFilter` applies per-document predicates (a score / length range) or a fixed top-k, while this manages the **cumulative** size of the kept set and can split the last document to fit.
+
+Size is measured by `counter`: `estimate` (default, `max(1, len(text)//4)` — a dependency-free token approximation), `tiktoken` (real BPE tokens via tiktoken), `char`, or `word`. The budget is always interpreted in the counter's unit, so the contract is never "tokens" while silently counting words.
+
+The component definition file is as follows:
+```yaml
+name: 'context_budget_compressor'
+description: 'fit recalled documents into a cumulative size budget'
+budget: 4096                 # max cumulative size, in the counter's unit
+counter: 'estimate'          # estimate | tiktoken | char | word
+truncate: true               # shorten the boundary document to fit
+tiktoken_encoding: 'cl100k_base'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.context_budget_compressor'
+  class: 'ContextBudgetCompressor'
+```
+- budget: Maximum cumulative size of the kept documents, measured in the unit of `counter`.
+- counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
+- truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
+- tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -230,3 +230,29 @@ metadata:
 - language: LLM 摘要的可选输出语言提示，如 `Chinese`（抽取式模式下忽略）。
 
 该组件始终返回单个 Document，其 `text` 为摘要内容。其 `metadata` 记录工作模式（`summarization_mode`：`llm` 或 `extractive`）、参与摘要的源文档数（`source_doc_count`）以及使用的 `llm_name`。
+
+### [ContextBudgetCompressor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.yaml)
+
+该组件把召回文档装进一个固定的累积大小预算（通常是 LLM 上下文窗口）。它沿召回列表——已由 store 或前置 reranker / 融合处理器排好序——按顺序保留文档，只要累计大小不超过 `budget`；对那个会超出预算的边界文档，可选择截断，使结果在不超预算的前提下尽可能用满预算。对应 issue #248 的*上下文窗口管理*方向。
+
+它与 `ThresholdFilter` 关注的维度不同：`ThresholdFilter` 做的是 per-document 谓词（分数/长度范围）或固定 top-k，而本组件管理的是保留集合的**累计**大小，并能把最后一个文档切分开来以恰好装下。
+
+大小由 `counter` 计量：`estimate`（默认，`max(1, len(text)//4)`，无依赖的 token 近似）、`tiktoken`（经 tiktoken 的真实 BPE token）、`char` 或 `word`。预算始终以所选 counter 的单位解释，不会出现"名义上是 token、实际按词数算"的误导。
+
+组件定义文件如下：
+```yaml
+name: 'context_budget_compressor'
+description: '把召回文档装进累计大小预算'
+budget: 4096                 # 最大累计大小，单位同 counter
+counter: 'estimate'          # estimate | tiktoken | char | word
+truncate: true               # 截断边界文档以装满预算
+tiktoken_encoding: 'cl100k_base'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.context_budget_compressor'
+  class: 'ContextBudgetCompressor'
+```
+- budget: 保留文档的最大累计大小，单位同 `counter`。
+- counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
+- truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
+- tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_context_budget_compressor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_context_budget_compressor.py
@@ -1,0 +1,207 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/16
+# @FileName: test_context_budget_compressor.py
+
+"""Tests for the ContextBudgetCompressor doc processor."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agentuniverse.agent.action.knowledge.doc_processor.\
+    context_budget_compressor as cbc_module
+from agentuniverse.agent.action.knowledge.doc_processor.\
+    context_budget_compressor import ContextBudgetCompressor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+_YAML_PATH = os.path.join(os.path.dirname(cbc_module.__file__),
+                          "context_budget_compressor.yaml")
+
+
+def _run(docs, **kwargs):
+    return ContextBudgetCompressor(**kwargs).process_docs(
+        [Document(text=d) if isinstance(d, str) else d for d in docs])
+
+
+class TestContextBudgetSelection(unittest.TestCase):
+    """Cumulative budget selection and boundary truncation."""
+
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(_run([], budget=10, counter="char"), [])
+
+    def test_non_positive_budget_returns_empty(self) -> None:
+        self.assertEqual(_run(["abc"], budget=0, counter="char"), [])
+        self.assertEqual(_run(["abc"], budget=-5, counter="char"), [])
+
+    def test_keeps_whole_docs_within_budget(self) -> None:
+        out = _run(["aa", "bb", "cc"], budget=4, counter="char", truncate=False)
+        self.assertEqual([d.text for d in out], ["aa", "bb"])
+
+    def test_stops_at_first_overflow_without_truncate(self) -> None:
+        out = _run(["aa", "bb", "cc"], budget=4, counter="char", truncate=False)
+        self.assertEqual(len(out), 2)
+
+    def test_truncates_boundary_doc_to_fit(self) -> None:
+        out = _run(["aaa", "bbbb"], budget=5, counter="char", truncate=True)
+        self.assertEqual([d.text for d in out], ["aaa", "bb"])
+        self.assertTrue(out[1].metadata.get("truncated"))
+
+    def test_single_doc_exceeding_budget_is_truncated(self) -> None:
+        out = _run(["abcdefghij"], budget=3, counter="char", truncate=True)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].text, "abc")
+        self.assertTrue(out[0].metadata.get("truncated"))
+
+    def test_single_doc_exceeding_budget_without_truncate_is_empty(self) -> None:
+        out = _run(["abcdefghij"], budget=3, counter="char", truncate=False)
+        self.assertEqual(out, [])
+
+    def test_input_order_preserved(self) -> None:
+        out = _run(["xx", "yy", "zz"], budget=6, counter="char", truncate=False)
+        self.assertEqual([d.text for d in out], ["xx", "yy", "zz"])
+
+    def test_truncated_doc_preserves_id_and_metadata(self) -> None:
+        original = Document(text="bbbb", metadata={"source": "readme.md"})
+        out = ContextBudgetCompressor(budget=3, counter="char").process_docs(
+            [original])
+        self.assertEqual(out[0].text, "bbb")
+        self.assertEqual(out[0].metadata.get("source"), "readme.md")
+        self.assertTrue(out[0].metadata.get("truncated"))
+        self.assertEqual(out[0].id, original.id)
+
+
+class TestContextBudgetCounters(unittest.TestCase):
+    """The counter choice changes how size is measured."""
+
+    def test_char_counter_counts_characters(self) -> None:
+        proc = ContextBudgetCompressor(budget=5, counter="char")
+        self.assertEqual(proc._count("hello"), 5)
+
+    def test_word_counter_truncates_by_words(self) -> None:
+        out = _run(["one two three four"], budget=3, counter="word",
+                   truncate=True)
+        self.assertEqual(out[0].text, "one two three")
+
+    def test_word_counter_counts_words(self) -> None:
+        proc = ContextBudgetCompressor(counter="word")
+        self.assertEqual(proc._count("a b c"), 3)
+
+    def test_estimate_counter_uses_chars_div_four(self) -> None:
+        proc = ContextBudgetCompressor(counter="estimate")
+        self.assertEqual(proc._count("x" * 12), 3)   # 12 // 4
+        self.assertEqual(proc._count(""), 1)         # at least 1
+
+    def test_tiktoken_counter_counts_real_tokens(self) -> None:
+        try:
+            import tiktoken
+            enc = tiktoken.get_encoding("cl100k_base")
+        except Exception:  # noqa: BLE001 - optional dependency
+            self.skipTest("tiktoken not installed")
+        proc = ContextBudgetCompressor(counter="tiktoken")
+        text = "hello world"
+        self.assertEqual(proc._count(text), len(enc.encode(text)))
+
+    def test_tiktoken_counter_truncates_by_tokens(self) -> None:
+        try:
+            import tiktoken
+            enc = tiktoken.get_encoding("cl100k_base")
+        except Exception:  # noqa: BLE001 - optional dependency
+            self.skipTest("tiktoken not installed")
+        # "hello world" is two tokens ('hello', ' world'); keep one.
+        out = _run(["hello world"], budget=1, counter="tiktoken", truncate=True)
+        self.assertEqual(out[0].text, enc.decode(enc.encode("hello world")[:1]))
+
+
+class TestContextBudgetConfig(unittest.TestCase):
+    """Initialization and configuration."""
+
+    def test_invalid_counter_raises(self) -> None:
+        configer = SimpleNamespace(name="cbc", description="d", counter="bytes")
+        with self.assertRaises(ValueError):
+            ContextBudgetCompressor()._initialize_by_component_configer(configer)
+
+    def test_attributes_loaded_from_configer(self) -> None:
+        configer = SimpleNamespace(
+            name="cbc", description="d",
+            budget=128, counter="word", truncate=False,
+            tiktoken_encoding="p50k_base")
+        proc = ContextBudgetCompressor()._initialize_by_component_configer(configer)
+        self.assertEqual(proc.budget, 128)
+        self.assertEqual(proc.counter, "word")
+        self.assertFalse(proc.truncate)
+        self.assertEqual(proc.tiktoken_encoding, "p50k_base")
+
+
+class TestContextBudgetRegistration(unittest.TestCase):
+    """The shipped yaml resolves through the real framework loader."""
+
+    def test_yaml_resolves_to_doc_processor_type(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.get_component_config_type(),
+            ComponentEnum.DOC_PROCESSOR.value)
+
+    def test_yaml_exposes_module_and_class(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.metadata_module,
+            "agentuniverse.agent.action.knowledge.doc_processor."
+            "context_budget_compressor")
+        self.assertEqual(component_configer.metadata_class,
+                         "ContextBudgetCompressor")
+
+
+class TestContextBudgetThroughKnowledgePipeline(unittest.TestCase):
+    """The compressor runs as a real post_processor through query_knowledge."""
+
+    def test_compresses_in_the_pipeline(self) -> None:
+        from agentuniverse.agent.action.knowledge import knowledge as \
+            knowledge_module
+        from agentuniverse.agent.action.knowledge.knowledge import Knowledge
+        import agentuniverse.base.annotation.trace as trace_module
+
+        class _FakeStore:
+            def query(self, query):
+                return [Document(text="aaaa"),
+                        Document(text="bbb"),
+                        Document(text="cc")]
+
+        compressor = ContextBudgetCompressor(budget=5, counter="char")
+        knowledge = Knowledge(
+            name="cbc_knowledge",
+            stores=["only_store"],
+            rag_router="base_router",
+            post_processors=["context_budget_compressor"],
+        )
+        router = MagicMock()
+        router.rag_route.return_value = [(Query(query_str="q"), "only_store")]
+
+        with patch.object(trace_module, "ConversationMemoryModule"), \
+                patch.object(trace_module, "Monitor") as monitor, \
+                patch.object(knowledge_module, "RagRouterManager") as router_mgr, \
+                patch.object(knowledge_module, "StoreManager") as store_mgr, \
+                patch.object(knowledge_module, "DocProcessorManager") as proc_mgr:
+            monitor.get_invocation_chain.return_value = []
+            router_mgr.return_value.get_instance_obj.return_value = router
+            store_mgr.return_value.get_instance_obj.side_effect = \
+                lambda code, **_: _FakeStore()
+            proc_mgr.return_value.get_instance_obj.return_value = compressor
+            out = knowledge.query_knowledge(query_str="q")
+
+        # "aaaa" (4) fits; "bbb" would overflow -> truncated to 1 char "b".
+        self.assertEqual([d.text for d in out], ["aaaa", "b"])
+        self.assertTrue(out[1].metadata.get("truncated"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_context_budget_compressor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_context_budget_compressor.py
@@ -120,6 +120,80 @@ class TestContextBudgetCounters(unittest.TestCase):
         self.assertEqual(out[0].text, enc.decode(enc.encode("hello world")[:1]))
 
 
+class TestContextBudgetTiktokenCache(unittest.TestCase):
+    """Encoders are cached per encoding name; bad encodings raise.
+
+    Guards the regression where a single module-global cache slot meant the
+    first compressor instance fixed the encoder for every later instance, and
+    an invalid first encoding silently forced every later instance onto the
+    estimate counter.
+    """
+
+    # cl100k_base and p50k_base disagree on this string (6 vs 7 tokens), so a
+    # later instance reusing the first instance's encoder would miscount.
+    _PROBE = "def __init__(self):"
+
+    def setUp(self) -> None:
+        cbc_module._TIKTOKEN_ENCODERS.clear()
+
+    def tearDown(self) -> None:
+        cbc_module._TIKTOKEN_ENCODERS.clear()
+
+    def test_each_instance_uses_its_configured_encoding(self) -> None:
+        import tiktoken
+        cl100k = ContextBudgetCompressor(counter="tiktoken",
+                                         tiktoken_encoding="cl100k_base")
+        p50k = ContextBudgetCompressor(counter="tiktoken",
+                                       tiktoken_encoding="p50k_base")
+        self.assertEqual(
+            cl100k._count(self._PROBE),
+            len(tiktoken.get_encoding("cl100k_base").encode(self._PROBE)))
+        self.assertEqual(
+            p50k._count(self._PROBE),
+            len(tiktoken.get_encoding("p50k_base").encode(self._PROBE)))
+        # The two encoders must be cached as distinct objects keyed by name.
+        self.assertIn("cl100k_base", cbc_module._TIKTOKEN_ENCODERS)
+        self.assertIn("p50k_base", cbc_module._TIKTOKEN_ENCODERS)
+        self.assertIsNot(
+            cbc_module._TIKTOKEN_ENCODERS["cl100k_base"],
+            cbc_module._TIKTOKEN_ENCODERS["p50k_base"])
+
+    def test_invalid_encoding_raises_configuration_error(self) -> None:
+        proc = ContextBudgetCompressor(
+            counter="tiktoken", tiktoken_encoding="not_a_real_encoding")
+        with self.assertRaises(ValueError) as ctx:
+            proc._count(self._PROBE)
+        self.assertIn("not_a_real_encoding", str(ctx.exception))
+
+    def test_invalid_encoding_before_valid_does_not_poison(self) -> None:
+        # The core regression: an invalid encoding on one instance must not
+        # silently push a later valid instance onto the estimate counter.
+        bad = ContextBudgetCompressor(
+            counter="tiktoken", tiktoken_encoding="not_a_real_encoding")
+        with self.assertRaises(ValueError):
+            bad._count(self._PROBE)
+        # Invalid lookups are not cached, so the cache stays clean.
+        self.assertNotIn("not_a_real_encoding", cbc_module._TIKTOKEN_ENCODERS)
+
+        good = ContextBudgetCompressor(
+            counter="tiktoken", tiktoken_encoding="cl100k_base")
+        import tiktoken
+        self.assertEqual(
+            good._count(self._PROBE),
+            len(tiktoken.get_encoding("cl100k_base").encode(self._PROBE)))
+
+    def test_missing_dependency_degrades_instead_of_raising(self) -> None:
+        # A missing optional dependency must degrade to the estimate counter,
+        # in contrast with an invalid encoding (which raises). Setting a
+        # sys.modules key to None makes `import tiktoken` raise ImportError.
+        import sys
+        proc = ContextBudgetCompressor(
+            counter="tiktoken", tiktoken_encoding="cl100k_base")
+        with patch.dict(sys.modules, {"tiktoken": None}):
+            estimate = proc._count(self._PROBE)
+        self.assertEqual(estimate, max(1, len(self._PROBE) // 4))
+
+
 class TestContextBudgetConfig(unittest.TestCase):
     """Initialization and configuration."""
 


### PR DESCRIPTION
## What

Adds `ContextBudgetCompressor`, a knowledge *post-processor* (#248) that fits recalled documents into a fixed cumulative size budget (typically the LLM context window). It walks the recalled list — already ranked by the store or an earlier reranker/fusion processor — keeping documents in order while their total size stays within `budget`; the boundary document that would overflow is optionally **truncated** so the budget is used fully without exceeding it.

## Why this component (distinct from ThresholdFilter)

`ThresholdFilter` applies **per-document** predicates (a score/length range) or a fixed top-k. This component manages a different axis — the **cumulative** size of the kept set — and can split the last document to fit. That is the standard "fit recall into the model's context window" job, which per-doc filtering cannot do.

## Honest counting (no "token = word count" trap)

Size is measured by an explicit `counter`, and the budget is always interpreted in that counter's unit, so the contract is never "tokens" while silently counting words:

| counter | size of a doc |
|---|---|
| `estimate` (default) | `max(1, len(text)//4)` — dependency-free token approximation |
| `tiktoken` | real BPE tokens via `tiktoken` (encoding configurable); falls back to `estimate` with a warning if tiktoken is absent |
| `char` | exact character count |
| `word` | exact whitespace word count |

## Config

```yaml
name: 'context_budget_compressor'
metadata:
  type: 'DOC_PROCESSOR'
  module: 'agentuniverse.agent.action.knowledge.doc_processor.context_budget_compressor'
  class: 'ContextBudgetCompressor'
budget: 4096
counter: 'estimate'
truncate: true
tiktoken_encoding: 'cl100k_base'
```

## Tests

`tests/.../test_context_budget_compressor.py` — 20, all pass:
- **Selection**: keeps whole docs within budget; stops at first overflow when `truncate=false`; truncates the boundary doc (and a single oversize doc) to fit when `truncate=true`; preserves input order; preserves the truncated doc's id and metadata and stamps `truncated: true`.
- **Counters**: char / word / estimate counts and truncation behave exactly; `tiktoken` counts real BPE tokens and truncates by token (skipped when tiktoken is not installed).
- **Config**: invalid `counter` raises; attributes load from the configer.
- **Registration**: shipped yaml resolves to `DOC_PROCESSOR` with the right module/class.
- **Integration**: compresses through the real `Knowledge.query_knowledge` → `post_processors` path.

`python -m unittest test_context_budget_compressor` → 20 passed.

Addresses the context-window-management direction of #248. Composes naturally after a reranker or `ReciprocalRankFusionProcessor` (which order the recall list this processor then trims).
