### PR TITLE
fix(tool): lazy load Google search dependency

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/google_search_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/google_search_tool.py
@@ -9,8 +9,18 @@ from typing import Optional
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from agentuniverse.base.util.env_util import get_from_env
-from langchain_community.utilities.google_serper import GoogleSerperAPIWrapper
 from pydantic import Field
+
+
+def _get_google_serper_api_wrapper():
+    try:
+        from langchain_community.utilities.google_serper import GoogleSerperAPIWrapper
+    except ImportError as exc:
+        raise ImportError(
+            "langchain-community is required to use GoogleSearchTool. "
+            "Install it with `pip install langchain-community`."
+        ) from exc
+    return GoogleSerperAPIWrapper
 
 
 class GoogleSearchTool(Tool):
@@ -26,10 +36,12 @@ class GoogleSearchTool(Tool):
 
     def execute(self, input: str):
         # get top10 results from Google search.
+        GoogleSerperAPIWrapper = _get_google_serper_api_wrapper()
         search = GoogleSerperAPIWrapper(serper_api_key=self.serper_api_key, k=10, gl="us", hl="en", type="search")
         return search.run(query=input)
 
     async def async_execute(self, input: str):
         # get top10 results from Google search.
+        GoogleSerperAPIWrapper = _get_google_serper_api_wrapper()
         search = GoogleSerperAPIWrapper(serper_api_key=self.serper_api_key, k=10, gl="us", hl="en", type="search")
         return await search.arun(query=input)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import google_search_tool as google_module
+from agentuniverse.agent.action.tool.common_tool.google_search_tool import GoogleSearchTool
+
+
+class FakeGoogleSerperAPIWrapper:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def run(self, query):
+        return {
+            "query": query,
+            "serper_api_key": self.kwargs["serper_api_key"],
+            "k": self.kwargs["k"],
+            "gl": self.kwargs["gl"],
+            "hl": self.kwargs["hl"],
+            "type": self.kwargs["type"],
+        }
+
+    async def arun(self, query):
+        return self.run(query)
+
+
+class TestGoogleSearchTool(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.tool = GoogleSearchTool(serper_api_key="test-key")
+
+    def test_execute_loads_serper_wrapper_lazily(self):
+        with patch.object(
+            google_module,
+            "_get_google_serper_api_wrapper",
+            return_value=FakeGoogleSerperAPIWrapper,
+        ) as load_wrapper:
+            result = self.tool.execute("agentUniverse")
+
+        load_wrapper.assert_called_once_with()
+        self.assertEqual(result["query"], "agentUniverse")
+        self.assertEqual(result["serper_api_key"], "test-key")
+        self.assertEqual(result["k"], 10)
+        self.assertEqual(result["gl"], "us")
+        self.assertEqual(result["hl"], "en")
+        self.assertEqual(result["type"], "search")
+
+    async def test_async_execute_loads_serper_wrapper_lazily(self):
+        with patch.object(
+            google_module,
+            "_get_google_serper_api_wrapper",
+            return_value=FakeGoogleSerperAPIWrapper,
+        ) as load_wrapper:
+            result = await self.tool.async_execute("agentUniverse")
+
+        load_wrapper.assert_called_once_with()
+        self.assertEqual(result["query"], "agentUniverse")
+        self.assertEqual(result["serper_api_key"], "test-key")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Move `GoogleSerperAPIWrapper` loading behind a small helper.
- Apply the lazy-loading path to both `execute` and `async_execute`.
- Keep module import independent from the optional Google Serper dependency until the tool is actually used.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/google_search_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `requests` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.