### PR TITLE
fix(knowledge): add request timeout and non-JSON guard to JinaReranker

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py
@@ -73,13 +73,18 @@ class JinaReranker(DocProcessor):
             response = requests.post(api_base, headers=headers, json=payload,
                                      timeout=self.request_timeout)
             response.raise_for_status()
-            results = response.json().get("results", [])
         except requests.exceptions.RequestException as e:
             raise Exception(f"Jina AI rerank API call error: {e}")
+
+        # Decode the body separately from the HTTP call. ``Response.json()``
+        # raises ``requests.exceptions.JSONDecodeError`` on a non-JSON body
+        # (e.g. an HTML error page from an upstream gateway). That exception
+        # inherits from both ``RequestException`` and ``ValueError``, so a
+        # single combined try block would misreport it as an API-call error;
+        # isolating JSON decoding here surfaces it as a non-JSON response.
+        try:
+            results = response.json().get("results", [])
         except ValueError as e:
-            # A non-JSON body (e.g. an HTML error page returned by an upstream
-            # gateway) makes response.json() raise ValueError; surface a clear
-            # message instead of letting the raw parse error escape.
             raise Exception(f"Jina AI rerank API returned a non-JSON response: {e}")
 
         rerank_docs = []
@@ -119,6 +124,23 @@ class JinaReranker(DocProcessor):
         if hasattr(doc_processor_configer, "top_n"):
             self.top_n = doc_processor_configer.top_n
         if hasattr(doc_processor_configer, "request_timeout"):
-            self.request_timeout = doc_processor_configer.request_timeout
+            self.request_timeout = self._validate_request_timeout(
+                doc_processor_configer.request_timeout)
 
         return self
+
+    @staticmethod
+    def _validate_request_timeout(value) -> int:
+        """Validate a configured request timeout.
+
+        ``requests`` treats ``None`` as "no timeout" and accepts ``0``/negative
+        values without complaint, so a bad config must fail loudly here instead
+        of hanging the rerank step or silently disabling the timeout.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise Exception(
+                f"Jina AI reranker request_timeout must be a positive number, got {value!r}.")
+        if value <= 0:
+            raise Exception(
+                f"Jina AI reranker request_timeout must be a positive number, got {value!r}.")
+        return value

--- a/agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py
@@ -22,10 +22,19 @@ class JinaReranker(DocProcessor):
 
     This processor reranks documents based on their relevance to a query
     using Jina AI's reranking models.
+
+    Attributes:
+        api_key: Jina AI API key. Falls back to the ``JINA_API_KEY`` env var.
+        model_name: Reranker model id.
+        top_n: Maximum number of documents returned after reranking.
+        request_timeout: Timeout in seconds for the rerank HTTP call. ``requests``
+            defaults to no timeout, so without this a stalled Jina API hangs the
+            whole rerank step indefinitely.
     """
     api_key: Optional[str] = None
     model_name: str = "jina-reranker-v2-base-multilingual"
     top_n: int = 10
