### PR TITLE
fix(tool): verify TLS on Jina API requests by default

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
@@ -11,6 +11,7 @@ import time
 from pydantic import Field
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from agentuniverse.base.util.env_util import get_from_env
+from loguru import logger
 import html
 
 
@@ -34,6 +35,8 @@ class JinaAITool(Tool):
     api_key: Optional[str] = Field(default_factory=lambda: get_from_env("JINA_API_KEY"))
     max_read_content_length: int = Field(10000, description="Maximum content length in characters")
     remove_image: bool = Field(True, description="Remove image from content")
+    verify_tls: bool = Field(True, description="Verify TLS certificates on Jina API "
+                                               "requests. Disable only for a trusted self-signed endpoint.")
     headers: Dict[str, str] = None
     def execute(self,
                 input: str = None,
@@ -91,16 +94,16 @@ class JinaAITool(Tool):
         for attempt in range(retries):
             try:
                 response = requests.get(
-                    url, 
-                    headers=self._get_headers(), 
-                    verify=False, 
+                    url,
+                    headers=self._get_headers(),
+                    verify=self.verify_tls,
                     timeout=timeout
                 )
                 response.raise_for_status()
                 content = response.json()
 
                 if content.get("code") != 200:
-                    print(f"Request failed with status code {content.get('code')}")
+                    logger.warning(f"Jina AI request to {url} failed with code {content.get('code')}")
                     return None
                     
                 return content

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
@@ -1,5 +1,4 @@
 # !/usr/bin/env python3
-# -*- coding:utf-8 -*-
 
 """Tests for JinaAITool TLS verification behaviour."""
 
@@ -50,19 +49,21 @@ class JinaAIToolTLSTest(unittest.TestCase):
             mock_get.return_value = resp
             out = io.StringIO()
             with redirect_stdout(out):
-                result = tool._make_api_request(
-                    "https://r.jina.ai/https://x", 10, "err")
+                result = tool._make_api_request("https://r.jina.ai/https://x", 10, "err")
         self.assertIsNone(result)
         # The failure is reported through the logger, never printed to stdout.
         self.assertEqual(out.getvalue(), "")
 
     def test_make_api_request_handles_http_error_without_response(self) -> None:
         tool = JinaAITool()
-        with patch.object(
-            jina_module.requests,
-            "get",
-            side_effect=requests.HTTPError("connection failed"),
-        ), patch.object(jina_module.time, "sleep"):
+        with (
+            patch.object(
+                jina_module.requests,
+                "get",
+                side_effect=requests.HTTPError("connection failed"),
+            ),
+            patch.object(jina_module.time, "sleep"),
+        ):
             result = tool._make_api_request(
                 "https://r.jina.ai/https://example.com",
                 timeout=1,

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
@@ -1,0 +1,59 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for JinaAITool TLS verification behaviour."""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+import agentuniverse.agent.action.tool.common_tool.jina_ai_tool as jina_module
+from agentuniverse.agent.action.tool.common_tool.jina_ai_tool import JinaAITool
+
+
+class JinaAIToolTLSTest(unittest.TestCase):
+    """TLS verification must be on by default, not hardcoded off."""
+
+    def _mock_ok_response(self) -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"code": 200, "data": {"content": "ok"}}
+        return resp
+
+    def test_verify_tls_true_by_default(self) -> None:
+        tool = JinaAITool()
+        self.assertTrue(tool.verify_tls)
+        with patch.object(jina_module.requests, "get") as mock_get:
+            mock_get.return_value = self._mock_ok_response()
+            tool._make_api_request("https://r.jina.ai/https://x", 10, "err")
+            _, kwargs = mock_get.call_args
+            # Secure default: certificates are verified.
+            self.assertIs(kwargs.get("verify"), True)
+
+    def test_verify_tls_can_be_disabled_via_config(self) -> None:
+        tool = JinaAITool(verify_tls=False)
+        with patch.object(jina_module.requests, "get") as mock_get:
+            mock_get.return_value = self._mock_ok_response()
+            tool._make_api_request("https://r.jina.ai/https://x", 10, "err")
+            _, kwargs = mock_get.call_args
+            self.assertIs(kwargs.get("verify"), False)
+
+    def test_non_200_logs_warning_without_writing_stdout(self) -> None:
+        tool = JinaAITool()
+        with patch.object(jina_module.requests, "get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"code": 401}
+            mock_get.return_value = resp
+            out = io.StringIO()
+            with redirect_stdout(out):
+                result = tool._make_api_request(
+                    "https://r.jina.ai/https://x", 10, "err")
+        self.assertIsNone(result)
+        # The failure is reported through the logger, never printed to stdout.
+        self.assertEqual(out.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`JinaAITool._make_api_request` called `requests.get(url, verify=False, ...)`, **disabling TLS certificate verification on every Jina read / search / fact-check request**. A network attacker could man-in-the-middle the connection and inject or alter the web/search content that flows into the agent's context (a prompt-injection vector over the wire). Jina's API serves a valid certificate, so there is no reason to disable verification.

## Changes

- Add a `verify_tls: bool = True` field so requests verify certificates by default (secure), while remaining configurable for a legitimate trusted self-signed endpoint.
- Replace a stray `print()` of a failed response code with `logger.warning()` (keeps stdout clean, consistent with the reader/logger work in #648/#647).
- Add `tests/test_jina_ai_tool.py` covering the secure default, the opt-out, and that a non-200 response is reported via the logger (stdout stays clean).

## Test plan

```
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_jina_ai_tool -v
```
All 3 tests pass.