### PR TITLE
fix(reader): validate 7z members before extraction

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/sevenzip_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/sevenzip_reader.py
@@ -119,7 +119,12 @@ class SevenZipReader(Reader):
                 for file_info in files_info:
                     file_info_map[file_info.filename] = file_info
 
-                # 遍历每个条目
+                approved_entries = []
+
+                # Validate the complete member list before extracting.  py7zr
+                # requires reset() between repeated extract() calls, so doing
+                # this in one bounded extraction avoids silently returning only
+                # the first valid file.
                 for entry_name in entries:
                     # 检查是否达到最大文件数限制
                     if file_count >= max_files:
@@ -162,19 +167,30 @@ class SevenZipReader(Reader):
                     if total_extracted + uncompressed_size > max_total_size:
                         break
 
-                    # 为每个文件创建独立的解压目录
-                    #extract_dir = os.path.join(temp_dir, f"extract_{file_count}")
-                    extract_dir = temp_dir
-                    os.makedirs(extract_dir, exist_ok=True)
+                    total_extracted += uncompressed_size
+                    file_count += 1
+                    approved_entries.append(entry_name)
 
+                extract_dir = temp_dir
+                os.makedirs(extract_dir, exist_ok=True)
+                if approved_entries:
+                    archive.extract(path=extract_dir, targets=approved_entries)
+
+                for entry_name in approved_entries:
+                    # 获取文件信息
+                    file_info = file_info_map.get(entry_name)
+                    if not file_info:
+                        continue
+
+                    # 获取未压缩大小
+                    uncompressed_size = file_info.uncompressed or 0
                     try:
-                        # 解压当前条目
-                        archive.extract(path=extract_dir, targets=[entry_name])
-                        
                         # 构建提取后的完整路径
                         extracted_path = Path(extract_dir) / entry_name
-                        total_extracted += uncompressed_size
-                        file_count += 1
+                        if not self._is_resolved_path_under(
+                            extracted_path, Path(extract_dir)
+                        ):
+                            continue
 
                         # 构建完整路径（包含父路径信息）
                         full_path = os.path.join(parent_path, entry_name) if parent_path else entry_name
@@ -231,6 +247,15 @@ class SevenZipReader(Reader):
         if ".." in posix_path.parts or ".." in windows_path.parts:
             return True
         return False
