### PR TITLE
fix(reader): remove web page debug output

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py
@@ -24,15 +24,12 @@ class WebPageReader(Reader):
     """
 
     def _load_data(self, url: str, ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: WebPageReader start load url={url}")
         if not isinstance(url, str) or not url:
             raise ValueError("WebPageReader._load_data requires a non-empty url string")
 
         html = self._fetch_html(url)
-        print(f"debugging: WebPageReader fetched html length={len(html)}")
 
         text, metadata_extra = self._extract_main_text(html, url)
-        print(f"debugging: WebPageReader extracted text length={len(text)}")
 
         metadata: Dict = {"source": "web", "url": url}
         metadata.update(metadata_extra)
@@ -44,7 +41,6 @@ class WebPageReader(Reader):
     def _fetch_html(self, url: str) -> str:
         try:
             import httpx  # type: ignore
-            print("debugging: WebPageReader using httpx")
             with httpx.Client(timeout=20.0, headers={
                 "User-Agent": "agentUniverse/1.0 (+https://github.com/)",
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -53,10 +49,8 @@ class WebPageReader(Reader):
                 resp.raise_for_status()
                 return resp.text
         except Exception as e_httpx:
-            print(f"debugging: WebPageReader httpx failed: {e_httpx}")
             try:
                 import requests  # type: ignore
-                print("debugging: WebPageReader using requests fallback")
                 resp = requests.get(url, timeout=20, headers={
                     "User-Agent": "agentUniverse/1.0 (+https://github.com/)",
                     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -70,31 +64,28 @@ class WebPageReader(Reader):
         # Try trafilatura
         try:
             import trafilatura  # type: ignore
-            print("debugging: WebPageReader using trafilatura")
             extracted = trafilatura.extract(html, include_links=False, include_images=False)
             if extracted and extracted.strip():
                 return extracted.strip(), {"extractor": "trafilatura"}
-        except Exception as e_traf:
-            print(f"debugging: WebPageReader trafilatura failed: {e_traf}")
+        except Exception:
+            pass
 
         # Fallback to readability
         try:
             from readability import Document as ReadabilityDocument  # type: ignore
             from bs4 import BeautifulSoup  # type: ignore
-            print("debugging: WebPageReader using readability-lxml")
             article_html = ReadabilityDocument(html).summary(html_partial=True)
             soup = BeautifulSoup(article_html, "lxml")
             text = soup.get_text("\n")
             text = "\n".join([line.strip() for line in text.splitlines() if line.strip()])
             if text:
                 return text, {"extractor": "readability"}
-        except Exception as e_read:
-            print(f"debugging: WebPageReader readability failed: {e_read}")
+        except Exception:
+            pass
 
         # Last resort: BeautifulSoup plain text
         try:
             from bs4 import BeautifulSoup  # type: ignore
-            print("debugging: WebPageReader using BeautifulSoup fallback")
             soup = BeautifulSoup(html, "lxml")
             for tag in soup(["script", "style", "noscript"]):
                 tag.extract()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_web_page_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_web_page_reader.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.web.web_page_reader import WebPageReader
+
+
+class FakeWebPageReader(WebPageReader):
+    def _fetch_html(self, url: str) -> str:
+        return "<html><body>Hello</body></html>"
+
+    def _extract_main_text(self, html: str, url: str):
+        return "Hello", {"extractor": "fake"}
+
+
+class TestWebPageReader(unittest.TestCase):
+    def test_load_data_does_not_print_debug_output(self):
+        reader = FakeWebPageReader()
+
+        with patch("builtins.print") as print_mock:
+            docs = reader._load_data("https://example.com")
+
+        print_mock.assert_not_called()
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].text, "Hello")
+        self.assertEqual(docs[0].metadata["url"], "https://example.com")
+        self.assertEqual(docs[0].metadata["extractor"], "fake")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked existing issues and pull requests for duplicate work. | 我已检查没有与此请求重复的功能。
- [x] I accept maintainer suggestions to modify or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果截图。
- [ ] I have added or modified the documentation related to this PR. | 我已经添加或修改了本次PR对应的文档说明。
- [ ] I have added examples and notes if needed. | 我已经添加了使用案例代码与文档说明。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容：**

- Remove unconditional debug `print` calls from `WebPageReader`.
- Keep the existing fetch and extraction fallback behavior unchanged.
- Prevent URL, extractor, and fallback details from being written to stdout during normal reader execution.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写)：**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_web_page_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_web_page_reader.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because project runtime dependencies such as `langchain_core` are not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写)：**

- None.