### PR TITLE
fix(agent): isolate per-tool failures instead of swallowing or crashing

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -399,8 +399,8 @@ class Agent(ComponentBase, ABC):
             try:
                 tool_input = {key: input_object.get_data(key) for key in tool.input_keys}
                 tool_results.append(str(tool.run(**tool_input)))
-            except:
-                LOGGER.warn(f'Tool {tool_name} call failed, maybe invalid or lack arguments')
+            except Exception as e:
+                LOGGER.warn(f'Tool {tool_name} call failed: {e}')
         return "\n\n".join(tool_results)
 
     async def async_invoke_tools(self, input_object: InputObject, **kwargs) -> str:
@@ -412,8 +412,11 @@ class Agent(ComponentBase, ABC):
             tool: Tool = ToolManager().get_instance_obj(tool_name)
             if tool is None:
                 continue
-            tool_input = {key: input_object.get_data(key) for key in tool.input_keys}
-            tool_results.append(await tool.async_run(**tool_input))
+            try:
+                tool_input = {key: input_object.get_data(key) for key in tool.input_keys}
+                tool_results.append(str(await tool.async_run(**tool_input)))
+            except Exception as e:
+                LOGGER.warn(f'Tool {tool_name} call failed: {e}')
         return "\n\n".join(tool_results)
 
     def invoke_knowledge(self, query_str: str, input_object: InputObject, **kwargs) -> str:

--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -400,7 +400,13 @@ class Agent(ComponentBase, ABC):
                 tool_input = {key: input_object.get_data(key) for key in tool.input_keys}
                 tool_results.append(str(tool.run(**tool_input)))
             except Exception as e:
+                # A failed tool is logged with the full exception for operators,
+                # but the downstream agent only sees a stable, non-sensitive
+                # marker so a partial execution cannot look like a complete
+                # success. The marker is per-tool so ordering of mixed
+                # success/failure results is preserved.
                 LOGGER.warn(f'Tool {tool_name} call failed: {e}')
+                tool_results.append(f'[tool {tool_name} failed]')
         return "\n\n".join(tool_results)
 
     async def async_invoke_tools(self, input_object: InputObject, **kwargs) -> str:
@@ -416,7 +422,11 @@ class Agent(ComponentBase, ABC):
                 tool_input = {key: input_object.get_data(key) for key in tool.input_keys}
                 tool_results.append(str(await tool.async_run(**tool_input)))
             except Exception as e:
+                # See invoke_tools: log the full exception, surface only a stable
+                # per-tool marker to the downstream agent so partial execution
+                # cannot be mistaken for a complete success.
                 LOGGER.warn(f'Tool {tool_name} call failed: {e}')
+                tool_results.append(f'[tool {tool_name} failed]')
         return "\n\n".join(tool_results)
 
     def invoke_knowledge(self, query_str: str, input_object: InputObject, **kwargs) -> str:

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from copy import deepcopy
 from unittest.mock import patch
@@ -46,17 +47,30 @@ def test_process_prompt_preserves_agent_input_for_repeated_calls():
 
 
 class TestInvokeToolsErrorIsolation(unittest.TestCase):
-    """A failing tool must not abort the whole tool invocation loop."""
+    """A failing tool must not abort the whole tool invocation loop.
 
-    def test_failing_tool_is_skipped_and_others_still_run(self):
+    The failure is preserved as an explicit, per-tool marker in the returned
+    string so a partial execution cannot look like a complete success to the
+    downstream agent; the raw exception (which may carry sensitive detail)
+    stays in the operator-facing log.
+    """
+
+    @staticmethod
+    def _make_tools():
         from agentuniverse.agent.action.tool.tool import Tool
 
-        class _BoomTool(Tool):
+        # The tool's NAME is "failing_tool"; the exception MESSAGE is the
+        # sensitive token "secret_token_value" so the leak test can tell them
+        # apart and assert only the name (not the exception) reaches the agent.
+        class _FailingTool(Tool):
             def execute(self, *args, **kwargs):
-                raise RuntimeError("boom")
+                raise RuntimeError("secret_token_value leaked")
 
             def run(self, **kwargs):
-                raise RuntimeError("boom")
+                raise RuntimeError("secret_token_value leaked")
+
+            async def async_run(self, **kwargs):
+                raise RuntimeError("secret_token_value leaked")
 
         class _OkTool(Tool):
             def execute(self, *args, **kwargs):
@@ -65,11 +79,80 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
             def run(self, **kwargs):
                 return "ok"
 
-        tools = {"boom": _BoomTool(input_keys=[]), "ok": _OkTool(input_keys=[])}
+            async def async_run(self, **kwargs):
+                return "ok"
+
+        return {
+            "failing_tool": _FailingTool(input_keys=[]),
+            "ok": _OkTool(input_keys=[]),
+        }
+
+    def test_failing_tool_leaves_marker_and_others_still_run(self):
+        tools = self._make_tools()
         with patch("agentuniverse.agent.agent.ToolManager") as mgr:
             mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
             agent = _StubAgent()
-            result = agent.invoke_tools(InputObject({}), tool_names=["ok", "boom", "ok"])
+            result = agent.invoke_tools(
+                InputObject({}), tool_names=["ok", "failing_tool", "ok"]
+            )
 
