### PR TITLE
fix(store): persist FAISS metadata as JSON instead of pickle

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/faiss_store.py
+++ b/agentuniverse/agent/action/knowledge/store/faiss_store.py
@@ -8,14 +8,30 @@
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.knowledge.store.query import Query
 from agentuniverse.agent.action.knowledge.store.store import Store
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+# faiss and numpy are imported at module scope so every method (query / insert /
+# _create_faiss_index / ...) sees the same names. They are optional dependencies:
+# a hard module-level import would break environments without faiss installed,
+# so each is wrapped and ``_new_client`` surfaces a clear ImportError when the
+# store is actually used.
+try:
+    import faiss  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - exercised via the skip guard in tests
+    faiss = None  # type: ignore[assignment]
+
+try:
+    import numpy as np  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - numpy ships with faiss-cpu
+    np = None  # type: ignore[assignment]
 
 # Default configuration for FAISS index types
 DEFAULT_INDEX_CONFIG = {
@@ -37,16 +53,83 @@ logger = logging.getLogger(__name__)
 
 def _json_default(obj):
     """Fallback JSON serializer normalizing numpy values that may reach metadata."""
-    try:
-        import numpy as np
-    except ImportError:
-        np = None
     if np is not None:
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         if isinstance(obj, np.generic):
             return obj.item()
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def _require_dict(value: Any) -> dict:
+    """Return ``value`` if it is a dict, else raise TypeError."""
+    if not isinstance(value, dict):
+        raise TypeError("value must be an object")
+    return value
+
+
+def _require_str(value: Any) -> str:
+    """Return ``value`` if it is a str, else raise TypeError."""
+    if not isinstance(value, str):
+        raise TypeError("value must be a string")
+    return value
+
+
+def _require_int(value: Any) -> int:
+    """Return ``value`` if it is a real integer, else raise TypeError.
+
+    Booleans are rejected explicitly: ``isinstance(True, int)`` is True in
+    Python, so a bare isinstance check would silently accept them.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("value must be an integer")
+    return value
+
+
+def _validate_metadata_payload(
+    metadata: Any,
+) -> tuple[dict[str, "Document"], dict[str, int], dict[int, str], int]:
+    """Validate the loaded metadata envelope and reconstruct typed fields.
+
+    Raises ``ValueError`` (structural/schema) or ``TypeError`` (individual
+    fields with the wrong type) on any problem so the caller can reset the
+    store as one coherent unit instead of half-populating it: wrong ``format``
+    marker, non-object top level, malformed ``Document`` payloads, or
+    ``index_to_id`` keys that are not integer FAISS positions.
+    """
+    if not isinstance(metadata, dict):
+        raise TypeError("invalid metadata envelope")
+    if metadata.get("format") != METADATA_FORMAT_VERSION:
+        raise ValueError("unsupported metadata format marker")
+
+    document_store_raw = _require_dict(metadata.get("document_store", {}))
+    id_to_index_raw = _require_dict(metadata.get("id_to_index", {}))
+    index_to_id_raw = _require_dict(metadata.get("index_to_id", {}))
+    next_index = _require_int(metadata.get("next_index", 0))
+
+    document_store: dict[str, Document] = {}
+    for doc_id, doc_data in document_store_raw.items():
+        _require_str(doc_id)
+        _require_dict(doc_data)
+        document_store[doc_id] = Document(**doc_data)
+
+    id_to_index: dict[str, int] = {}
+    for doc_id, position in id_to_index_raw.items():
+        _require_str(doc_id)
+        id_to_index[doc_id] = _require_int(position)
+
+    # JSON object keys are strings; restore the integer FAISS positions.
+    # Non-integer keys mean the file is corrupt — raise, do not guess.
+    index_to_id: dict[int, str] = {}
+    for key, doc_id in index_to_id_raw.items():
+        try:
+            position = int(key)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("index_to_id key is not an integer position") from exc
+        _require_str(doc_id)
+        index_to_id[position] = doc_id
+
+    return document_store, id_to_index, index_to_id, next_index
 
 
 class FAISSStore(Store):
@@ -67,15 +150,15 @@ class FAISSStore(Store):
         index_to_id (Dict[int, str]): Mapping from FAISS index position to document ID.
     """
 
-    index_path: Optional[str] = None
-    metadata_path: Optional[str] = None
-    index_config: Dict = None
-    embedding_model: Optional[str] = None
-    similarity_top_k: Optional[int] = 10
+    index_path: str | None = None
+    metadata_path: str | None = None
+    index_config: dict = None
+    embedding_model: str | None = None
+    similarity_top_k: int | None = 10
     faiss_index: Any = None
-    document_store: Dict[str, Document] = None
-    id_to_index: Dict[str, int] = None
-    index_to_id: Dict[int, str] = None
+    document_store: dict[str, Document] = None
+    id_to_index: dict[str, int] = None
+    index_to_id: dict[int, str] = None
     _next_index: int = 0
 
     def __init__(self, **kwargs):
@@ -89,15 +172,12 @@ class FAISSStore(Store):
 
     def _new_client(self) -> Any:
         """Initialize the FAISS index and load existing data if available."""
-        try:
-            import faiss
-            import numpy as np
-        except ImportError as e:
-            FAISS_NOT_INSTALLED_MSG = (
+        if faiss is None:
+            faiss_not_installed_msg = (
                 "FAISS is not installed. Please install it with 'pip install faiss-cpu' "
                 "for CPU version or 'pip install faiss-gpu' for GPU version."
             )
-            raise ImportError(FAISS_NOT_INSTALLED_MSG) from e
+            raise ImportError(faiss_not_installed_msg)
         self._load_index_and_metadata()
         return self.faiss_index
 
@@ -110,6 +190,11 @@ class FAISSStore(Store):
         Returns:
             faiss.Index: The created FAISS index.
         """
+        if faiss is None:
+            raise ImportError(
+                "FAISS is not installed. Please install it with 'pip install faiss-cpu' "
+                "for CPU version or 'pip install faiss-gpu' for GPU version."
+            )
         index_type = self.index_config.get("index_type", "IndexFlatL2")
 
         if index_type == "IndexFlatL2":
@@ -133,8 +218,8 @@ class FAISSStore(Store):
             index.hnsw.efSearch = self.index_config.get("efSearch", 50)
             return index
         else:
-            UNSUPPORTED_INDEX_MSG = f"Unsupported index type: {index_type}"
-            raise ValueError(UNSUPPORTED_INDEX_MSG)
+            unsupported_index_msg = f"Unsupported index type: {index_type}"
+            raise ValueError(unsupported_index_msg)
 
     def _load_index_and_metadata(self):
         """Load existing FAISS index and metadata from disk."""
@@ -166,29 +251,40 @@ class FAISSStore(Store):
         loading it cannot execute arbitrary code: pickle deserialization of a
         writable metadata file is an RCE vector. A legacy pickle-format file is
         therefore unreadable and the caller resets to an empty store.
+
+        On any structural problem — wrong ``format`` marker, top-level shape
+        that is not an object, individual ``Document`` payloads that do not
+        reconstruct, or non-integer ``index_to_id`` keys — the whole metadata
+        set is discarded and the caller resets to an empty store, so the loaded
+        FAISS index and metadata can never end up in an incoherent state.
         """
         if not (self.metadata_path and os.path.exists(self.metadata_path)):
             return False
         try:
-            with open(self.metadata_path, "r", encoding="utf-8") as f:
+            with open(self.metadata_path, encoding="utf-8") as f:
                 metadata = json.load(f)
         except (OSError, ValueError) as exc:
             logger.warning(
                 f"Failed to read metadata from {self.metadata_path}: {exc}. "
                 "If this is a legacy pickle-format file from an older agentUniverse "
                 "version, it is no longer supported (pickle deserialization is an RCE "
-                "vector); re-index to regenerate it as JSON.")
+                "vector); re-index to regenerate it as JSON."
+            )
             return False
-        self.document_store = {
-            doc_id: Document(**doc_data)
-            for doc_id, doc_data in metadata.get("document_store", {}).items()
-        }
-        self.id_to_index = dict(metadata.get("id_to_index", {}))
-        # JSON object keys are strings; restore the integer FAISS positions.
-        self.index_to_id = {
-            int(k): v for k, v in metadata.get("index_to_id", {}).items()
-        }
-        self._next_index = metadata.get("next_index", 0)
+
+        try:
+            document_store, id_to_index, index_to_id, next_index = _validate_metadata_payload(metadata)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                f"Metadata at {self.metadata_path} failed schema validation: {exc}; "
+                "resetting to an empty store to keep the FAISS index coherent."
+            )
+            return False
+
+        self.document_store = document_store
+        self.id_to_index = id_to_index
+        self.index_to_id = index_to_id
+        self._next_index = next_index
         logger.info(f"Loaded metadata from {self.metadata_path}")
         return True
 
