### PR TITLE
fix(reader): reject unsafe rar member paths

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/rar_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/rar_reader.py
@@ -8,7 +8,7 @@
 import os
 import tempfile
 import shutil
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Union, Optional, Dict, Type, Set
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
@@ -124,7 +124,7 @@ class RarReader(Reader):
                     if entry.is_dir():
                         continue
 
-                    if '..' in entry.filename or entry.filename.startswith('/'):
+                    if self._is_unsafe_entry_name(entry.filename):
                         continue
 
                     compressed_size = entry.compress_size
@@ -187,6 +187,20 @@ class RarReader(Reader):
             raise ValueError(f"Failed to read RAR file: {str(e)}")
 
         return documents
+
+    @staticmethod
+    def _is_unsafe_entry_name(entry_name: str) -> bool:
+        """Return whether an archive entry can escape the extraction root."""
+        if not entry_name or entry_name == ".":
+            return True
+
+        posix_path = PurePosixPath(entry_name)
+        windows_path = PureWindowsPath(entry_name)
+        if posix_path.is_absolute() or windows_path.is_absolute():
+            return True
+        if ".." in posix_path.parts or ".." in windows_path.parts:
+            return True
+        return False
 
     def _process_file(
         self,

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py
@@ -866,6 +866,21 @@ class TestRarReaderEdgeCases(unittest.TestCase):
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
+    def test_rejects_unsafe_archive_entry_names(self):
+        unsafe_names = [
+            "../escape.txt",
+            "safe/../../escape.txt",
+            "/tmp/escape.txt",
+            r"..\escape.txt",
+            r"safe\..\escape.txt",
+            r"C:\Windows\escape.txt",
+        ]
+        for entry_name in unsafe_names:
+            with self.subTest(entry_name=entry_name):
+                self.assertTrue(self.reader._is_unsafe_entry_name(entry_name))
+
+        self.assertFalse(self.reader._is_unsafe_entry_name("docs/readme.txt"))
+
     def test_empty_rar(self):
         """Test empty RAR file"""
         try:


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Add shared RAR entry-name validation before extracting archive members.
- Reject absolute paths, `..` traversal, Windows drive paths, and backslash traversal attempts.
- Keep valid relative archive paths unchanged for normal reader behavior.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/rar_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `langchain_core` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.