### PR TITLE
feat(tool): add structured PowerPointTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/__init__.py
+++ b/agentuniverse/agent/action/tool/common_tool/__init__.py
@@ -7,9 +7,11 @@
 # @FileName: __init__.py
 
 from .github_tool import GitHubTool
+from .powerpoint_tool import PowerPointTool
 from .yahoo_finance_tool import YahooFinanceTool
 
 __all__ = [
     'GitHubTool',
+    'PowerPointTool',
     'YahooFinanceTool',
 ]

--- a/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+
+"""PowerPoint presentation creation and inspection tool."""
+
+# Validation failures are converted to structured tool responses at the public
+# execute boundary, so bespoke exception subclasses would add no useful signal.
+# ruff: noqa: TRY003, TRY004
+
+import os
+import tempfile
+import zipfile
+from typing import Any, ClassVar, cast
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import (
+    resolve_safe_path,
+)
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class PowerPointTool(Tool):
+    """Create, append to, read, and inspect ``.pptx`` presentations.
+
+    ``python-pptx`` is loaded only when an operation needs it. All file paths
+    are confined to ``base_dir`` and writes use a temporary file followed by
+    ``os.replace`` so a failed save cannot corrupt an existing presentation.
+
+    Slide input is intentionally structured rather than accepting executable
+    template code. Each slide may contain ``title``, ``subtitle``, ``bullets``,
+    ``table``, ``notes``, and a supported ``layout`` name.
+    """
+
+    base_dir: str = "."
+    max_read_bytes: int = 20 * 1024 * 1024
+    max_write_bytes: int = 20 * 1024 * 1024
+    max_uncompressed_bytes: int = 100 * 1024 * 1024
+    max_archive_entries: int = 5_000
+    max_slides: int = 100
+    max_text_chars: int = 50_000
+    max_table_rows: int = 50
+    max_table_columns: int = 20
+
+    _LAYOUT_INDEX: ClassVar[dict[str, int]] = {
+        "title": 0,
+        "title_content": 1,
+        "section": 2,
+        "title_only": 5,
+        "blank": 6,
+    }
+    _SLIDE_FIELDS: ClassVar[set[str]] = {
+        "title",
+        "subtitle",
+        "bullets",
+        "table",
+        "notes",
+        "layout",
+    }
+    _METADATA_FIELDS: ClassVar[set[str]] = {
+        "title",
+        "subject",
+        "author",
+        "keywords",
+        "comments",
+        "category",
+    }
+
+    def execute(
+        self,
+        mode: str,
+        file_path: str,
+        slides: list[dict[str, Any]] | None = None,
+        overwrite: bool = False,
+        template_path: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Run a PowerPoint operation.
+
+        Args:
+            mode: One of ``create``, ``append``, ``read``, or ``info``.
+            file_path: Presentation path, resolved underneath ``base_dir``.
+            slides: Structured slide specifications for create/append.
+            overwrite: Whether create mode may replace an existing file.
+            template_path: Optional PPTX template used by create mode.
+            metadata: Optional core presentation properties for create mode.
+
+        Returns:
+            A structured success or error dictionary.
+        """
+        try:
+            self._validate_configuration()
+            normalized_mode = self._normalize_mode(mode)
+            safe_path = self._resolve_pptx_path(file_path, "file_path")
+
+            if normalized_mode == "create":
+                return self._create(
+                    safe_path,
+                    slides,
+                    overwrite,
+                    template_path,
+                    metadata,
+                )
+            if normalized_mode == "append":
+                return self._append(safe_path, slides)
+            if normalized_mode == "read":
+                return self._read(safe_path)
+            return self._info(safe_path)
+        except ImportError as exc:
+            return self._error(
+                file_path,
+                "dependency_error",
+                "python-pptx is required for PowerPoint operations. Install it with: pip install python-pptx",
+                detail=str(exc),
+            )
+        except (TypeError, ValueError) as exc:
+            return self._error(file_path, "validation_error", str(exc))
+        except Exception as exc:  # library-specific parse/write failures
+            return self._error(
+                file_path,
+                "operation_error",
+                f"PowerPoint operation failed: {exc}",
+            )
+
+    @staticmethod
+    def _error(
+        file_path: Any,
+        error_type: str,
+        message: str,
+        detail: str | None = None,
+    ) -> dict[str, Any]:
+        result = {
+            "status": "error",
+            "error_type": error_type,
+            "error": message,
+            "file_path": file_path,
+        }
+        if detail:
+            result["detail"] = detail
+        return result
+
+    def _validate_configuration(self) -> None:
+        limits = {
+            "max_read_bytes": self.max_read_bytes,
+            "max_write_bytes": self.max_write_bytes,
+            "max_uncompressed_bytes": self.max_uncompressed_bytes,
+            "max_archive_entries": self.max_archive_entries,
+            "max_slides": self.max_slides,
+            "max_text_chars": self.max_text_chars,
+            "max_table_rows": self.max_table_rows,
+            "max_table_columns": self.max_table_columns,
+        }
+        for name, value in limits.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str) or not mode.strip():
+            raise ValueError("mode must be a non-empty string")
+        normalized = mode.strip().lower()
+        allowed = {"create", "append", "read", "info"}
+        if normalized not in allowed:
+            raise ValueError(f"invalid mode {mode!r}; expected one of: {', '.join(sorted(allowed))}")
+        return normalized
+
+    def _resolve_pptx_path(self, file_path: str, field_name: str) -> str:
+        if not isinstance(file_path, str) or not file_path.strip():
+            raise ValueError(f"{field_name} must be a non-empty string")
+        if os.path.splitext(file_path)[1].lower() != ".pptx":
+            raise ValueError(f"{field_name} must have a .pptx extension")
+        return cast(str, resolve_safe_path(file_path, self.base_dir))
+
+    def _ensure_readable(self, file_path: str, field_name: str = "file_path") -> None:
+        if not os.path.isfile(file_path):
+            raise ValueError(f"{field_name} does not exist: {file_path}")
+        size = os.path.getsize(file_path)
+        if size > self.max_read_bytes:
+            raise ValueError(f"{field_name} size {size} bytes exceeds max_read_bytes ({self.max_read_bytes})")
+        self._validate_archive_safety(file_path, field_name)
+
+    def _validate_archive_safety(self, file_path: str, field_name: str = "file_path") -> None:
+        """Bound the ZIP container before python-pptx expands it."""
+        try:
+            with zipfile.ZipFile(file_path) as archive:
+                entries = archive.infolist()
+                if len(entries) > self.max_archive_entries:
+                    raise ValueError(
+                        f"{field_name} contains {len(entries)} archive entries, "
+                        f"exceeding max_archive_entries ({self.max_archive_entries})"
+                    )
+                uncompressed_size = sum(entry.file_size for entry in entries)
+                if uncompressed_size > self.max_uncompressed_bytes:
+                    raise ValueError(
+                        f"{field_name} expands to {uncompressed_size} bytes, "
+                        f"exceeding max_uncompressed_bytes ({self.max_uncompressed_bytes})"
+                    )
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f"{field_name} is not a valid PPTX ZIP archive") from exc
+
+    @staticmethod
+    def _load_pptx() -> tuple[Any, Any]:
+        try:
+            from pptx import Presentation
+            from pptx.util import Inches
+        except ImportError as exc:
+            raise ImportError("No module named 'pptx'") from exc
+        return Presentation, Inches
+
+    def _create(
+        self,
+        file_path: str,
+        slides: list[dict[str, Any]] | None,
+        overwrite: bool,
+        template_path: str | None,
+        metadata: dict[str, str] | None,
+    ) -> dict[str, Any]:
+        if not isinstance(overwrite, bool):
+            raise ValueError("overwrite must be a boolean")
+        if os.path.exists(file_path) and not overwrite:
+            raise ValueError(f"file already exists: {file_path}; set overwrite=true to replace it")
+
+        validated_slides = self._validate_slides(slides, current_count=0)
+        validated_metadata = self._validate_metadata(metadata)
+        safe_template = None
+        if template_path is not None:
+            safe_template = self._resolve_pptx_path(template_path, "template_path")
+            self._ensure_readable(safe_template, "template_path")
+
+        Presentation, Inches = self._load_pptx()
+        presentation = Presentation(safe_template) if safe_template else Presentation()
+        if len(presentation.slides) + len(validated_slides) > self.max_slides:
+            raise ValueError(f"template slides plus requested slides exceed max_slides ({self.max_slides})")
+        self._apply_metadata(presentation, validated_metadata)
+        for spec in validated_slides:
+            self._add_slide(presentation, spec, Inches)
+
+        self._atomic_save(presentation, file_path)
+        return {
+            "status": "success",
+            "mode": "create",
+            "file_path": file_path,
+            "slides_added": len(validated_slides),
+            "slide_count": len(presentation.slides),
+            "file_size": os.path.getsize(file_path),
+            "template_path": safe_template,
+            "overwritten": overwrite,
+        }
+
+    def _append(
+        self,
+        file_path: str,
+        slides: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        self._ensure_readable(file_path)
+        Presentation, Inches = self._load_pptx()
+        presentation = Presentation(file_path)
+        existing_count = len(presentation.slides)
+        validated_slides = self._validate_slides(
+            slides,
+            current_count=existing_count,
+        )
+        for spec in validated_slides:
+            self._add_slide(presentation, spec, Inches)
+        self._atomic_save(presentation, file_path)
+        return {
+            "status": "success",
+            "mode": "append",
+            "file_path": file_path,
+            "slides_added": len(validated_slides),
+            "slide_count": len(presentation.slides),
+            "file_size": os.path.getsize(file_path),
+        }
+
+    def _read(self, file_path: str) -> dict[str, Any]:
+        self._ensure_readable(file_path)
+        Presentation, _ = self._load_pptx()
+        presentation = Presentation(file_path)
+        self._validate_presentation_slide_count(presentation)
+
+        remaining = self.max_text_chars
+        truncated = False
+        slide_results = []
+        for slide_number, slide in enumerate(presentation.slides, start=1):
+            title_shape = slide.shapes.title
+            title, remaining, was_truncated = self._bounded_text(
+                title_shape.text if title_shape is not None else "", remaining
+            )
+            truncated = truncated or was_truncated
+            texts = []
+            tables = []
+            for shape in slide.shapes:
+                if getattr(shape, "has_table", False):
+                    rows = []
+                    for row in shape.table.rows:
+                        output_row = []
+                        for cell in row.cells:
+                            value, remaining, cut = self._bounded_text(cell.text, remaining)
+                            truncated = truncated or cut
+                            output_row.append(value)
+                        rows.append(output_row)
+                    tables.append(rows)
+                    continue
+                if not getattr(shape, "has_text_frame", False):
+                    continue
+                if title_shape is not None and shape.shape_id == title_shape.shape_id:
+                    continue
+                value, remaining, cut = self._bounded_text(shape.text, remaining)
+                truncated = truncated or cut
+                if value:
+                    texts.append(value)
+
+            notes = ""
+            if getattr(slide, "has_notes_slide", False):
+                notes_frame = slide.notes_slide.notes_text_frame
+                notes, remaining, cut = self._bounded_text(
+                    notes_frame.text if notes_frame is not None else "", remaining
+                )
+                truncated = truncated or cut
+
+            slide_results.append(
+                {
+                    "slide_number": slide_number,
+                    "title": title,
+                    "texts": texts,
+                    "tables": tables,
+                    "notes": notes,
+                }
+            )
+
+        return {
+            "status": "success",
+            "mode": "read",
+            "file_path": file_path,
+            "slide_count": len(presentation.slides),
+            "slides": slide_results,
+            "truncated": truncated,
+            "max_text_chars": self.max_text_chars,
+        }
+
+    def _info(self, file_path: str) -> dict[str, Any]:
+        self._ensure_readable(file_path)
+        Presentation, _ = self._load_pptx()
+        presentation = Presentation(file_path)
+        self._validate_presentation_slide_count(presentation)
+
+        slide_info = []
+        for slide_number, slide in enumerate(presentation.slides, start=1):
+            title_shape = slide.shapes.title
+            title = title_shape.text.strip() if title_shape is not None else ""
+            slide_info.append(
+                {
+                    "slide_number": slide_number,
+                    "title": title[:500],
+                    "shape_count": len(slide.shapes),
+                    "table_count": sum(1 for shape in slide.shapes if getattr(shape, "has_table", False)),
+                    "has_notes": bool(getattr(slide, "has_notes_slide", False)),
+                }
+            )
+
+        props = presentation.core_properties
+        return {
+            "status": "success",
+            "mode": "info",
+            "file_path": file_path,
+            "file_size": os.path.getsize(file_path),
+            "slide_count": len(presentation.slides),
+            "slide_width": int(presentation.slide_width),
+            "slide_height": int(presentation.slide_height),
+            "metadata": {field: getattr(props, field, "") or "" for field in sorted(self._METADATA_FIELDS)},
+            "slides": slide_info,
+        }
+
+    def _validate_presentation_slide_count(self, presentation: Any) -> None:
+        count = len(presentation.slides)
+        if count > self.max_slides:
+            raise ValueError(f"presentation has {count} slides, exceeding max_slides ({self.max_slides})")
+
+    def _validate_slides(  # noqa: C901
+        self,
+        slides: list[dict[str, Any]] | None,
+        current_count: int,
+    ) -> list[dict[str, Any]]:
+        if not isinstance(slides, list) or not slides:
+            raise ValueError("slides must be a non-empty list")
+        if current_count + len(slides) > self.max_slides:
+            raise ValueError(
+                f"result would have {current_count + len(slides)} slides, exceeding max_slides ({self.max_slides})"
+            )
+
+        total_chars = 0
+        validated = []
+        for index, raw_spec in enumerate(slides, start=1):
+            if not isinstance(raw_spec, dict):
+                raise ValueError(f"slides[{index - 1}] must be an object")
+            unknown = set(raw_spec) - self._SLIDE_FIELDS
+            if unknown:
+                raise ValueError(f"slides[{index - 1}] has unknown fields: {', '.join(sorted(unknown))}")
+            spec = dict(raw_spec)
+            for field in ("title", "subtitle", "notes"):
+                value = spec.get(field, "")
+                if not isinstance(value, str):
+                    raise ValueError(f"slides[{index - 1}].{field} must be a string")
+                spec[field] = value
+                total_chars += len(value)
+
+            layout = spec.get("layout", "auto")
+            if not isinstance(layout, str):
+                raise ValueError(f"slides[{index - 1}].layout must be a string")
+            layout = layout.strip().lower()
+            allowed_layouts = {"auto", *self._LAYOUT_INDEX}
+            if layout not in allowed_layouts:
+                raise ValueError(f"slides[{index - 1}].layout must be one of: {', '.join(sorted(allowed_layouts))}")
+            spec["layout"] = layout
+
+            bullets = spec.get("bullets", [])
+            if not isinstance(bullets, list):
+                raise ValueError(f"slides[{index - 1}].bullets must be a list")
+            normalized_bullets = []
+            for bullet_index, bullet in enumerate(bullets):
+                if isinstance(bullet, str):
+                    text, level = bullet, 0
+                elif isinstance(bullet, dict):
+                    unknown_bullet = set(bullet) - {"text", "level"}
+                    if unknown_bullet:
+                        raise ValueError(
+                            f"slides[{index - 1}].bullets[{bullet_index}] has "
+                            f"unknown fields: {', '.join(sorted(unknown_bullet))}"
+                        )
+                    raw_text = bullet.get("text")
+                    level = bullet.get("level", 0)
+                    if not isinstance(raw_text, str):
+                        raise ValueError(f"slides[{index - 1}].bullets[{bullet_index}].text must be a string")
+                    text = raw_text
+                else:
+                    raise ValueError(f"slides[{index - 1}].bullets[{bullet_index}] must be a string or object")
+                if isinstance(level, bool) or not isinstance(level, int) or not 0 <= level <= 8:
+                    raise ValueError(
+                        f"slides[{index - 1}].bullets[{bullet_index}].level must be an integer from 0 to 8"
+                    )
+                normalized_bullets.append({"text": text, "level": level})
+                total_chars += len(text)
+            spec["bullets"] = normalized_bullets
+
+            table = spec.get("table", [])
+            if table is None:
+                table = []
+            if not isinstance(table, list):
+                raise ValueError(f"slides[{index - 1}].table must be a list")
+            if len(table) > self.max_table_rows:
+                raise ValueError(f"slides[{index - 1}].table exceeds max_table_rows ({self.max_table_rows})")
+            max_columns = 0
+            normalized_table = []
+            for row_index, row in enumerate(table):
+                if not isinstance(row, list):
+                    raise ValueError(f"slides[{index - 1}].table[{row_index}] must be a list")
+                max_columns = max(max_columns, len(row))
+                if max_columns > self.max_table_columns:
+                    raise ValueError(f"slides[{index - 1}].table exceeds max_table_columns ({self.max_table_columns})")
+                output_row = []
+                for value in row:
+                    if value is None:
+                        value = ""
+                    elif not isinstance(value, (str, int, float, bool)):
+                        raise ValueError(f"slides[{index - 1}].table cells must be scalar values")
+                    value = str(value)
+                    output_row.append(value)
+                    total_chars += len(value)
+                normalized_table.append(output_row)
+            if table and max_columns == 0:
+                raise ValueError(f"slides[{index - 1}].table must contain cells")
+            spec["table"] = normalized_table
+
+            if not any((spec["title"], spec["subtitle"], spec["bullets"], spec["table"], spec["notes"])):
+                raise ValueError(f"slides[{index - 1}] must contain content")
+            validated.append(spec)
+
+        if total_chars > self.max_text_chars:
+            raise ValueError(
+                f"slide content has {total_chars} characters, exceeding max_text_chars ({self.max_text_chars})"
+            )
+        return validated
+
+    def _validate_metadata(
+        self,
+        metadata: dict[str, str] | None,
+    ) -> dict[str, str]:
+        if metadata is None:
+            return {}
+        if not isinstance(metadata, dict):
+            raise ValueError("metadata must be an object")
+        unknown = set(metadata) - self._METADATA_FIELDS
+        if unknown:
+            raise ValueError(f"metadata has unknown fields: {', '.join(sorted(unknown))}")
+        result = {}
+        for field, value in metadata.items():
+            if not isinstance(value, str):
+                raise ValueError(f"metadata.{field} must be a string")
+            if len(value) > 2_000:
+                raise ValueError(f"metadata.{field} exceeds 2000 characters")
+            result[field] = value
+        return result
+
+    @staticmethod
+    def _apply_metadata(presentation: Any, metadata: dict[str, str]) -> None:
+        props = presentation.core_properties
+        for field, value in metadata.items():
+            setattr(props, field, value)
+
+    def _add_slide(  # noqa: C901
+        self,
+        presentation: Any,
+        spec: dict[str, Any],
+        Inches: Any,
+    ) -> None:
+        layout_name = spec["layout"]
+        if layout_name == "auto":
+            layout_name = "title" if spec["subtitle"] and not spec["bullets"] and not spec["table"] else "title_content"
+        requested_index = self._LAYOUT_INDEX[layout_name]
+        layout_index = requested_index if requested_index < len(presentation.slide_layouts) else 0
+        slide = presentation.slides.add_slide(presentation.slide_layouts[layout_index])
+
+        title_shape = slide.shapes.title
+        if spec["title"]:
+            if title_shape is not None:
+                title_shape.text = spec["title"]
+            else:
+                title_shape = slide.shapes.add_textbox(Inches(0.7), Inches(0.35), Inches(8.6), Inches(0.8))
+                title_shape.text_frame.text = spec["title"]
+
+        if spec["subtitle"]:
+            subtitle_shape = self._find_body_placeholder(slide, title_shape)
+            if layout_name in {"title", "section"} and subtitle_shape is not None:
+                subtitle_shape.text_frame.text = spec["subtitle"]
+            else:
+                subtitle_shape = slide.shapes.add_textbox(Inches(0.8), Inches(1.2), Inches(8.4), Inches(0.55))
+                subtitle_shape.text_frame.text = spec["subtitle"]
+
+        if spec["bullets"]:
+            body_shape = self._find_body_placeholder(slide, title_shape)
+            if body_shape is None or (spec["subtitle"] and layout_name in {"title", "section"}):
+                body_top = 1.9 if spec["subtitle"] else 1.45
+                body_height = 2.0 if spec["table"] else 5.2
+                body_shape = slide.shapes.add_textbox(Inches(0.9), Inches(body_top), Inches(8.2), Inches(body_height))
+            self._set_bullets(body_shape.text_frame, spec["bullets"])
+
+        if spec["table"]:
+            rows = len(spec["table"])
+            columns = max(len(row) for row in spec["table"])
+            top = 4.0 if spec["bullets"] else (2.0 if spec["subtitle"] else 1.6)
+            height = max(0.7, min(3.0, rows * 0.45))
+            table_shape = slide.shapes.add_table(
+                rows,
+                columns,
+                Inches(0.7),
+                Inches(top),
+                Inches(8.6),
+                Inches(height),
+            )
+            table = table_shape.table
+            for row_index, row in enumerate(spec["table"]):
+                for column_index in range(columns):
+                    table.cell(row_index, column_index).text = row[column_index] if column_index < len(row) else ""
+
+        if spec["notes"]:
+            notes_frame = slide.notes_slide.notes_text_frame
+            if notes_frame is not None:
+                notes_frame.text = spec["notes"]
+
+    @staticmethod
+    def _find_body_placeholder(slide: Any, title_shape: Any) -> Any | None:
+        for shape in slide.placeholders:
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            if title_shape is not None and shape.shape_id == title_shape.shape_id:
+                continue
+            return shape
+        return None
+
+    @staticmethod
+    def _set_bullets(text_frame: Any, bullets: list[dict[str, Any]]) -> None:
+        text_frame.clear()
+        for index, bullet in enumerate(bullets):
+            paragraph = text_frame.paragraphs[0] if index == 0 else text_frame.add_paragraph()
+            paragraph.text = bullet["text"]
+            paragraph.level = bullet["level"]
+
+    def _atomic_save(self, presentation: Any, file_path: str) -> None:
+        directory = os.path.dirname(file_path)
+        os.makedirs(directory, exist_ok=True)
+        temporary_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=".powerpoint-",
+                suffix=".pptx",
+                dir=directory,
+                delete=False,
+            ) as temporary:
+                temporary_path = temporary.name
+            presentation.save(temporary_path)
+            size = os.path.getsize(temporary_path)
+            if size > self.max_write_bytes:
+                raise ValueError(f"generated file size {size} bytes exceeds max_write_bytes ({self.max_write_bytes})")
+            self._validate_archive_safety(temporary_path, "generated presentation")
+            os.replace(temporary_path, file_path)
+            temporary_path = None
+        finally:
+            if temporary_path and os.path.exists(temporary_path):
+                os.unlink(temporary_path)
+
+    @staticmethod
+    def _bounded_text(text: Any, remaining: int) -> tuple[str, int, bool]:
+        normalized = str(text or "").strip()
+        if not normalized:
+            return "", remaining, False
+        if len(normalized) <= remaining:
+            return normalized, remaining - len(normalized), False
+        if remaining <= 0:
+            return "", 0, True
+        if remaining == 1:
+            return "…", 0, True
+        return normalized[: remaining - 1] + "…", 0, True

--- a/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
@@ -62,6 +62,7 @@ class PowerPointTool(Tool):
         "comments",
         "category",
     }
+    _FALLBACK_TITLE_SHAPE_NAME: ClassVar[str] = "agentUniverse Title"
 
     def execute(
         self,
@@ -281,7 +282,7 @@ class PowerPointTool(Tool):
         truncated = False
         slide_results = []
         for slide_number, slide in enumerate(presentation.slides, start=1):
-            title_shape = slide.shapes.title
+            title_shape = self._get_title_shape(slide)
             title, remaining, was_truncated = self._bounded_text(
                 title_shape.text if title_shape is not None else "", remaining
             )
@@ -345,7 +346,7 @@ class PowerPointTool(Tool):
 
         slide_info = []
         for slide_number, slide in enumerate(presentation.slides, start=1):
-            title_shape = slide.shapes.title
+            title_shape = self._get_title_shape(slide)
             title = title_shape.text.strip() if title_shape is not None else ""
             slide_info.append(
                 {
@@ -525,6 +526,7 @@ class PowerPointTool(Tool):
                 title_shape.text = spec["title"]
             else:
                 title_shape = slide.shapes.add_textbox(Inches(0.7), Inches(0.35), Inches(8.6), Inches(0.8))
+                title_shape.name = self._FALLBACK_TITLE_SHAPE_NAME
                 title_shape.text_frame.text = spec["title"]
 
         if spec["subtitle"]:
@@ -575,6 +577,16 @@ class PowerPointTool(Tool):
                 continue
             return shape
         return None
+
+    def _get_title_shape(self, slide: Any) -> Any | None:
+        """Return a native title placeholder or a title textbox created by this tool."""
+        native_title = slide.shapes.title
+        if native_title is not None:
+            return native_title
+        return next(
+            (shape for shape in slide.shapes if shape.name == self._FALLBACK_TITLE_SHAPE_NAME),
+            None,
+        )
 
     @staticmethod
     def _set_bullets(text_frame: Any, bullets: list[dict[str, Any]]) -> None:

--- a/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
@@ -35,6 +35,7 @@ class PowerPointTool(Tool):
     max_uncompressed_bytes: int = 100 * 1024 * 1024
     max_archive_entries: int = 5_000
     max_slides: int = 100
+    max_shapes_per_slide: int = 200
     max_text_chars: int = 50_000
     max_table_rows: int = 50
     max_table_columns: int = 20
@@ -144,6 +145,7 @@ class PowerPointTool(Tool):
             "max_uncompressed_bytes": self.max_uncompressed_bytes,
             "max_archive_entries": self.max_archive_entries,
             "max_slides": self.max_slides,
+            "max_shapes_per_slide": self.max_shapes_per_slide,
             "max_text_chars": self.max_text_chars,
             "max_table_rows": self.max_table_rows,
             "max_table_columns": self.max_table_columns,
@@ -272,51 +274,48 @@ class PowerPointTool(Tool):
             "file_size": os.path.getsize(file_path),
         }
 
-    def _read(self, file_path: str) -> dict[str, Any]:
+    def _read(self, file_path: str) -> dict[str, Any]:  # noqa: C901
         self._ensure_readable(file_path)
         Presentation, _ = self._load_pptx()
         presentation = Presentation(file_path)
         self._validate_presentation_slide_count(presentation)
 
-        remaining = self.max_text_chars
-        truncated = False
-        slide_results = []
+        # Read-side budgets mirror create/append: a compact XML presentation
+        # can still expand into a huge Python structure if every shape/table/
+        # row/cell is walked, so traversal stops the moment any budget is
+        # exhausted instead of padding the result with empty strings.
+        budget = _ReadBudget(self)
+        slide_results: list[dict[str, Any]] = []
         for slide_number, slide in enumerate(presentation.slides, start=1):
             title_shape = self._get_title_shape(slide)
-            title, remaining, was_truncated = self._bounded_text(
-                title_shape.text if title_shape is not None else "", remaining
-            )
-            truncated = truncated or was_truncated
-            texts = []
-            tables = []
+            title = budget.consume_text(title_shape.text if title_shape is not None else "")[0]
+            texts: list[str] = []
+            tables: list[list[list[str]]] = []
+            shape_count = 0
             for shape in slide.shapes:
+                if shape_count >= self.max_shapes_per_slide:
+                    budget.mark_truncated()
+                    break
                 if getattr(shape, "has_table", False):
-                    rows = []
-                    for row in shape.table.rows:
-                        output_row = []
-                        for cell in row.cells:
-                            value, remaining, cut = self._bounded_text(cell.text, remaining)
-                            truncated = truncated or cut
-                            output_row.append(value)
-                        rows.append(output_row)
-                    tables.append(rows)
+                    shape_count += 1
+                    tables.append(self._read_table(shape.table, budget))
                     continue
                 if not getattr(shape, "has_text_frame", False):
                     continue
                 if title_shape is not None and shape.shape_id == title_shape.shape_id:
                     continue
-                value, remaining, cut = self._bounded_text(shape.text, remaining)
-                truncated = truncated or cut
+                shape_count += 1
+                value = budget.consume_text(shape.text)[0]
                 if value:
                     texts.append(value)
+                if budget.chars_exhausted():
+                    budget.mark_truncated()
+                    break
 
             notes = ""
             if getattr(slide, "has_notes_slide", False):
                 notes_frame = slide.notes_slide.notes_text_frame
-                notes, remaining, cut = self._bounded_text(
-                    notes_frame.text if notes_frame is not None else "", remaining
-                )
-                truncated = truncated or cut
+                notes = budget.consume_text(notes_frame.text if notes_frame is not None else "")[0]
 
             slide_results.append(
                 {
@@ -327,6 +326,8 @@ class PowerPointTool(Tool):
                     "notes": notes,
                 }
             )
+            if budget.chars_exhausted():
+                break
 
         return {
             "status": "success",
@@ -334,9 +335,31 @@ class PowerPointTool(Tool):
             "file_path": file_path,
             "slide_count": len(presentation.slides),
             "slides": slide_results,
-            "truncated": truncated,
+            "truncated": budget.truncated,
             "max_text_chars": self.max_text_chars,
+            "max_slides": self.max_slides,
+            "max_shapes_per_slide": self.max_shapes_per_slide,
+            "max_table_rows": self.max_table_rows,
+            "max_table_columns": self.max_table_columns,
         }
+
+    def _read_table(self, table: Any, budget: "_ReadBudget") -> list[list[str]]:
+        rows: list[list[str]] = []
+        for row_index, row in enumerate(table.rows):
+            if row_index >= self.max_table_rows:
+                budget.mark_truncated()
+                break
+            values: list[str] = []
+            for column_index, cell in enumerate(row.cells):
+                if column_index >= self.max_table_columns:
+                    budget.mark_truncated()
+                    break
+                values.append(budget.consume_text(cell.text)[0])
+            rows.append(values)
+            if budget.chars_exhausted():
+                budget.mark_truncated()
+                break
+        return rows
 
     def _info(self, file_path: str) -> dict[str, Any]:
         self._ensure_readable(file_path)
@@ -631,3 +654,45 @@ class PowerPointTool(Tool):
         if remaining == 1:
             return "…", 0, True
         return normalized[: remaining - 1] + "…", 0, True
+
+
+class _ReadBudget:
+    """Tracks the char budget consumed across a presentation read.
+
+    A crafted PPTX can pack in many slides, shapes, tables, rows, and cells.
+    This accumulator centralises the text-char budget so the read stops the
+    moment it is exhausted, instead of continuing to walk every shape and
+    padding the result with empty strings. Slide/table/row/column caps are
+    enforced inline against the tool's configured limits; this budget owns the
+    shared text budget that spans all of them. Mirrors the WordDocumentTool
+    read contract.
+    """
+
+    __slots__ = ("remaining_chars", "truncated")
+
+    def __init__(self, tool: "PowerPointTool") -> None:
+        self.remaining_chars = tool.max_text_chars
+        self.truncated = False
+
+    def chars_exhausted(self) -> bool:
+        return self.remaining_chars <= 0
+
+    def mark_truncated(self) -> None:
+        self.truncated = True
+
+    def consume_text(self, value: Any) -> tuple[str, bool]:
+        """Return (bounded_text, was_cut). Empty results do not consume budget."""
+        normalized = str(value or "").strip()
+        if not normalized:
+            return "", False
+        if len(normalized) <= self.remaining_chars:
+            self.remaining_chars -= len(normalized)
+            return normalized, False
+        if self.remaining_chars <= 0:
+            return "", True
+        if self.remaining_chars == 1:
+            self.remaining_chars = 0
+            return "…", True
+        kept = self.remaining_chars
+        self.remaining_chars = 0
+        return normalized[: max(0, kept - 1)] + "…", True

--- a/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.yaml
@@ -1,0 +1,115 @@
+name: powerpoint_tool
+description: Create, append to, read, or inspect PowerPoint PPTX presentations from structured slide data. Requires the optional python-pptx package.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.powerpoint_tool
+  class: PowerPointTool
+input_keys:
+  - mode
+  - file_path
+base_dir: .
+max_read_bytes: 20971520
+max_write_bytes: 20971520
+max_uncompressed_bytes: 104857600
+max_archive_entries: 5000
+max_slides: 100
+max_text_chars: 50000
+max_table_rows: 50
+max_table_columns: 20
+args_model:
+  mode:
+    type: string
+    description: Operation mode — create, append, read, or info.
+    required: true
+  file_path:
+    type: string
+    description: PPTX path underneath the configured base_dir.
+    required: true
+  slides:
+    type: array
+    description: Structured slide objects used by create and append modes.
+    required: false
+  overwrite:
+    type: boolean
+    description: Allow create mode to replace an existing presentation.
+    required: false
+    default: false
+  template_path:
+    type: string
+    description: Optional PPTX template underneath base_dir for create mode.
+    required: false
+  metadata:
+    type: object
+    description: Optional core properties (title, subject, author, keywords, comments, category).
+    required: false
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: ["create", "append", "read", "info"]
+      description: PowerPoint operation mode.
+    file_path:
+      type: string
+      description: PPTX path underneath the configured base_dir.
+    slides:
+      type: array
+      description: Slides for create/append. Each supports title, subtitle, bullets, table, notes, and layout.
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          subtitle:
+            type: string
+          bullets:
+            type: array
+            items:
+              anyOf:
+                - type: string
+                - type: object
+                  properties:
+                    text:
+                      type: string
+                    level:
+                      type: integer
+                      minimum: 0
+                      maximum: 8
+                  required: ["text"]
+                  additionalProperties: false
+          table:
+            type: array
+            items:
+              type: array
+              items:
+                type: ["string", "number", "boolean", "null"]
+          notes:
+            type: string
+          layout:
+            type: string
+            enum: ["auto", "title", "title_content", "section", "title_only", "blank"]
+        additionalProperties: false
+    overwrite:
+      type: boolean
+      default: false
+    template_path:
+      type: string
+    metadata:
+      type: object
+      properties:
+        title:
+          type: string
+        subject:
+          type: string
+        author:
+          type: string
+        keywords:
+          type: string
+        comments:
+          type: string
+        category:
+          type: string
+      additionalProperties: false
+  required: ["mode", "file_path"]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -202,3 +202,92 @@ Parameter Description:
     response_content_type: the output format for the HTTP request result. If set to 'json', the result will be returned in JSON format; if set to 'text', it will be returned as plain text.
 This tool can be used directly without  requiring any keys.
 
+
+
+## 4. Office Tools
+
+### 4.1 PowerPoint
+
+`PowerPointTool` creates, appends to, reads, and inspects `.pptx` files from
+structured data. Install the optional Office dependency before using it:
+
+```bash
+pip install "agentUniverse[office_ext]"
+# source checkout alternative: pip install python-pptx
+```
+
+The built-in component configuration is
+[`powerpoint_tool.yaml`](../../../../../../agentuniverse/agent/action/tool/common_tool/powerpoint_tool.yaml):
+
+```yaml
+name: powerpoint_tool
+description: Create, append to, read, or inspect PowerPoint PPTX presentations from structured slide data.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.powerpoint_tool
+  class: PowerPointTool
+input_keys: [mode, file_path]
+base_dir: .
+max_read_bytes: 20971520
+max_write_bytes: 20971520
+max_uncompressed_bytes: 104857600
+max_archive_entries: 5000
+max_slides: 100
+max_text_chars: 50000
+```
+
+Create a presentation:
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("powerpoint_tool")
+result = tool.run(
+    mode="create",
+    file_path="reports/q2-review.pptx",
+    overwrite=False,
+    metadata={"title": "Q2 Review", "author": "Finance Agent"},
+    slides=[
+        {
+            "title": "Q2 Review",
+            "subtitle": "Revenue and regional performance",
+            "notes": "Open with the consolidated revenue result.",
+        },
+        {
+            "title": "Highlights",
+            "bullets": [
+                "Revenue grew 20% year over year",
+                {"text": "APAC led growth", "level": 1},
+            ],
+            "table": [
+                ["Metric", "Q2", "YoY"],
+                ["Revenue", "$123M", "+20%"],
+            ],
+        },
+    ],
+)
+```
+
+Use `mode="append"` with another `slides` list to add slides to an existing
+deck. `mode="read"` returns bounded slide text, tables, and speaker notes;
+`mode="info"` returns file metadata and per-slide shape/table information.
+Create mode can also receive a `template_path` underneath `base_dir`; existing
+template slides are retained and the generated slides are appended.
+
+Supported slide fields are:
+
+- `title`, `subtitle`, and `notes`: strings.
+- `bullets`: strings or `{ "text": "...", "level": 0 }` objects. Levels are
+  restricted to 0–8.
+- `table`: a two-dimensional array of scalar cell values.
+- `layout`: `auto`, `title`, `title_content`, `section`, `title_only`, or
+  `blank`.
+
+The tool confines `file_path` and `template_path` to `base_dir`, including
+resolved symlinks. It rejects oversized files, slide/table/text limits, unknown
+input fields, and implicit overwrites. Writes are atomic: the new presentation
+is saved and size-checked in the destination directory before it replaces the
+target, so a failed write does not corrupt an existing deck. The `read` result
+is capped by `max_text_chars` and reports `truncated: true` when the context
+budget is exhausted.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -356,3 +356,87 @@ metadata:
     json_parse 输入参数是否需要是要HTTP解析，POST请求时需要设置为True,GET请求需要设置为False
     response_content_type http请求结果的解析方式，设置为json时，会返回json结果，设置为text时会返回text结果
 该工具可以直接使用，无需任何keys
+
+
+## 4. Office 工具
+
+### 4.1 PowerPoint
+
+`PowerPointTool` 可以根据结构化数据创建、追加、读取和检查 `.pptx` 文件。
+使用前需要安装可选的 Office 依赖：
+
+```bash
+pip install "agentUniverse[office_ext]"
+# 从源码运行时也可以使用：pip install python-pptx
+```
+
+内置组件配置位于
+[`powerpoint_tool.yaml`](../../../../../../agentuniverse/agent/action/tool/common_tool/powerpoint_tool.yaml)：
+
+```yaml
+name: powerpoint_tool
+description: Create, append to, read, or inspect PowerPoint PPTX presentations from structured slide data.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.powerpoint_tool
+  class: PowerPointTool
+input_keys: [mode, file_path]
+base_dir: .
+max_read_bytes: 20971520
+max_write_bytes: 20971520
+max_uncompressed_bytes: 104857600
+max_archive_entries: 5000
+max_slides: 100
+max_text_chars: 50000
+```
+
+创建演示文稿示例：
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("powerpoint_tool")
+result = tool.run(
+    mode="create",
+    file_path="reports/q2-review.pptx",
+    overwrite=False,
+    metadata={"title": "第二季度复盘", "author": "财务智能体"},
+    slides=[
+        {
+            "title": "第二季度复盘",
+            "subtitle": "营收与区域表现",
+            "notes": "开场先说明合并口径营收。",
+        },
+        {
+            "title": "核心指标",
+            "bullets": [
+                "营收同比增长 20%",
+                {"text": "亚太地区增长领先", "level": 1},
+            ],
+            "table": [
+                ["指标", "第二季度", "同比"],
+                ["营收", "1.23 亿美元", "+20%"],
+            ],
+        },
+    ],
+)
+```
+
+使用 `mode="append"` 并传入新的 `slides` 列表，可以向已有文件追加幻灯片。
+`mode="read"` 返回受长度限制的幻灯片文本、表格和演讲者备注；
+`mode="info"` 返回文件元数据以及每页的形状、表格信息。创建模式还可以传入
+`base_dir` 内的 `template_path`，保留模板原有页面并在其后追加生成内容。
+
+每个幻灯片对象支持以下字段：
+
+- `title`、`subtitle`、`notes`：字符串。
+- `bullets`：字符串，或 `{ "text": "...", "level": 0 }` 对象；层级限制为 0–8。
+- `table`：仅包含标量单元格值的二维数组。
+- `layout`：`auto`、`title`、`title_content`、`section`、`title_only` 或 `blank`。
+
+工具会将 `file_path` 和 `template_path` 限制在 `base_dir` 中，符号链接解析后也不能
+逃逸。工具会拒绝超出文件、幻灯片、表格或文本限制的输入，拒绝未知字段，并且默认
+禁止覆盖现有文件。写入采用原子替换：先在目标目录保存并检查临时文件，成功后才替换
+目标文件，写入失败不会破坏原演示文稿。`read` 结果受 `max_text_chars` 限制；上下文
+预算耗尽时返回 `truncated: true`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ duckduckgo-search = "^6.3.5"
 primp = "^0.6.5"
 wikipedia= "^1.4.0"
 openpyxl = "^3.1.5"
+python-pptx = { version = "^1.0.2", optional = true }
 pillow = "^10.4.0"
 jieba = "^0.42.1"
 networkx = "^3.3"
@@ -78,6 +79,7 @@ beautifulsoup4 = "^4.12.0"
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]
 store_ext = ["pymilvus"]
+office_ext = ["python-pptx"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
@@ -100,6 +100,32 @@ class TestPowerPointValidation(unittest.TestCase):
         result = self.tool.execute(mode="info", file_path="many-entries.pptx")
         self.assertIn("max_archive_entries", result["error"])
 
+    def test_rejects_file_size_over_read_limit_before_parsing(self) -> None:
+        presentation_path = os.path.join(self.base_dir, "oversized.pptx")
+        with open(presentation_path, "wb") as output:
+            output.write(b"PK" + b"x" * 30)
+        self.tool.max_read_bytes = 16
+
+        result = self.tool.execute(mode="read", file_path="oversized.pptx")
+
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("max_read_bytes", result["error"])
+
+    def test_rejects_invalid_template_archive(self) -> None:
+        with open(os.path.join(self.base_dir, "template.pptx"), "wb") as output:
+            output.write(b"not-a-template")
+
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            template_path="template.pptx",
+            slides=[{"title": "Generated"}],
+        )
+
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("template_path is not a valid PPTX ZIP archive", result["error"])
+        self.assertFalse(os.path.exists(os.path.join(self.base_dir, "deck.pptx")))
+
     def test_create_requires_non_empty_slides(self) -> None:
         result = self.tool.execute(
             mode="create",
@@ -176,6 +202,26 @@ class TestPowerPointValidation(unittest.TestCase):
         self.tool.max_write_bytes = 16
         with self.assertRaisesRegex(ValueError, "max_write_bytes"):
             self.tool._atomic_save(OversizedPresentation(), destination)
+        with open(destination, "rb") as existing:
+            self.assertEqual(existing.read(), original)
+        leftovers = [name for name in os.listdir(self.base_dir) if name.startswith(".powerpoint-")]
+        self.assertEqual(leftovers, [])
+
+    def test_atomic_save_preserves_destination_when_expansion_limit_fails(self) -> None:
+        destination = os.path.join(self.base_dir, "deck.pptx")
+        original = b"existing-presentation"
+        with open(destination, "wb") as output:
+            output.write(original)
+
+        class ExpandingPresentation:
+            @staticmethod
+            def save(path):
+                with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+                    archive.writestr("ppt/slides/slide1.xml", "x" * 64)
+
+        self.tool.max_uncompressed_bytes = 32
+        with self.assertRaisesRegex(ValueError, "max_uncompressed_bytes"):
+            self.tool._atomic_save(ExpandingPresentation(), destination)
         with open(destination, "rb") as existing:
             self.assertEqual(existing.read(), original)
         leftovers = [name for name in os.listdir(self.base_dir) if name.startswith(".powerpoint-")]
@@ -328,6 +374,79 @@ class TestPowerPointOperations(unittest.TestCase):
             slides=[{"title": "One too many"}],
         )
         self.assertIn("exceeding max_slides", result["error"])
+
+    def test_unicode_ragged_table_and_explicit_layout_round_trip(self) -> None:
+        created = self.tool.execute(
+            mode="create",
+            file_path="unicode.pptx",
+            slides=[
+                {
+                    "layout": "title_only",
+                    "title": "全球发布 🚀",
+                    "bullets": ["Español", {"text": "日本語", "level": 1}],
+                    "table": [["地区", "ARR", "Owner"], ["亚太", 42]],
+                    "notes": "演讲人备注 ✓",
+                }
+            ],
+        )
+
+        self.assertEqual(created["status"], "success")
+        read = self.tool.execute(mode="read", file_path="unicode.pptx")
+        self.assertEqual(read["slides"][0]["title"], "全球发布 🚀")
+        self.assertIn("Español", read["slides"][0]["texts"][0])
+        self.assertIn("日本語", read["slides"][0]["texts"][0])
+        self.assertEqual(read["slides"][0]["tables"][0][1], ["亚太", "42", ""])
+        self.assertEqual(read["slides"][0]["notes"], "演讲人备注 ✓")
+
+    def test_create_uses_write_limit_not_read_limit(self) -> None:
+        self.tool.max_read_bytes = 1
+        self.tool.max_write_bytes = 2 * 1024 * 1024
+
+        created = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "Generated independently of the read limit"}],
+        )
+
+        self.assertEqual(created["status"], "success")
+        self.assertGreater(created["file_size"], self.tool.max_read_bytes)
+
+    def test_append_write_failure_preserves_original_presentation(self) -> None:
+        self._create_deck()
+        deck_path = os.path.join(self.base_dir, "deck.pptx")
+        with open(deck_path, "rb") as original_file:
+            original = original_file.read()
+        self.tool.max_write_bytes = 1
+
+        result = self.tool.execute(
+            mode="append",
+            file_path="deck.pptx",
+            slides=[{"title": "Must not be partially written"}],
+        )
+
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("max_write_bytes", result["error"])
+        with open(deck_path, "rb") as unchanged_file:
+            self.assertEqual(unchanged_file.read(), original)
+
+    def test_template_slide_count_is_checked_before_destination_write(self) -> None:
+        self.tool.execute(
+            mode="create",
+            file_path="template.pptx",
+            slides=[{"title": "Template one"}, {"title": "Template two"}],
+        )
+        self.tool.max_slides = 2
+
+        result = self.tool.execute(
+            mode="create",
+            file_path="from-template.pptx",
+            template_path="template.pptx",
+            slides=[{"title": "Would exceed the limit"}],
+        )
+
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("template slides plus requested slides", result["error"])
+        self.assertFalse(os.path.exists(os.path.join(self.base_dir, "from-template.pptx")))
 
 
 class TestPowerPointRegistration(unittest.TestCase):

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
@@ -462,6 +462,84 @@ class TestPowerPointOperations(unittest.TestCase):
         self.assertIn("template slides plus requested slides", result["error"])
         self.assertFalse(os.path.exists(os.path.join(self.base_dir, "from-template.pptx")))
 
+    # -- read-side structural bounds (regression for crafted PPTX expansion) --
+
+    def test_read_caps_slide_count(self) -> None:
+        # More slides than max_slides; read still succeeds but the archive
+        # guard rejects the file before parsing.
+        many_slides = [{"title": f"slide {i}"} for i in range(5)]
+        self.tool.execute(mode="create", file_path="many.pptx", slides=many_slides)
+        self.tool.max_slides = 2
+        result = self.tool.execute(mode="read", file_path="many.pptx")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("exceeding max_slides", result["error"])
+
+    def test_read_caps_shapes_per_slide(self) -> None:
+        # A slide with a body plus a table carries multiple shapes; the read
+        # must stop at max_shapes_per_slide instead of walking every shape and
+        # expanding every table cell into the result.
+        self.tool.execute(
+            mode="create",
+            file_path="shapes.pptx",
+            slides=[{"title": "t", "bullets": ["b1", "b2"], "table": [["a", "b"], ["c", "d"]]}],
+        )
+        # Lower the cap so the table shape is never reached; the read reports
+        # truncated and emits no table rows.
+        self.tool.max_shapes_per_slide = 1
+        result = self.tool.execute(mode="read", file_path="shapes.pptx")
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["slides"][0]["tables"], [])
+
+    def test_read_caps_table_rows(self) -> None:
+        # A table with more rows than max_table_rows; read must stop early.
+        big_rows = [[f"r{i}c0", f"r{i}c1"] for i in range(40)]
+        self.tool.execute(
+            mode="create",
+            file_path="rows.pptx",
+            slides=[{"title": "t", "table": big_rows}],
+        )
+        self.tool.max_table_rows = 5
+        result = self.tool.execute(mode="read", file_path="rows.pptx")
+        self.assertEqual(result["status"], "success")
+        for table in result["slides"][0]["tables"]:
+            self.assertLessEqual(len(table), self.tool.max_table_rows)
+        self.assertTrue(result["truncated"])
+
+    def test_read_caps_table_columns(self) -> None:
+        # A wide table; read must stop at max_table_columns per row.
+        wide_row = [str(i) for i in range(15)]
+        self.tool.execute(
+            mode="create",
+            file_path="wide.pptx",
+            slides=[{"title": "t", "table": [wide_row, wide_row]}],
+        )
+        self.tool.max_table_columns = 4
+        result = self.tool.execute(mode="read", file_path="wide.pptx")
+        self.assertEqual(result["status"], "success")
+        for table in result["slides"][0]["tables"]:
+            for row in table:
+                self.assertLessEqual(len(row), self.tool.max_table_columns)
+        self.assertTrue(result["truncated"])
+
+    def test_read_stops_when_text_budget_exhausted(self) -> None:
+        # Once max_text_chars is consumed, the read must stop traversing rather
+        # than continuing to walk every remaining slide/shape and padding the
+        # result with empty strings.
+        slides = [{"title": f"title-{i}", "bullets": [f"body text line {i}"]} for i in range(15)]
+        self.tool.execute(mode="create", file_path="mixed.pptx", slides=slides)
+        self.tool.max_text_chars = 30
+        result = self.tool.execute(mode="read", file_path="mixed.pptx")
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(result["truncated"])
+        # No empty-string padding from continued traversal after budget hit.
+        emitted = sum(
+            len(slide["title"]) + sum(len(text) for text in slide["texts"]) + len(slide["notes"])
+            for slide in result["slides"]
+        )
+        # Allow a small overshoot for the truncation ellipsis on the last field.
+        self.assertLessEqual(emitted, self.tool.max_text_chars + len(result["slides"]))
+
 
 class TestPowerPointRegistration(unittest.TestCase):
     """Load the shipped YAML through the real component pipeline."""

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+
+"""Tests for the built-in PowerPointTool."""
+
+import importlib.util
+import os
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import powerpoint_tool as ppt_module
+from agentuniverse.agent.action.tool.common_tool.powerpoint_tool import PowerPointTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import (
+    ApplicationConfigManager,
+)
+from agentuniverse.base.config.component_configer.component_configer import (
+    ComponentConfiger,
+)
+from agentuniverse.base.config.component_configer.configers.tool_configer import (
+    ToolConfiger,
+)
+from agentuniverse.base.config.configer import Configer
+
+PPTX_AVAILABLE = importlib.util.find_spec("pptx") is not None
+YAML_PATH = os.path.join(os.path.dirname(ppt_module.__file__), "powerpoint_tool.yaml")
+
+
+class TestPowerPointValidation(unittest.TestCase):
+    """Input, configuration, path, and atomic-write boundaries."""
+
+    def setUp(self) -> None:
+        self.temp_dir_context = tempfile.TemporaryDirectory()
+        self.base_dir = self.temp_dir_context.name
+        self.tool = PowerPointTool(base_dir=self.base_dir)
+
+    def tearDown(self) -> None:
+        self.temp_dir_context.cleanup()
+
+    def test_invalid_mode_is_structured_error(self) -> None:
+        result = self.tool.execute(mode="delete", file_path="deck.pptx")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("invalid mode", result["error"])
+
+    def test_rejects_non_pptx_extension(self) -> None:
+        result = self.tool.execute(mode="info", file_path="deck.ppt")
+        self.assertIn(".pptx extension", result["error"])
+
+    def test_rejects_parent_path_escape(self) -> None:
+        result = self.tool.execute(mode="info", file_path="../deck.pptx")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("escapes the allowed directory", result["error"])
+
+    def test_rejects_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as outside:
+            outside_file = os.path.join(outside, "outside.pptx")
+            with open(outside_file, "wb") as output:
+                output.write(b"not a presentation")
+            os.symlink(outside, os.path.join(self.base_dir, "linked"))
+            result = self.tool.execute(
+                mode="info",
+                file_path="linked/outside.pptx",
+            )
+        self.assertIn("escapes the allowed directory", result["error"])
+
+    def test_rejects_invalid_config_limit(self) -> None:
+        self.tool.max_slides = 0
+        result = self.tool.execute(mode="info", file_path="deck.pptx")
+        self.assertIn("max_slides must be a positive integer", result["error"])
+
+    def test_rejects_boolean_config_limit(self) -> None:
+        self.tool.max_text_chars = True
+        result = self.tool.execute(mode="info", file_path="deck.pptx")
+        self.assertIn("max_text_chars must be a positive integer", result["error"])
+
+    def test_rejects_invalid_pptx_archive(self) -> None:
+        with open(os.path.join(self.base_dir, "invalid.pptx"), "wb") as output:
+            output.write(b"not-a-zip")
+        result = self.tool.execute(mode="info", file_path="invalid.pptx")
+        self.assertIn("not a valid PPTX ZIP archive", result["error"])
+
+    def test_rejects_archive_expansion_over_limit(self) -> None:
+        archive_path = os.path.join(self.base_dir, "oversized.pptx")
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("ppt/slides/slide1.xml", "x" * 100)
+        self.tool.max_uncompressed_bytes = 32
+        result = self.tool.execute(mode="info", file_path="oversized.pptx")
+        self.assertIn("max_uncompressed_bytes", result["error"])
+
+    def test_rejects_archive_entry_count_over_limit(self) -> None:
+        archive_path = os.path.join(self.base_dir, "many-entries.pptx")
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one", "1")
+            archive.writestr("two", "2")
+        self.tool.max_archive_entries = 1
+        result = self.tool.execute(mode="info", file_path="many-entries.pptx")
+        self.assertIn("max_archive_entries", result["error"])
+
+    def test_create_requires_non_empty_slides(self) -> None:
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[],
+        )
+        self.assertIn("slides must be a non-empty list", result["error"])
+
+    def test_rejects_unknown_slide_field(self) -> None:
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "Hello", "script": "do something"}],
+        )
+        self.assertIn("unknown fields: script", result["error"])
+
+    def test_rejects_invalid_bullet_level(self) -> None:
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[
+                {
+                    "title": "Hello",
+                    "bullets": [{"text": "Too deep", "level": 9}],
+                }
+            ],
+        )
+        self.assertIn("integer from 0 to 8", result["error"])
+
+    def test_rejects_table_column_overflow(self) -> None:
+        self.tool.max_table_columns = 2
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "Data", "table": [[1, 2, 3]]}],
+        )
+        self.assertIn("max_table_columns", result["error"])
+
+    def test_rejects_text_budget_overflow(self) -> None:
+        self.tool.max_text_chars = 5
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "sixsix"}],
+        )
+        self.assertIn("exceeding max_text_chars", result["error"])
+
+    def test_missing_dependency_has_install_hint(self) -> None:
+        with patch.object(
+            self.tool,
+            "_load_pptx",
+            side_effect=ImportError("missing"),
+        ):
+            result = self.tool.execute(
+                mode="create",
+                file_path="deck.pptx",
+                slides=[{"title": "Hello"}],
+            )
+        self.assertEqual(result["error_type"], "dependency_error")
+        self.assertIn("pip install python-pptx", result["error"])
+
+    def test_atomic_save_preserves_destination_when_size_limit_fails(self) -> None:
+        destination = os.path.join(self.base_dir, "deck.pptx")
+        original = b"existing-presentation"
+        with open(destination, "wb") as output:
+            output.write(original)
+
+        class OversizedPresentation:
+            @staticmethod
+            def save(path):
+                with open(path, "wb") as output:
+                    output.write(b"x" * 32)
+
+        self.tool.max_write_bytes = 16
+        with self.assertRaisesRegex(ValueError, "max_write_bytes"):
+            self.tool._atomic_save(OversizedPresentation(), destination)
+        with open(destination, "rb") as existing:
+            self.assertEqual(existing.read(), original)
+        leftovers = [name for name in os.listdir(self.base_dir) if name.startswith(".powerpoint-")]
+        self.assertEqual(leftovers, [])
+
+
+@unittest.skipUnless(PPTX_AVAILABLE, "python-pptx is required")
+class TestPowerPointOperations(unittest.TestCase):
+    """Real, deterministic PPTX round trips without network access."""
+
+    def setUp(self) -> None:
+        self.temp_dir_context = tempfile.TemporaryDirectory()
+        self.base_dir = self.temp_dir_context.name
+        self.tool = PowerPointTool(base_dir=self.base_dir)
+
+    def tearDown(self) -> None:
+        self.temp_dir_context.cleanup()
+
+    def _create_deck(self, file_path: str = "deck.pptx"):
+        return self.tool.execute(
+            mode="create",
+            file_path=file_path,
+            slides=[
+                {
+                    "title": "Quarterly Review",
+                    "subtitle": "Q2 2026",
+                    "notes": "Open with the headline.",
+                },
+                {
+                    "title": "Highlights",
+                    "bullets": [
+                        "Revenue grew 20%",
+                        {"text": "APAC led growth", "level": 1},
+                    ],
+                    "table": [
+                        ["Metric", "Value"],
+                        ["Revenue", 123],
+                    ],
+                    "notes": "Explain the regional mix.",
+                },
+            ],
+            metadata={"title": "Quarterly Review", "author": "agentUniverse"},
+        )
+
+    def test_create_read_and_info_round_trip(self) -> None:
+        created = self._create_deck()
+        self.assertEqual(created["status"], "success")
+        self.assertEqual(created["slide_count"], 2)
+        self.assertTrue(os.path.isfile(created["file_path"]))
+
+        read = self.tool.execute(mode="read", file_path="deck.pptx")
+        self.assertEqual(read["status"], "success")
+        self.assertFalse(read["truncated"])
+        self.assertEqual(read["slides"][0]["title"], "Quarterly Review")
+        self.assertIn("Q2 2026", read["slides"][0]["texts"])
+        self.assertEqual(read["slides"][0]["notes"], "Open with the headline.")
+        self.assertIn("Revenue grew 20%", read["slides"][1]["texts"][0])
+        self.assertEqual(read["slides"][1]["tables"][0][1], ["Revenue", "123"])
+
+        info = self.tool.execute(mode="info", file_path="deck.pptx")
+        self.assertEqual(info["slide_count"], 2)
+        self.assertEqual(info["metadata"]["title"], "Quarterly Review")
+        self.assertEqual(info["metadata"]["author"], "agentUniverse")
+        self.assertEqual(info["slides"][1]["table_count"], 1)
+        self.assertTrue(info["slides"][0]["has_notes"])
+
+    def test_append_preserves_existing_slides(self) -> None:
+        self._create_deck()
+        appended = self.tool.execute(
+            mode="append",
+            file_path="deck.pptx",
+            slides=[{"title": "Next Steps", "bullets": ["Ship the release"]}],
+        )
+        self.assertEqual(appended["status"], "success")
+        self.assertEqual(appended["slides_added"], 1)
+        self.assertEqual(appended["slide_count"], 3)
+        read = self.tool.execute(mode="read", file_path="deck.pptx")
+        self.assertEqual(read["slides"][0]["title"], "Quarterly Review")
+        self.assertEqual(read["slides"][2]["title"], "Next Steps")
+
+    def test_create_refuses_overwrite_and_preserves_file(self) -> None:
+        self._create_deck()
+        deck_path = os.path.join(self.base_dir, "deck.pptx")
+        with open(deck_path, "rb") as original_file:
+            original = original_file.read()
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "Replacement"}],
+        )
+        self.assertEqual(result["status"], "error")
+        self.assertIn("set overwrite=true", result["error"])
+        with open(deck_path, "rb") as unchanged_file:
+            self.assertEqual(unchanged_file.read(), original)
+
+    def test_create_can_overwrite_explicitly(self) -> None:
+        self._create_deck()
+        result = self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "Replacement"}],
+            overwrite=True,
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(result["overwritten"])
+        self.assertEqual(result["slide_count"], 1)
+
+    def test_template_preserves_template_slides(self) -> None:
+        self.tool.execute(
+            mode="create",
+            file_path="template.pptx",
+            slides=[{"title": "Template Cover"}],
+        )
+        created = self.tool.execute(
+            mode="create",
+            file_path="from-template.pptx",
+            template_path="template.pptx",
+            slides=[{"title": "Generated Slide"}],
+        )
+        self.assertEqual(created["status"], "success")
+        self.assertEqual(created["slide_count"], 2)
+        read = self.tool.execute(mode="read", file_path="from-template.pptx")
+        self.assertEqual(
+            [slide["title"] for slide in read["slides"]],
+            ["Template Cover", "Generated Slide"],
+        )
+
+    def test_read_truncates_to_context_budget(self) -> None:
+        self.tool.execute(
+            mode="create",
+            file_path="deck.pptx",
+            slides=[{"title": "A long title", "bullets": ["long body text"]}],
+        )
+        self.tool.max_text_chars = 8
+        read = self.tool.execute(mode="read", file_path="deck.pptx")
+        self.assertEqual(read["status"], "success")
+        self.assertTrue(read["truncated"])
+        emitted = sum(
+            len(slide["title"]) + sum(len(text) for text in slide["texts"]) + len(slide["notes"])
+            for slide in read["slides"]
+        )
+        self.assertLessEqual(emitted, 8)
+
+    def test_append_rejects_result_over_slide_limit(self) -> None:
+        self._create_deck()
+        self.tool.max_slides = 2
+        result = self.tool.execute(
+            mode="append",
+            file_path="deck.pptx",
+            slides=[{"title": "One too many"}],
+        )
+        self.assertIn("exceeding max_slides", result["error"])
+
+
+class TestPowerPointRegistration(unittest.TestCase):
+    """Load the shipped YAML through the real component pipeline."""
+
+    def setUp(self) -> None:
+        self.configer = Configer(path=os.path.abspath(YAML_PATH)).load()
+        try:
+            self.previous_app_configer = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous_app_configer = None
+
+    def tearDown(self) -> None:
+        ApplicationConfigManager().app_configer = self.previous_app_configer
+
+    def test_yaml_resolves_to_tool_component(self) -> None:
+        component = ComponentConfiger().load_by_configer(self.configer)
+        self.assertEqual(
+            component.get_component_config_type(),
+            ComponentEnum.TOOL.value,
+        )
+        self.assertEqual(
+            component.metadata_module,
+            "agentuniverse.agent.action.tool.common_tool.powerpoint_tool",
+        )
+        self.assertEqual(component.metadata_class, "PowerPointTool")
+
+    def test_tool_manager_resolves_configured_tool(self) -> None:
+        tool_configer = ToolConfiger().load_by_configer(self.configer)
+        app_configer = AppConfiger()
+        app_configer.tool_configer_map = {tool_configer.name: tool_configer}
+        ApplicationConfigManager().app_configer = app_configer
+
+        tool = ToolManager().get_instance_obj(tool_configer.name)
+
+        self.assertIsInstance(tool, PowerPointTool)
+        self.assertEqual(tool.name, "powerpoint_tool")
+        self.assertEqual(tool.input_keys, ["mode", "file_path"])
+        self.assertEqual(tool.max_slides, 100)
+        self.assertEqual(tool.max_uncompressed_bytes, 104_857_600)
+        self.assertEqual(
+            tool.args_model_schema["properties"]["mode"]["enum"],
+            ["create", "append", "read", "info"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_powerpoint_tool.py
@@ -398,6 +398,20 @@ class TestPowerPointOperations(unittest.TestCase):
         self.assertEqual(read["slides"][0]["tables"][0][1], ["亚太", "42", ""])
         self.assertEqual(read["slides"][0]["notes"], "演讲人备注 ✓")
 
+    def test_blank_layout_fallback_title_round_trip(self) -> None:
+        created = self.tool.execute(
+            mode="create",
+            file_path="blank-layout.pptx",
+            slides=[{"layout": "blank", "title": "Semantic fallback title"}],
+        )
+
+        self.assertEqual(created["status"], "success")
+        read = self.tool.execute(mode="read", file_path="blank-layout.pptx")
+        info = self.tool.execute(mode="info", file_path="blank-layout.pptx")
+        self.assertEqual(read["slides"][0]["title"], "Semantic fallback title")
+        self.assertNotIn("Semantic fallback title", read["slides"][0]["texts"])
+        self.assertEqual(info["slides"][0]["title"], "Semantic fallback title")
+
     def test_create_uses_write_limit_not_read_limit(self) -> None:
         self.tool.max_read_bytes = 1
         self.tool.max_write_bytes = 2 * 1024 * 1024


### PR DESCRIPTION
## Summary

- add a built-in `PowerPointTool` with structured `create`, `append`, `read`, and `info` modes
- support title/subtitle slides, nested bullets, ragged tables, speaker notes, six layout choices, PPTX templates, and core metadata
- register the tool through YAML and the common-tool package, document it in English and Chinese, and expose `python-pptx` through the optional `office_ext` dependency
- add 33 unit/integration tests covering component registration, real PPTX round trips, Unicode content, blank-layout title semantics, templates, overwrite behavior, and bounded/atomic failure paths

## Safety and reliability

- confines presentation and template paths to `base_dir`, including symlink-escape checks
- bounds compressed input size, ZIP entry count, expanded archive size, slide count, text volume, and table dimensions
- saves through a same-directory temporary file and atomically replaces the destination only after all output checks pass
- refuses implicit overwrite and preserves the original file when append/save validation fails
- lazily imports `python-pptx` and returns a structured installation hint when the optional dependency is unavailable

## Validation

Local macOS / Python 3.11:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_powerpoint_tool
Ran 33 tests in 0.177s — OK

python -m ruff check ...
All checks passed!

python -m ruff format --check ...
2 files already formatted
```

Ubuntu 22.04 x86_64 server / Python 3.10.12 / python-pptx 1.0.2:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_powerpoint_tool
Ran 33 tests in 0.534s — OK

seeded mixed-content stress run
STRESS_OK seed=25220260718 workflows=75 persisted_slides=295
```

The server stress run exercised create/read/info/append workflows across every supported layout with multilingual text, nested bullets, ragged tables, notes, metadata, and nested output paths. Template behavior was covered by the real-PPTX unit suite on both machines. It exposed a blank-layout title round-trip issue; the implementation now marks fallback title textboxes and recognizes them during read/info.

Partially addresses #252.