@@ -213,30 +309,53 @@ class FAISSStore(Store):
         self._write_metadata_file()
 
     def _write_metadata_file(self) -> None:
-        """Write document metadata to ``metadata_path`` as JSON."""
+        """Write document metadata to ``metadata_path`` as JSON.
+
+        Writes through a temporary file in the same directory and atomically
+        replaces the target, so an interrupted write cannot destroy the last
+        usable metadata file: readers either see the previous version or the
+        fully-written new one, never a half-flushed JSON document.
+        """
         if not self.metadata_path:
             return
+        directory = Path(self.metadata_path).parent
+        temporary = None
         try:
-            # Ensure directory exists
-            Path(self.metadata_path).parent.mkdir(parents=True, exist_ok=True)
+            directory.mkdir(parents=True, exist_ok=True)
             metadata = {
                 "format": METADATA_FORMAT_VERSION,
-                "document_store": {
-                    doc_id: doc.model_dump(mode="json")
-                    for doc_id, doc in self.document_store.items()
-                },
+                "document_store": {doc_id: doc.model_dump(mode="json") for doc_id, doc in self.document_store.items()},
                 "id_to_index": self.id_to_index,
                 # FAISS positions are ints; store them as strings for JSON.
                 "index_to_id": {str(k): v for k, v in self.index_to_id.items()},
                 "next_index": self._next_index,
             }
-            with open(self.metadata_path, "w", encoding="utf-8") as f:
-                json.dump(metadata, f, ensure_ascii=False, default=_json_default)
+            # Write to a sibling temp file first, fsync, then atomic rename.
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                prefix=".faiss-metadata-",
+                suffix=".tmp",
+                dir=str(directory),
+                delete=False,
+            ) as tmp:
+                temporary = tmp.name
+                json.dump(metadata, tmp, ensure_ascii=False, default=_json_default)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(temporary, self.metadata_path)
+            temporary = None
             logger.info(f"Saved metadata to {self.metadata_path}")
         except Exception:
             logger.exception("Failed to save metadata")
+        finally:
+            if temporary and os.path.exists(temporary):
+                try:
+                    os.unlink(temporary)
+                except OSError:
+                    logger.debug("Could not remove stale metadata temp file %s", temporary, exc_info=True)
 
-    def _get_embedding(self, text: str, text_type: str = "document") -> List[float]:
+    def _get_embedding(self, text: str, text_type: str = "document") -> list[float]:
         """Get embedding for a text using the configured embedding model.
 
         Args:
@@ -247,8 +366,8 @@ class FAISSStore(Store):
             List[float]: The embedding vector.
         """
         if not self.embedding_model:
-            NO_EMBEDDING_MSG = "No embedding model configured. Please specify an embedding_model."
-            raise ValueError(NO_EMBEDDING_MSG)
+            no_embedding_msg = "No embedding model configured. Please specify an embedding_model."
+            raise ValueError(no_embedding_msg)
 
         try:
             embedding_instance = EmbeddingManager().get_instance_obj(self.embedding_model)
@@ -259,7 +378,7 @@ class FAISSStore(Store):
             logger.warning(f"Failed to get embeddings: {e}")
             return []
 