+    request_timeout: int = 30
 
     def _process_docs(self, origin_docs: List[Document], query: Query = None) -> List[Document]:
         """Rerank documents based on their relevance to the query.
@@ -61,11 +70,17 @@ class JinaReranker(DocProcessor):
         }
 
         try:
-            response = requests.post(api_base, headers=headers, json=payload)
+            response = requests.post(api_base, headers=headers, json=payload,
+                                     timeout=self.request_timeout)
             response.raise_for_status()
             results = response.json().get("results", [])
         except requests.exceptions.RequestException as e:
             raise Exception(f"Jina AI rerank API call error: {e}")
+        except ValueError as e:
+            # A non-JSON body (e.g. an HTML error page returned by an upstream
+            # gateway) makes response.json() raise ValueError; surface a clear
+            # message instead of letting the raw parse error escape.
+            raise Exception(f"Jina AI rerank API returned a non-JSON response: {e}")
 
         rerank_docs = []
         for result in results:
@@ -103,5 +118,7 @@ class JinaReranker(DocProcessor):
             self.model_name = doc_processor_configer.model_name
         if hasattr(doc_processor_configer, "top_n"):
             self.top_n = doc_processor_configer.top_n
+        if hasattr(doc_processor_configer, "request_timeout"):
+            self.request_timeout = doc_processor_configer.request_timeout
 
         return self

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
@@ -7,6 +7,7 @@
 # @FileName: test_jina_reranker.py
 
 import unittest
+import requests
 from unittest.mock import patch, MagicMock
 
 from agentuniverse.agent.action.knowledge.doc_processor.jina_reranker import JinaReranker
@@ -80,7 +81,8 @@ class TestJinaReranker(unittest.TestCase):
                 'query': 'test query',
                 'documents': [doc.text for doc in self.test_docs],
                 'top_n': 10
-            }
+            },
+            timeout=30
         )
 
         self.assertEqual(len(result_docs), 5)
@@ -116,7 +118,8 @@ class TestJinaReranker(unittest.TestCase):
                 'query': 'test query',
                 'documents': [doc.text for doc in self.test_docs],
                 'top_n': 2
-            }
+            },
+            timeout=30
         )
 
         self.assertEqual(len(result_docs), 2)
@@ -131,6 +134,45 @@ class TestJinaReranker(unittest.TestCase):
         self.reranker.api_key = 'test_api_key'
         result_docs = self.reranker._process_docs([], self.test_query)
         self.assertEqual(len(result_docs), 0)
+
+    @patch('requests.post')
+    def test_process_docs_passes_default_timeout(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'results': []}
+        mock_post.return_value = mock_response
+        self.reranker.api_key = 'test_api_key'
+        self.reranker._process_docs(self.test_docs, self.test_query)
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs.get('timeout'), 30)
+
+    @patch('requests.post')
+    def test_process_docs_passes_custom_request_timeout(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'results': []}
+        mock_post.return_value = mock_response
+        self.reranker.api_key = 'test_api_key'
+        self.reranker.request_timeout = 5
+        self.reranker._process_docs(self.test_docs, self.test_query)
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs.get('timeout'), 5)
+
+    @patch('requests.post')
+    def test_process_docs_timeout_error_is_surfaced(self, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout('timed out')
+        self.reranker.api_key = 'test_api_key'
+        with self.assertRaises(Exception) as context:
+            self.reranker._process_docs(self.test_docs, self.test_query)
+        self.assertIn('Jina AI rerank API call error', str(context.exception))
+
+    @patch('requests.post')
+    def test_process_docs_non_json_response_is_surfaced(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError('not json')
+        mock_post.return_value = mock_response
+        self.reranker.api_key = 'test_api_key'
+        with self.assertRaises(Exception) as context:
+            self.reranker._process_docs(self.test_docs, self.test_query)
+        self.assertIn('non-JSON', str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
@@ -166,13 +166,56 @@ class TestJinaReranker(unittest.TestCase):
 
     @patch('requests.post')
     def test_process_docs_non_json_response_is_surfaced(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.json.side_effect = ValueError('not json')
+        # Use a real Response whose .json() raises
+        # requests.exceptions.JSONDecodeError — the actual exception a non-JSON
+        # body produces. JSONDecodeError inherits from BOTH RequestException
+        # and ValueError, so a naive except-ordering would misreport it as an
+        # API-call error; this test pins the non-JSON path.
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = b'<html>upstream error page</html>'
         mock_post.return_value = mock_response
         self.reranker.api_key = 'test_api_key'
         with self.assertRaises(Exception) as context:
             self.reranker._process_docs(self.test_docs, self.test_query)
         self.assertIn('non-JSON', str(context.exception))
+        self.assertNotIn('API call error', str(context.exception))
+
+    def _make_configer_with_timeout(self, request_timeout):
+        cfg = Configer()
+        cfg.value = {
+            'name': 'jina_reranker',
+            'description': 'reranker use jina api',
+            'request_timeout': request_timeout,
+        }
+        configer = ComponentConfiger()
+        configer.load_by_configer(cfg)
+        return configer
+
+    def test_initialize_rejects_non_numeric_request_timeout(self):
+        for bad in ('not-a-number', None, [30]):
+            reranker = JinaReranker()
+            with self.assertRaises(Exception) as context:
+                reranker._initialize_by_component_configer(
+                    self._make_configer_with_timeout(bad))
+            self.assertIn('request_timeout', str(context.exception))
+
+    def test_initialize_rejects_non_positive_request_timeout(self):
+        # 0 / negative are invalid; True/False are bools (an int subclass) and
+        # must also be rejected so a YAML `true` does not silently become 1.
+        for bad in (0, -5, True, False):
+            reranker = JinaReranker()
+            with self.assertRaises(Exception) as context:
+                reranker._initialize_by_component_configer(
+                    self._make_configer_with_timeout(bad))
+            self.assertIn('request_timeout', str(context.exception))
+
+    def test_initialize_accepts_valid_request_timeout(self):
+        for good in (1, 30, 5.5):
+            reranker = JinaReranker()
+            reranker._initialize_by_component_configer(
+                self._make_configer_with_timeout(good))
+            self.assertEqual(reranker.request_timeout, good)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
`JinaReranker._process_docs` called `requests.post` without a timeout, so a stalled Jina rerank API hung the whole rerank step indefinitely (`requests` defaults to no timeout).

## Changes
- Add a configurable `request_timeout` attribute (default `30`s, overridable via yaml) and pass it to `requests.post`.
- Catch `ValueError` from `response.json()` so a non-JSON body (e.g. an HTML error page from an upstream gateway) surfaces a clear message instead of a raw parse error.
- `request_timeout` is read from the component configer like `model_name` / `top_n`.

## Tests
Updated the existing call-arg assertions (the call now carries `timeout`) and added coverage for the default/custom timeout, the timeout-error path, and the non-JSON path. `python -m unittest` — 9 passed.