### PR TITLE
feat(tool): add bounded PDF manipulation tool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/__init__.py
+++ b/agentuniverse/agent/action/tool/common_tool/__init__.py
@@ -7,9 +7,11 @@
 # @FileName: __init__.py
 
 from .github_tool import GitHubTool
+from .pdf_tool import PDFTool
 from .yahoo_finance_tool import YahooFinanceTool
 
 __all__ = [
     'GitHubTool',
+    'PDFTool',
     'YahooFinanceTool',
 ]

--- a/agentuniverse/agent/action/tool/common_tool/pdf_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/pdf_tool.py
@@ -183,14 +183,15 @@ class PDFTool(Tool):
         _, Writer = self._classes()
         os.makedirs(directory, exist_ok=True)
         stem = os.path.splitext(os.path.basename(source))[0]
-        outputs = []
-        for index in indexes:
-            destination = os.path.join(directory, f"{stem}-page-{index + 1}.pdf")
+        # Preflight every destination before writing any page. This prevents a
+        # late overwrite conflict from leaving a partially split document set.
+        outputs = [os.path.join(directory, f"{stem}-page-{index + 1}.pdf") for index in indexes]
+        for destination in outputs:
             self._check_overwrite(destination, overwrite)
+        for index, destination in zip(indexes, outputs, strict=True):
             writer = Writer()
             writer.add_page(reader.pages[index])
             self._save(writer, destination)