-    def query(self, query: Query, **kwargs) -> List[Document]:  # noqa: C901
+    def query(self, query: Query, **kwargs) -> list[Document]:  # noqa: C901
         """Query the FAISS index with the given query and return the top k results.
 
         Args:
@@ -322,7 +441,7 @@ class FAISSStore(Store):
             logger.exception("Error during FAISS search")
             return []
 
-    def insert_document(self, documents: List[Document], **kwargs):  # noqa: C901
+    def insert_document(self, documents: list[Document], **kwargs):  # noqa: C901
         """Insert documents into the FAISS index.
 
         Args:
@@ -396,7 +515,7 @@ class FAISSStore(Store):
         # Save to disk
         self._save_index_and_metadata()
 
-    def upsert_document(self, documents: List[Document], **kwargs):
+    def upsert_document(self, documents: list[Document], **kwargs):
         """Upsert documents into the FAISS index."""
         # For FAISS, we need to delete and re-insert for updates
         docs_to_insert = []
@@ -416,7 +535,7 @@ class FAISSStore(Store):
         all_docs = docs_to_update + docs_to_insert
         self.insert_document(all_docs, **kwargs)
 
-    def update_document(self, documents: List[Document], **kwargs):
+    def update_document(self, documents: list[Document], **kwargs):
         """Update documents in the FAISS index."""
         # For FAISS, update is the same as upsert
         self.upsert_document(documents, **kwargs)
@@ -459,11 +578,11 @@ class FAISSStore(Store):
         """Get the total number of documents in the store."""
         return len(self.document_store)
 
-    def get_document_by_id(self, document_id: str) -> Optional[Document]:
+    def get_document_by_id(self, document_id: str) -> Document | None:
         """Get a document by its ID."""
         return self.document_store.get(document_id)
 
-    def list_document_ids(self) -> List[str]:
+    def list_document_ids(self) -> list[str]:
         """List all document IDs in the store."""
         return list(self.document_store.keys())
 

--- a/agentuniverse/agent/action/knowledge/store/faiss_store.py
+++ b/agentuniverse/agent/action/knowledge/store/faiss_store.py
@@ -88,6 +88,7 @@ def _require_int(value: Any) -> int:
 
 def _validate_metadata_payload(
     metadata: Any,
+    faiss_ntotal: int | None = None,
 ) -> tuple[dict[str, "Document"], dict[str, int], dict[int, str], int]:
     """Validate the loaded metadata envelope and reconstruct typed fields.
 
@@ -96,6 +97,18 @@ def _validate_metadata_payload(
     store as one coherent unit instead of half-populating it: wrong ``format``
     marker, non-object top level, malformed ``Document`` payloads, or
     ``index_to_id`` keys that are not integer FAISS positions.
+
+    Beyond per-field types, the payload must satisfy the relational invariants
+    that keep the in-memory metadata consistent with the FAISS index — these
+    two are persisted as separate files and a crash can leave them out of sync:
+
+    - ``id_to_index`` and ``index_to_id`` are exact inverses;
+    - every ID referenced by the mappings exists in ``document_store`` and
+      matches the persisted ``Document.id``;
+    - positions and ``next_index`` are non-negative, and ``next_index`` is at
+      least one past the highest used position;
+    - when ``faiss_ntotal`` is supplied, the number of mapped positions agrees
+      with the number of vectors the FAISS index actually holds.
     """
     if not isinstance(metadata, dict):
         raise TypeError("invalid metadata envelope")
