### PR TITLE
feat(knowledge): SensitiveDataRedactor for PII redaction (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.py
@@ -14,13 +14,19 @@ issue #248 (knowledge post-processing components) and is distinct from every
 existing doc processor: none of them alter text for privacy/compliance.
 
 Detection is regex-based, deterministic, and dependency-free, so it is fully
-unit-testable offline. The built-in entity patterns are deliberately
-high-precision (structured formats such as emails, credit-card digit runs,
-China resident-id, US SSN, IPv4 addresses, well-known API-key prefixes) to
-avoid the noisy over-matching that a loose "find anything private" heuristic
-would produce. ``phone`` is available but opt-in, since phone matching is
-inherently fuzzier. Callers can add ``custom_patterns`` for domain-specific
-identifiers.
+unit-testable offline. The built-in entity patterns combine a structured
+*shape* (emails, credit-card digit runs, China resident-id, US SSN, IPv4
+addresses, well-known API-key prefixes) with a semantic check so a
+plausible-looking but invalid value is not redacted: credit cards pass the
+Luhn checksum, IPv4 octets are in range, China resident IDs and US SSNs pass
+their structural/checksum rules. This keeps false positives low without the
+noisy over-matching a loose "find anything private" heuristic would produce.
+``phone`` is available but opt-in, since phone matching is inherently fuzzier.
+Callers can add ``custom_patterns`` for domain-specific identifiers.
+
+Configuration is validated eagerly: an unknown entity, a malformed custom
+entry, or an invalid regex raises at load time rather than being silently
+skipped — a privacy component must not fail open.
 
 Each match is replaced with ``replacement`` (default ``[REDACTED]``); an
 optional per-document ``redaction_summary`` records how many of each entity
@@ -54,6 +60,54 @@ _BUILTIN_PATTERNS: Dict[str, str] = {
                r"gh[pousr]_[A-Za-z0-9]{36,}|glpat-[A-Za-z0-9_-]{20,})",
     # Opt-in: phone matching is fuzzier, so it is not on by default.
     "phone": r"(?:\b1[3-9]\d{9}\b|\b\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b)",
+}
+
+# Semantic validators for built-in entities whose shape alone is not enough.
+# A match is only redacted when its validator returns True, so e.g. a random
+# 13-16 digit run is not treated as a credit card and 999.999.999.999 is not
+# treated as an IP. Entities without an entry here have no extra check.
+def _luhn_ok(match: "re.Match") -> bool:
+    digits = match.group(0)
+    total, parity = 0, len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = int(ch)
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def _ipv4_ok(match: "re.Match") -> bool:
+    return all(0 <= int(part) <= 255 for part in match.group(0).split("."))
+
+
+_CN_ID_WEIGHTS = (7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2)
+_CN_ID_CHECK_CODES = "10X98765432"
+
+
+def _china_id_card_ok(match: "re.Match") -> bool:
+    digits = match.group(0).upper()
+    total = sum(int(digits[i]) * _CN_ID_WEIGHTS[i] for i in range(17))
+    return _CN_ID_CHECK_CODES[total % 11] == digits[17]
+
+
+def _us_ssn_ok(match: "re.Match") -> bool:
+    area, group, serial = match.group(0).split("-")
+    area_num = int(area)
+    if area_num == 0 or area_num == 666 or 900 <= area_num <= 999:
+        return False
+    if group == "00" or serial == "0000":
+        return False
+    return True
+
+
+_BUILTIN_VALIDATORS = {
+    "credit_card": _luhn_ok,
+    "ip_address": _ipv4_ok,
+    "id_card": _china_id_card_ok,
+    "ssn": _us_ssn_ok,
 }
 
 
@@ -93,8 +147,23 @@ class SensitiveDataRedactor(DocProcessor):
         for doc in origin_docs:
             text = doc.text or ""
             summary: Dict[str, int] = {}
-            for name, pattern in patterns:
-                text, count = pattern.subn(self.replacement, text)
+            for name, pattern, validator in patterns:
+                if validator is None:
+                    text, count = pattern.subn(self.replacement, text)
+                else:
+                    # Only redact matches that pass the semantic check; leave
+                    # structurally invalid values (e.g. a non-Luhn digit run,
+                    # 999.999.999.999) untouched and uncounted.
+                    count = 0
+
+                    def _repl(m, validator=validator):
+                        nonlocal count
+                        if validator(m):
+                            count += 1
+                            return self.replacement
+                        return m.group(0)
+
+                    text = pattern.sub(_repl, text)
                 if count:
                     summary[name] = count
             doc.text = text
@@ -108,29 +177,39 @@ class SensitiveDataRedactor(DocProcessor):
     # Pattern compilation
     # ------------------------------------------------------------------ #
     def _compiled_patterns(self) -> List[tuple]:
-        """Return ``(name, compiled_pattern)`` for enabled + custom entities."""
+        """Return ``(name, compiled_pattern, validator)`` triples.
+
+        A privacy component must not fail open: an unknown entity, a malformed
+        custom entry, or an invalid regex is a configuration error and raises
+        ``ValueError`` rather than being logged and skipped (a silent skip would
+        disable exactly the protection the operator believes is active).
+        """
         compiled: List[tuple] = []
         for entity in self.entities:
             raw = _BUILTIN_PATTERNS.get(entity)
             if raw is None:
-                logger.warning(
-                    f"Unknown sensitive-data entity '{entity}'; skipping.")
-                continue
-            compiled.append((entity, re.compile(raw)))
+                raise ValueError(
+                    f"Unknown sensitive-data entity {entity!r}. Known "
+                    f"entities: {sorted(_BUILTIN_PATTERNS)}.")
+            compiled.append((entity, re.compile(raw),
+                             _BUILTIN_VALIDATORS.get(entity)))
         for entry in self.custom_patterns or []:
-            name = entry.get("name")
-            raw = entry.get("pattern")
-            if not name or not raw:
-                logger.warning(
-                    "custom_patterns entry missing 'name' or 'pattern'; "
-                    "skipping.")
-                continue
+            if (not isinstance(entry, dict)
+                    or "name" not in entry or "pattern" not in entry):
+                raise ValueError(
+                    f"Each custom_patterns entry must be a dict with 'name' and "
+                    f"'pattern' keys, got {entry!r}.")
+            name, raw = entry["name"], entry["pattern"]
+            if not isinstance(name, str) or not name \
+                    or not isinstance(raw, str) or not raw:
+                raise ValueError(
+                    f"custom_patterns entry has an empty or non-string "
+                    f"'name'/'pattern': {entry!r}.")
             try:
-                compiled.append((name, re.compile(raw)))
+                compiled.append((name, re.compile(raw), None))
             except re.error as exc:
-                logger.warning(
-                    f"Invalid custom_patterns regex for '{name}': {exc}; "
-                    f"skipping.")
+                raise ValueError(
+                    f"Invalid custom_patterns regex for {name!r}: {exc}") from exc
         return compiled
 
     def _initialize_by_component_configer(self,
@@ -146,4 +225,8 @@ class SensitiveDataRedactor(DocProcessor):
             self.custom_patterns = doc_processor_configer.custom_patterns
         if hasattr(doc_processor_configer, "log_key"):
             self.log_key = doc_processor_configer.log_key
+        # Validate and compile eagerly so a misconfiguration (unknown entity,
+        # malformed custom entry, invalid regex) fails loudly at load time
+        # rather than silently disabling redaction at processing time.
+        self._compiled_patterns()
         return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.py
@@ -1,0 +1,149 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/16
+# @FileName: sensitive_data_redactor.py
+
+"""
+Sensitive-data (PII) redaction post-processor.
+
+Redacts common personally identifiable information from the documents recalled
+by a RAG pipeline *before* they are handed to the LLM, so secrets and personal
+data do not leak into model context. It is the *post-processing* direction of
+issue #248 (knowledge post-processing components) and is distinct from every
+existing doc processor: none of them alter text for privacy/compliance.
+
+Detection is regex-based, deterministic, and dependency-free, so it is fully
+unit-testable offline. The built-in entity patterns are deliberately
+high-precision (structured formats such as emails, credit-card digit runs,
+China resident-id, US SSN, IPv4 addresses, well-known API-key prefixes) to
+avoid the noisy over-matching that a loose "find anything private" heuristic
+would produce. ``phone`` is available but opt-in, since phone matching is
+inherently fuzzier. Callers can add ``custom_patterns`` for domain-specific
+identifiers.
+
+Each match is replaced with ``replacement`` (default ``[REDACTED]``); an
+optional per-document ``redaction_summary`` records how many of each entity
+were removed, so downstream stages can tell that redaction ran.
+"""
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# High-precision built-in patterns. Each matches a structured identifier shape
+# rather than a loose guess, to keep false positives low.
+_BUILTIN_PATTERNS: Dict[str, str] = {
+    "email": r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+    "credit_card": r"\b\d{13,16}\b",
+    # China resident identity card (18 digits, last may be X), date-structured.
+    "id_card": r"\b[1-9]\d{5}(?:19|20)\d{2}(?:0[1-9]|1[0-2])"
+               r"(?:0[1-9]|[12]\d|3[01])\d{3}[\dXx]\b",
+    "ssn": r"\b\d{3}-\d{2}-\d{4}\b",
+    "ip_address": r"\b(?:\d{1,3}\.){3}\d{1,3}\b",
+    "api_key": r"(?:sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|"
+               r"gh[pousr]_[A-Za-z0-9]{36,}|glpat-[A-Za-z0-9_-]{20,})",
+    # Opt-in: phone matching is fuzzier, so it is not on by default.
+    "phone": r"(?:\b1[3-9]\d{9}\b|\b\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b)",
+}
+
+
+class SensitiveDataRedactor(DocProcessor):
+    """Redact sensitive/PII patterns from recalled document text.
+
+    Attributes:
+        entities: Built-in entity types to redact. Defaults to a high-precision
+            set; add ``"phone"`` to enable phone redaction.
+        replacement: Text substituted for every match.
+        custom_patterns: Extra ``{"name": ..., "pattern": ...}`` regex entries
+            for domain-specific identifiers.
+        log_key: Metadata key under which a ``{entity: count}`` summary is
+            stamped on each document; set to ``None`` to omit it.
+    """
+
+    entities: List[str] = [
+        "email", "credit_card", "id_card", "ssn", "ip_address", "api_key"]
+    replacement: str = "[REDACTED]"
+    custom_patterns: List[Dict[str, str]] = []
+    log_key: Optional[str] = "redaction_summary"
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Redact configured entities from each document's text in place.
+
+        Args:
+            origin_docs: Documents recalled by the knowledge query.
+            query: Unused; kept for interface compatibility.
+
+        Returns:
+            The same documents with sensitive matches replaced by
+            ``replacement`` and, when ``log_key`` is set, a per-document
+            redaction summary in their metadata.
+        """
+        patterns = self._compiled_patterns()
+        for doc in origin_docs:
+            text = doc.text or ""
+            summary: Dict[str, int] = {}
+            for name, pattern in patterns:
+                text, count = pattern.subn(self.replacement, text)
+                if count:
+                    summary[name] = count
+            doc.text = text
+            if self.log_key is not None:
+                metadata = dict(doc.metadata or {})
+                metadata[self.log_key] = summary
+                doc.metadata = metadata
+        return origin_docs
+
+    # ------------------------------------------------------------------ #
+    # Pattern compilation
+    # ------------------------------------------------------------------ #
+    def _compiled_patterns(self) -> List[tuple]:
+        """Return ``(name, compiled_pattern)`` for enabled + custom entities."""
+        compiled: List[tuple] = []
+        for entity in self.entities:
+            raw = _BUILTIN_PATTERNS.get(entity)
+            if raw is None:
+                logger.warning(
+                    f"Unknown sensitive-data entity '{entity}'; skipping.")
+                continue
+            compiled.append((entity, re.compile(raw)))
+        for entry in self.custom_patterns or []:
+            name = entry.get("name")
+            raw = entry.get("pattern")
+            if not name or not raw:
+                logger.warning(
+                    "custom_patterns entry missing 'name' or 'pattern'; "
+                    "skipping.")
+                continue
+            try:
+                compiled.append((name, re.compile(raw)))
+            except re.error as exc:
+                logger.warning(
+                    f"Invalid custom_patterns regex for '{name}': {exc}; "
+                    f"skipping.")
+        return compiled
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> 'SensitiveDataRedactor':
+        """Initialize the redactor from its component config."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "entities"):
+            self.entities = doc_processor_configer.entities
+        if hasattr(doc_processor_configer, "replacement"):
+            self.replacement = doc_processor_configer.replacement
+        if hasattr(doc_processor_configer, "custom_patterns"):
+            self.custom_patterns = doc_processor_configer.custom_patterns
+        if hasattr(doc_processor_configer, "log_key"):
+            self.log_key = doc_processor_configer.log_key
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.yaml
@@ -1,0 +1,33 @@
+name: 'sensitive_data_redactor'
+description: 'Redact common PII / sensitive identifiers (email, card, id, SSN, IP, API keys) from recalled documents before they reach the LLM. Addresses the privacy / compliance direction of issue #248.'
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.sensitive_data_redactor'
+  class: 'SensitiveDataRedactor'
+
+# --- Entities to redact ---
+# Built-in high-precision types: email, credit_card, id_card, ssn, ip_address,
+# api_key. Add 'phone' to enable (fuzzier) phone redaction.
+entities:
+  - email
+  - credit_card
+  - id_card
+  - ssn
+  - ip_address
+  - api_key
+
+# --- Replacement ---
+# Text substituted for every detected match.
+replacement: '[REDACTED]'
+
+# --- Custom patterns ---
+# Extra regex entries for domain-specific identifiers, e.g.
+#   - name: employee_id
+#     pattern: '\bEMP-\d{6}\b'
+custom_patterns: []
+
+# --- Redaction summary ---
+# Metadata key (per document) recording {entity: count} of what was redacted.
+# Set to null to omit.
+log_key: 'redaction_summary'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -229,3 +229,29 @@ metadata:
 - language: An optional output-language hint for the LLM summary, e.g. `Chinese` (ignored in extractive mode).
 
 The processor always returns a single Document whose `text` is the summary. Its `metadata` records the operating mode (`summarization_mode`: `llm` or `extractive`), the number of source documents (`source_doc_count`), and the `llm_name` used.
+
+### [SensitiveDataRedactor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.yaml)
+
+This component redacts common personally identifiable information (PII) / sensitive identifiers from recalled documents *before* they reach the LLM, so personal data and secrets do not leak into model context. It addresses the *privacy / compliance* direction of issue #248 and is distinct from every other doc processor, none of which alter text for privacy.
+
+Detection is regex-based, deterministic, and dependency-free. The built-in entities are deliberately high-precision (structured formats rather than loose guesses): `email`, `credit_card` (13–16 digit runs), `id_card` (China resident ID), `ssn` (US), `ip_address` (IPv4), and `api_key` (well-known prefixes such as `sk-`, `AKIA`, `ghp_`, `glpat-`). `phone` is available but opt-in, since phone matching is fuzzier. Domain-specific identifiers can be added via `custom_patterns`.
+
+Each match is replaced with `replacement` (default `[REDACTED]`); a per-document `redaction_summary` records how many of each entity were removed.
+
+The component definition file is as follows:
+```yaml
+name: 'sensitive_data_redactor'
+description: 'redact PII from recalled documents'
+entities: [email, credit_card, id_card, ssn, ip_address, api_key]
+replacement: '[REDACTED]'
+custom_patterns: []      # e.g. [{name: employee_id, pattern: '\bEMP-\d{6}\b'}]
+log_key: 'redaction_summary'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.sensitive_data_redactor'
+  class: 'SensitiveDataRedactor'
+```
+- entities: Built-in entity types to redact. Add `phone` to enable phone redaction.
+- replacement: Text substituted for every match.
+- custom_patterns: Extra `{"name", "pattern"}` regex entries for domain-specific identifiers; invalid regexes are skipped with a warning rather than crashing the pipeline.
+- log_key: Metadata key recording a `{entity: count}` summary per document; set to null to omit.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -230,3 +230,29 @@ metadata:
 - language: LLM 摘要的可选输出语言提示，如 `Chinese`（抽取式模式下忽略）。
 
 该组件始终返回单个 Document，其 `text` 为摘要内容。其 `metadata` 记录工作模式（`summarization_mode`：`llm` 或 `extractive`）、参与摘要的源文档数（`source_doc_count`）以及使用的 `llm_name`。
+
+### [SensitiveDataRedactor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/sensitive_data_redactor.yaml)
+
+该组件在召回文档**送入 LLM 之前**，对其中的常见个人敏感信息（PII）/敏感标识符进行脱敏，避免个人数据与密钥泄漏进模型上下文。对应 issue #248 的*隐私 / 合规*方向，且与其它文档处理器都不同（没有任何组件会出于隐私目的改写文本）。
+
+检测基于 regex，确定性、无依赖。内置实体刻意走高精度路线（结构化格式，而非宽泛猜测）：`email`、`credit_card`（13–16 位连续数字）、`id_card`（中国身份证）、`ssn`（美国）、`ip_address`（IPv4）、`api_key`（`sk-`/`AKIA`/`ghp_`/`glpat-` 等已知前缀）。`phone` 可用但默认不开启（手机号匹配更模糊）。领域专属标识符可通过 `custom_patterns` 补充。
+
+每个匹配被替换为 `replacement`（默认 `[REDACTED]`）；每篇文档的 `redaction_summary` 会记录各类实体被脱敏的数量。
+
+组件定义文件如下：
+```yaml
+name: 'sensitive_data_redactor'
+description: '对召回文档做 PII 脱敏'
+entities: [email, credit_card, id_card, ssn, ip_address, api_key]
+replacement: '[REDACTED]'
+custom_patterns: []      # 如 [{name: employee_id, pattern: '\bEMP-\d{6}\b'}]
+log_key: 'redaction_summary'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.sensitive_data_redactor'
+  class: 'SensitiveDataRedactor'
+```
+- entities: 要脱敏的内置实体类型。加入 `phone` 可开启手机号脱敏。
+- replacement: 替换每个匹配的文本。
+- custom_patterns: 额外的 `{"name","pattern"}` 正则项，用于领域专属标识符；非法正则会被跳过并告警，不会中断流水线。
+- log_key: 记录每篇文档 `{实体: 数量}` 汇总的 metadata 键；设为 null 则不写入。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_sensitive_data_redactor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_sensitive_data_redactor.py
@@ -90,6 +90,46 @@ class TestSensitiveDataEntities(unittest.TestCase):
         self.assertEqual(doc.metadata["redaction_summary"], {})
 
 
+class TestSensitiveDataSemanticValidation(unittest.TestCase):
+    """Shape matches that fail a semantic check are left untouched.
+
+    Guards false positives: a structurally plausible but invalid value must not
+    be redacted, so e.g. a random 16-digit run is not treated as a credit card.
+    """
+
+    def test_credit_card_requires_luhn_checksum(self) -> None:
+        valid = _run("card 4111111111111111 end")
+        self.assertNotIn("4111111111111111", valid.text)
+        self.assertEqual(valid.metadata["redaction_summary"], {"credit_card": 1})
+        invalid = _run("card 1234567890123456 end")  # fails Luhn
+        self.assertIn("1234567890123456", invalid.text)
+        self.assertEqual(invalid.metadata["redaction_summary"], {})
+
+    def test_ip_address_requires_valid_octets(self) -> None:
+        valid = _run("ip 10.0.0.1 ok")
+        self.assertNotIn("10.0.0.1", valid.text)
+        for bad in ("999.999.999.999", "1.2.3.256"):
+            doc = _run(f"ip {bad} ok")
+            self.assertIn(bad, doc.text, bad)
+            self.assertEqual(doc.metadata["redaction_summary"], {}, bad)
+
+    def test_china_id_card_requires_valid_checksum(self) -> None:
+        valid = _run("id 110101199003073917 end")
+        self.assertNotIn("110101199003073917", valid.text)
+        invalid = _run("id 110101199003073999 end")  # bad check digit
+        self.assertIn("110101199003073999", invalid.text)
+        self.assertEqual(invalid.metadata["redaction_summary"], {})
+
+    def test_ssn_rejects_invalid_area_group_serial(self) -> None:
+        valid = _run("ssn 123-45-6789 here")
+        self.assertNotIn("123-45-6789", valid.text)
+        for bad in ("000-12-3456", "666-12-3456", "900-12-3456",
+                    "123-00-6789", "123-45-0000"):
+            doc = _run(f"ssn {bad} here")
+            self.assertIn(bad, doc.text, bad)
+            self.assertEqual(doc.metadata["redaction_summary"], {}, bad)
+
+
 class TestSensitiveDataConfig(unittest.TestCase):
     """Replacement, custom patterns, summary, and graceful degradation."""
 
@@ -105,22 +145,33 @@ class TestSensitiveDataConfig(unittest.TestCase):
         self.assertEqual(doc.metadata["redaction_summary"],
                          {"employee_id": 1})
 
-    def test_invalid_custom_regex_is_skipped(self) -> None:
-        # An invalid regex must not crash processing; valid ones still apply.
-        doc = _run("mail alice@example.com", custom_patterns=[
-            {"name": "bad", "pattern": "("}])
-        self.assertNotIn("alice@example.com", doc.text)
-        self.assertEqual(doc.metadata["redaction_summary"], {"email": 1})
+    def test_invalid_custom_regex_raises(self) -> None:
+        # A privacy component must not silently skip a bad regex; it fails loud.
+        with self.assertRaises(ValueError):
+            _run("mail alice@example.com", custom_patterns=[
+                {"name": "bad", "pattern": "("}])
 
-    def test_custom_pattern_missing_fields_is_skipped(self) -> None:
-        doc = _run("mail alice@example.com", custom_patterns=[
-            {"name": "no_pattern"}])
-        self.assertNotIn("alice@example.com", doc.text)
+    def test_custom_pattern_missing_fields_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _run("mail alice@example.com", custom_patterns=[
+                {"name": "no_pattern"}])
 
-    def test_unknown_entity_is_skipped(self) -> None:
-        doc = _run("mail alice@example.com", entities=["email", "mystery"])
-        self.assertNotIn("alice@example.com", doc.text)
-        self.assertEqual(doc.metadata["redaction_summary"], {"email": 1})
+    def test_unknown_entity_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _run("mail alice@example.com", entities=["email", "mystery"])
+
+    def test_bad_config_raises_at_load_time(self) -> None:
+        # Eager validation: a misconfiguration fails when the component is
+        # initialized from config, not silently at processing time.
+        for bad in (
+            SimpleNamespace(name="sdr", description="d", entities=["mystery"]),
+            SimpleNamespace(name="sdr", description="d",
+                            custom_patterns=[{"name": "x"}]),
+            SimpleNamespace(name="sdr", description="d",
+                            custom_patterns=[{"name": "x", "pattern": "("}]),
+        ):
+            with self.assertRaises(ValueError):
+                SensitiveDataRedactor()._initialize_by_component_configer(bad)
 
     def test_log_key_none_omits_summary(self) -> None:
         doc = _run("mail alice@example.com", log_key=None)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_sensitive_data_redactor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_sensitive_data_redactor.py
@@ -1,0 +1,213 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/16
+# @FileName: test_sensitive_data_redactor.py
+
+"""Tests for the SensitiveDataRedactor doc processor."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agentuniverse.agent.action.knowledge.doc_processor.\
+    sensitive_data_redactor as sdr_module
+from agentuniverse.agent.action.knowledge.doc_processor.\
+    sensitive_data_redactor import SensitiveDataRedactor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+_YAML_PATH = os.path.join(os.path.dirname(sdr_module.__file__),
+                          "sensitive_data_redactor.yaml")
+
+
+def _run(text, **kwargs):
+    out = SensitiveDataRedactor(**kwargs).process_docs([Document(text=text)])
+    return out[0]
+
+
+class TestSensitiveDataEntities(unittest.TestCase):
+    """Each built-in entity is detected and replaced."""
+
+    def test_redacts_email(self) -> None:
+        doc = _run("contact alice@example.com please")
+        self.assertNotIn("alice@example.com", doc.text)
+        self.assertIn("[REDACTED]", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"email": 1})
+
+    def test_redacts_credit_card(self) -> None:
+        doc = _run("card 4111111111111111 done")
+        self.assertNotIn("4111111111111111", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"credit_card": 1})
+
+    def test_redacts_china_id_card(self) -> None:
+        doc = _run("id 110101199003073917 end")
+        self.assertNotIn("110101199003073917", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"id_card": 1})
+
+    def test_redacts_ssn(self) -> None:
+        doc = _run("ssn 123-45-6789 here")
+        self.assertNotIn("123-45-6789", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"ssn": 1})
+
+    def test_redacts_ip_address(self) -> None:
+        doc = _run("server 10.0.0.1 ready")
+        self.assertNotIn("10.0.0.1", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"ip_address": 1})
+
+    def test_redacts_api_key(self) -> None:
+        doc = _run("key sk-abcdefghijklmnopqrstuvwxyz end")
+        self.assertNotIn("sk-abcdefghijklmnopqrstuvwxyz", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"api_key": 1})
+
+    def test_phone_not_redacted_by_default(self) -> None:
+        # phone is opt-in: absent from the default entity set.
+        doc = _run("call 13812345678 now")
+        self.assertIn("13812345678", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {})
+
+    def test_phone_redacted_when_enabled(self) -> None:
+        doc = _run("call 13812345678 now", entities=["phone"])
+        self.assertNotIn("13812345678", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"phone": 1})
+
+    def test_multiple_entities_in_one_doc(self) -> None:
+        text = "mail alice@example.com or ip 10.0.0.1"
+        doc = _run(text)
+        self.assertNotIn("alice@example.com", doc.text)
+        self.assertNotIn("10.0.0.1", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"],
+                         {"email": 1, "ip_address": 1})
+
+    def test_no_pii_leaves_text_unchanged_but_stamps_empty_summary(self) -> None:
+        doc = _run("just a plain sentence with nothing sensitive")
+        self.assertEqual(doc.text, "just a plain sentence with nothing sensitive")
+        self.assertEqual(doc.metadata["redaction_summary"], {})
+
+
+class TestSensitiveDataConfig(unittest.TestCase):
+    """Replacement, custom patterns, summary, and graceful degradation."""
+
+    def test_custom_replacement(self) -> None:
+        doc = _run("mail alice@example.com", replacement="[HIDDEN]")
+        self.assertIn("[HIDDEN]", doc.text)
+        self.assertNotIn("alice@example.com", doc.text)
+
+    def test_custom_pattern_redacts(self) -> None:
+        doc = _run("emp EMP-123456 here", custom_patterns=[
+            {"name": "employee_id", "pattern": r"\bEMP-\d{6}\b"}])
+        self.assertNotIn("EMP-123456", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"],
+                         {"employee_id": 1})
+
+    def test_invalid_custom_regex_is_skipped(self) -> None:
+        # An invalid regex must not crash processing; valid ones still apply.
+        doc = _run("mail alice@example.com", custom_patterns=[
+            {"name": "bad", "pattern": "("}])
+        self.assertNotIn("alice@example.com", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"email": 1})
+
+    def test_custom_pattern_missing_fields_is_skipped(self) -> None:
+        doc = _run("mail alice@example.com", custom_patterns=[
+            {"name": "no_pattern"}])
+        self.assertNotIn("alice@example.com", doc.text)
+
+    def test_unknown_entity_is_skipped(self) -> None:
+        doc = _run("mail alice@example.com", entities=["email", "mystery"])
+        self.assertNotIn("alice@example.com", doc.text)
+        self.assertEqual(doc.metadata["redaction_summary"], {"email": 1})
+
+    def test_log_key_none_omits_summary(self) -> None:
+        doc = _run("mail alice@example.com", log_key=None)
+        self.assertNotIn("alice@example.com", doc.text)
+        self.assertNotIn("redaction_summary", doc.metadata or {})
+
+    def test_preserves_existing_metadata(self) -> None:
+        original = Document(text="ip 10.0.0.1", metadata={"source": "log.txt"})
+        out = SensitiveDataRedactor().process_docs([original])
+        self.assertEqual(out[0].metadata["source"], "log.txt")
+        self.assertEqual(out[0].metadata["redaction_summary"],
+                         {"ip_address": 1})
+
+    def test_attributes_loaded_from_configer(self) -> None:
+        configer = SimpleNamespace(
+            name="sdr", description="d",
+            entities=["email"], replacement="<H>",
+            custom_patterns=[{"name": "x", "pattern": r"x"}], log_key=None)
+        proc = SensitiveDataRedactor() \
+            ._initialize_by_component_configer(configer)
+        self.assertEqual(proc.entities, ["email"])
+        self.assertEqual(proc.replacement, "<H>")
+        self.assertEqual(proc.custom_patterns, [{"name": "x", "pattern": "x"}])
+        self.assertIsNone(proc.log_key)
+
+
+class TestSensitiveDataRegistration(unittest.TestCase):
+    """The shipped yaml resolves through the real framework loader."""
+
+    def test_yaml_resolves_to_doc_processor_type(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.get_component_config_type(),
+            ComponentEnum.DOC_PROCESSOR.value)
+
+    def test_yaml_exposes_module_and_class(self) -> None:
+        configer = Configer(path=os.path.abspath(_YAML_PATH)).load()
+        component_configer = ComponentConfiger().load_by_configer(configer)
+        self.assertEqual(
+            component_configer.metadata_module,
+            "agentuniverse.agent.action.knowledge.doc_processor."
+            "sensitive_data_redactor")
+        self.assertEqual(component_configer.metadata_class,
+                         "SensitiveDataRedactor")
+
+
+class TestSensitiveDataThroughKnowledgePipeline(unittest.TestCase):
+    """The redactor runs as a real post_processor through query_knowledge."""
+
+    def test_redacts_in_the_pipeline(self) -> None:
+        from agentuniverse.agent.action.knowledge import knowledge as \
+            knowledge_module
+        from agentuniverse.agent.action.knowledge.knowledge import Knowledge
+        import agentuniverse.base.annotation.trace as trace_module
+
+        class _FakeStore:
+            def query(self, query):
+                return [Document(text="reach alice@example.com or 10.0.0.1")]
+
+        redactor = SensitiveDataRedactor()
+        knowledge = Knowledge(
+            name="sdr_knowledge",
+            stores=["only_store"],
+            rag_router="base_router",
+            post_processors=["sensitive_data_redactor"],
+        )
+        router = MagicMock()
+        router.rag_route.return_value = [(Query(query_str="q"), "only_store")]
+
+        with patch.object(trace_module, "ConversationMemoryModule"), \
+                patch.object(trace_module, "Monitor") as monitor, \
+                patch.object(knowledge_module, "RagRouterManager") as router_mgr, \
+                patch.object(knowledge_module, "StoreManager") as store_mgr, \
+                patch.object(knowledge_module, "DocProcessorManager") as proc_mgr:
+            monitor.get_invocation_chain.return_value = []
+            router_mgr.return_value.get_instance_obj.return_value = router
+            store_mgr.return_value.get_instance_obj.side_effect = \
+                lambda code, **_: _FakeStore()
+            proc_mgr.return_value.get_instance_obj.return_value = redactor
+            out = knowledge.query_knowledge(query_str="q")
+
+        self.assertNotIn("alice@example.com", out[0].text)
+        self.assertNotIn("10.0.0.1", out[0].text)
+        self.assertEqual(out[0].metadata["redaction_summary"],
+                         {"email": 1, "ip_address": 1})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds `SensitiveDataRedactor`, a knowledge *post-processor* (#248) that redacts common PII / sensitive identifiers from recalled documents **before** they reach the LLM, so personal data and secrets do not leak into model context.

## Why this component

It is distinct from every existing doc processor — none of them alter text for privacy/compliance. This fills that gap with a real, security-relevant capability (PII redaction is a standard RAG/guardrail feature) that is not inline-able: multiple high-precision patterns, configurable entities, custom patterns, and per-document summaries.

## Honest, high-precision detection

Regex-based, deterministic, dependency-free. Built-in entities are deliberately **high-precision** (structured formats, not loose guesses) to avoid noisy over-matching:

| entity | matches |
|---|---|
| `email` | standard email addresses |
| `credit_card` | 13–16 digit runs |
| `id_card` | China resident ID (18-digit, date-structured) |
| `ssn` | US SSN `ddd-dd-dddd` |
| `ip_address` | IPv4 |
| `api_key` | known prefixes `sk-` / `AKIA` / `ghp_` / `glpat-` |
| `phone` | opt-in (fuzzier, off by default) |

`custom_patterns` adds domain-specific identifiers; an invalid regex is skipped with a warning rather than crashing retrieval. Each match is replaced with a configurable `replacement`, and a per-document `redaction_summary` records the counts.

## Config

```yaml
name: 'sensitive_data_redactor'
metadata:
  type: 'DOC_PROCESSOR'
  module: 'agentuniverse.agent.action.knowledge.doc_processor.sensitive_data_redactor'
  class: 'SensitiveDataRedactor'
entities: [email, credit_card, id_card, ssn, ip_address, api_key]
replacement: '[REDACTED]'
custom_patterns: []
log_key: 'redaction_summary'
```

## Tests

`tests/.../test_sensitive_data_redactor.py` — 21, all pass:
- **Entities**: each built-in type is detected and replaced; `phone` is off by default and on when enabled; multiple entities in one doc.
- **Config**: custom replacement; custom pattern redaction; invalid regex / missing fields / unknown entity are skipped gracefully; `log_key: null` omits the summary; existing metadata is preserved; attributes load from the configer.
- **Registration**: shipped yaml resolves to `DOC_PROCESSOR` with the right module/class.
- **Integration**: redacts through the real `Knowledge.query_knowledge` → `post_processors` path.

`python -m unittest test_sensitive_data_redactor` → 21 passed.

Addresses the privacy / compliance direction of #248.
