### PR TITLE
fix(agent): avoid mutating configured tool names

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -377,9 +377,7 @@ class Agent(ComponentBase, ABC):
         return self._get_tool_names()
 
     def _get_tool_names(self) -> list:
-        tool_name_list = self.agent_model.action.get('tool', [])
-        if tool_name_list is None:
-            tool_name_list = []
+        tool_name_list = list(self.agent_model.action.get('tool') or [])
         for toolkit_name in self.agent_model.action.get('toolkit', []):
             toolkit = ToolkitManager().get_instance_obj(toolkit_name)
             tool_name_list.extend(toolkit.tool_names)

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -41,3 +41,30 @@ def test_process_prompt_preserves_agent_input_for_repeated_calls():
 
     assert agent_input == original_input
     assert first_prompt.messages == second_prompt.messages
+
+
+def test_tool_names_does_not_mutate_agent_action(monkeypatch):
+    class _StubToolkit:
+        def __init__(self):
+            self.tool_names = ["toolkit_tool"]
+
+    class _StubToolkitManager:
+        def get_instance_obj(self, toolkit_name):
+            assert toolkit_name == "test_toolkit"
+            return _StubToolkit()
+
+    monkeypatch.setattr(
+        "agentuniverse.agent.agent.ToolkitManager",
+        _StubToolkitManager,
+    )
+    agent = _StubAgent()
+    agent.agent_model = AgentModel(
+        action={
+            "tool": ["direct_tool"],
+            "toolkit": ["test_toolkit"],
+        }
+    )
+
+    assert agent.tool_names == ["direct_tool", "toolkit_tool"]
+    assert agent.tool_names == ["direct_tool", "toolkit_tool"]
+    assert agent.agent_model.action["tool"] == ["direct_tool"]


### PR DESCRIPTION
## Summary

Copy the configured direct-tool list before appending toolkit tools so reading `Agent.tool_names` remains side-effect free.

Before this change, each property access permanently appended toolkit entries to `AgentModel.action["tool"]`; repeated agent runs could therefore invoke the same toolkit tool multiple times.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/test_agent.py -k "tool_names or process_prompt" -q` (2 passed)
- `ruff check --no-fix tests/test_agentuniverse/unit/agent/test_agent.py`
- `python -m black --check tests/test_agentuniverse/unit/agent/test_agent.py`
- `python -m py_compile agentuniverse/agent/agent.py tests/test_agentuniverse/unit/agent/test_agent.py`

No dependencies or public APIs are changed.