-        # The failing tool was skipped; both good invocations are joined.
-        self.assertEqual(result, "ok\n\nok")
+        # The failing tool is replaced by a stable per-tool marker, in order, so
+        # the downstream agent can tell this was a partial execution rather than
+        # a clean "ok\n\nok".
+        self.assertEqual(result, "ok\n\n[tool failing_tool failed]\n\nok")
+
+    def test_failed_tool_marker_does_not_leak_exception_detail(self):
+        tools = self._make_tools()
+        with patch("agentuniverse.agent.agent.ToolManager") as mgr:
+            mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
+            agent = _StubAgent()
+            result = agent.invoke_tools(InputObject({}), tool_names=["failing_tool"])
+
+        # The exception message and type must not reach the downstream agent;
+        # only the stable, tool-named marker is visible.
+        self.assertEqual(result, "[tool failing_tool failed]")
+        self.assertNotIn("secret_token_value", result)
+        self.assertNotIn("RuntimeError", result)
+
+    def test_mixed_success_failure_ordering_is_preserved(self):
+        tools = self._make_tools()
+        with patch("agentuniverse.agent.agent.ToolManager") as mgr:
+            mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
+            agent = _StubAgent()
+            # failing first, then ok, then failing again — output order must match.
+            result = agent.invoke_tools(
+                InputObject({}), tool_names=["failing_tool", "ok", "failing_tool"]
+            )
+        self.assertEqual(
+            result, "[tool failing_tool failed]\n\nok\n\n[tool failing_tool failed]"
+        )
+
+    def test_async_failing_tool_leaves_marker_and_others_still_run(self):
+        tools = self._make_tools()
+        with patch("agentuniverse.agent.agent.ToolManager") as mgr:
+            mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
+            agent = _StubAgent()
+            result = asyncio.new_event_loop().run_until_complete(
+                agent.async_invoke_tools(
+                    InputObject({}), tool_names=["ok", "failing_tool", "ok"]
+                )
+            )
+
+        # Same contract as the sync path: failing tool is a stable marker, in
+        # order, without leaking the exception detail.
+        self.assertEqual(result, "ok\n\n[tool failing_tool failed]\n\nok")
+        self.assertNotIn("secret_token_value", result)
+
+    def test_async_mixed_success_failure_ordering_is_preserved(self):
+        tools = self._make_tools()
+        with patch("agentuniverse.agent.agent.ToolManager") as mgr:
+            mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
+            agent = _StubAgent()
+            result = asyncio.new_event_loop().run_until_complete(
+                agent.async_invoke_tools(
+                    InputObject({}), tool_names=["failing_tool", "ok", "failing_tool"]
+                )
+            )
+        self.assertEqual(
+            result, "[tool failing_tool failed]\n\nok\n\n[tool failing_tool failed]"
+        )

--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -1,4 +1,6 @@
+import unittest
 from copy import deepcopy
+from unittest.mock import patch
 
 from agentuniverse.agent.agent import Agent
 from agentuniverse.agent.agent_model import AgentModel
@@ -41,3 +43,33 @@ def test_process_prompt_preserves_agent_input_for_repeated_calls():
 
     assert agent_input == original_input
     assert first_prompt.messages == second_prompt.messages
+
+
+class TestInvokeToolsErrorIsolation(unittest.TestCase):
+    """A failing tool must not abort the whole tool invocation loop."""
+
+    def test_failing_tool_is_skipped_and_others_still_run(self):
+        from agentuniverse.agent.action.tool.tool import Tool
+
+        class _BoomTool(Tool):
+            def execute(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+            def run(self, **kwargs):
+                raise RuntimeError("boom")
+
+        class _OkTool(Tool):
+            def execute(self, *args, **kwargs):
+                return "ok"
+
+            def run(self, **kwargs):
+                return "ok"
+
+        tools = {"boom": _BoomTool(input_keys=[]), "ok": _OkTool(input_keys=[])}
+        with patch("agentuniverse.agent.agent.ToolManager") as mgr:
+            mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
+            agent = _StubAgent()
+            result = agent.invoke_tools(InputObject({}), tool_names=["ok", "boom", "ok"])
+
+        # The failing tool was skipped; both good invocations are joined.
+        self.assertEqual(result, "ok\n\nok")


### PR DESCRIPTION
## Summary

Two related robustness bugs in tool invocation:

- `invoke_tools` used a **bare `except:`** that swallowed every exception (including `KeyboardInterrupt`/`SystemExit`) and logged only a generic `'maybe invalid or lack arguments'` guess — the actual error was discarded, so a tool failure was nearly impossible to diagnose (same silent-failure pattern flagged across the knowledge PRs).
- `async_invoke_tools` had **no `try/except` at all**, so a single failing tool raised out and aborted the whole agent run, losing every other tool's result. It also didn't `str()` results, so a non-string return would break `"\n\n".join`.

## Changes

- Both paths now catch `Exception` (not `BaseException`), log the **actual error** (`f'Tool {tool_name} call failed: {e}'`), and let the remaining tools continue.
- `async_invoke_tools` now stringifies results like the sync path, so a non-string tool return cannot break the join.

## Test

New `TestInvokeToolsErrorIsolation` in `test_agent.py`: stubs a failing tool and two good tools via a patched `ToolManager`, then asserts the failing tool is skipped and the good results are joined (`"ok\n\nok"`).

```
python -m unittest tests.test_agentuniverse.unit.agent.test_agent.TestInvokeToolsErrorIsolation
```
Passes locally.