### PR TITLE
fix(tool): parse API scalar body values safely

### DIFF
--- a/agentuniverse/agent/action/tool/api_tool.py
+++ b/agentuniverse/agent/action/tool/api_tool.py
@@ -44,22 +44,13 @@ class APITool(Tool):
                 if 'type' in option:
                     # Attempt to convert the value based on the type.
                     if option['type'] == 'integer' or option['type'] == 'int':
-                        return int(value)
+                        return self._convert_integer(value)
                     elif option['type'] == 'number':
-                        if '.' in str(value):
-                            return float(value)
-                        else:
-                            return int(value)
+                        return self._convert_number(value)
                     elif option['type'] == 'string':
                         return str(value)
                     elif option['type'] == 'boolean':
-                        if str(value).lower() in ['true', '1']:
-                            return True
-                        elif str(value).lower() in ['false', '0']:
-                            return False
-                        else:
-                            # Not a boolean, try next option
-                            continue
+                        return self._convert_boolean(value)
                     elif option['type'] == 'null' and not value:
                         return None
                     else:
@@ -78,17 +69,13 @@ class APITool(Tool):
         try:
             if 'type' in property:
                 if property['type'] == 'integer' or property['type'] == 'int':
-                    return int(value)
+                    return self._convert_integer(value)
                 elif property['type'] == 'number':
-                    # check if it is a float
-                    if '.' in value:
-                        return float(value)
-                    else:
-                        return int(value)
+                    return self._convert_number(value)
                 elif property['type'] == 'string':
                     return str(value)
                 elif property['type'] == 'boolean':
-                    return bool(value)
+                    return self._convert_boolean(value)
                 elif property['type'] == 'null':
                     if value is None:
                         return None
@@ -109,6 +96,36 @@ class APITool(Tool):
                 return self.convert_body_property_any_of(property, value, property['anyOf'])
         except ValueError as e:
             return value
+
+    @staticmethod
+    def _convert_integer(value: Any) -> int:
+        if isinstance(value, bool):
+            raise ValueError("boolean is not an integer")
+        return int(value)
+
+    @staticmethod
+    def _convert_number(value: Any) -> int | float:
+        if isinstance(value, bool):
+            raise ValueError("boolean is not a number")
+        if isinstance(value, (int, float)):
+            return value
+        value_text = str(value).strip()
+        if "." in value_text or "e" in value_text.lower():
+            return float(value_text)
+        return int(value_text)
+
+    @staticmethod
+    def _convert_boolean(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)) and value in (0, 1):
+            return bool(value)
+        value_text = str(value).strip().lower()
+        if value_text in ["true", "1"]:
+            return True
+        if value_text in ["false", "0"]:
+            return False
+        raise ValueError(f"Invalid boolean value: {value}")
 
     def do_http_request(self, url: str, method: str, headers: dict[str, Any],
                         parameters: dict[str, Any]) -> httpx.Response:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.action.tool.api_tool import APITool
+
+
+class TestAPIToolTypeConversion(unittest.TestCase):
+    def setUp(self):
+        self.tool = APITool()
+
+    def test_boolean_string_false_is_false(self):
+        result = self.tool.convert_body_property_type(
+            {"type": "boolean"},
+            "false",
+        )
+
+        self.assertIs(result, False)
+
+    def test_boolean_rejects_unknown_strings(self):
+        result = self.tool.convert_body_property_type(
+            {"type": "boolean"},
+            "definitely",
+        )
+
+        self.assertEqual(result, "definitely")
+
+    def test_boolean_numeric_zero_and_one(self):
+        self.assertIs(
+            self.tool.convert_body_property_type({"type": "boolean"}, 0),
+            False,
+        )
+        self.assertIs(
+            self.tool.convert_body_property_type({"type": "boolean"}, 1),
+            True,
+        )
+
+    def test_number_accepts_native_numeric_values(self):
+        self.assertEqual(
+            self.tool.convert_body_property_type({"type": "number"}, 12),
+            12,
+        )
+        self.assertEqual(
+            self.tool.convert_body_property_type({"type": "number"}, 12.5),
+            12.5,
+        )
+
+    def test_anyof_uses_same_scalar_conversion(self):
+        result = self.tool.convert_body_property_any_of(
+            {},
+            "false",
+            [{"type": "boolean"}, {"type": "string"}],
+        )
+
+        self.assertIs(result, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Add shared scalar conversion helpers for integer, number, and boolean request-body values.
- Fix boolean conversion so strings such as `"false"` and `"0"` do not become `True` through Python truthiness.
- Make numeric conversion accept native `int` and `float` values without doing string-only membership checks.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py`
- `python -m py_compile agentuniverse/agent/action/tool/api_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `httpx` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.