@@ -111,12 +124,24 @@ def _validate_metadata_payload(
     for doc_id, doc_data in document_store_raw.items():
         _require_str(doc_id)
         _require_dict(doc_data)
-        document_store[doc_id] = Document(**doc_data)
+        document = Document(**doc_data)
+        # The persisted Document.id must agree with the key it was stored under;
+        # otherwise the mappings below could not be trusted to point at it.
+        if document.id != doc_id:
+            raise ValueError(
+                f"document_store key {doc_id!r} does not match Document.id "
+                f"{document.id!r}")
+        document_store[doc_id] = document
 
     id_to_index: dict[str, int] = {}
     for doc_id, position in id_to_index_raw.items():
         _require_str(doc_id)
-        id_to_index[doc_id] = _require_int(position)
+        position = _require_int(position)
+        if position < 0:
+            raise ValueError(
+                f"id_to_index[{doc_id!r}] position must be non-negative, "
+                f"got {position}")
+        id_to_index[doc_id] = position
 
     # JSON object keys are strings; restore the integer FAISS positions.
     # Non-integer keys mean the file is corrupt — raise, do not guess.
@@ -127,9 +152,71 @@ def _validate_metadata_payload(
         except (TypeError, ValueError) as exc:
             raise ValueError("index_to_id key is not an integer position") from exc
         _require_str(doc_id)
+        if position < 0:
+            raise ValueError(
+                f"index_to_id key {position} must be non-negative")
         index_to_id[position] = doc_id
 
+    if next_index < 0:
+        raise ValueError(f"next_index must be non-negative, got {next_index}")
+
+    # Relational invariants — see docstring.
+    _check_mapping_invariants(
+        document_store=document_store,
+        id_to_index=id_to_index,
+        index_to_id=index_to_id,
+        next_index=next_index,
+        faiss_ntotal=faiss_ntotal,
+    )
+
     return document_store, id_to_index, index_to_id, next_index
+
+
+def _check_mapping_invariants(
+    document_store: dict,
+    id_to_index: dict,
+    index_to_id: dict,
+    next_index: int,
+    faiss_ntotal: int | None,
+) -> None:
+    """Assert the cross-field invariants that keep metadata + index coherent."""
+    # id_to_index and index_to_id must be exact inverses.
+    for doc_id, position in id_to_index.items():
+        if index_to_id.get(position) != doc_id:
+            raise ValueError(
+                f"id_to_index and index_to_id are not inverses at "
+                f"position {position} (id {doc_id!r})")
+    for position, doc_id in index_to_id.items():
+        if id_to_index.get(doc_id) != position:
+            raise ValueError(
+                f"id_to_index and index_to_id are not inverses at "
+                f"id {doc_id!r} (position {position})")
+
+    # Every mapped id must exist in document_store.
+    for doc_id in id_to_index:
+        if doc_id not in document_store:
+            raise ValueError(
+                f"id_to_index references id {doc_id!r} that is not in "
+                f"document_store")
+
+    # next_index must be strictly greater than every used position so the next
+    # insert cannot collide with an existing vector slot.
+    if index_to_id:
+        max_position = max(index_to_id)
+        if next_index <= max_position:
+            raise ValueError(
+                f"next_index ({next_index}) must be greater than the highest "
+                f"used position ({max_position})")
+
+    # When we know how many vectors the FAISS index actually holds, the number
+    # of mapped positions must agree — a mismatch means the index and metadata
+    # files are from different generations (the index/metadata incoherence the
+    # previous review asked us to prevent).
+    if faiss_ntotal is not None and len(index_to_id) != faiss_ntotal:
+        raise ValueError(
+            f"metadata maps {len(index_to_id)} vectors but the loaded FAISS "
+            f"index holds {faiss_ntotal}; the index and metadata files are "
+            f"out of sync — re-index to regenerate them as one coherent unit")
 
 
 class FAISSStore(Store):
@@ -222,17 +309,41 @@ class FAISSStore(Store):
             raise ValueError(unsupported_index_msg)
 
     def _load_index_and_metadata(self):
-        """Load existing FAISS index and metadata from disk."""
+        """Load existing FAISS index and metadata from disk.
+
+        Fail closed as one store: when either half cannot be loaded and
+        validated, both are discarded. The FAISS index file and the JSON
+        metadata file are persisted separately, so a crash (or a hand-edited
+        file) can leave them generations out of sync — keeping a loaded index
+        around when its metadata is gone/corrupt would let a later insert or
+        query address a vector whose document is missing or wrong (the
+        index/metadata incoherence a previous review asked us to prevent).
+        """
+        loaded_index = None
         if self.index_path and os.path.exists(self.index_path):
             try:
-                self.faiss_index = faiss.read_index(self.index_path)
+                loaded_index = faiss.read_index(self.index_path)
                 logger.info(f"Loaded FAISS index from {self.index_path}")
             except Exception as e:
                 logger.warning(f"Failed to load FAISS index: {e}")
-                self.faiss_index = None
 
-        if not self._read_metadata_file():
+        # Pass the loaded index's ntotal into metadata validation so a
+        # generation mismatch (right shape, wrong vector count) is caught
+        # here rather than silently accepted.
+        faiss_ntotal = loaded_index.ntotal if loaded_index is not None else None
+        if not self._read_metadata_file(faiss_ntotal=faiss_ntotal):
+            # Metadata could not be loaded/validated — discard BOTH halves so
+            # the store starts empty and coherent, never index-only.
+            logger.warning(
+                "Metadata could not be loaded; discarding the in-memory FAISS "
+                "index as well to keep the store coherent. Re-index to "
+                "regenerate the index and metadata together.")
+            self.faiss_index = None
             self._reset_metadata()
+            return
+
+        # Metadata is valid and consistent with the loaded index (if any).
+        self.faiss_index = loaded_index
 
         # If no index was loaded and we have metadata, create empty index
         if self.faiss_index is None and self.document_store:
@@ -243,7 +354,7 @@ class FAISSStore(Store):
                     self.faiss_index = self._create_faiss_index(dimension)
                     break
 
-    def _read_metadata_file(self) -> bool:
+    def _read_metadata_file(self, faiss_ntotal: int | None = None) -> bool:
         """Load document metadata from ``metadata_path`` as JSON.
 
         Returns True on success, False if the path is unset/missing or the file
@@ -254,9 +365,11 @@ class FAISSStore(Store):
 
         On any structural problem — wrong ``format`` marker, top-level shape
         that is not an object, individual ``Document`` payloads that do not
-        reconstruct, or non-integer ``index_to_id`` keys — the whole metadata
-        set is discarded and the caller resets to an empty store, so the loaded
-        FAISS index and metadata can never end up in an incoherent state.
+        reconstruct, non-integer ``index_to_id`` keys, a broken inverse-mapping
+        invariant, or a mismatch against ``faiss_ntotal`` — the whole metadata
+        set is discarded and the caller resets to an empty store (and, in
+        ``_load_index_and_metadata``, discards the loaded FAISS index too), so
+        the loaded index and metadata can never end up in an incoherent state.
         """
         if not (self.metadata_path and os.path.exists(self.metadata_path)):
             return False
@@ -273,7 +386,8 @@ class FAISSStore(Store):
             return False
 
         try:
-            document_store, id_to_index, index_to_id, next_index = _validate_metadata_payload(metadata)
+            document_store, id_to_index, index_to_id, next_index = _validate_metadata_payload(
+                metadata, faiss_ntotal=faiss_ntotal)
         except (ValueError, TypeError) as exc:
             logger.warning(
                 f"Metadata at {self.metadata_path} failed schema validation: {exc}; "

--- a/agentuniverse/agent/action/knowledge/store/faiss_store.py
+++ b/agentuniverse/agent/action/knowledge/store/faiss_store.py
@@ -5,9 +5,9 @@
 # @Email   : saswatsusmoy9@gmail.com
 # @FileName: faiss_store.py
 
+import json
 import logging
 import os
-import pickle
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -28,8 +28,25 @@ DEFAULT_INDEX_CONFIG = {
     "nprobe": 10,  # For IVF search
 }
 
+# On-disk metadata format tag, so future format changes can be detected/migrated.
+METADATA_FORMAT_VERSION = "faiss-store-metadata-v1"
+
 # Set up logger
 logger = logging.getLogger(__name__)
+
+
+def _json_default(obj):
+    """Fallback JSON serializer normalizing numpy values that may reach metadata."""
+    try:
+        import numpy as np
+    except ImportError:
+        np = None
+    if np is not None:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.generic):
+            return obj.item()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 class FAISSStore(Store):
@@ -129,19 +146,7 @@ class FAISSStore(Store):
                 logger.warning(f"Failed to load FAISS index: {e}")
                 self.faiss_index = None
 
-        if self.metadata_path and os.path.exists(self.metadata_path):
-            try:
-                with open(self.metadata_path, "rb") as f:
-                    metadata = pickle.load(f)  # noqa: S301
-                    self.document_store = metadata.get("document_store", {})
-                    self.id_to_index = metadata.get("id_to_index", {})
-                    self.index_to_id = metadata.get("index_to_id", {})
-                    self._next_index = metadata.get("next_index", 0)
-                logger.info(f"Loaded metadata from {self.metadata_path}")
-            except Exception as e:
-                logger.warning(f"Failed to load metadata: {e}")
-                self._reset_metadata()
-        else:
+        if not self._read_metadata_file():
             self._reset_metadata()
 
         # If no index was loaded and we have metadata, create empty index
@@ -152,6 +157,40 @@ class FAISSStore(Store):
                     dimension = len(doc.embedding)
                     self.faiss_index = self._create_faiss_index(dimension)
                     break
+
+    def _read_metadata_file(self) -> bool:
+        """Load document metadata from ``metadata_path`` as JSON.
+
+        Returns True on success, False if the path is unset/missing or the file
+        could not be parsed. Metadata is persisted as JSON (not pickle) so that
+        loading it cannot execute arbitrary code: pickle deserialization of a
+        writable metadata file is an RCE vector. A legacy pickle-format file is
+        therefore unreadable and the caller resets to an empty store.
+        """
+        if not (self.metadata_path and os.path.exists(self.metadata_path)):
+            return False
+        try:
+            with open(self.metadata_path, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                f"Failed to read metadata from {self.metadata_path}: {exc}. "
+                "If this is a legacy pickle-format file from an older agentUniverse "
+                "version, it is no longer supported (pickle deserialization is an RCE "
+                "vector); re-index to regenerate it as JSON.")
+            return False
+        self.document_store = {
+            doc_id: Document(**doc_data)
+            for doc_id, doc_data in metadata.get("document_store", {}).items()
+        }
+        self.id_to_index = dict(metadata.get("id_to_index", {}))
+        # JSON object keys are strings; restore the integer FAISS positions.
+        self.index_to_id = {
+            int(k): v for k, v in metadata.get("index_to_id", {}).items()
+        }
+        self._next_index = metadata.get("next_index", 0)
+        logger.info(f"Loaded metadata from {self.metadata_path}")
+        return True
 
     def _reset_metadata(self):
         """Reset metadata to empty state."""
@@ -171,21 +210,31 @@ class FAISSStore(Store):
             except Exception:
                 logger.exception("Failed to save FAISS index")
 
-        if self.metadata_path:
-            try:
-                # Ensure directory exists
-                Path(self.metadata_path).parent.mkdir(parents=True, exist_ok=True)
-                metadata = {
-                    "document_store": self.document_store,
-                    "id_to_index": self.id_to_index,
-                    "index_to_id": self.index_to_id,
-                    "next_index": self._next_index,
-                }
-                with open(self.metadata_path, "wb") as f:
-                    pickle.dump(metadata, f)
-                logger.info(f"Saved metadata to {self.metadata_path}")
-            except Exception:
-                logger.exception("Failed to save metadata")
+        self._write_metadata_file()
+
+    def _write_metadata_file(self) -> None:
+        """Write document metadata to ``metadata_path`` as JSON."""
+        if not self.metadata_path:
+            return
+        try:
+            # Ensure directory exists
+            Path(self.metadata_path).parent.mkdir(parents=True, exist_ok=True)
+            metadata = {
+                "format": METADATA_FORMAT_VERSION,
+                "document_store": {
+                    doc_id: doc.model_dump(mode="json")
+                    for doc_id, doc in self.document_store.items()
+                },
+                "id_to_index": self.id_to_index,
+                # FAISS positions are ints; store them as strings for JSON.
+                "index_to_id": {str(k): v for k, v in self.index_to_id.items()},
+                "next_index": self._next_index,
+            }
+            with open(self.metadata_path, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, ensure_ascii=False, default=_json_default)
+            logger.info(f"Saved metadata to {self.metadata_path}")
+        except Exception:
+            logger.exception("Failed to save metadata")
 
     def _get_embedding(self, text: str, text_type: str = "document") -> List[float]:
         """Get embedding for a text using the configured embedding model.

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
@@ -12,7 +12,7 @@ import pickle
 import shutil
 import tempfile
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 try:
     import faiss  # noqa: F401
@@ -588,6 +588,7 @@ class TestFAISSStoreMetadataSerialization(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.metadata_path = os.path.join(self.temp_dir, "metadata.json")
         from agentuniverse.agent.action.knowledge.store.faiss_store import FAISSStore
+
         self.FAISSStore = FAISSStore
 
     def tearDown(self):
@@ -619,7 +620,7 @@ class TestFAISSStoreMetadataSerialization(unittest.TestCase):
         store._write_metadata_file()
 
         # The file on disk is genuine JSON, not a pickle bytestream.
-        with open(self.metadata_path, "r", encoding="utf-8") as f:
+        with open(self.metadata_path, encoding="utf-8") as f:
             raw = json.load(f)
         self.assertEqual(raw["format"], "faiss-store-metadata-v1")
 
@@ -650,9 +651,105 @@ class TestFAISSStoreMetadataSerialization(unittest.TestCase):
         # The loader must treat the pickle file as invalid JSON and reset,
         # without ever unpickling (executing) it.
         self.assertFalse(store._read_metadata_file())
-        self.assertFalse(os.path.exists(marker),
-                         "pickle payload was executed during metadata load — RCE!")
+        self.assertFalse(os.path.exists(marker), "pickle payload was executed during metadata load — RCE!")
         self.assertEqual(store.get_document_count(), 0)
+
+    # -- reviewer regressions: schema validation + atomic write --
+
+    def _seed_valid_store(self):
+        store = self._store()
+        store.document_store = {
+            "doc1": Document(id="doc1", text="hello", embedding=[0.1, 0.2]),
+        }
+        store.id_to_index = {"doc1": 0}
+        store.index_to_id = {0: "doc1"}
+        store._next_index = 1
+        store._write_metadata_file()
+        return store
+
+    def test_wrong_format_marker_resets_store(self):
+        self._seed_valid_store()
+        # Tamper with the format marker only; everything else is valid JSON.
+        with open(self.metadata_path, encoding="utf-8") as f:
+            data = json.load(f)
+        data["format"] = "some-other-format-v2"
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        store = self._store()
+        self.assertFalse(store._read_metadata_file())
+        # The store is fully reset, not half-populated.
+        self.assertEqual(store.get_document_count(), 0)
+        self.assertEqual(store.id_to_index, {})
+        self.assertEqual(store.index_to_id, {})
+
+    def test_top_level_non_object_resets_store(self):
+        # Syntactically valid JSON, but the top level is a list, not an object.
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump([{"format": "faiss-store-metadata-v1"}], f)
+        store = self._store()
+        self.assertFalse(store._read_metadata_file())
+        self.assertEqual(store.get_document_count(), 0)
+
+    def test_invalid_document_payload_resets_store(self):
+        self._seed_valid_store()
+        with open(self.metadata_path, encoding="utf-8") as f:
+            data = json.load(f)
+        # document_store entry is not a dict -> Document(**doc_data) would fail.
+        data["document_store"]["doc1"] = "not-an-object"
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        store = self._store()
+        self.assertFalse(store._read_metadata_file())
+        # Whole set discarded; no partial population.
+        self.assertEqual(store.get_document_count(), 0)
+
+    def test_non_integer_index_to_id_key_resets_store(self):
+        self._seed_valid_store()
+        with open(self.metadata_path, encoding="utf-8") as f:
+            data = json.load(f)
+        # A non-integer position key cannot be restored to an int FAISS slot.
+        data["index_to_id"] = {"not-a-number": "doc1"}
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        store = self._store()
+        self.assertFalse(store._read_metadata_file())
+        self.assertEqual(store.index_to_id, {})
+
+    def test_metadata_write_is_atomic(self):
+        # An interrupted write must not corrupt the last good file: write a
+        # valid file, then force a failure during the atomic replace step, and
+        # verify the previous version is intact and no temp file leaked.
+        store = self._seed_valid_store()
+        with open(self.metadata_path, encoding="utf-8") as f:
+            first_snapshot = f.read()
+
+        # Patch os.replace to raise; the write must swallow the error and clean
+        # up its temp file rather than leaving a half-written metadata.json.
+        with patch(
+            "agentuniverse.agent.action.knowledge.store.faiss_store.os.replace",
+            side_effect=OSError("simulated crash"),
+        ):
+            store._write_metadata_file()
+
+        # The previously-written good file is untouched.
+        with open(self.metadata_path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), first_snapshot)
+        # No stale temp files leaked in the directory.
+        leftovers = [n for n in os.listdir(self.temp_dir) if n.startswith(".faiss-metadata-")]
+        self.assertEqual(leftovers, [], f"stale temp files left behind: {leftovers}")
+
+        # And a subsequent clean write still round-trips.
+        store.document_store["doc2"] = Document(id="doc2", text="two", embedding=[0.3, 0.4])
+        store.id_to_index["doc2"] = 1
+        store.index_to_id[1] = "doc2"
+        store._next_index = 2
+        store._write_metadata_file()
+        reloaded = self._store()
+        self.assertTrue(reloaded._read_metadata_file())
+        self.assertEqual(reloaded.get_document_count(), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
@@ -752,6 +752,209 @@ class TestFAISSStoreMetadataSerialization(unittest.TestCase):
         self.assertEqual(reloaded.get_document_count(), 2)
 
 
+class TestFAISSStoreMetadataRelationalInvariants(unittest.TestCase):
+    """The payload must satisfy cross-field invariants, not just field types.
+
+    The index file and the metadata file are persisted separately, so a crash
+    (or a hand-edit) can leave them internally inconsistent. These tests pin
+    each invariant the loader enforces.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.metadata_path = os.path.join(self.temp_dir, "metadata.json")
+        from agentuniverse.agent.action.knowledge.store.faiss_store import FAISSStore
+        self.FAISSStore = FAISSStore
+
+    def tearDown(self):
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _store(self):
+        return self.FAISSStore(
+            index_path=None,
+            metadata_path=self.metadata_path,
+            embedding_model=None,
+        )
+
+    def _valid_payload(self) -> dict:
+        return {
+            "format": "faiss-store-metadata-v1",
+            "document_store": {
+                "doc1": {"id": "doc1", "text": "one", "embedding": [0.1, 0.2]},
+                "doc2": {"id": "doc2", "text": "two", "embedding": [0.3, 0.4]},
+            },
+            "id_to_index": {"doc1": 0, "doc2": 1},
+            "index_to_id": {"0": "doc1", "1": "doc2"},
+            "next_index": 2,
+        }
+
+    def _write_payload(self, payload: dict) -> None:
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+    def test_document_id_mismatch_with_key_is_rejected(self) -> None:
+        payload = self._valid_payload()
+        # Key says doc1, but the persisted Document.id disagrees.
+        payload["document_store"]["doc1"] = {"id": "docX", "text": "one", "embedding": [0.1, 0.2]}
+        self._write_payload(payload)
+        self.assertFalse(self._store()._read_metadata_file())
+
+    def test_non_inverse_mappings_are_rejected(self) -> None:
+        payload = self._valid_payload()
+        # id_to_index maps doc1 -> 0, but index_to_id maps 0 -> doc2.
+        payload["index_to_id"] = {"0": "doc2", "1": "doc1"}
+        self._write_payload(payload)
+        self.assertFalse(self._store()._read_metadata_file())
+
+    def test_mapping_references_missing_document_is_rejected(self) -> None:
+        payload = self._valid_payload()
+        # id_to_index references doc3 which is not in document_store.
+        payload["id_to_index"]["doc3"] = 2
+        payload["index_to_id"]["2"] = "doc3"
+        payload["next_index"] = 3
+        self._write_payload(payload)
+        self.assertFalse(self._store()._read_metadata_file())
+
+    def test_next_index_not_past_highest_position_is_rejected(self) -> None:
+        payload = self._valid_payload()
+        # Highest used position is 1, but next_index says 1 — the next insert
+        # would collide with position 1.
+        payload["next_index"] = 1
+        self._write_payload(payload)
+        self.assertFalse(self._store()._read_metadata_file())
+
+    def test_negative_position_is_rejected(self) -> None:
+        payload = self._valid_payload()
+        payload["id_to_index"] = {"doc1": -1, "doc2": 1}
+        payload["index_to_id"] = {"-1": "doc1", "1": "doc2"}
+        self._write_payload(payload)
+        self.assertFalse(self._store()._read_metadata_file())
+
+    def test_ntotal_mismatch_against_loaded_index_is_rejected(self) -> None:
+        # The metadata maps 2 vectors, but we tell validation the loaded FAISS
+        # index holds 5 — a generation mismatch between the two files.
+        store = self._store()
+        self._write_payload(self._valid_payload())
+        self.assertFalse(store._read_metadata_file(faiss_ntotal=5))
+
+    def test_ntotal_match_is_accepted(self) -> None:
+        store = self._store()
+        self._write_payload(self._valid_payload())
+        self.assertTrue(store._read_metadata_file(faiss_ntotal=2))
+
+
+@unittest.skipUnless(FAISS_AVAILABLE, "FAISS not available")
+class TestFAISSStoreIndexMetadataCoherence(unittest.TestCase):
+    """End-to-end: a corrupt-metadata reload must discard the FAISS index too.
+
+    Reproduces the exact regression the reviewer reported: one persisted
+    document, a corrupted metadata file, reload, and a new insert. Before the
+    fix the loaded index stayed in memory with stale ntotal while metadata was
+    empty, so the next insert produced an index with two vectors but a
+    metadata map of {0: "new"} — and querying the old vector returned the new
+    document. The store must now fail closed as one unit.
+    """
+
+    def setUp(self):
+        import faiss
+        import numpy as np
+        self.faiss = faiss
+        self.np = np
+        self.temp_dir = tempfile.mkdtemp()
+        self.index_path = os.path.join(self.temp_dir, "index.faiss")
+        self.metadata_path = os.path.join(self.temp_dir, "metadata.json")
+        from agentuniverse.agent.action.knowledge.store.faiss_store import FAISSStore
+        self.FAISSStore = FAISSStore
+
+    def tearDown(self):
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _new_store(self) -> "FAISSStore":
+        store = self.FAISSStore(
+            index_path=self.index_path,
+            metadata_path=self.metadata_path,
+            embedding_model=None,
+        )
+        store._new_client()
+        return store
+
+    def _persist_one_document(self) -> None:
+        store = self._new_store()
+        store.insert_document([
+            Document(id="old_doc", text="old text", embedding=[1.0, 0.0, 0.0]),
+        ])
+        self.assertEqual(store.faiss_index.ntotal, 1)
+
+    def _corrupt_metadata_format_marker(self) -> None:
+        with open(self.metadata_path, encoding="utf-8") as f:
+            payload = json.load(f)
+        payload["format"] = "some-other-format"
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+    def test_corrupt_metadata_discards_loaded_index(self) -> None:
+        # Persist one document, corrupt the metadata format marker, reload.
+        self._persist_one_document()
+        # Sanity: the index file exists and holds one vector.
+        self.assertEqual(self.faiss.read_index(self.index_path).ntotal, 1)
+        self._corrupt_metadata_format_marker()
+
+        store = self._new_store()
+        # The loaded index must have been discarded — the store starts empty
+        # and coherent, not index-only.
+        self.assertIsNone(store.faiss_index)
+        self.assertEqual(store.get_document_count(), 0)
+        self.assertEqual(store.id_to_index, {})
+        self.assertEqual(store.index_to_id, {})
+        self.assertEqual(store._next_index, 0)
+
+    def test_insert_after_corrupt_reload_does_not_orphan_vectors(self) -> None:
+        # The end-to-end regression: corrupt reload + new insert must not
+        # leave the index with a vector that maps to the wrong document.
+        self._persist_one_document()
+        self._corrupt_metadata_format_marker()
+
+        store = self._new_store()
+        store.insert_document([
+            Document(id="new_doc", text="new text", embedding=[0.0, 1.0, 0.0]),
+        ])
+
+        # Exactly one vector now (the new one), and it maps to new_doc only.
+        self.assertIsNotNone(store.faiss_index)
+        self.assertEqual(store.faiss_index.ntotal, 1)
+        self.assertEqual(set(store.index_to_id.values()), {"new_doc"})
+        self.assertEqual(store.get_document_count(), 1)
+
+        # Querying must never return a stale mapping: the only retrievable
+        # document is new_doc.
+        from agentuniverse.agent.action.knowledge.store.query import Query
+        results = store.query(Query(embeddings=[[0.0, 1.0, 0.0]]))
+        result_ids = [r.id for r in results]
+        self.assertEqual(result_ids, ["new_doc"])
+        self.assertNotIn("old_doc", result_ids)
+
+    def test_generation_mismatch_between_index_and_metadata_discards_both(self) -> None:
+        # Persist one document, then hand-write a metadata file that maps zero
+        # vectors while the index still holds one — a generation mismatch.
+        self._persist_one_document()
+        # Overwrite metadata with an empty-but-valid payload (0 vectors).
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump({
+                "format": "faiss-store-metadata-v1",
+                "document_store": {},
+                "id_to_index": {},
+                "index_to_id": {},
+                "next_index": 0,
+            }, f)
+
+        store = self._new_store()
+        # The mismatch (index ntotal=1 vs metadata 0 vectors) must fail closed.
+        self.assertIsNone(store.faiss_index)
+        self.assertEqual(store.get_document_count(), 0)
+
+
 if __name__ == "__main__":
     # Configure test logging
     logging.basicConfig(level=logging.WARNING)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
@@ -5,8 +5,10 @@
 # @Email   : saswatsusmoy9@gmail.com
 # @FileName: test_faiss_store.py
 
+import json
 import logging
 import os
+import pickle
 import shutil
 import tempfile
 import unittest
@@ -557,6 +559,100 @@ class TestFAISSStore(unittest.TestCase):
                 query = Query(embeddings=[doc.embedding])
                 results = store.query(query)
                 self.assertGreater(len(results), 0, f"Document {doc_id} should be queryable")
+
+
+class _RCEPickleBomb:
+    """A pickle payload that creates a marker file when unpickled.
+
+    Defined at module scope so it is genuinely unpicklable. Used to prove the
+    FAISS metadata loader never calls ``pickle.load``: if it did, unpickling an
+    instance would create the marker file.
+    """
+
+    def __init__(self, marker_path: str):
+        self._marker = marker_path
+
+    def __reduce__(self):
+        return (open, (self._marker, "w"))
+
+
+class TestFAISSStoreMetadataSerialization(unittest.TestCase):
+    """Metadata persistence is JSON (not pickle) and round-trips without FAISS.
+
+    These tests exercise the metadata read/write helpers directly, so they run
+    even when the optional FAISS dependency is absent. They lock in the security
+    fix: persisted metadata is JSON, so loading it cannot execute code.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.metadata_path = os.path.join(self.temp_dir, "metadata.json")
+        from agentuniverse.agent.action.knowledge.store.faiss_store import FAISSStore
+        self.FAISSStore = FAISSStore
+
+    def tearDown(self):
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _store(self, metadata_path=None) -> "FAISSStore":
+        return self.FAISSStore(
+            index_path=None,
+            metadata_path=self.metadata_path if metadata_path is None else metadata_path,
+            embedding_model=None,
+        )
+
+    def test_metadata_round_trips_as_json(self):
+        store = self._store()
+        store.document_store = {
+            "doc1": Document(
+                id="doc1",
+                text="hello world",
+                metadata={"category": "demo", "score": 0.5},
+                embedding=[0.1, 0.2, 0.3],
+                keywords={"ai", "rag"},
+            ),
+        }
+        store.id_to_index = {"doc1": 0}
+        store.index_to_id = {0: "doc1"}
+        store._next_index = 1
+
+        store._write_metadata_file()
+
+        # The file on disk is genuine JSON, not a pickle bytestream.
+        with open(self.metadata_path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+        self.assertEqual(raw["format"], "faiss-store-metadata-v1")
+
+        loaded = self._store()
+        self.assertTrue(loaded._read_metadata_file())
+
+        doc = loaded.document_store["doc1"]
+        self.assertEqual(doc.text, "hello world")
+        self.assertEqual(doc.metadata["category"], "demo")
+        self.assertEqual(doc.embedding, [0.1, 0.2, 0.3])
+        self.assertEqual(doc.keywords, {"ai", "rag"})
+        self.assertEqual(loaded.id_to_index, {"doc1": 0})
+        # Integer FAISS positions survive the JSON string-key round-trip.
+        self.assertEqual(loaded.index_to_id, {0: "doc1"})
+        self.assertIsInstance(next(iter(loaded.index_to_id)), int)
+        self.assertEqual(loaded._next_index, 1)
+
+    def test_missing_metadata_file_returns_false(self):
+        store = self._store(metadata_path=os.path.join(self.temp_dir, "absent.json"))
+        self.assertFalse(store._read_metadata_file())
+
+    def test_legacy_pickle_payload_is_not_executed(self):
+        marker = os.path.join(self.temp_dir, "pwned_marker")
+        with open(self.metadata_path, "wb") as f:
+            pickle.dump(_RCEPickleBomb(marker), f)
+
+        store = self._store()
+        # The loader must treat the pickle file as invalid JSON and reset,
+        # without ever unpickling (executing) it.
+        self.assertFalse(store._read_metadata_file())
+        self.assertFalse(os.path.exists(marker),
+                         "pickle payload was executed during metadata load — RCE!")
+        self.assertEqual(store.get_document_count(), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`FAISSStore._load_index_and_metadata` loaded document metadata with `pickle.load`. **Pickle deserialization of a writable `metadata_path` file is an arbitrary-code-execution vector** — a malicious or tampered metadata file runs code on load. The path is taken from component configuration, so any file the process can read is in scope (shared filesystems, config injection, supply-chain).

Persist the metadata as **JSON** instead, which cannot execute code on load.

## Changes

- `_read_metadata_file` / `_write_metadata_file` factor the metadata I/O into testable helpers. Load uses `json.load`; save uses `json.dump`.
- `Document` objects serialize via `model_dump(mode="json")` and restore via the `Document` constructor; `Set` fields (keywords) round-trip correctly.
- Integer FAISS positions (`index_to_id` keys) survive the JSON string-key round-trip (`int(k)` on load).
- A `format: "faiss-store-metadata-v1"` tag is written for future compatibility.
- **Backward compatibility / migration:** a legacy pickle-format file is no longer loadable. The loader reports it as invalid JSON with a clear message explaining the deprecation (pickle = RCE vector) and that the store should be re-indexed, then resets to empty rather than deserializing it. This is intentional — auto-loading legacy pickle would reintroduce the vulnerability.

## Tests

Added `TestFAISSStoreMetadataSerialization`, which runs **without** the optional FAISS dependency (it exercises the metadata helpers directly):
- `test_metadata_round_trips_as_json` — text / metadata / embedding / keywords / integer index keys all survive a save→load cycle, and the file on disk is genuine JSON.
- `test_missing_metadata_file_returns_false`.
- `test_legacy_pickle_payload_is_not_executed` — writes an RCE pickle payload (`__reduce__` → `open(marker)`); asserts the loader returns false, resets to empty, and **never executes the payload** (marker file absent).

Locally: `17 tests, 3 passed, 14 skipped` (the 14 existing FAISS tests skip without `faiss` installed and run in CI).

```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_faiss_store
```

## Review follow-up (2026-07-20)
- validate the format marker and complete JSON payload shape, including documents and integer index keys
- reset FAISS index plus metadata coherently for every reconstruction failure
- write metadata through a same-directory temporary file, `fsync`, and atomic `os.replace`
- fixed the module-level FAISS import lifecycle exposed by a real `faiss-cpu` installation
- added valid-but-corrupt JSON, unsupported-version, reconstruction-failure, atomic-write interruption, and full installed-FAISS regressions
- implementation is in `10d143a9`
