### PR TITLE
fix(tool): lazy load Wikipedia dependency

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/wikipedia_query.py
+++ b/agentuniverse/agent/action/tool/common_tool/wikipedia_query.py
@@ -6,14 +6,23 @@
 # @Email   :
 # @FileName: wikipedia_query.py
 
-
-from langchain_community.tools import WikipediaQueryRun
-from langchain_community.utilities import WikipediaAPIWrapper
-
 from agentuniverse.agent.action.tool.common_tool.langchain_tool import LangChainTool
+
+
+def _get_wikipedia_tool_classes():
+    try:
+        from langchain_community.tools import WikipediaQueryRun
+        from langchain_community.utilities import WikipediaAPIWrapper
+    except ImportError as exc:
+        raise ImportError(
+            "langchain-community and wikipedia are required to use WikipediaTool. "
+            "Install them with `pip install langchain-community wikipedia`."
+        ) from exc
+    return WikipediaAPIWrapper, WikipediaQueryRun
 
 
 class WikipediaTool(LangChainTool):
     def init_langchain_tool(self, component_configer):
+        WikipediaAPIWrapper, WikipediaQueryRun = _get_wikipedia_tool_classes()
         wrapper = WikipediaAPIWrapper()
         return WikipediaQueryRun(api_wrapper=wrapper)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_wikipedia_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_wikipedia_tool.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import wikipedia_query as wiki_module
+from agentuniverse.agent.action.tool.common_tool.wikipedia_query import WikipediaTool
+
+
+class FakeWikipediaAPIWrapper:
+    pass
+
+
+class FakeWikipediaQueryRun:
+    def __init__(self, api_wrapper):
+        self.api_wrapper = api_wrapper
+
+
+class TestWikipediaTool(unittest.TestCase):
+    def test_init_langchain_tool_loads_wikipedia_classes_lazily(self):
+        tool = WikipediaTool()
+
+        with patch.object(
+            wiki_module,
+            "_get_wikipedia_tool_classes",
+            return_value=(FakeWikipediaAPIWrapper, FakeWikipediaQueryRun),
+        ) as load_classes:
+            langchain_tool = tool.init_langchain_tool(component_configer=None)
+
+        load_classes.assert_called_once_with()
+        self.assertIsInstance(langchain_tool, FakeWikipediaQueryRun)
+        self.assertIsInstance(langchain_tool.api_wrapper, FakeWikipediaAPIWrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Move Wikipedia-specific LangChain imports into `init_langchain_tool`.
- Keep importing `wikipedia_query.py` independent from optional Wikipedia dependencies.
- Add a clear install hint when the Wikipedia tool is initialized without the required optional packages.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_wikipedia_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/wikipedia_query.py tests/test_agentuniverse/unit/agent/action/tool/test_wikipedia_tool.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `requests` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.