### PR TITLE
fix(agent): handle empty streaming responses

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -363,6 +363,8 @@ class Agent(ComponentBase, ABC):
         return streaming
 
     def generate_result(self, data: list[dict | str]):
+        if not data:
+            return ""
         if isinstance(data[0], str):
             return "".join(data)
         text = [val.get('text') for val in data]

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -41,3 +41,9 @@ def test_process_prompt_preserves_agent_input_for_repeated_calls():
 
     assert agent_input == original_input
     assert first_prompt.messages == second_prompt.messages
+
+
+def test_generate_result_returns_empty_text_for_empty_stream():
+    agent = _StubAgent()
+
+    assert agent.generate_result([]) == ""


### PR DESCRIPTION
## Summary

Return an empty string when a streaming agent chain produces no chunks instead of indexing an empty list and raising `IndexError`.

This preserves the existing result type for text streams and lets callers handle a legitimate empty model response without an unrelated aggregation failure.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/test_agent.py -q` (2 passed)
- `ruff check --no-fix tests/test_agentuniverse/unit/agent/test_agent.py`
- `python -m black --check tests/test_agentuniverse/unit/agent/test_agent.py`
- `python -m py_compile agentuniverse/agent/agent.py tests/test_agentuniverse/unit/agent/test_agent.py`

No dependencies or public APIs are changed.