### PR TITLE
fix(reader): reset website crawl state

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py
@@ -63,6 +63,9 @@ class WebsiteBs4Reader(Reader):
         if not url.startswith(('http://', 'https://')):
             raise ValueError("Invalid URL format")
 
+        self._visited = set()
+        self._urls_to_crawl = []
+
         # Update config from ext_info if provided
         if ext_info:
             if 'max_depth' in ext_info:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_website_bs4_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_website_bs4_reader.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.file.website_bs4_reader import WebsiteBs4Reader
+
+
+class WebsiteBs4ReaderTest(unittest.TestCase):
+    def test_load_data_resets_crawl_state_between_calls(self):
+        url = "https://example.com"
+        reader = WebsiteBs4Reader()
+        reader._visited.add(url)
+        reader._urls_to_crawl.append((url, 2))
+
+        with patch.object(reader, "_crawl_website", return_value={url: "example text"}):
+            docs = reader._load_data(url)
+
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].text, "example text")
+        self.assertEqual(reader._visited, set())
+        self.assertEqual(reader._urls_to_crawl, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Reset `WebsiteBs4Reader` crawl state at the start of each `_load_data` call.
- Prevent previously visited URLs and queued crawl items from leaking into later loads on the same reader instance.
- Keep the existing crawling and extraction behavior unchanged for a single load.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_website_bs4_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_website_bs4_reader.py`
- `git diff --check`

Focused unittest could not be completed locally because the current environment is missing project dependencies such as `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.