### PR TITLE
feat(context): add provenance-aware context records (#500)

### DIFF
--- a/agentuniverse/base/context/__init__.py
+++ b/agentuniverse/base/context/__init__.py
@@ -1,7 +1,19 @@
-# !/usr/bin/env python3
-# -*- coding:utf-8 -*-
+"""Context propagation and provenance utilities."""
 
-# @Time    : 2024/3/29 15:07
-# @Author  : fanen.lhy
-# @Email   : fanen.lhy@antgroup.com
-# @FileName: __init__.py
+from agentuniverse.base.context.context_provenance import (
+    AuthorityLevel,
+    ContextProvenanceManager,
+    ContextRecord,
+    ContextScope,
+    ContextSource,
+    ContextStatus,
+)
+
+__all__ = [
+    "AuthorityLevel",
+    "ContextProvenanceManager",
+    "ContextRecord",
+    "ContextScope",
+    "ContextSource",
+    "ContextStatus",
+]

--- a/agentuniverse/base/context/context_provenance.py
+++ b/agentuniverse/base/context/context_provenance.py
@@ -69,7 +69,11 @@ class ContextRecord:
 
     def is_active(self, at: datetime | None = None) -> bool:
         point = at or datetime.now(timezone.utc)
-        return self.status == ContextStatus.ACTIVE and (self.expires_at is None or self.expires_at > point)
+        return (
+            self.status == ContextStatus.ACTIVE
+            and self.observed_at <= point
+            and (self.expires_at is None or self.expires_at > point)
+        )
 
     @property
     def value_hash(self) -> str:
@@ -196,6 +200,8 @@ class ContextProvenanceManager:
     ) -> ContextRecord:
         """Copy a record into a wider scope without escalating authority."""
         source_record = self.get(record_id)
+        if not source_record.is_active():
+            raise ValueError("only active records can be promoted")
         target = self._enum(ContextScope, target_scope, "target_scope")
         if target <= source_record.scope:
             raise ValueError("target_scope must be wider than the source scope")
@@ -224,7 +230,10 @@ class ContextProvenanceManager:
 
     def set_status(self, record_id: str, status: ContextStatus | str) -> ContextRecord:
         normalized = self._enum(ContextStatus, status, "status")
-        updated = replace(self.get(record_id), status=normalized)
+        record = self.get(record_id)
+        if record.status != ContextStatus.ACTIVE and normalized != record.status:
+            raise ValueError("terminal context records cannot change status")
+        updated = replace(record, status=normalized)
         self._replace(updated)
         return updated
 

