### PR TITLE
fix(tool): gate RunCommandTool behind allow_command_execution opt-in

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional
 from dataclasses import dataclass
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from loguru import logger
 
 
 class CommandStatus(Enum):
@@ -71,9 +72,28 @@ _command_results: Dict[int, CommandResult] = {}
 
 
 class RunCommandTool(Tool):
+    """Tool for executing shell commands either synchronously or asynchronously.
+
+    .. warning::
+        **Security:** this tool runs **arbitrary shell commands on the host**
+        via ``subprocess`` with ``shell=True``. There is no sandboxing, command
+        allow-list, or resource limiting. A prompt injection that reaches this
+        tool escalates directly to arbitrary command execution and full host
+        compromise.
+
+        Because of that, the tool is **disabled by default**, mirroring
+        :class:`PythonREPLTool`. Set ``allow_command_execution: True`` to opt
+        in, and only do so in a fully trusted, isolated environment. Do not
+        equip an agent that processes untrusted input (documents, web pages,
+        chat messages) with this tool.
+
+    Attributes:
+        allow_command_execution (bool): Explicit opt-in flag. Defaults to
+            ``False`` so the tool refuses to execute commands until an
+            integrator acknowledges the risk above.
     """
-    Tool for executing shell commands either synchronously or asynchronously.
-    """
+
+    allow_command_execution: bool = False
 
     def execute(self, command: str | ToolInput, cwd: str = None, blocking: bool = True) -> str:
         if isinstance(command, ToolInput):
@@ -81,6 +101,24 @@ class RunCommandTool(Tool):
             cwd = params.get("cwd", cwd)
             blocking = params.get("blocking", blocking)
             command = params.get("command")
+        if not self.allow_command_execution:
+            logger.warning(
+                "RunCommandTool.execute is disabled (allow_command_execution=False). "
+                "It runs arbitrary shell commands via subprocess(shell=True) with no "
+                "sandboxing; set allow_command_execution=True to opt in only for "
+                "trusted environments.")
+            disabled = CommandResult(
+                thread_id=threading.get_ident(),
+                status=CommandStatus.ERROR,
+                stdout="",
+                stderr=("RunCommandTool is disabled by default because it executes "
+                        "arbitrary shell commands on the host without sandboxing. Set "
+                        "`allow_command_execution: True` to opt in, and only do so in a "
+                        "trusted, isolated environment."),
+                start_time=time.time(),
+            )
+            disabled.end_time = disabled.start_time
+            return disabled.message
         cwd = cwd or os.getcwd()
         return self._run_command(command, cwd, blocking)
 

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_run_command.py
@@ -25,7 +25,18 @@ class RunCommandToolTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.tool = RunCommandTool()
+        # Opt in explicitly: RunCommandTool is disabled by default because it
+        # runs arbitrary shell commands (see allow_command_execution).
+        self.tool = RunCommandTool(allow_command_execution=True)
+
+    def test_disabled_by_default_refuses(self) -> None:
+        """A default RunCommandTool must refuse to execute anything."""
+        tool = RunCommandTool()
+        result = json.loads(tool.execute(ToolInput({
+            'command': 'echo should_not_run', 'blocking': True})))
+        self.assertEqual(result['status'], CommandStatus.ERROR.value)
+        self.assertNotIn('should_not_run', result.get('stdout', ''))
+        self.assertIn('allow_command_execution', result['stderr'])
 
     def test_blocking_command_execution(self) -> None:
         """Test synchronous command execution"""


### PR DESCRIPTION
## Summary

`RunCommandTool` executes arbitrary shell commands via `subprocess.Popen(command, shell=True)` with **no sandboxing, command allow-list, or resource limiting**. A prompt injection that reaches this tool escalates directly to arbitrary command execution and full host compromise.

The sibling `PythonREPLTool` was already hardened with an `allow_code_execution` opt-in (default off), and the file tools (`WriteFileTool`/`ViewFileTool`) use `resolve_safe_path` against path traversal — but `RunCommandTool` ran by default with no gate, leaving it as the inconsistent, unsafe outlier in `common_tool/`.

## Changes

- Add `allow_command_execution: bool = False` (mirrors `PythonREPLTool.allow_code_execution`); the tool refuses to run and logs a warning until an integrator opts in.
- Security `.. warning::` in the class docstring spelling out the prompt-injection → RCE path.
- Existing tests opt in explicitly (`RunCommandTool(allow_command_execution=True)`); added `test_disabled_by_default_refuses` asserting a default instance refuses.

## Notes

- **Behaviour change:** a default `RunCommandTool()` no longer executes commands — integrators must set `allow_command_execution: True` (e.g. in the tool yaml/constructor). This is intentional and matches the precedent set by `PythonREPLTool`.
- All 5 tests in `test_run_command.py` pass.

## Test plan

```
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_run_command -v
```