### PR TITLE
fix(tool): handle Jina HTTP errors without response

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
@@ -106,9 +106,11 @@ class JinaAITool(Tool):
                 return content
                 
             except requests.HTTPError as e:
-                error_msg = (f"Access forbidden. Please check your API key and permissions. Error: {str(e)}" 
-                           if e.response.status_code == 403 
-                           else f"HTTP Error: {str(e)}")
+                response = e.response
+                status_code = response.status_code if response is not None else None
+                error_msg = (f"Access forbidden. Please check your API key and permissions. Error: {str(e)}"
+                             if status_code == 403
+                             else f"HTTP Error: {str(e)}")
                 if attempt < retries - 1:
                     time.sleep(2 ** attempt)
                     continue

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+import requests
+
+from agentuniverse.agent.action.tool.common_tool.jina_ai_tool import JinaAITool
+
+
+class JinaAIToolTest(unittest.TestCase):
+    def test_make_api_request_handles_http_error_without_response(self):
+        tool = JinaAITool()
+
+        with patch(
+            'agentuniverse.agent.action.tool.common_tool.jina_ai_tool.requests.get',
+            side_effect=requests.HTTPError('connection failed')
+        ), patch(
+            'agentuniverse.agent.action.tool.common_tool.jina_ai_tool.time.sleep'
+        ):
+            result = tool._make_api_request(
+                'https://r.jina.ai/https://example.com',
+                timeout=1,
+                error_prefix='Error reading URL'
+            )
+
+        self.assertIn('HTTP Error', result)
+        self.assertIn('connection failed', result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `JinaAITool` error handling when `requests.HTTPError` is raised without a response object.
- Keep the existing 403-specific message when a response is available.
- Return the original HTTP error message for response-less failures instead of raising an additional `AttributeError`.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.