### PR TITLE
fix(tool): lazy load Python REPL dependency

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/python_repl.py
+++ b/agentuniverse/agent/action/tool/common_tool/python_repl.py
@@ -7,11 +7,22 @@
 # @FileName: python_repl.py
 
 import re
+from typing import Any
 
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
-from langchain_community.utilities import PythonREPL
 from loguru import logger
 from pydantic import Field
+
+
+def _get_python_repl():
+    try:
+        from langchain_community.utilities import PythonREPL
+    except ImportError as exc:
+        raise ImportError(
+            "langchain-community is required to use PythonREPLTool. "
+            "Install it with `pip install langchain-community`."
+        ) from exc
+    return PythonREPL()
 
 
 class PythonREPLTool(Tool):
@@ -35,8 +46,13 @@ class PythonREPLTool(Tool):
             the risk above.
     """
 
-    client: PythonREPL = Field(default_factory=lambda: PythonREPL())
+    client: Any = Field(default=None)
     allow_code_execution: bool = False
+
+    def _get_client(self):
+        if self.client is None:
+            self.client = _get_python_repl()
+        return self.client
 
     def execute(self, input: str):
         """Execute the Python code extracted from ``input``.
@@ -59,9 +75,10 @@ class PythonREPLTool(Tool):
         if len(matches) == 0:
             pattern = re.compile(r"```py(.*?)``", re.DOTALL)
             matches = pattern.findall(input)
+        client = self._get_client()
         if len(matches) == 0:
-            return self.client.run(input)
-        res = self.client.run(matches[0])
+            return client.run(input)
+        res = client.run(matches[0])
         if res == "" or res is None:
             return "ERROR: 你的python代码中没有使用print输出任何内容，请参考工具示例"
         else:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_python_repl_lazy_import.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_python_repl_lazy_import.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import python_repl as repl_module
+from agentuniverse.agent.action.tool.common_tool.python_repl import PythonREPLTool
+
+
+class FakePythonREPL:
+    def __init__(self):
+        self.inputs = []
+
+    def run(self, code):
+        self.inputs.append(code)
+        return "ok"
+
+
+class TestPythonREPLLazyImport(unittest.TestCase):
+    def test_disabled_tool_does_not_load_python_repl(self):
+        tool = PythonREPLTool(allow_code_execution=False)
+
+        with patch.object(
+            repl_module,
+            "_get_python_repl",
+            side_effect=AssertionError("client should not be loaded"),
+        ):
+            result = tool.execute("print('hello')")
+
+        self.assertIn("disabled by default", result)
+
+    def test_enabled_tool_loads_client_lazily(self):
+        fake_client = FakePythonREPL()
+        tool = PythonREPLTool(allow_code_execution=True)
+
+        with patch.object(
+            repl_module,
+            "_get_python_repl",
+            return_value=fake_client,
+        ) as load_client:
+            result = tool.execute("print('hello')")
+
+        load_client.assert_called_once_with()
+        self.assertEqual(result, "ok")
+        self.assertEqual(fake_client.inputs, ["print('hello')"])
+
+    def test_existing_client_is_reused(self):
+        fake_client = FakePythonREPL()
+        tool = PythonREPLTool(client=fake_client, allow_code_execution=True)
+
+        with patch.object(
+            repl_module,
+            "_get_python_repl",
+            side_effect=AssertionError("existing client should be reused"),
+        ):
+            result = tool.execute("```python\nprint('hello')\n```")
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(fake_client.inputs, ["\nprint('hello')\n"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Remove the module-level `PythonREPL` import from `python_repl.py`.
- Lazily create the Python REPL client only after `allow_code_execution=True` and execution is actually requested.
- Keep the existing default-disabled safety behavior unchanged.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_python_repl_lazy_import.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/python_repl.py tests/test_agentuniverse/unit/agent/action/tool/test_python_repl_lazy_import.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `requests` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.