--- a/agentuniverse/base/context/context_provenance.py
+++ b/agentuniverse/base/context/context_provenance.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Provenance-aware context records for long-running agents."""
+
+import copy
+import hashlib
+import json
+import uuid
+from contextvars import ContextVar, Token
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum, IntEnum
+from typing import Any
+
+from agentuniverse.base.annotation.singleton import singleton
+
+# Public validation intentionally uses built-in exceptions with actionable text.
+# ruff: noqa: TRY003
+
+
+class ContextSource(str, Enum):
+    USER = "user"
+    SYSTEM = "system"
+    AGENT = "agent"
+    TOOL = "tool"
+    MEMORY = "memory"
+    KNOWLEDGE = "knowledge"
+
+
+class ContextScope(IntEnum):
+    TURN = 0
+    TASK = 1
+    SESSION = 2
+    GLOBAL = 3
+
+
+class AuthorityLevel(IntEnum):
+    UNVERIFIED = 0
+    AGENT = 10
+    TOOL = 20
+    USER = 30
+    SYSTEM = 40
+
+
+class ContextStatus(str, Enum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    EXPIRED = "expired"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class ContextRecord:
+    """Immutable context value plus its origin, authority, and lifecycle."""
+
+    id: str
+    key: str
+    value: Any
+    source: ContextSource
+    scope: ContextScope
+    authority: AuthorityLevel
+    observed_at: datetime
+    confidence: float = 1.0
+    actor_id: str | None = None
+    expires_at: datetime | None = None
+    status: ContextStatus = ContextStatus.ACTIVE
+    supersedes: tuple[str, ...] = ()
+    parent_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def is_active(self, at: datetime | None = None) -> bool:
+        point = at or datetime.now(timezone.utc)
+        return self.status == ContextStatus.ACTIVE and (self.expires_at is None or self.expires_at > point)
+
+    @property
+    def value_hash(self) -> str:
+        try:
+            payload = json.dumps(self.value, sort_keys=True, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            payload = repr(self.value)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@singleton
+class ContextProvenanceManager:
+    """Manage immutable provenance records in the current async context."""
+
+    def __init__(self) -> None:
+        self._records: ContextVar[tuple[ContextRecord, ...]] = ContextVar("context_provenance_records", default=())
+
+    def add(
+        self,
+        key: str,
+        value: Any,
+        source: ContextSource | str,
+        scope: ContextScope | int = ContextScope.TURN,
+        authority: AuthorityLevel | int = AuthorityLevel.UNVERIFIED,
+        confidence: float = 1.0,
+        actor_id: str | None = None,
+        observed_at: datetime | None = None,
+        expires_at: datetime | None = None,
+        metadata: dict[str, Any] | None = None,
+        supersede: bool = True,
+    ) -> ContextRecord:
+        """Add a record and supersede same-scope records of no greater authority."""
+        normalized_key = self._key(key)
+        normalized_source = self._enum(ContextSource, source, "source")
+        normalized_scope = self._enum(ContextScope, scope, "scope")
+        normalized_authority = self._enum(AuthorityLevel, authority, "authority")
+        confidence = self._confidence(confidence)
+        observed = self._datetime(observed_at or datetime.now(timezone.utc), "observed_at")
+        expiry = self._datetime(expires_at, "expires_at") if expires_at is not None else None
+        if expiry is not None and expiry <= observed:
+            raise ValueError("expires_at must be later than observed_at")
+        if actor_id is not None and (not isinstance(actor_id, str) or not actor_id.strip()):
+            raise ValueError("actor_id must be a non-empty string")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise TypeError("metadata must be an object")
+
+        records = list(self._records.get())
+        superseded_ids = []
+        if supersede:
+            for index, existing in enumerate(records):
+                if (
+                    existing.key == normalized_key
+                    and existing.scope == normalized_scope
+                    and existing.is_active(observed)
+                    and existing.authority <= normalized_authority
+                ):
+                    superseded_ids.append(existing.id)
+                    records[index] = replace(existing, status=ContextStatus.SUPERSEDED)
+        record = ContextRecord(
+            id=str(uuid.uuid4()),
+            key=normalized_key,
+            value=copy.deepcopy(value),
+            source=normalized_source,
+            scope=normalized_scope,
+            authority=normalized_authority,
+            observed_at=observed,
+            confidence=confidence,
+            actor_id=actor_id,
+            expires_at=expiry,
+            supersedes=tuple(superseded_ids),
+            metadata=copy.deepcopy(metadata or {}),
+        )
+        records.append(record)
+        self._records.set(tuple(records))
+        return record
+
+    def resolve(
+        self,
+        key: str,
+        scope: ContextScope | int | None = None,
+        at: datetime | None = None,
+        default: Any = None,
+    ) -> Any:
+        """Resolve the best active value by authority, confidence, and recency."""
+        records = self.active(key, scope=scope, at=at)
+        if not records:
+            return default
+        winner = max(
+            records, key=lambda item: (int(item.authority), item.confidence, item.observed_at, int(item.scope))
+        )
+        return copy.deepcopy(winner.value)
+
+    def active(
+        self,
+        key: str | None = None,
+        scope: ContextScope | int | None = None,
+        at: datetime | None = None,
+    ) -> list[ContextRecord]:
+        normalized_key = self._key(key) if key is not None else None
+        normalized_scope = self._enum(ContextScope, scope, "scope") if scope is not None else None
+        point = self._datetime(at or datetime.now(timezone.utc), "at")
+        return [
+            item
+            for item in self._records.get()
+            if item.is_active(point)
+            and (normalized_key is None or item.key == normalized_key)
+            and (normalized_scope is None or item.scope == normalized_scope)
+        ]
+
+    def history(self, key: str | None = None) -> list[ContextRecord]:
+        normalized = self._key(key) if key is not None else None
+        return [item for item in self._records.get() if normalized is None or item.key == normalized]
+
+    def conflicts(self, key: str, scope: ContextScope | int | None = None) -> list[ContextRecord]:
+        records = self.active(key, scope=scope)
+        return records if len({record.value_hash for record in records}) > 1 else []
+
+    def promote(
+        self,
+        record_id: str,
+        target_scope: ContextScope | int,
+        authority: AuthorityLevel | int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> ContextRecord:
+        """Copy a record into a wider scope without escalating authority."""
+        source_record = self.get(record_id)
+        target = self._enum(ContextScope, target_scope, "target_scope")
+        if target <= source_record.scope:
+            raise ValueError("target_scope must be wider than the source scope")
+        target_authority = (
+            source_record.authority if authority is None else self._enum(AuthorityLevel, authority, "authority")
+        )
+        if target_authority > source_record.authority:
+            raise ValueError("promotion cannot increase authority")
+        combined_metadata = copy.deepcopy(source_record.metadata)
+        combined_metadata.update(metadata or {})
+        promoted = self.add(
+            key=source_record.key,
+            value=source_record.value,
+            source=source_record.source,
+            scope=target,
+            authority=target_authority,
+            confidence=source_record.confidence,
+            actor_id=source_record.actor_id,
+            observed_at=datetime.now(timezone.utc),
+            expires_at=source_record.expires_at,
+            metadata=combined_metadata,
+        )
+        updated = replace(promoted, parent_id=source_record.id)
+        self._replace(updated)
+        return updated
+
+    def set_status(self, record_id: str, status: ContextStatus | str) -> ContextRecord:
+        normalized = self._enum(ContextStatus, status, "status")
+        updated = replace(self.get(record_id), status=normalized)
+        self._replace(updated)
+        return updated
+
+    def get(self, record_id: str) -> ContextRecord:
+        if not isinstance(record_id, str) or not record_id:
+            raise ValueError("record_id must be a non-empty string")
+        for record in self._records.get():
+            if record.id == record_id:
+                return record
+        raise KeyError(f"context provenance record not found: {record_id}")
+
+    def snapshot(self) -> tuple[ContextRecord, ...]:
+        return copy.deepcopy(self._records.get())
+
+    def restore(self, snapshot: tuple[ContextRecord, ...]) -> Token:
+        if not isinstance(snapshot, tuple) or any(not isinstance(item, ContextRecord) for item in snapshot):
+            raise TypeError("snapshot must be a tuple of ContextRecord objects")
+        return self._records.set(copy.deepcopy(snapshot))
+
+    def reset(self, token: Token) -> None:
+        self._records.reset(token)
+
+    def clear(self) -> None:
+        self._records.set(())
+
+    def export(self) -> list[dict[str, Any]]:
+        result = []
+        for record in self._records.get():
+            item = asdict(record)
+            item.update(
+                source=record.source.value,
+                scope=record.scope.name.lower(),
+                authority=record.authority.name.lower(),
+                status=record.status.value,
+                observed_at=record.observed_at.isoformat(),
+                expires_at=record.expires_at.isoformat() if record.expires_at else None,
+            )
+            result.append(item)
+        return result
+
+    def _replace(self, updated: ContextRecord) -> None:
+        records = list(self._records.get())
+        for index, record in enumerate(records):
+            if record.id == updated.id:
+                records[index] = updated
+                self._records.set(tuple(records))
+                return
+        raise KeyError(updated.id)
+
+    @staticmethod
+    def _key(value: Any) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("key must be a non-empty string")
+        return value.strip()
+
+    @staticmethod
+    def _confidence(value: Any) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not 0 <= float(value) <= 1:
+            raise ValueError("confidence must be between 0 and 1")
+        return float(value)
+
+    @staticmethod
+    def _datetime(value: Any, field_name: str) -> datetime:
+        if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError(f"{field_name} must be a timezone-aware datetime")
+        return value
+
+    @staticmethod
+    def _enum(enum_type: Any, value: Any, field_name: str) -> Any:
+        try:
+            if isinstance(value, str) and issubclass(enum_type, IntEnum):
+                return enum_type[value.upper()]
+            return enum_type(value)
+        except (KeyError, TypeError, ValueError) as exc:
+            choices = ", ".join(str(item.value) for item in enum_type)
+            raise ValueError(f"{field_name} must be one of: {choices}") from exc

--- a/agentuniverse/base/context/context_provenance.py
+++ b/agentuniverse/base/context/context_provenance.py
@@ -63,6 +63,7 @@ class ContextRecord:
     actor_id: str | None = None
     expires_at: datetime | None = None
     status: ContextStatus = ContextStatus.ACTIVE
+    status_changed_at: datetime | None = None
     supersedes: tuple[str, ...] = ()
     parent_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -70,9 +71,12 @@ class ContextRecord:
     def is_active(self, at: datetime | None = None) -> bool:
         point = at or datetime.now(timezone.utc)
         return (
-            self.status == ContextStatus.ACTIVE
-            and self.observed_at <= point
+            self.observed_at <= point
             and (self.expires_at is None or self.expires_at > point)
+            and (
+                self.status == ContextStatus.ACTIVE
+                or (self.status_changed_at is not None and self.status_changed_at > point)
+            )
         )
 
     @property
@@ -131,7 +135,11 @@ class ContextProvenanceManager:
                     and existing.authority <= normalized_authority
                 ):
                     superseded_ids.append(existing.id)
-                    records[index] = replace(existing, status=ContextStatus.SUPERSEDED)
+                    records[index] = replace(
+                        existing,
+                        status=ContextStatus.SUPERSEDED,
+                        status_changed_at=observed,
+                    )
         record = ContextRecord(
             id=str(uuid.uuid4()),
             key=normalized_key,
@@ -233,7 +241,10 @@ class ContextProvenanceManager:
         record = self.get(record_id)
         if record.status != ContextStatus.ACTIVE and normalized != record.status:
             raise ValueError("terminal context records cannot change status")
-        updated = replace(record, status=normalized)
+        changed_at = record.status_changed_at
+        if record.status == ContextStatus.ACTIVE and normalized != ContextStatus.ACTIVE:
+            changed_at = datetime.now(timezone.utc)
+        updated = replace(record, status=normalized, status_changed_at=changed_at)
         self._replace(updated)
         return updated
 
@@ -270,6 +281,7 @@ class ContextProvenanceManager:
                 status=record.status.value,
                 observed_at=record.observed_at.isoformat(),
                 expires_at=record.expires_at.isoformat() if record.expires_at else None,
+                status_changed_at=record.status_changed_at.isoformat() if record.status_changed_at else None,
             )
             result.append(item)
         return result

--- a/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Context/Context_Provenance.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Context/Context_Provenance.md
@@ -1,0 +1,14 @@
+# Context Provenance
+
+`ContextProvenanceManager` is an opt-in foundation for context engineering. It keeps immutable values with `source`, `observed_at`, `confidence`, `scope`, `authority`, expiry, actor, and lineage instead of mixing user facts, tool observations, and agent inferences in an untyped dictionary.
+
+```python
+from agentuniverse.base.context import AuthorityLevel, ContextProvenanceManager, ContextScope
+
+manager = ContextProvenanceManager()
+manager.add("customer_region", "APAC", source="agent", authority=AuthorityLevel.AGENT)
+manager.add("customer_region", "EMEA", source="user", authority=AuthorityLevel.USER, scope=ContextScope.SESSION)
+region = manager.resolve("customer_region")
+```
+
+Records with equal key and scope are superseded only by a new record of equal or greater authority. Lower-authority contradictions remain observable through `conflicts()` but cannot override system/user facts during `resolve()`. `promote()` moves a record from turn to task/session/global scope while preserving lineage and forbidding authority escalation. Expiry, rejection, history, export, snapshots, and async-task isolation are supported. Existing `FrameworkContextManager` behavior is unchanged.

--- a/docs/guidebook/zh/In-Depth_Guides/技术组件/上下文/上下文来源追踪.md
+++ b/docs/guidebook/zh/In-Depth_Guides/技术组件/上下文/上下文来源追踪.md
@@ -1,0 +1,5 @@
+# 上下文来源追踪
+
+`ContextProvenanceManager` 是可选的上下文工程基础组件。它使用不可变记录保存 `source`、`observed_at`、`confidence`、`scope`、`authority`、过期时间、写入者和继承关系，避免把用户事实、工具观察和智能体推断混在无类型字典中。
+
+同一 key 和 scope 的记录只有在新记录权威等级不低于旧记录时才会被替代。低权威冲突仍可通过 `conflicts()` 审计，但 `resolve()` 不会让它覆盖系统或用户事实。`promote()` 支持从 turn 晋升到 task/session/global，同时保留来源链并禁止提升权威等级。组件还支持过期、驳回、历史、导出、快照恢复和异步任务隔离；原有 `FrameworkContextManager` 行为不变。

--- a/tests/test_agentuniverse/unit/base/context/test_context_provenance.py
+++ b/tests/test_agentuniverse/unit/base/context/test_context_provenance.py
@@ -39,8 +39,17 @@ class ContextProvenanceManagerTest(unittest.TestCase):
         low = self.manager.add("region", "guessed", "agent", authority=AuthorityLevel.AGENT)
         high = self.manager.add("region", "confirmed", "user", authority=AuthorityLevel.USER)
         self.assertEqual(self.manager.get(low.id).status, ContextStatus.SUPERSEDED)
+        self.assertIsNotNone(self.manager.get(low.id).status_changed_at)
         self.assertIn(low.id, high.supersedes)
         self.assertEqual(self.manager.resolve("region"), "confirmed")
+
+    def test_historical_resolution_survives_supersession(self):
+        first_at = datetime.now(timezone.utc) - timedelta(minutes=2)
+        second_at = first_at + timedelta(minutes=1)
+        self.manager.add("region", "old", "agent", observed_at=first_at)
+        self.manager.add("region", "new", "user", observed_at=second_at)
+        self.assertEqual(self.manager.resolve("region", at=first_at), "old")
+        self.assertEqual(self.manager.resolve("region", at=second_at), "new")
 
     def test_lower_authority_cannot_supersede_higher(self):
         system = self.manager.add("policy", "required", "system", authority=AuthorityLevel.SYSTEM)
@@ -74,9 +83,10 @@ class ContextProvenanceManagerTest(unittest.TestCase):
     def test_future_observation_is_not_active_early(self):
         now = datetime.now(timezone.utc)
         observed = now + timedelta(minutes=1)
+        self.manager.add("forecast", "current", "tool", observed_at=now)
         record = self.manager.add("forecast", "ready", "tool", observed_at=observed)
         self.assertFalse(record.is_active(now))
-        self.assertIsNone(self.manager.resolve("forecast", at=now))
+        self.assertEqual(self.manager.resolve("forecast", at=now), "current")
         self.assertEqual(self.manager.resolve("forecast", at=observed), "ready")
 
     def test_rejects_expiry_before_observation(self):

--- a/tests/test_agentuniverse/unit/base/context/test_context_provenance.py
+++ b/tests/test_agentuniverse/unit/base/context/test_context_provenance.py
@@ -71,6 +71,14 @@ class ContextProvenanceManagerTest(unittest.TestCase):
         self.assertEqual(self.manager.resolve("token", at=now + timedelta(seconds=2)), None)
         self.assertTrue(record.is_active(now))
 
+    def test_future_observation_is_not_active_early(self):
+        now = datetime.now(timezone.utc)
+        observed = now + timedelta(minutes=1)
+        record = self.manager.add("forecast", "ready", "tool", observed_at=observed)
+        self.assertFalse(record.is_active(now))
+        self.assertIsNone(self.manager.resolve("forecast", at=now))
+        self.assertEqual(self.manager.resolve("forecast", at=observed), "ready")
+
     def test_rejects_expiry_before_observation(self):
         now = datetime.now(timezone.utc)
         with self.assertRaisesRegex(ValueError, "later"):
@@ -97,11 +105,24 @@ class ContextProvenanceManagerTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "wider"):
             self.manager.promote(source.id, ContextScope.TURN)
 
+    def test_rejected_record_cannot_be_promoted(self):
+        source = self.manager.add("decision", "x", "agent")
+        self.manager.set_status(source.id, ContextStatus.REJECTED)
+        with self.assertRaisesRegex(ValueError, "only active"):
+            self.manager.promote(source.id, ContextScope.SESSION)
+
     def test_status_transition(self):
         record = self.manager.add("claim", "x", "agent")
         updated = self.manager.set_status(record.id, ContextStatus.REJECTED)
         self.assertEqual(updated.status, ContextStatus.REJECTED)
         self.assertEqual(self.manager.resolve("claim"), None)
+
+    def test_terminal_status_cannot_be_reactivated(self):
+        record = self.manager.add("claim", "x", "agent")
+        self.manager.set_status(record.id, ContextStatus.REJECTED)
+        with self.assertRaisesRegex(ValueError, "terminal"):
+            self.manager.set_status(record.id, ContextStatus.ACTIVE)
+        self.assertEqual(self.manager.get(record.id).status, ContextStatus.REJECTED)
 
     def test_snapshot_restore_and_reset(self):
         self.manager.add("one", 1, "user")

--- a/tests/test_agentuniverse/unit/base/context/test_context_provenance.py
+++ b/tests/test_agentuniverse/unit/base/context/test_context_provenance.py
@@ -1,0 +1,142 @@
+import asyncio
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from agentuniverse.base.context.context_provenance import (
+    AuthorityLevel,
+    ContextProvenanceManager,
+    ContextRecord,
+    ContextScope,
+    ContextSource,
+    ContextStatus,
+)
+
+
+class ContextProvenanceManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.manager = ContextProvenanceManager()
+        self.manager.clear()
+
+    def tearDown(self):
+        self.manager.clear()
+
+    def test_add_and_resolve(self):
+        record = self.manager.add(
+            "customer", {"tier": "gold"}, ContextSource.USER, ContextScope.SESSION, AuthorityLevel.USER
+        )
+        self.assertIsInstance(record, ContextRecord)
+        self.assertEqual(self.manager.resolve("customer"), {"tier": "gold"})
+
+    def test_deep_copies_mutable_values(self):
+        value = {"items": [1]}
+        self.manager.add("state", value, "user")
+        value["items"].append(2)
+        resolved = self.manager.resolve("state")
+        resolved["items"].append(3)
+        self.assertEqual(self.manager.resolve("state"), {"items": [1]})
+
+    def test_higher_authority_supersedes_lower(self):
+        low = self.manager.add("region", "guessed", "agent", authority=AuthorityLevel.AGENT)
+        high = self.manager.add("region", "confirmed", "user", authority=AuthorityLevel.USER)
+        self.assertEqual(self.manager.get(low.id).status, ContextStatus.SUPERSEDED)
+        self.assertIn(low.id, high.supersedes)
+        self.assertEqual(self.manager.resolve("region"), "confirmed")
+
+    def test_lower_authority_cannot_supersede_higher(self):
+        system = self.manager.add("policy", "required", "system", authority=AuthorityLevel.SYSTEM)
+        agent = self.manager.add("policy", "optional", "agent", authority=AuthorityLevel.AGENT)
+        self.assertEqual(self.manager.get(system.id).status, ContextStatus.ACTIVE)
+        self.assertEqual(self.manager.resolve("policy"), "required")
+        self.assertEqual({record.id for record in self.manager.conflicts("policy")}, {system.id, agent.id})
+
+    def test_same_value_is_not_conflict(self):
+        self.manager.add("currency", "USD", "tool", supersede=False)
+        self.manager.add("currency", "USD", "agent", supersede=False)
+        self.assertEqual(self.manager.conflicts("currency"), [])
+
+    def test_scope_filter(self):
+        self.manager.add("language", "turn", "user", scope=ContextScope.TURN, supersede=False)
+        self.manager.add("language", "session", "user", scope=ContextScope.SESSION, supersede=False)
+        self.assertEqual(self.manager.resolve("language", ContextScope.TURN), "turn")
+        self.assertEqual(self.manager.resolve("language", ContextScope.SESSION), "session")
+
+    def test_confidence_breaks_authority_tie(self):
+        self.manager.add("answer", "low", "agent", authority=10, confidence=0.4, supersede=False)
+        self.manager.add("answer", "high", "agent", authority=10, confidence=0.9, supersede=False)
+        self.assertEqual(self.manager.resolve("answer"), "high")
+
+    def test_expired_record_is_not_active(self):
+        now = datetime.now(timezone.utc)
+        record = self.manager.add("token", "value", "tool", observed_at=now, expires_at=now + timedelta(seconds=1))
+        self.assertEqual(self.manager.resolve("token", at=now + timedelta(seconds=2)), None)
+        self.assertTrue(record.is_active(now))
+
+    def test_rejects_expiry_before_observation(self):
+        now = datetime.now(timezone.utc)
+        with self.assertRaisesRegex(ValueError, "later"):
+            self.manager.add("x", 1, "tool", observed_at=now, expires_at=now)
+
+    def test_rejects_naive_datetime(self):
+        with self.assertRaisesRegex(ValueError, "timezone-aware"):
+            self.manager.add("x", 1, "tool", observed_at=datetime.now())
+
+    def test_promotion_preserves_parent_and_authority(self):
+        source = self.manager.add("decision", "approve", "user", scope=ContextScope.TURN, authority=AuthorityLevel.USER)
+        promoted = self.manager.promote(source.id, ContextScope.SESSION)
+        self.assertEqual(promoted.parent_id, source.id)
+        self.assertEqual(promoted.authority, AuthorityLevel.USER)
+        self.assertEqual(promoted.scope, ContextScope.SESSION)
+
+    def test_promotion_cannot_escalate_authority(self):
+        source = self.manager.add("decision", "draft", "agent", authority=AuthorityLevel.AGENT)
+        with self.assertRaisesRegex(ValueError, "cannot increase"):
+            self.manager.promote(source.id, ContextScope.SESSION, AuthorityLevel.USER)
+
+    def test_promotion_requires_wider_scope(self):
+        source = self.manager.add("decision", "x", "agent", scope=ContextScope.SESSION)
+        with self.assertRaisesRegex(ValueError, "wider"):
+            self.manager.promote(source.id, ContextScope.TURN)
+
+    def test_status_transition(self):
+        record = self.manager.add("claim", "x", "agent")
+        updated = self.manager.set_status(record.id, ContextStatus.REJECTED)
+        self.assertEqual(updated.status, ContextStatus.REJECTED)
+        self.assertEqual(self.manager.resolve("claim"), None)
+
+    def test_snapshot_restore_and_reset(self):
+        self.manager.add("one", 1, "user")
+        snapshot = self.manager.snapshot()
+        self.manager.add("two", 2, "user")
+        token = self.manager.restore(snapshot)
+        self.assertEqual(self.manager.resolve("two"), None)
+        self.manager.reset(token)
+        self.assertEqual(self.manager.resolve("two"), 2)
+
+    def test_export_is_serializable_shape(self):
+        self.manager.add("one", 1, "user", scope=ContextScope.TASK, authority=AuthorityLevel.USER)
+        exported = self.manager.export()[0]
+        self.assertEqual(exported["source"], "user")
+        self.assertEqual(exported["scope"], "task")
+        self.assertEqual(exported["authority"], "user")
+        self.assertIn("observed_at", exported)
+
+    def test_invalid_confidence(self):
+        with self.assertRaisesRegex(ValueError, "between 0 and 1"):
+            self.manager.add("x", 1, "agent", confidence=1.1)
+
+    def test_async_context_isolation(self):
+        async def worker(value):
+            self.manager.clear()
+            self.manager.add("worker", value, "agent")
+            await asyncio.sleep(0)
+            return self.manager.resolve("worker")
+
+        async def run():
+            return await asyncio.gather(worker("a"), worker("b"))
+
+        self.assertEqual(asyncio.run(run()), ["a", "b"])
+        self.assertIsNone(self.manager.resolve("worker"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds an opt-in `ContextProvenanceManager` foundation for the context-engineering direction of #500.

Long-running agents currently pass many values through untyped context dictionaries, which makes user facts, system policy, tool observations, and agent inferences indistinguishable. This contribution introduces immutable context records carrying:

- source and actor;
- observation/expiry time;
- confidence;
- turn/task/session/global scope;
- unverified/agent/tool/user/system authority;
- active/superseded/expired/rejected lifecycle;
- supersession and promotion lineage;
- arbitrary metadata.

## Resolution and governance

- Equal-key/scope records are superseded only by a new record of equal or greater authority.
- Lower-authority contradictions remain visible through `conflicts()` but cannot override higher-authority facts in `resolve()`.
- Resolution is deterministic by authority, confidence, recency, and scope.
- `promote()` moves a value to a wider scope while preserving parent lineage and forbidding authority escalation.
- Expiry, rejection, history, export, deep-copy isolation, snapshots/restoration, and explicit clearing are supported.
- Records live in a `ContextVar`, preserving isolation across concurrent async tasks.

The feature is opt-in and does not change existing `FrameworkContextManager` behavior.

## Documentation

Adds English and Chinese context-provenance guides with usage and policy semantics, and exports the new domain types from `agentuniverse.base.context`.

## Tests

`python -m unittest test_context_provenance` → **22 passed**.

Coverage includes supersession, authority protection, conflicts, scope filters, confidence tie-breaking, future observations, historical supersession, expiry and timezone validation, terminal lifecycle transitions, promotion rules, rejection, snapshots, export shape, deep-copy behavior, and concurrent async isolation. The suite was repeated successfully on Ubuntu 22.04 x86_64 with Python 3.10.12 in a clean virtual environment.

## Ubuntu server experiment

Repeated independently on an Ubuntu 22.04 x86_64 server with Python 3.10.12 in a clean virtual environment.

- Ran all 22 lifecycle, authority, temporal-resolution, snapshot, export, deep-copy, and async-isolation tests: all passed.
- The temporal cases verify that future observations do not activate early and that supersession does not destroy historical resolution at earlier timestamps.
- Terminal lifecycle cases verify that rejected/superseded records cannot be reactivated or promoted.
- Result: 22/22 tests passed under the repository's supported Python 3.10 runtime.

Partially addresses #500.

## Maintainer review status (2026-07-20)
This PR is now a **draft**. The isolated manager is technically tested, but the requested architecture work is still unresolved: it is not integrated with `FrameworkContextManager` or an agent/runtime consumer, and authority assignment is not yet a trustworthy boundary. No additional standalone policy API will be pushed until the composition model and trusted-writer contract are defined.

Remaining acceptance work:
- integrate minimally with the existing runtime context path;
- derive authority at trusted ingestion boundaries instead of accepting caller-selected authority;
- prove lower-authority input cannot forge or override protected system context in an end-to-end agent test.
