### PR TITLE
fix(reader): skip unsafe zip members

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/zip_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/zip_reader.py
@@ -224,6 +224,8 @@ class ZipReader(Reader):
         if not member:
             return None
         normalized = PurePosixPath(member)
+        if normalized.is_absolute() or ".." in normalized.parts:
+            return None
         parts = [part for part in normalized.parts if part not in {"", ".", ".."}]
         if not parts:
             return None

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py
@@ -480,6 +480,19 @@ class TestZipReader(unittest.TestCase):
             path = doc.metadata.get("archive_path", "")
             self.assertNotIn("..", path)
 
+    def test_unsafe_members_are_skipped_not_normalized(self) -> None:
+        archive_path = Path(self.temp_dir.name) / "unsafe_members.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("../outside.txt", "blocked")
+            archive.writestr("/absolute.txt", "blocked")
+            archive.writestr("safe/file.txt", "allowed")
+
+        docs = self.reader._load_data(archive_path)
+
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["archive_path"], "safe/file.txt")
+        self.assertEqual(docs[0].text, "allowed")
+
     def test_hidden_and_system_files(self) -> None:
         archive_path = Path(self.temp_dir.name) / "hidden.zip"
         with zipfile.ZipFile(archive_path, "w") as archive:


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING_zh.md)。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Make `ZipReader` skip unsafe archive members instead of normalizing them into safe-looking paths.
- Reject absolute member paths and entries containing `..`.
- Preserve the existing behavior for valid archive members.
- Add regression coverage to ensure unsafe entries are ignored while safe files are still loaded.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/zip_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py`
- `git diff --check`

Focused unittest could not be completed locally because the current environment is missing project dependencies such as `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.