### PR TITLE
fix(tool): lazy load Google v2 search dependency

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/google_search_tool_v2.py
+++ b/agentuniverse/agent/action/tool/common_tool/google_search_tool_v2.py
@@ -6,14 +6,22 @@
 # @FileName: google_search_tool.py
 
 import json
-import requests
-from typing import Optional, Dict, Any, List
-from urllib.parse import quote_plus
+from typing import Optional
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 from agentuniverse.base.util.env_util import get_from_env
-from langchain_community.utilities.google_serper import GoogleSerperAPIWrapper
 from pydantic import Field
+
+
+def _get_google_serper_api_wrapper():
+    try:
+        from langchain_community.utilities.google_serper import GoogleSerperAPIWrapper
+    except ImportError as exc:
+        raise ImportError(
+            "langchain-community is required to use Google Serper search. "
+            "Install it with `pip install langchain-community`."
+        ) from exc
+    return GoogleSerperAPIWrapper
 
 
 class GoogleSearchTool(Tool):
@@ -60,6 +68,7 @@ class GoogleSearchTool(Tool):
         hl = hl or self.default_hl
         
         try:
+            GoogleSerperAPIWrapper = _get_google_serper_api_wrapper()
             search = GoogleSerperAPIWrapper(
                 serper_api_key=self.serper_api_key, 
                 k=k, 
@@ -83,6 +92,7 @@ class GoogleSearchTool(Tool):
         hl = hl or self.default_hl
         
         try:
+            GoogleSerperAPIWrapper = _get_google_serper_api_wrapper()
             search = GoogleSerperAPIWrapper(
                 serper_api_key=self.serper_api_key, 
                 k=k, 
@@ -182,6 +192,7 @@ class GoogleScholarSearchTool(Tool):
         scholar_query = self._build_scholar_query(query, year, author, journal)
         
         try:
+            GoogleSerperAPIWrapper = _get_google_serper_api_wrapper()
             search = GoogleSerperAPIWrapper(
                 serper_api_key=self.serper_api_key, 
                 k=k, 
@@ -204,6 +215,7 @@ class GoogleScholarSearchTool(Tool):
         scholar_query = self._build_scholar_query(query, year, author, journal)
         
         try:
+            GoogleSerperAPIWrapper = _get_google_serper_api_wrapper()
             search = GoogleSerperAPIWrapper(
                 serper_api_key=self.serper_api_key, 
                 k=k, 

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool_v2.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool_v2.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import google_search_tool_v2 as google_v2_module
+from agentuniverse.agent.action.tool.common_tool.google_search_tool_v2 import (
+    GoogleScholarSearchTool,
+    GoogleSearchTool,
+)
+
+
+class FakeGoogleSerperAPIWrapper:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def run(self, query):
+        return f"result for {query}"
+
+    async def arun(self, query):
+        return self.run(query)
+
+
+class TestGoogleSearchToolV2(unittest.IsolatedAsyncioTestCase):
+    def test_missing_key_uses_mock_without_loading_serper_wrapper(self):
+        tool = GoogleSearchTool(serper_api_key=None)
+
+        with patch.object(
+            google_v2_module,
+            "_get_google_serper_api_wrapper",
+            side_effect=AssertionError("wrapper should not be loaded"),
+        ):
+            result = tool.execute("agentUniverse")
+
+        self.assertIn("未配置SERPER_API_KEY", result)
+
+    def test_execute_loads_serper_wrapper_for_real_search(self):
+        tool = GoogleSearchTool(serper_api_key="test-key")
+
+        with patch.object(
+            google_v2_module,
+            "_get_google_serper_api_wrapper",
+            return_value=FakeGoogleSerperAPIWrapper,
+        ) as load_wrapper:
+            result = tool.execute("agentUniverse", search_type="news", k=3)
+
+        load_wrapper.assert_called_once_with()
+        self.assertIn("agentUniverse", result)
+
+    async def test_async_execute_loads_serper_wrapper_for_real_search(self):
+        tool = GoogleSearchTool(serper_api_key="test-key")
+
+        with patch.object(
+            google_v2_module,
+            "_get_google_serper_api_wrapper",
+            return_value=FakeGoogleSerperAPIWrapper,
+        ) as load_wrapper:
+            result = await tool.async_execute("agentUniverse")
+
+        load_wrapper.assert_called_once_with()
+        self.assertIn("agentUniverse", result)
+
+    def test_scholar_missing_key_uses_mock_without_loading_wrapper(self):
+        tool = GoogleScholarSearchTool(serper_api_key=None)
+
+        with patch.object(
+            google_v2_module,
+            "_get_google_serper_api_wrapper",
+            side_effect=AssertionError("wrapper should not be loaded"),
+        ):
+            result = tool.execute("agentUniverse")
+
+        self.assertIn("未配置SERPER_API_KEY", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Move `GoogleSerperAPIWrapper` loading in `google_search_tool_v2.py` behind a small helper.
- Preserve the existing mock result path when `SERPER_API_KEY` is not configured.
- Apply the lazy-loading path to normal search, async search, scholar search, and async scholar search.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool_v2.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/google_search_tool_v2.py tests/test_agentuniverse/unit/agent/action/tool/test_google_search_tool_v2.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `requests` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.