### PR TITLE
feat(store): add PostgreSQL pgvector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/pgvector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/pgvector_store.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""PostgreSQL pgvector knowledge store."""
+
+# Dynamic SQL interpolates only table/operator identifiers validated against fixed allowlists.
+# ruff: noqa: TRY003, S608
+
+import json
+import os
+import re
+from typing import Any, ClassVar
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class PGVectorStore(Store):
+    """Persistent vector store backed by PostgreSQL and the pgvector extension."""
+
+    connection_url: str | None = None
+    table_name: str = "agentuniverse_documents"
+    embedding_model: str | None = None
+    dimensions: int | None = None
+    distance: str = "cosine"
+    similarity_top_k: int = 10
+    create_table: bool = True
+    create_hnsw_index: bool = True
+    client: Any = None
+    async_client: Any = None
+
+    _IDENTIFIER: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    _DISTANCES: ClassVar[dict[str, tuple[str, str]]] = {
+        "cosine": ("<=>", "vector_cosine_ops"),
+        "l2": ("<->", "vector_l2_ops"),
+        "inner_product": ("<#>", "vector_ip_ops"),
+    }
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "PGVectorStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "connection_url",
+            "table_name",
+            "embedding_model",
+            "dimensions",
+            "distance",
+            "similarity_top_k",
+            "create_table",
+            "create_hnsw_index",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config(require_dimensions=False)
+        return self
+
+    def _validate_config(self, require_dimensions: bool = True) -> None:
+        if not self._IDENTIFIER.fullmatch(self.table_name or ""):
+            raise ValueError("table_name must be a simple PostgreSQL identifier")
+        self.distance = (self.distance or "").lower()
+        if self.distance not in self._DISTANCES:
+            raise ValueError("distance must be cosine, l2, or inner_product")
+        if (
+            isinstance(self.similarity_top_k, bool)
+            or not isinstance(self.similarity_top_k, int)
+            or self.similarity_top_k <= 0
+        ):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if self.dimensions is not None and (
+            isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0
+        ):
+            raise ValueError("dimensions must be a positive integer")
+        if require_dimensions and self.dimensions is None:
+            raise ValueError("dimensions must be configured or inferred from the first document")
+
+    @staticmethod
+    def _dependencies() -> tuple[Any, Any, Any]:
+        try:
+            import psycopg
+            from pgvector.psycopg import register_vector, register_vector_async
+        except ImportError as exc:
+            raise ImportError("PGVectorStore requires psycopg[binary] and pgvector") from exc
+        return psycopg, register_vector, register_vector_async
+
+    def _url(self) -> str:
+        value = self.connection_url or os.getenv("PGVECTOR_CONNECTION_URL")
+        if not value:
+            raise ValueError("connection_url is required; set it in YAML or PGVECTOR_CONNECTION_URL")
+        return value
+
+    def _new_client(self) -> Any:
+        psycopg, register_vector, _ = self._dependencies()
+        self.client = psycopg.connect(self._url(), autocommit=True)
+        register_vector(self.client)
+        if self.create_table and self.dimensions:
+            self._ensure_table(self.dimensions)
+        return self.client
+
+    async def _new_async_client(self) -> Any:
+        psycopg, _, register_vector_async = self._dependencies()
+        self.async_client = await psycopg.AsyncConnection.connect(self._url(), autocommit=True)
+        await register_vector_async(self.async_client)
+        if self.create_table and self.dimensions:
+            await self._async_ensure_table(self.dimensions)
+        return self.async_client
+
+    def _ensure_client(self) -> Any:
+        return self.client or self._new_client()
+
+    async def _ensure_async_client(self) -> Any:
+        return self.async_client or await self._new_async_client()
+
+    def _table_sql(self, dimensions: int) -> list[str]:
+        self.dimensions = self.dimensions or dimensions
+        if dimensions != self.dimensions:
+            raise ValueError(f"embedding dimension {dimensions} does not match configured dimensions {self.dimensions}")
+        self._validate_config()
+        statements = [
+            "CREATE EXTENSION IF NOT EXISTS vector",
+            f"CREATE TABLE IF NOT EXISTS {self.table_name} (id TEXT PRIMARY KEY, text TEXT NOT NULL, metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb, embedding vector({self.dimensions}) NOT NULL)",
+        ]
+        if self.create_hnsw_index:
+            operator_class = self._DISTANCES[self.distance][1]
+            statements.append(
+                f"CREATE INDEX IF NOT EXISTS {self.table_name}_embedding_hnsw ON {self.table_name} USING hnsw (embedding {operator_class})"
+            )
+        return statements
+
+    def _ensure_table(self, dimensions: int) -> None:
+        connection = self._ensure_client()
+        for statement in self._table_sql(dimensions):
+            connection.execute(statement)
+
+    async def _async_ensure_table(self, dimensions: int) -> None:
+        connection = await self._ensure_async_client()
+        for statement in self._table_sql(dimensions):
+            await connection.execute(statement)
+
+    def _embedding_for_query(self, query: Query) -> list[float]:
+        if query.embeddings:
+            vector = query.embeddings[0]
+        elif self.embedding_model and query.query_str:
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            vector = model.get_embeddings([query.query_str], text_type="query")[0]
+        else:
+            raise ValueError("query requires embeddings or an embedding_model plus query_str")
+        self._check_vector(vector)
+        return vector
+
+    def _vectors_for_documents(self, documents: list[Document]) -> list[list[float]]:
+        missing = [index for index, document in enumerate(documents) if not document.embedding]
+        if missing:
+            if not self.embedding_model:
+                raise ValueError("documents without embeddings require embedding_model")
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            generated = model.get_embeddings([documents[index].text or "" for index in missing])
+            for index, vector in zip(missing, generated, strict=True):
+                documents[index].embedding = vector
+        vectors = [document.embedding for document in documents]
+        for vector in vectors:
+            self._check_vector(vector)
+        return vectors
+
+    def _check_vector(self, vector: Any) -> None:
+        if (
+            not isinstance(vector, list)
+            or not vector
+            or any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in vector)
+        ):
+            raise ValueError("embedding must be a non-empty numeric list")
+        if self.dimensions is None:
+            self.dimensions = len(vector)
+        if len(vector) != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {len(vector)} does not match configured dimensions {self.dimensions}"
+            )
+
+    def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        self._ensure_table(len(vector))
+        top_k = query.similarity_top_k or self.similarity_top_k
+        if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
+            raise ValueError("similarity_top_k must be a positive integer")
+        filters = kwargs.get("metadata_filter")
+        where, params = "", [vector]
+        if filters is not None:
+            if not isinstance(filters, dict):
+                raise TypeError("metadata_filter must be an object")
+            where = " WHERE metadata @> %s::jsonb"
+            params.append(json.dumps(filters))
+        operator = self._DISTANCES[self.distance][0]
+        params.append(top_k)
+        sql = f"SELECT id, text, metadata, embedding, embedding {operator} %s AS distance FROM {self.table_name}{where} ORDER BY distance LIMIT %s"
+        rows = self._ensure_client().execute(sql, params).fetchall()
+        return self._rows_to_documents(rows)
+
+    async def async_query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        await self._async_ensure_table(len(vector))
+        top_k = query.similarity_top_k or self.similarity_top_k
+        filters = kwargs.get("metadata_filter")
+        where, params = "", [vector]
+        if filters is not None:
+            if not isinstance(filters, dict):
+                raise TypeError("metadata_filter must be an object")
+            where, params = " WHERE metadata @> %s::jsonb", [vector, json.dumps(filters)]
+        operator = self._DISTANCES[self.distance][0]
+        params.append(top_k)
+        cursor = await (await self._ensure_async_client()).execute(
+            f"SELECT id, text, metadata, embedding, embedding {operator} %s AS distance FROM {self.table_name}{where} ORDER BY distance LIMIT %s",
+            params,
+        )
+        return self._rows_to_documents(await cursor.fetchall())
+
+    def upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        self._ensure_table(len(vectors[0]))
+        sql = f"INSERT INTO {self.table_name} (id, text, metadata, embedding) VALUES (%s, %s, %s::jsonb, %s) ON CONFLICT (id) DO UPDATE SET text=EXCLUDED.text, metadata=EXCLUDED.metadata, embedding=EXCLUDED.embedding"
+        connection = self._ensure_client()
+        with connection.cursor() as cursor:
+            cursor.executemany(
+                sql,
+                [
+                    (document.id, document.text or "", json.dumps(document.metadata or {}), vector)
+                    for document, vector in zip(documents, vectors, strict=True)
+                ],
+            )
+
+    async def async_upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        await self._async_ensure_table(len(vectors[0]))
+        sql = f"INSERT INTO {self.table_name} (id, text, metadata, embedding) VALUES (%s, %s, %s::jsonb, %s) ON CONFLICT (id) DO UPDATE SET text=EXCLUDED.text, metadata=EXCLUDED.metadata, embedding=EXCLUDED.embedding"
+        connection = await self._ensure_async_client()
+        async with connection.cursor() as cursor:
+            await cursor.executemany(
+                sql,
+                [
+                    (document.id, document.text or "", json.dumps(document.metadata or {}), vector)
+                    for document, vector in zip(documents, vectors, strict=True)
+                ],
+            )
+
+    def insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs: Any) -> None:
+        self._ensure_client().execute(f"DELETE FROM {self.table_name} WHERE id = %s", [str(document_id)])
+
+    async def async_delete_document(self, document_id: str, **kwargs: Any) -> None:
+        await (await self._ensure_async_client()).execute(
+            f"DELETE FROM {self.table_name} WHERE id = %s", [str(document_id)]
+        )
+
+    @staticmethod
+    def _rows_to_documents(rows: Any) -> list[Document]:
+        return [
+            Document(id=str(row[0]), text=row[1], metadata=row[2] or {}, embedding=list(row[3] or []))
+            for row in (rows or [])
+        ]

--- a/agentuniverse/agent/action/knowledge/store/pgvector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/pgvector_store.py
@@ -91,6 +91,8 @@ class PGVectorStore(Store):
     def _new_client(self) -> Any:
         psycopg, register_vector, _ = self._dependencies()
         self.client = psycopg.connect(self._url(), autocommit=True)
+        # pgvector adapters query the vector type, so the extension must exist first.
+        self.client.execute("CREATE EXTENSION IF NOT EXISTS vector")
         register_vector(self.client)
         if self.create_table and self.dimensions:
             self._ensure_table(self.dimensions)
@@ -99,6 +101,8 @@ class PGVectorStore(Store):
     async def _new_async_client(self) -> Any:
         psycopg, _, register_vector_async = self._dependencies()
         self.async_client = await psycopg.AsyncConnection.connect(self._url(), autocommit=True)
+        # Async registration has the same ordering requirement as sync registration.
+        await self.async_client.execute("CREATE EXTENSION IF NOT EXISTS vector")
         await register_vector_async(self.async_client)
         if self.create_table and self.dimensions:
             await self._async_ensure_table(self.dimensions)
@@ -175,12 +179,16 @@ class PGVectorStore(Store):
                 f"embedding dimension {len(vector)} does not match configured dimensions {self.dimensions}"
             )
 
-    def query(self, query: Query, **kwargs: Any) -> list[Document]:
-        vector = self._embedding_for_query(query)
-        self._ensure_table(len(vector))
+    def _top_k(self, query: Query) -> int:
         top_k = query.similarity_top_k or self.similarity_top_k
         if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
             raise ValueError("similarity_top_k must be a positive integer")
+        return top_k
+
+    def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        self._ensure_table(len(vector))
         filters = kwargs.get("metadata_filter")
         where, params = "", [vector]
         if filters is not None:
@@ -196,8 +204,8 @@ class PGVectorStore(Store):
 
     async def async_query(self, query: Query, **kwargs: Any) -> list[Document]:
         vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
         await self._async_ensure_table(len(vector))
-        top_k = query.similarity_top_k or self.similarity_top_k
         filters = kwargs.get("metadata_filter")
         where, params = "", [vector]
         if filters is not None:

--- a/agentuniverse/agent/action/knowledge/store/pgvector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/pgvector_store.py
@@ -198,7 +198,9 @@ class PGVectorStore(Store):
             params.append(json.dumps(filters))
         operator = self._DISTANCES[self.distance][0]
         params.append(top_k)
-        sql = f"SELECT id, text, metadata, embedding, embedding {operator} %s AS distance FROM {self.table_name}{where} ORDER BY distance LIMIT %s"
+        # psycopg adapts a Python list as float8[], so cast the query parameter to
+        # vector explicitly before applying pgvector's distance operators.
+        sql = f"SELECT id, text, metadata, embedding, embedding {operator} %s::vector AS distance FROM {self.table_name}{where} ORDER BY distance LIMIT %s"
         rows = self._ensure_client().execute(sql, params).fetchall()
         return self._rows_to_documents(rows)
 
@@ -215,7 +217,7 @@ class PGVectorStore(Store):
         operator = self._DISTANCES[self.distance][0]
         params.append(top_k)
         cursor = await (await self._ensure_async_client()).execute(
-            f"SELECT id, text, metadata, embedding, embedding {operator} %s AS distance FROM {self.table_name}{where} ORDER BY distance LIMIT %s",
+            f"SELECT id, text, metadata, embedding, embedding {operator} %s::vector AS distance FROM {self.table_name}{where} ORDER BY distance LIMIT %s",
             params,
         )
         return self._rows_to_documents(await cursor.fetchall())
@@ -275,6 +277,20 @@ class PGVectorStore(Store):
     @staticmethod
     def _rows_to_documents(rows: Any) -> list[Document]:
         return [
-            Document(id=str(row[0]), text=row[1], metadata=row[2] or {}, embedding=list(row[3] or []))
+            Document(
+                id=str(row[0]),
+                text=row[1],
+                metadata=row[2] or {},
+                embedding=PGVectorStore._embedding_list(row[3]),
+            )
             for row in (rows or [])
         ]
+
+    @staticmethod
+    def _embedding_list(value: Any) -> list[float]:
+        if value is None:
+            return []
+        # Registered pgvector adapters return pgvector.Vector, which exposes
+        # to_list() but deliberately does not implement Python iteration.
+        to_list = getattr(value, "to_list", None)
+        return to_list() if callable(to_list) else list(value)

--- a/agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example
@@ -1,0 +1,14 @@
+name: pgvector_store
+description: PostgreSQL pgvector knowledge store
+connection_url: postgresql://postgres:postgres@localhost:5432/agentuniverse
+table_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+create_table: true
+create_hnsw_index: true
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.pgvector_store
+  class: PGVectorStore

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -80,3 +80,6 @@ store = ['sample_standard_app.intelligence.agentic.knowledge.store']
 - [Chroma](../../../In-Depth_Guides/Tech_Capabilities/Storage/ChromaDB.md)
 - [Milvus](../../../In-Depth_Guides/Tech_Capabilities/Storage/Milvus.md)
 - [Sqlite](../../../In-Depth_Guides/Tech_Capabilities/Storage/Sqlite.md)
+## PGVectorStore
+
+`PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -80,3 +80,6 @@ store = ['sample_standard_app.intelligence.agentic.knowledge.store']
 - [Chroma](../../技术组件/存储/ChromaDB.md)
 - [Milvus](../../技术组件/存储/Milvus.md)
 - [Sqlite](../../技术组件/存储/Sqlite.md)
+## PGVectorStore
+
+`PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ tqdm = "^4.66.3"
 sphinx-rtd-theme = "^2.0.0"
 aliyun-log-python-sdk = { version = "0.8.8", optional = true}
 pymilvus = { version = "^2.4.3", optional = true}
+psycopg = { version = "^3.2.0", extras = ["binary"], optional = true}
+pgvector = { version = "^0.3.0", optional = true}
 googleapis-common-protos = "^1.63.0"
 myst-parser = "^2.0.0"
 qianfan = "^0.3.12"
@@ -77,7 +79,7 @@ beautifulsoup4 = "^4.12.0"
 
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]
-store_ext = ["pymilvus"]
+store_ext = ["pymilvus", "psycopg", "pgvector"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_pgvector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_pgvector_store.py
@@ -90,6 +90,7 @@ class PGVectorStoreTest(unittest.TestCase):
         self.assertEqual(result[0].id, "one")
         select = next(call for call in connection.calls if call[0].startswith("SELECT"))
         self.assertIn("metadata @>", select[0])
+        self.assertIn("%s::vector", select[0])
         self.assertEqual(json.loads(select[1][1]), {"team": "a"})
         self.assertEqual(select[1][-1], 3)
 
@@ -136,6 +137,13 @@ class PGVectorStoreTest(unittest.TestCase):
         docs = PGVectorStore._rows_to_documents([("1", "hello", None, (0.1, 0.2), 0.3)])
         self.assertEqual(docs[0].metadata, {})
         self.assertEqual(docs[0].embedding, [0.1, 0.2])
+
+    def test_rows_to_documents_supports_pgvector_value(self):
+        vector = Mock()
+        vector.to_list.return_value = [0.1, 0.2]
+        docs = PGVectorStore._rows_to_documents([("1", "hello", {}, vector, 0.3)])
+        self.assertEqual(docs[0].embedding, [0.1, 0.2])
+        vector.to_list.assert_called_once_with()
 
     def test_missing_dependency_hint(self):
         with patch.dict("sys.modules", {"psycopg": None}), self.assertRaisesRegex(ImportError, "psycopg"):

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_pgvector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_pgvector_store.py
@@ -42,6 +42,26 @@ class FakeConnection:
 
 
 class PGVectorStoreTest(unittest.TestCase):
+    def test_new_client_creates_extension_before_registering(self):
+        connection = FakeConnection()
+        psycopg = Mock()
+        psycopg.connect.return_value = connection
+
+        def register(conn):
+            self.assertIs(conn, connection)
+            self.assertEqual(connection.calls[0][0], "CREATE EXTENSION IF NOT EXISTS vector")
+
+        store = PGVectorStore(connection_url="postgresql://test", create_table=False)
+        with patch.object(store, "_dependencies", return_value=(psycopg, register, Mock())):
+            self.assertIs(store._new_client(), connection)
+
+    def test_invalid_top_k_fails_before_database_access(self):
+        connection = FakeConnection()
+        store = PGVectorStore(client=connection, dimensions=2)
+        with self.assertRaisesRegex(ValueError, "similarity_top_k"):
+            store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=-1))
+        self.assertEqual(connection.calls, [])
+
     def test_table_sql_cosine(self):
         store = PGVectorStore(dimensions=3, table_name="docs")
         statements = store._table_sql(3)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_pgvector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_pgvector_store.py
@@ -1,0 +1,145 @@
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.pgvector_store import PGVectorStore
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class FakeCursor:
+    def __init__(self):
+        self.batches = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def executemany(self, sql, rows):
+        self.batches.append((sql, list(rows)))
+
+
+class FakeConnection:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.calls = []
+        self.cursor_obj = FakeCursor()
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+        return self
+
+    def fetchall(self):
+        return self.rows
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+class PGVectorStoreTest(unittest.TestCase):
+    def test_table_sql_cosine(self):
+        store = PGVectorStore(dimensions=3, table_name="docs")
+        statements = store._table_sql(3)
+        self.assertIn("vector(3)", statements[1])
+        self.assertIn("vector_cosine_ops", statements[2])
+
+    def test_rejects_unsafe_table_name(self):
+        with self.assertRaisesRegex(ValueError, "identifier"):
+            PGVectorStore(table_name="docs; DROP TABLE users")._validate_config(False)
+
+    def test_rejects_dimension_mismatch(self):
+        store = PGVectorStore(dimensions=3)
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            store._check_vector([1.0, 2.0])
+
+    def test_infers_dimension(self):
+        store = PGVectorStore()
+        store._check_vector([1.0, 2.0, 3.0])
+        self.assertEqual(store.dimensions, 3)
+
+    def test_query_with_metadata_filter(self):
+        rows = [("one", "text", {"team": "a"}, [1.0, 0.0], 0.1)]
+        connection = FakeConnection(rows)
+        store = PGVectorStore(client=connection, dimensions=2, table_name="docs")
+        result = store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=3), metadata_filter={"team": "a"})
+        self.assertEqual(result[0].id, "one")
+        select = next(call for call in connection.calls if call[0].startswith("SELECT"))
+        self.assertIn("metadata @>", select[0])
+        self.assertEqual(json.loads(select[1][1]), {"team": "a"})
+        self.assertEqual(select[1][-1], 3)
+
+    def test_query_requires_embedding(self):
+        store = PGVectorStore(client=FakeConnection(), dimensions=2)
+        with self.assertRaisesRegex(ValueError, "requires embeddings"):
+            store.query(Query(query_str="hello"))
+
+    def test_query_uses_embedding_component(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = PGVectorStore(client=FakeConnection(), dimensions=2, embedding_model="embed")
+        with patch("agentuniverse.agent.action.knowledge.store.pgvector_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.query(Query(query_str="hello"))
+        manager.return_value.get_instance_obj.assert_called_once_with("embed", strict=True)
+
+    def test_upsert_parameterizes_values(self):
+        connection = FakeConnection()
+        store = PGVectorStore(client=connection, dimensions=2, table_name="docs")
+        store.upsert_document([Document(id="1", text="hello", metadata={"a": 1}, embedding=[0.1, 0.2])])
+        sql, rows = connection.cursor_obj.batches[0]
+        self.assertIn("ON CONFLICT", sql)
+        self.assertEqual(rows[0][0], "1")
+        self.assertEqual(json.loads(rows[0][2]), {"a": 1})
+
+    def test_upsert_generates_missing_embeddings(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = PGVectorStore(client=FakeConnection(), dimensions=2, embedding_model="embed")
+        document = Document(text="hello")
+        with patch("agentuniverse.agent.action.knowledge.store.pgvector_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.upsert_document([document])
+        self.assertEqual(document.embedding, [0.1, 0.2])
+
+    def test_delete_is_parameterized(self):
+        connection = FakeConnection()
+        store = PGVectorStore(client=connection, table_name="docs")
+        store.delete_document("x' OR true")
+        self.assertEqual(connection.calls[-1][1], ["x' OR true"])
+
+    def test_rows_to_documents(self):
+        docs = PGVectorStore._rows_to_documents([("1", "hello", None, (0.1, 0.2), 0.3)])
+        self.assertEqual(docs[0].metadata, {})
+        self.assertEqual(docs[0].embedding, [0.1, 0.2])
+
+    def test_missing_dependency_hint(self):
+        with patch.dict("sys.modules", {"psycopg": None}), self.assertRaisesRegex(ImportError, "psycopg"):
+            PGVectorStore._dependencies()
+
+    def test_connection_url_from_environment(self):
+        with patch.dict("os.environ", {"PGVECTOR_CONNECTION_URL": "postgresql://test"}):
+            self.assertEqual(PGVectorStore()._url(), "postgresql://test")
+
+    def test_component_schema(self):
+        config = Configer()
+        config.value = {
+            "name": "pgvector_store",
+            "dimensions": 3,
+            "metadata": {
+                "type": "STORE",
+                "module": "agentuniverse.agent.action.knowledge.store.pgvector_store",
+                "class": "PGVectorStore",
+            },
+        }
+        component = ComponentConfiger().load_by_configer(config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.STORE.value)
+        self.assertEqual(component.metadata_class, "PGVectorStore")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `PGVectorStore`, a PostgreSQL + pgvector knowledge store for #259.

## Capabilities

- synchronous and asynchronous insert/upsert/update/delete/query;
- cosine, L2, and inner-product distance;
- JSONB metadata containment filters;
- precomputed embeddings or automatic embedding through `EmbeddingManager`;
- strict vector type/dimension validation with first-write dimension inference;
- automatic `vector` extension/table creation and optional HNSW index;
- configurable table, dimensions, distance, top-k, and connection URL;
- connection URL can be provided through `PGVECTOR_CONNECTION_URL` instead of committed configuration.

Document values and metadata filters are parameterized. Dynamic SQL contains only a table identifier validated against a strict identifier regex and an operator selected from a fixed allowlist.

## Dependency and configuration

`psycopg[binary]` and `pgvector` are optional members of the existing `store_ext` extra. A copyable `pgvector_store.yaml.example` is included rather than an auto-loaded live configuration, so importing/scanning the framework never attempts an unsolicited database connection.

English and Chinese Store guides document setup and credential handling.

## Tests

`python -m unittest test_pgvector_store` → **17 passed**.

The deterministic suite uses fake connections and covers extension/adapter initialization order, SQL/schema generation, table-name injection rejection, dimensions and top-k validation, metadata filtering, managed embeddings, parameterized upsert/delete, native `pgvector.Vector` row conversion, optional-dependency errors, environment configuration, and the real component metadata contract. In addition, the actual store passed synchronous and asynchronous CRUD/query/filter tests on Ubuntu 22.04 x86_64 with Python 3.10.12 against a Docker-hosted PostgreSQL 16 server with the pgvector extension and an HNSW index.

## Ubuntu server experiment

Repeated independently on an Ubuntu 22.04 x86_64 server with Python 3.10.12. A disposable `pgvector/pgvector:pg16` Docker container provided a real PostgreSQL 16 database; the container and test table were removed after the run.

- Ran all 17 deterministic unit and component-contract tests: all passed.
- Exercised the actual `PGVectorStore`, not a SQL-only surrogate, with `psycopg` 3.3.4 and `pgvector` 0.5.0.
- Verified extension-before-adapter initialization, table creation, three-dimensional vectors, HNSW index creation, cosine and L2 queries, JSONB containment filters, upsert/update/delete, native `pgvector.Vector` decoding, and both sync and async clients.
- Result: the complete sync/async CRUD-query-filter-index workflow passed against the real database.

Partially addresses #259 (additional VectorDB components).
