### PR TITLE
fix(agent): preserve tool configuration and empty streams

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -363,6 +363,8 @@ class Agent(ComponentBase, ABC):
         return streaming
 
     def generate_result(self, data: list[dict | str]):
+        if not data:
+            return ""
         if isinstance(data[0], str):
             return "".join(data)
         text = [val.get('text') for val in data]

--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -377,9 +377,7 @@ class Agent(ComponentBase, ABC):
         return self._get_tool_names()
 
     def _get_tool_names(self) -> list:
-        tool_name_list = self.agent_model.action.get('tool', [])
-        if tool_name_list is None:
-            tool_name_list = []
+        tool_name_list = list(self.agent_model.action.get('tool') or [])
         for toolkit_name in self.agent_model.action.get('toolkit', []):
             toolkit = ToolkitManager().get_instance_obj(toolkit_name)
             tool_name_list.extend(toolkit.tool_names)

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -41,3 +41,30 @@ def test_process_prompt_preserves_agent_input_for_repeated_calls():
 
     assert agent_input == original_input
     assert first_prompt.messages == second_prompt.messages
+
+
+def test_tool_names_does_not_mutate_agent_action(monkeypatch):
+    class _StubToolkit:
+        def __init__(self):
+            self.tool_names = ["toolkit_tool"]
+
+    class _StubToolkitManager:
+        def get_instance_obj(self, toolkit_name):
+            assert toolkit_name == "test_toolkit"
+            return _StubToolkit()
+
+    monkeypatch.setattr(
+        "agentuniverse.agent.agent.ToolkitManager",
+        _StubToolkitManager,
+    )
+    agent = _StubAgent()
+    agent.agent_model = AgentModel(
+        action={
+            "tool": ["direct_tool"],
+            "toolkit": ["test_toolkit"],
+        }
+    )
+
+    assert agent.tool_names == ["direct_tool", "toolkit_tool"]
+    assert agent.tool_names == ["direct_tool", "toolkit_tool"]
+    assert agent.agent_model.action["tool"] == ["direct_tool"]

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -68,3 +68,9 @@ def test_tool_names_does_not_mutate_agent_action(monkeypatch):
     assert agent.tool_names == ["direct_tool", "toolkit_tool"]
     assert agent.tool_names == ["direct_tool", "toolkit_tool"]
     assert agent.agent_model.action["tool"] == ["direct_tool"]
+
+
+def test_generate_result_returns_empty_text_for_empty_stream():
+    agent = _StubAgent()
+
+    assert agent.generate_result([]) == ""


### PR DESCRIPTION
## Summary

- copy configured direct tool names before appending toolkit tools, preventing repeated property reads from mutating `AgentModel.action`
- return an empty string when a streaming chain produces no chunks instead of raising `IndexError`

## Reproduction

Before this change:

- reading `agent.tool_names` twice appended the same toolkit tool twice and permanently changed the configured direct-tool list
- `Agent.generate_result([])` indexed `data[0]` and failed

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/test_agent.py -q` (3 passed)
- `ruff check --no-fix tests/test_agentuniverse/unit/agent/test_agent.py`
- `python -m black --check tests/test_agentuniverse/unit/agent/test_agent.py`
- `python -m py_compile agentuniverse/agent/agent.py tests/test_agentuniverse/unit/agent/test_agent.py`
- `git diff upstream/master...HEAD --check`

No repository dependencies or public APIs are changed.