-            outputs.append(destination)
         return {
             "status": "success",
             "mode": "split",

--- a/agentuniverse/agent/action/tool/common_tool/pdf_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/pdf_tool.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Bounded PDF manipulation tool."""
+
+import os
+import tempfile
+from typing import Any, cast
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+
+# Public execute() converts validation exceptions to structured tool responses.
+# ruff: noqa: TRY003
+
+
+class PDFTool(Tool):
+    """Merge, split, rotate, extract, and inspect PDF files."""
+
+    base_dir: str = "."
+    max_read_bytes: int = 50 * 1024 * 1024
+    max_write_bytes: int = 50 * 1024 * 1024
+    max_pages: int = 1_000
+    max_text_chars: int = 100_000
+    max_input_files: int = 100
+
+    def execute(
+        self,
+        mode: str,
+        file_path: str,
+        input_paths: list[str] | None = None,
+        output_path: str | None = None,
+        output_dir: str | None = None,
+        pages: list[int] | None = None,
+        rotation: int = 90,
+        overwrite: bool = False,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        try:
+            self._validate_config()
+            operation = self._mode(mode)
+            path = self._pdf_path(file_path, "file_path")
+            if operation == "merge":
+                return self._merge(path, input_paths, overwrite, metadata)
+            if operation == "split":
+                return self._split(path, output_dir, pages, overwrite)
+            if operation == "rotate":
+                return self._rotate(path, output_path, pages, rotation, overwrite)
+            if operation == "extract":
+                return self._extract(path, pages)
+            return self._info(path)
+        except ImportError as exc:
+            return self._error(
+                file_path, "dependency_error", "pypdf is required. Install with: pip install pypdf", str(exc)
+            )
+        except (TypeError, ValueError) as exc:
+            return self._error(file_path, "validation_error", str(exc))
+        except Exception as exc:
+            return self._error(file_path, "operation_error", f"PDF operation failed: {exc}")
+
+    @staticmethod
+    def _error(path: Any, kind: str, message: str, detail: str | None = None) -> dict[str, Any]:
+        result = {"status": "error", "error_type": kind, "error": message, "file_path": path}
+        if detail:
+            result["detail"] = detail
+        return result
+
+    def _validate_config(self) -> None:
+        for name in ("max_read_bytes", "max_write_bytes", "max_pages", "max_text_chars", "max_input_files"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+
+    @staticmethod
+    def _mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        operation = mode.strip().lower()
+        if operation not in {"merge", "split", "rotate", "extract", "info"}:
+            raise ValueError("mode must be merge, split, rotate, extract, or info")
+        return operation
+
+    def _pdf_path(self, value: str, field: str) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{field} must be a non-empty string")
+        if os.path.splitext(value)[1].lower() != ".pdf":
+            raise ValueError(f"{field} must have a .pdf extension")
+        return cast(str, resolve_safe_path(value, self.base_dir))
+
+    def _directory(self, value: str) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("output_dir must be a non-empty string")
+        return cast(str, resolve_safe_path(value, self.base_dir))
+
+    def _check_file(self, path: str, field: str = "file_path") -> None:
+        if not os.path.isfile(path):
+            raise ValueError(f"{field} does not exist: {path}")
+        if os.path.getsize(path) > self.max_read_bytes:
+            raise ValueError(f"{field} exceeds max_read_bytes ({self.max_read_bytes})")
+        with open(path, "rb") as stream:
+            if stream.read(5) != b"%PDF-":
+                raise ValueError(f"{field} is not a PDF file")
+
+    @staticmethod
+    def _classes() -> tuple[Any, Any]:
+        try:
+            from pypdf import PdfReader, PdfWriter
+        except ImportError as exc:
+            raise ImportError("No module named 'pypdf'") from exc
+        return PdfReader, PdfWriter
+
+    def _reader(self, path: str) -> Any:
+        self._check_file(path)
+        Reader, _ = self._classes()
+        reader = Reader(path)
+        if reader.is_encrypted:
+            raise ValueError("encrypted PDFs are not supported")
+        if len(reader.pages) > self.max_pages:
+            raise ValueError(f"PDF exceeds max_pages ({self.max_pages})")
+        return reader
+
+    def _page_indexes(self, pages: Any, count: int) -> list[int]:
+        if pages is None:
+            return list(range(count))
+        if not isinstance(pages, list) or not pages:
+            raise ValueError("pages must be a non-empty list of 1-based page numbers")
+        indexes = []
+        for page in pages:
+            if isinstance(page, bool) or not isinstance(page, int) or not 1 <= page <= count:
+                raise ValueError(f"page numbers must be between 1 and {count}")
+            if page - 1 not in indexes:
+                indexes.append(page - 1)
+        return indexes
+
+    def _metadata(self, value: Any) -> dict[str, str]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise TypeError("metadata must be an object")
+        result = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not isinstance(item, str) or len(item) > 2_000:
+                raise ValueError("metadata keys and values must be bounded strings")
+            result[key if key.startswith("/") else f"/{key}"] = item
+        return result
+
+    def _merge(self, output: str, inputs: Any, overwrite: bool, metadata: Any) -> dict[str, Any]:
+        if not isinstance(inputs, list) or not inputs:
+            raise ValueError("input_paths must be a non-empty list")
+        if len(inputs) > self.max_input_files:
+            raise ValueError(f"input_paths exceed max_input_files ({self.max_input_files})")
+        self._check_overwrite(output, overwrite)
+        _, Writer = self._classes()
+        writer = Writer()
+        total = 0
+        safe_inputs = []
+        for index, value in enumerate(inputs):
+            path = self._pdf_path(value, f"input_paths[{index}]")
+            reader = self._reader(path)
+            safe_inputs.append(path)
+            total += len(reader.pages)
+            if total > self.max_pages:
+                raise ValueError(f"merged PDF exceeds max_pages ({self.max_pages})")
+            for page in reader.pages:
+                writer.add_page(page)
+        properties = self._metadata(metadata)
+        if properties:
+            writer.add_metadata(properties)
+        self._save(writer, output)
+        return {
+            "status": "success",
+            "mode": "merge",
+            "file_path": output,
+            "input_paths": safe_inputs,
+            "page_count": total,
+            "file_size": os.path.getsize(output),
+        }
+
+    def _split(self, source: str, output_dir: Any, pages: Any, overwrite: bool) -> dict[str, Any]:
+        reader = self._reader(source)
+        indexes = self._page_indexes(pages, len(reader.pages))
+        directory = self._directory(output_dir)
+        _, Writer = self._classes()
+        os.makedirs(directory, exist_ok=True)
+        stem = os.path.splitext(os.path.basename(source))[0]
+        outputs = []
+        for index in indexes:
+            destination = os.path.join(directory, f"{stem}-page-{index + 1}.pdf")
+            self._check_overwrite(destination, overwrite)
+            writer = Writer()
+            writer.add_page(reader.pages[index])
+            self._save(writer, destination)
+            outputs.append(destination)
+        return {
+            "status": "success",
+            "mode": "split",
+            "file_path": source,
+            "output_paths": outputs,
+            "page_count": len(outputs),
+        }
+
+    def _rotate(self, source: str, output: Any, pages: Any, rotation: Any, overwrite: bool) -> dict[str, Any]:
+        if isinstance(rotation, bool) or not isinstance(rotation, int) or rotation not in {90, 180, 270}:
+            raise ValueError("rotation must be 90, 180, or 270")
+        destination = self._pdf_path(output, "output_path")
+        self._check_overwrite(destination, overwrite)
+        reader = self._reader(source)
+        indexes = set(self._page_indexes(pages, len(reader.pages)))
+        _, Writer = self._classes()
+        writer = Writer()
+        for index, page in enumerate(reader.pages):
+            if index in indexes:
+                page.rotate(rotation)
+            writer.add_page(page)
+        self._save(writer, destination)
+        return {
+            "status": "success",
+            "mode": "rotate",
+            "file_path": source,
+            "output_path": destination,
+            "rotated_pages": [i + 1 for i in sorted(indexes)],
+            "rotation": rotation,
+        }
+
+    def _extract(self, source: str, pages: Any) -> dict[str, Any]:
+        reader = self._reader(source)
+        indexes = self._page_indexes(pages, len(reader.pages))
+        remaining = self.max_text_chars
+        truncated = False
+        output = []
+        for index in indexes:
+            text = (reader.pages[index].extract_text() or "").strip()
+            if len(text) > remaining:
+                text = (text[: max(0, remaining - 1)] + "…") if remaining else ""
+                remaining = 0
+                truncated = True
+            else:
+                remaining -= len(text)
+            output.append({"page": index + 1, "text": text})
+        return {
+            "status": "success",
+            "mode": "extract",
+            "file_path": source,
+            "pages": output,
+            "truncated": truncated,
+            "max_text_chars": self.max_text_chars,
+        }
+
+    def _info(self, source: str) -> dict[str, Any]:
+        reader = self._reader(source)
+        return {
+            "status": "success",
+            "mode": "info",
+            "file_path": source,
+            "file_size": os.path.getsize(source),
+            "page_count": len(reader.pages),
+            "metadata": {str(key): str(value) for key, value in (reader.metadata or {}).items()},
+        }
+
+    @staticmethod
+    def _check_overwrite(path: str, overwrite: bool) -> None:
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        if os.path.exists(path) and not overwrite:
+            raise ValueError(f"file exists: {path}; set overwrite=true")
+
+    def _save(self, writer: Any, destination: str) -> None:
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=".pdf-", suffix=".pdf", dir=os.path.dirname(destination), delete=False
+            ) as output:
+                temporary = output.name
+                writer.write(output)
+            if os.path.getsize(temporary) > self.max_write_bytes:
+                raise ValueError("generated PDF exceeds max_write_bytes")
+            os.replace(temporary, destination)
+            temporary = None
+        finally:
+            if temporary and os.path.exists(temporary):
+                os.unlink(temporary)

--- a/agentuniverse/agent/action/tool/common_tool/pdf_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/pdf_tool.yaml
@@ -1,0 +1,35 @@
+name: pdf_tool
+description: Merge, split, rotate, extract text from, or inspect PDF files. Requires pypdf.
+tool_type: api
+metadata: {type: TOOL, module: agentuniverse.agent.action.tool.common_tool.pdf_tool, class: PDFTool}
+input_keys: [mode, file_path]
+base_dir: .
+max_read_bytes: 52428800
+max_write_bytes: 52428800
+max_pages: 1000
+max_text_chars: 100000
+max_input_files: 100
+args_model:
+  mode: {type: string, required: true}
+  file_path: {type: string, required: true}
+  input_paths: {type: array, required: false}
+  output_path: {type: string, required: false}
+  output_dir: {type: string, required: false}
+  pages: {type: array, required: false}
+  rotation: {type: integer, required: false, default: 90}
+  overwrite: {type: boolean, required: false, default: false}
+  metadata: {type: object, required: false}
+args_model_schema:
+  type: object
+  properties:
+    mode: {type: string, enum: [merge, split, rotate, extract, info]}
+    file_path: {type: string}
+    input_paths: {type: array, items: {type: string}}
+    output_path: {type: string}
+    output_dir: {type: string}
+    pages: {type: array, items: {type: integer, minimum: 1}}
+    rotation: {type: integer, enum: [90, 180, 270], default: 90}
+    overwrite: {type: boolean, default: false}
+    metadata: {type: object}
+  required: [mode, file_path]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -202,3 +202,7 @@ Parameter Description:
     response_content_type: the output format for the HTTP request result. If set to 'json', the result will be returned in JSON format; if set to 'text', it will be returned as plain text.
 This tool can be used directly without  requiring any keys.
 
+
+## 4. PDF Tool
+
+The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -356,3 +356,7 @@ metadata:
     json_parse 输入参数是否需要是要HTTP解析，POST请求时需要设置为True,GET请求需要设置为False
     response_content_type http请求结果的解析方式，设置为json时，会返回json结果，设置为text时会返回text结果
 该工具可以直接使用，无需任何keys
+
+## 4. PDF 工具
+
+内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ primp = "^0.6.5"
 wikipedia= "^1.4.0"
 openpyxl = "^3.1.5"
 pillow = "^10.4.0"
+pypdf = { version = "^5.0.0", optional = true }
 jieba = "^0.42.1"
 networkx = "^3.3"
 httpx = ">=0.27.2"
@@ -78,6 +79,7 @@ beautifulsoup4 = "^4.12.0"
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]
 store_ext = ["pymilvus"]
+pdf_ext = ["pypdf"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_pdf_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_pdf_tool.py
@@ -1,0 +1,127 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pypdf import PdfReader, PdfWriter
+
+from agentuniverse.agent.action.tool.common_tool import pdf_tool as pdf_module
+from agentuniverse.agent.action.tool.common_tool.pdf_tool import PDFTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = os.path.join(os.path.dirname(pdf_module.__file__), "pdf_tool.yaml")
+
+
+class PDFToolTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.tool = PDFTool(base_dir=self.directory.name)
+        self.make_pdf("one.pdf", 1)
+        self.make_pdf("two.pdf", 2)
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def make_pdf(self, name, pages):
+        writer = PdfWriter()
+        for _ in range(pages):
+            writer.add_blank_page(width=100, height=200)
+        writer.add_metadata({"/Title": name})
+        with open(os.path.join(self.directory.name, name), "wb") as output:
+            writer.write(output)
+
+    def test_info(self):
+        result = self.tool.execute(mode="info", file_path="two.pdf")
+        self.assertEqual(result["page_count"], 2)
+        self.assertEqual(result["metadata"]["/Title"], "two.pdf")
+
+    def test_merge(self):
+        result = self.tool.execute(
+            mode="merge", file_path="merged.pdf", input_paths=["one.pdf", "two.pdf"], metadata={"Title": "Merged"}
+        )
+        self.assertEqual(result["page_count"], 3)
+        self.assertEqual(len(PdfReader(result["file_path"]).pages), 3)
+
+    def test_split_selected_pages(self):
+        result = self.tool.execute(mode="split", file_path="two.pdf", output_dir="parts", pages=[2])
+        self.assertEqual(result["page_count"], 1)
+        self.assertTrue(result["output_paths"][0].endswith("two-page-2.pdf"))
+
+    def test_rotate(self):
+        result = self.tool.execute(
+            mode="rotate", file_path="two.pdf", output_path="rotated.pdf", pages=[1], rotation=90
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(PdfReader(result["output_path"]).pages[0].rotation, 90)
+
+    def test_extract_blank_pages(self):
+        result = self.tool.execute(mode="extract", file_path="two.pdf", pages=[1])
+        self.assertEqual(result["pages"], [{"page": 1, "text": ""}])
+
+    def test_refuses_overwrite(self):
+        result = self.tool.execute(mode="merge", file_path="one.pdf", input_paths=["two.pdf"])
+        self.assertIn("overwrite=true", result["error"])
+
+    def test_invalid_page(self):
+        result = self.tool.execute(mode="extract", file_path="one.pdf", pages=[2])
+        self.assertIn("between 1 and 1", result["error"])
+
+    def test_invalid_rotation(self):
+        result = self.tool.execute(mode="rotate", file_path="one.pdf", output_path="r.pdf", rotation=45)
+        self.assertIn("90, 180, or 270", result["error"])
+
+    def test_path_escape(self):
+        result = self.tool.execute(mode="info", file_path="../one.pdf")
+        self.assertIn("escapes the allowed directory", result["error"])
+
+    def test_non_pdf_signature(self):
+        with open(os.path.join(self.directory.name, "bad.pdf"), "wb") as output:
+            output.write(b"hello")
+        result = self.tool.execute(mode="info", file_path="bad.pdf")
+        self.assertIn("not a PDF", result["error"])
+
+    def test_page_limit(self):
+        self.tool.max_pages = 1
+        result = self.tool.execute(mode="info", file_path="two.pdf")
+        self.assertIn("max_pages", result["error"])
+
+    def test_missing_dependency_hint(self):
+        with patch.object(self.tool, "_classes", side_effect=ImportError("missing")):
+            result = self.tool.execute(mode="info", file_path="one.pdf")
+        self.assertIn("pip install pypdf", result["error"])
+
+
+class PDFToolRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=os.path.abspath(YAML_PATH)).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "PDFTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, PDFTool)
+        self.assertEqual(tool.input_keys, ["mode", "file_path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_pdf_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_pdf_tool.py
@@ -53,6 +53,18 @@ class PDFToolTest(unittest.TestCase):
         self.assertEqual(result["page_count"], 1)
         self.assertTrue(result["output_paths"][0].endswith("two-page-2.pdf"))
 
+    def test_split_preflights_all_destinations(self):
+        parts = os.path.join(self.directory.name, "parts")
+        os.makedirs(parts)
+        existing = os.path.join(parts, "two-page-2.pdf")
+        with open(existing, "wb") as output:
+            output.write(b"existing")
+        result = self.tool.execute(mode="split", file_path="two.pdf", output_dir="parts", pages=[1, 2])
+        self.assertIn("overwrite=true", result["error"])
+        self.assertFalse(os.path.exists(os.path.join(parts, "two-page-1.pdf")))
+        with open(existing, "rb") as unchanged:
+            self.assertEqual(unchanged.read(), b"existing")
+
     def test_rotate(self):
         result = self.tool.execute(
             mode="rotate", file_path="two.pdf", output_path="rotated.pdf", pages=[1], rotation=90


### PR DESCRIPTION
## What

Adds a built-in `PDFTool` under the additional tools direction of #252.

It provides five bounded modes:

- `merge` — combine PDFs and optionally set metadata;
- `split` — emit selected pages as individual PDFs;
- `rotate` — rotate selected pages into a new PDF;
- `extract` — return text from selected pages under a context budget;
- `info` — return page count, size, and metadata.

## Safety and behavior

- every source/destination directory is confined to `base_dir` by the shared safe-path resolver;
- validates PDF extension, `%PDF-` signature, encryption state, page ranges, rotation, and configuration;
- bounds input files, pages, read/write bytes, and extracted text;
- encrypted PDFs fail explicitly rather than producing partial output;
- existing outputs are never replaced without `overwrite=true`;
- all writes use a same-directory temporary file and atomic `os.replace`;
- `pypdf` is an optional lazy dependency exposed through `pdf_ext`.

## Integration

Includes a registerable built-in YAML, common-tool export, English/Chinese documentation, and registration tests through the real framework loader and `ToolManager`.

## Tests

`python -m unittest test_pdf_tool` → **15 passed**.

The suite creates real temporary PDFs offline and covers info, merge, atomic split-destination preflight, rotate, extraction, overwrite protection, page/rotation validation, safe paths, signature/page limits, missing dependency guidance, and component registration. A supplemental seeded stress run completed 75 merge/rotate/split/info workflows and verified every generated page. The full targeted suite and stress run were repeated successfully on Ubuntu 22.04 x86_64 with Python 3.10.12 in a clean virtual environment.

## Ubuntu server experiment

Repeated independently on an Ubuntu 22.04 x86_64 server with Python 3.10.12 in a clean virtual environment using `pypdf` 6.14.2.

- Ran all 15 targeted unit and framework-registration tests: all passed.
- Ran 75 deterministic randomized workflows (seed `20260718`) with 1–5 inputs and 1–8 pages per input.
- Each workflow merged PDFs, rotated a random page subset, split selected pages, reopened every output, and verified page counts and rotation values.
- Result: 75/75 workflows passed; every split output reopened as a valid one-page PDF.

Partially addresses #252 (additional/Office document tools).
