### PR TITLE
fix(tool): parse YouTube duration days

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/youtube_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/youtube_tool.py
@@ -49,13 +49,14 @@ class YouTubeTool(Tool):
 
     def parse_duration(self, duration_str):
         """Converts ISO 8601 duration format to seconds"""
-        match = re.match(r'PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?', duration_str)
+        match = re.fullmatch(r'P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?', duration_str)
         if not match:
             return 0
-        hours = int(match.group(1)) if match.group(1) else 0
-        minutes = int(match.group(2)) if match.group(2) else 0
-        seconds = int(match.group(3)) if match.group(3) else 0
-        return hours * 3600 + minutes * 60 + seconds
+        days = int(match.group(1)) if match.group(1) else 0
+        hours = int(match.group(2)) if match.group(2) else 0
+        minutes = int(match.group(3)) if match.group(3) else 0
+        seconds = int(match.group(4)) if match.group(4) else 0
+        return days * 86400 + hours * 3600 + minutes * 60 + seconds
 
     @retry(3, 1.0)
     def _search_videos(self, query: str) -> List[Dict]:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
@@ -185,5 +185,11 @@ class YouTubeToolTest(unittest.TestCase):
         result = self.tool.execute(mode=tool_input.mode)
         self.assertTrue(result != [])
 
+    def test_parse_duration_with_day_component(self) -> None:
+        self.assertEqual(self.tool.parse_duration('P1DT2H3M4S'), 93784)
+
+    def test_parse_duration_rejects_partial_trailing_text(self) -> None:
+        self.assertEqual(self.tool.parse_duration('PT1Mbad'), 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `parse_duration` so it can parse ISO 8601 durations that include a day component, such as `P1DT2H3M4S`.
- Use full-pattern matching to avoid partially accepting malformed duration strings with trailing text.
- Keep the existing hour/minute/second parsing behavior unchanged.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/youtube_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.