### PR TITLE
fix(tool): lazy load Bing search dependency

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/bing_search_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/bing_search_tool.py
@@ -8,12 +8,21 @@
 from typing import Optional
 
 from pydantic import Field
-from langchain_community.utilities import BingSearchAPIWrapper
 
 from agentuniverse.agent.action.tool.common_tool.mock_search_tool import MockSearchTool
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from agentuniverse.base.util.env_util import get_from_env
 
+
+def _get_bing_search_api_wrapper():
+    try:
+        from langchain_community.utilities import BingSearchAPIWrapper
+    except ImportError as exc:
+        raise ImportError(
+            "langchain-community is required to use BingSearchTool with "
+            "BING_SUBSCRIPTION_KEY. Install it with `pip install langchain-community`."
+        ) from exc
+    return BingSearchAPIWrapper
 
 
 class BingSearchTool(Tool):
@@ -30,6 +39,7 @@ class BingSearchTool(Tool):
             return MockSearchTool().execute(input)
         query = input
         # get top5 results from Bing search.
+        BingSearchAPIWrapper = _get_bing_search_api_wrapper()
         search = BingSearchAPIWrapper(bing_subscription_key=self.bing_subscription_key, k=5,
                                       bing_search_url=self.bing_search_url)
         return search.run(query=query)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_bing_search_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_bing_search_tool.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import bing_search_tool as bing_module
+from agentuniverse.agent.action.tool.common_tool.bing_search_tool import BingSearchTool
+
+
+class FakeBingSearchAPIWrapper:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def run(self, query):
+        return {
+            "query": query,
+            "subscription_key": self.kwargs["bing_subscription_key"],
+            "search_url": self.kwargs["bing_search_url"],
+            "k": self.kwargs["k"],
+        }
+
+
+class TestBingSearchTool(unittest.TestCase):
+    def test_missing_key_uses_mock_without_loading_bing_wrapper(self):
+        tool = BingSearchTool(bing_subscription_key=None)
+
+        with patch.object(
+            bing_module,
+            "_get_bing_search_api_wrapper",
+            side_effect=AssertionError("wrapper should not be loaded"),
+        ):
+            result = tool.execute("BYD news")
+
+        self.assertIn("比亚迪", result)
+
+    def test_wrapper_is_loaded_only_for_real_bing_requests(self):
+        tool = BingSearchTool(
+            bing_subscription_key="test-key",
+            bing_search_url="https://example.com/search",
+        )
+
+        with patch.object(
+            bing_module,
+            "_get_bing_search_api_wrapper",
+            return_value=FakeBingSearchAPIWrapper,
+        ) as load_wrapper:
+            result = tool.execute("agentUniverse")
+
+        load_wrapper.assert_called_once_with()
+        self.assertEqual(result["query"], "agentUniverse")
+        self.assertEqual(result["subscription_key"], "test-key")
+        self.assertEqual(result["search_url"], "https://example.com/search")
+        self.assertEqual(result["k"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Move `BingSearchAPIWrapper` loading behind a helper that runs only for real Bing requests.
- Preserve the existing mock-search fallback when `BING_SUBSCRIPTION_KEY` is not configured.
- Surface a clear install hint if Bing is used without the optional `langchain-community` dependency.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_bing_search_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/bing_search_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_bing_search_tool.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `requests` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.