### PR TITLE
fix(tool): validate command status thread id

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/command_status_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/command_status_tool.py
@@ -12,11 +12,26 @@ from agentuniverse.agent.action.tool.common_tool.run_command_tool import get_com
 
 
 class CommandStatusTool(Tool):
+    @staticmethod
+    def _normalize_thread_id(thread_id):
+        if isinstance(thread_id, bool):
+            raise ValueError("thread_id must be an integer")
+        if isinstance(thread_id, int):
+            return thread_id
+        if isinstance(thread_id, str) and thread_id.isdigit():
+            return int(thread_id)
+        raise ValueError("thread_id must be an integer")
+
     def execute(self, thread_id: int | ToolInput) -> str:
         if isinstance(thread_id, ToolInput):
             thread_id = thread_id.get_data("thread_id")
-        if isinstance(thread_id, str) and thread_id.isdigit():
-            thread_id = int(thread_id)
+        try:
+            thread_id = self._normalize_thread_id(thread_id)
+        except ValueError as e:
+            return json.dumps({
+                "error": str(e),
+                "status": "error"
+            })
 
         result = get_command_result(thread_id)
 

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
@@ -80,6 +80,36 @@ class CommandStatusToolTest(unittest.TestCase):
         self.assertIn('error', status_result)
         self.assertEqual(status_result['status'], 'not_found')
 
+    def test_string_thread_id_is_parsed(self):
+        status_input = ToolInput({
+            'thread_id': '12345678'
+        })
+        status_json = self.status_tool.execute(status_input)
+        status_result = json.loads(status_json)
+
+        self.assertIn('error', status_result)
+        self.assertEqual(status_result['status'], 'not_found')
+
+    def test_malformed_thread_id_returns_input_error(self):
+        status_input = ToolInput({
+            'thread_id': 'abc'
+        })
+        status_json = self.status_tool.execute(status_input)
+        status_result = json.loads(status_json)
+
+        self.assertEqual(status_result['status'], 'error')
+        self.assertIn('thread_id must be an integer', status_result['error'])
+
+    def test_boolean_thread_id_returns_input_error(self):
+        status_input = ToolInput({
+            'thread_id': True
+        })
+        status_json = self.status_tool.execute(status_input)
+        status_result = json.loads(status_json)
+
+        self.assertEqual(status_result['status'], 'error')
+        self.assertIn('thread_id must be an integer', status_result['error'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Add input validation for `CommandStatusTool` `thread_id`.
- Accept integer values and canonical numeric strings.
- Reject booleans and malformed string values with a clear input error instead of letting invalid values flow into the command manager.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/command_status_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py`
- `git diff --check`

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.