### PR TITLE
fix(tool): preserve custom SSRF proxy timeout

### DIFF
--- a/agentuniverse/agent/action/tool/utils/ssrf_proxy.py
+++ b/agentuniverse/agent/action/tool/utils/ssrf_proxy.py
@@ -19,12 +19,12 @@ proxies = {
 
 
 def make_request(method, url, **kwargs):
+    kwargs.setdefault("timeout", 20)
     if SSRF_PROXY_ALL_URL:
-        return httpx.request(method=method, url=url, proxy=SSRF_PROXY_ALL_URL, timeout=20, **kwargs)
+        kwargs["proxy"] = SSRF_PROXY_ALL_URL
     elif proxies:
-        return httpx.request(method=method, url=url, proxies=proxies, timeout=20, **kwargs)
-    else:
-        return httpx.request(method=method, url=url, timeout=20, **kwargs)
+        kwargs["proxies"] = proxies
+    return httpx.request(method=method, url=url, **kwargs)
 
 
 def get(url, **kwargs):

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.utils import ssrf_proxy
+
+
+class TestSSRFProxy(unittest.TestCase):
+    def test_default_timeout_is_used_when_not_provided(self):
+        with patch.object(ssrf_proxy, "SSRF_PROXY_ALL_URL", ""):
+            with patch.object(ssrf_proxy, "proxies", None):
+                with patch.object(ssrf_proxy.httpx, "request", return_value="ok") as request:
+                    result = ssrf_proxy.get("https://example.com")
+
+        self.assertEqual(result, "ok")
+        request.assert_called_once_with(
+            method="GET",
+            url="https://example.com",
+            timeout=20,
+        )
+
+    def test_caller_timeout_overrides_default(self):
+        with patch.object(ssrf_proxy, "SSRF_PROXY_ALL_URL", ""):
+            with patch.object(ssrf_proxy, "proxies", None):
+                with patch.object(ssrf_proxy.httpx, "request", return_value="ok") as request:
+                    result = ssrf_proxy.get("https://example.com", timeout=5)
+
+        self.assertEqual(result, "ok")
+        request.assert_called_once_with(
+            method="GET",
+            url="https://example.com",
+            timeout=5,
+        )
+
+    def test_proxy_url_is_added_without_overwriting_timeout(self):
+        with patch.object(ssrf_proxy, "SSRF_PROXY_ALL_URL", "http://proxy.local"):
+            with patch.object(ssrf_proxy.httpx, "request", return_value="ok") as request:
+                result = ssrf_proxy.post("https://example.com", timeout=3)
+
+        self.assertEqual(result, "ok")
+        request.assert_called_once_with(
+            method="POST",
+            url="https://example.com",
+            timeout=3,
+            proxy="http://proxy.local",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Preserve caller-provided `timeout` values in `ssrf_proxy.make_request`.
- Keep the existing default timeout of 20 seconds when no timeout is supplied.
- Add proxy arguments through `kwargs` so timeout and proxy options are composed in one place.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py`
- `python -m py_compile agentuniverse/agent/action/tool/utils/ssrf_proxy.py tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `httpx` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.