### PR TITLE
fix(store): parameterize Neo4j node_ids_query to prevent Cypher injection

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/neo4j_store.py
+++ b/agentuniverse/agent/action/knowledge/store/neo4j_store.py
@@ -94,13 +94,14 @@ class Neo4jStore(Store):
             return self._records_to_documents(query.query_str, records)
 
         elif query_type == "node_ids_query":
-            node_ids = query.query_str
-            if not node_ids:
+            node_ids_raw = query.query_str
+            if not node_ids_raw:
                 return []
-            cypher_query = self._build_node_ids_query(json.loads(query.query_str))
-            query_params = query.ext_info.get("query_params", {})
-            records = self.execute_cypher(cypher_query, query_params)
-            return self._records_to_documents(node_ids, records)
+            node_ids = self._parse_node_ids(node_ids_raw)
+            node_query, node_params = self._build_node_ids_query(node_ids)
+            query_params = {**query.ext_info.get("query_params", {}), **node_params}
+            records = self.execute_cypher(node_query, query_params)
+            return self._records_to_documents(node_ids_raw, records)
         else:
             raise NotImplementedError('This query type is not allowed in neo4j store.')
 
@@ -131,9 +132,48 @@ class Neo4jStore(Store):
         return "MATCH (n) RETURN n LIMIT 10"
 
 
-    def _build_node_ids_query(self, node_ids: List[int]) -> str:
-        ids_str = ", ".join(str(i) for i in node_ids)
-        return f"MATCH (n) WHERE id(n) IN [{ids_str}] RETURN n"
+    @staticmethod
+    def _parse_node_ids(raw: str) -> List[int]:
+        """Parse and validate a JSON list of node ids from ``raw``.
+
+        Each entry must be an integer (booleans are rejected even though they
+        are an int subclass). Anything else raises ``ValueError`` so a
+        non-integer payload can never reach the Cypher query text.
+        """
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"node_ids_query expects a JSON list of integers, got: {raw!r}"
+            ) from exc
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"node_ids_query expects a JSON list of integers, got "
+                f"{type(parsed).__name__}"
+            )
+        validated: List[int] = []
+        for i, value in enumerate(parsed):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(
+                    f"node_ids_query entry #{i} must be an integer, got {value!r}"
+                )
+            validated.append(value)
+        if not validated:
+            raise ValueError("node_ids_query received an empty list of ids")
+        return validated
+
+    @staticmethod
+    def _build_node_ids_query(node_ids: List[int]):
+        """Build a parameterized node-id Cypher query.
+
+        The ids are bound as the ``$au_node_ids`` query parameter rather than
+        interpolated into the query text, so a caller cannot inject Cypher via
+        the query string. Returns ``(query_str, params)``.
+        """
+        return (
+            "MATCH (n) WHERE id(n) IN $au_node_ids RETURN n",
+            {"au_node_ids": list(node_ids)},
+        )
 
 
     def insert_document(self, documents: List[Document], **kwargs: Any):

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_store.py
@@ -1,0 +1,71 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for Neo4jStore node_ids_query construction.
+
+These tests cover the Cypher-injection fix: node ids are bound as a query
+parameter instead of interpolated into the query text, and the parsed payload
+is validated as a list of integers.
+
+neo4j_store imports the optional ``neo4j`` package at module load. The methods
+under test are pure (they never touch the driver), so when ``neo4j`` is not
+installed we stub it merely to make the module importable.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+try:
+    import neo4j  # noqa: F401
+    _NEO4J_INSTALLED = True
+except ImportError:
+    _NEO4J_INSTALLED = False
+    sys.modules.setdefault("neo4j", MagicMock())
+
+from agentuniverse.agent.action.knowledge.store.neo4j_store import Neo4jStore
+
+
+class TestNeo4jNodeIdsQuery(unittest.TestCase):
+    """node_ids_query must parameterize ids and reject non-integer payloads."""
+
+    def setUp(self):
+        # No connection is made; the methods under test are pure.
+        self.store = Neo4jStore()
+
+    def test_build_node_ids_query_is_parameterized(self):
+        query, params = self.store._build_node_ids_query([1, 2, 3])
+        self.assertEqual(query, "MATCH (n) WHERE id(n) IN $au_node_ids RETURN n")
+        # No id value is interpolated into the query text.
+        self.assertNotIn("1", query.replace("$au_node_ids", ""))
+        self.assertEqual(params, {"au_node_ids": [1, 2, 3]})
+
+    def test_parse_node_ids_accepts_int_list(self):
+        self.assertEqual(self.store._parse_node_ids("[1, 2, 3]"), [1, 2, 3])
+
+    def test_parse_node_ids_rejects_injection_payload(self):
+        # A payload that would inject Cypher if string-interpolated is rejected.
+        with self.assertRaises(ValueError):
+            self.store._parse_node_ids('["1) OR 1=1 OR id(n) IN (1"]')
+
+    def test_parse_node_ids_rejects_non_list(self):
+        with self.assertRaises(ValueError):
+            self.store._parse_node_ids('"not a list"')
+        with self.assertRaises(ValueError):
+            self.store._parse_node_ids("42")
+
+    def test_parse_node_ids_rejects_bool_float_and_empty(self):
+        with self.assertRaises(ValueError):  # bool is an int subclass
+            self.store._parse_node_ids("[true, 1]")
+        with self.assertRaises(ValueError):  # floats are not node ids
+            self.store._parse_node_ids("[1.5]")
+        with self.assertRaises(ValueError):
+            self.store._parse_node_ids("[]")
+
+    def test_parse_node_ids_rejects_invalid_json(self):
+        with self.assertRaises(ValueError):
+            self.store._parse_node_ids("not json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Neo4jStore._build_node_ids_query` interpolated node ids **directly into the Cypher query text**:

```python
ids_str = ", ".join(str(i) for i in node_ids)
return f"MATCH (n) WHERE id(n) IN [{ids_str}] RETURN n"
```

The ids came from `json.loads(query.query_str)` with **no validation** that the entries are integers (the type hint notwithstanding). A caller could pass a JSON list of non-integer values — e.g. `["1) OR 1=1 OR id(n) IN (1"]` — to **inject arbitrary Cypher** and read or modify graph data.

`query.query_str` is agent/user-controlled input, so this is reachable.

## Changes

- Bind the ids as the **`$au_node_ids` query parameter** (`session.run(query, au_node_ids=[...])`) instead of interpolating them. The query text is now constant, so no payload can alter it.
- Add `_parse_node_ids` to validate the payload is a JSON **list of integers** before it reaches the driver: booleans (an int subclass), floats, non-lists, and empty lists are rejected with a clear `ValueError`. User-supplied `query_params` from `ext_info` are still merged in.

## Tests

New `test_neo4j_store.py`. The methods under test are pure (no driver), so when the optional `neo4j` package is absent the module is stubbed to stay importable and the suite still runs:
- `test_build_node_ids_query_is_parameterized` — query text is the constant with `$au_node_ids`, ids are in the params dict, not the text.
- `test_parse_node_ids_rejects_injection_payload` — the Cypher-injection string is rejected.
- non-list / bool / float / empty / invalid-JSON rejection.

```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_neo4j_store -v
```
6 tests pass locally (without neo4j installed).