+
+    @staticmethod
+    def _is_resolved_path_under(path: Path, root: Path) -> bool:
+        """Return whether the resolved output path stays inside root."""
+        try:
+            path.resolve().relative_to(root.resolve())
+            return True
+        except ValueError:
+            return False
 
     def _process_file(
         self,

--- a/agentuniverse/agent/action/knowledge/reader/file/sevenzip_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/sevenzip_reader.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import shutil
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Union, Optional, Dict, Type
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
@@ -105,8 +105,6 @@ class SevenZipReader(Reader):
         documents = []  # 存储提取的文档
         total_extracted = 0  # 已提取文件总大小
         file_count = 0  # 已处理文件计数
-        with py7zr.SevenZipFile(str(sevenzip_path), 'r') as archive:
-            archive.extractall(path=temp_dir)
 
         try:
             # 以只读模式打开7Z文件
@@ -135,8 +133,8 @@ class SevenZipReader(Reader):
                     if entry_name=='.':
                         continue
 
-                    # 安全检查：跳过包含".."或绝对路径的文件名
-                    if '..' in entry_name or entry_name.startswith('/'):
+                    # 安全检查：跳过路径穿越和绝对路径
+                    if self._is_unsafe_entry_name(entry_name):
                         continue
 
                     # 获取文件信息
@@ -171,8 +169,7 @@ class SevenZipReader(Reader):
 
                     try:
                         # 解压当前条目
-                        #archive.extract(path=extract_dir, targets=[entry_name])
-                        #archive.extract(entry_name,extract_dir)
+                        archive.extract(path=extract_dir, targets=[entry_name])
                         
                         # 构建提取后的完整路径
                         extracted_path = Path(extract_dir) / entry_name
@@ -220,6 +217,20 @@ class SevenZipReader(Reader):
             raise ValueError(f"Error processing 7Z file: {str(e)}")
 
         return documents
+
+    @staticmethod
+    def _is_unsafe_entry_name(entry_name: str) -> bool:
+        """Return whether an archive entry can escape the extraction root."""
+        if not entry_name or entry_name == ".":
+            return True
+
+        posix_path = PurePosixPath(entry_name)
+        windows_path = PureWindowsPath(entry_name)
+        if posix_path.is_absolute() or windows_path.is_absolute():
+            return True
+        if ".." in posix_path.parts or ".." in windows_path.parts:
+            return True
+        return False
 
     def _process_file(
         self,

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_sevenzip_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_sevenzip_reader.py
@@ -447,6 +447,22 @@ class TestSevenZipReaderEdgeCases(unittest.TestCase):
     def tearDown(self):
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
+
+    def test_rejects_unsafe_archive_entry_names(self):
+        unsafe_names = [
+            "../escape.txt",
+            "safe/../../escape.txt",
+            "/tmp/escape.txt",
+            r"..\escape.txt",
+            r"safe\..\escape.txt",
+            r"C:\Windows\escape.txt",
+        ]
+        for entry_name in unsafe_names:
+            with self.subTest(entry_name=entry_name):
+                self.assertTrue(self.reader._is_unsafe_entry_name(entry_name))
+
+        self.assertFalse(self.reader._is_unsafe_entry_name("docs/readme.txt"))
+
     def test_empty_7z_archive(self):
         try:
             import py7zr

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_sevenzip_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_sevenzip_reader.py
@@ -463,6 +463,57 @@ class TestSevenZipReaderEdgeCases(unittest.TestCase):
 
         self.assertFalse(self.reader._is_unsafe_entry_name("docs/readme.txt"))
 
+    def test_resolved_output_path_must_stay_under_extract_root(self):
+        root = Path(self.temp_dir) / "extract"
+        root.mkdir()
+
+        self.assertTrue(
+            self.reader._is_resolved_path_under(root / "safe" / "file.txt", root)
+        )
+        self.assertFalse(
+            self.reader._is_resolved_path_under(root / ".." / "escape.txt", root)
+        )
+
+    def test_extracts_multiple_safe_members_and_skips_unsafe_members(self):
+        try:
+            import py7zr
+        except ImportError:
+            self.skipTest("py7zr not available")
+
+        source_dir = os.path.join(self.temp_dir, "source")
+        os.makedirs(source_dir, exist_ok=True)
+        alpha_path = os.path.join(source_dir, "alpha.txt")
+        beta_path = os.path.join(source_dir, "beta.txt")
+        gamma_path = os.path.join(source_dir, "gamma.txt")
+        for path, content in [
+            (alpha_path, "alpha content"),
+            (beta_path, "beta content"),
+            (gamma_path, "gamma content"),
+        ]:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+        sevenzip_path = os.path.join(self.temp_dir, "mixed_safe_unsafe.7z")
+        try:
+            with py7zr.SevenZipFile(sevenzip_path, "w") as archive:
+                archive.write(alpha_path, "safe/alpha.txt")
+                archive.write(beta_path, "safe/beta.txt")
+                archive.write(gamma_path, "nested/gamma.txt")
+                archive.write(alpha_path, "../escape.txt")
+                archive.write(beta_path, r"C:\Windows\escape.txt")
+        except Exception as e:
+            self.skipTest(f"Failed to create mixed safe/unsafe 7Z: {e}")
+
+        documents = self.reader._load_data(sevenzip_path)
+
+        extracted_names = {doc.metadata.get("file_name") for doc in documents}
+        self.assertEqual(extracted_names, {"alpha.txt", "beta.txt", "gamma.txt"})
+        archive_paths = {doc.metadata.get("archive_path") for doc in documents}
+        self.assertEqual(
+            archive_paths,
+            {"safe/alpha.txt", "safe/beta.txt", "nested/gamma.txt"}
+        )
+
     def test_empty_7z_archive(self):
         try:
             import py7zr


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Validate 7z archive entry names before extraction.
- Remove the eager `extractall` call so unsafe entries are skipped before touching the filesystem.
- Reject absolute paths, `..` traversal, Windows drive paths, and backslash traversal attempts.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_sevenzip_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/sevenzip_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_sevenzip_reader.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `langchain_core` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.