### PR TITLE
fix(reader): handle non-ok web PDF responses

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/web_pdf_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/web_pdf_reader.py
@@ -37,3 +37,4 @@ class WebPdfReader(Reader):
                 extract_text_to_fp(pdf_memory_file, output_string, output_type='text', codec='utf-8')
                 text = output_string.getvalue().decode('utf-8')
                 return [Document(text=text, metadata={"source": web_pdf_url})]
+        return []

--- a/agentuniverse/agent/action/knowledge/reader/file/web_pdf_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/web_pdf_reader.py
@@ -22,19 +22,26 @@ class WebPdfReader(Reader):
     def _load_data(self, web_pdf_url: str) -> List[Document]:
         if web_pdf_url is None:
             return []
-        response = requests.get(web_pdf_url)
-        if response.status_code == 200:
-            # download the pdf file and convert it into a memory file.
-            pdf_memory_file = BytesIO(response.content)
-            try:
-                from pdfminer.high_level import extract_text_to_fp
-            except ImportError:
-                raise ImportError(
-                    "pdfminer.six is required to read PDF files: `pip install pdfminer.six`"
-                )
-            # parse the pdf file and get the text content.
-            with BytesIO() as output_string:
-                extract_text_to_fp(pdf_memory_file, output_string, output_type='text', codec='utf-8')
-                text = output_string.getvalue().decode('utf-8')
-                return [Document(text=text, metadata={"source": web_pdf_url})]
-        return []
+        try:
+            response = requests.get(web_pdf_url, timeout=20)
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status_code = getattr(exc.response, "status_code", None)
+            status = f"HTTP {status_code}" if status_code is not None else "HTTP error"
+            raise RuntimeError(f"Failed to fetch PDF from {web_pdf_url}: {status}") from exc
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Failed to fetch PDF from {web_pdf_url}: {exc}") from exc
+
+        # download the pdf file and convert it into a memory file.
+        pdf_memory_file = BytesIO(response.content)
+        try:
+            from pdfminer.high_level import extract_text_to_fp
+        except ImportError:
+            raise ImportError(
+                "pdfminer.six is required to read PDF files: `pip install pdfminer.six`"
+            )
+        # parse the pdf file and get the text content.
+        with BytesIO() as output_string:
+            extract_text_to_fp(pdf_memory_file, output_string, output_type='text', codec='utf-8')
+            text = output_string.getvalue().decode('utf-8')
+            return [Document(text=text, metadata={"source": web_pdf_url})]

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.file.web_pdf_reader import WebPdfReader
+
+
+class TestWebPdfReader(unittest.TestCase):
+    def test_non_ok_response_returns_empty_list(self):
+        reader = WebPdfReader()
+
+        with patch(
+            'agentuniverse.agent.action.knowledge.reader.file.web_pdf_reader.requests.get',
+            return_value=SimpleNamespace(status_code=404, content=b'')
+        ):
+            docs = reader._load_data('https://example.com/missing.pdf')
+
+        self.assertEqual(docs, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py
@@ -2,23 +2,36 @@
 # -*- coding:utf-8 -*-
 
 import unittest
-from types import SimpleNamespace
 from unittest.mock import patch
+
+import requests
 
 from agentuniverse.agent.action.knowledge.reader.file.web_pdf_reader import WebPdfReader
 
 
+class NonOkResponse:
+    status_code = 404
+    content = b''
+
+    def raise_for_status(self):
+        raise requests.HTTPError("404 Client Error", response=self)
+
+
 class TestWebPdfReader(unittest.TestCase):
-    def test_non_ok_response_returns_empty_list(self):
+    def test_non_ok_response_surfaces_fetch_error(self):
         reader = WebPdfReader()
+        url = 'https://example.com/missing.pdf'
 
         with patch(
             'agentuniverse.agent.action.knowledge.reader.file.web_pdf_reader.requests.get',
-            return_value=SimpleNamespace(status_code=404, content=b'')
-        ):
-            docs = reader._load_data('https://example.com/missing.pdf')
+            return_value=NonOkResponse()
+        ) as mock_get:
+            with self.assertRaises(RuntimeError) as context:
+                reader._load_data(url)
 
-        self.assertEqual(docs, [])
+        self.assertIn(url, str(context.exception))
+        self.assertIn('HTTP 404', str(context.exception))
+        mock_get.assert_called_once_with(url, timeout=20)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Fix `WebPdfReader._load_data` so non-200 HTTP responses return an empty list.
- Avoid returning `None` implicitly when the remote PDF request fails.
- Keep successful 200-response parsing behavior unchanged.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/web_pdf_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.