### PR TITLE
fix(tool): parse YouTube stat counts safely

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/youtube_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/youtube_tool.py
@@ -58,6 +58,16 @@ class YouTubeTool(Tool):
         seconds = int(match.group(4)) if match.group(4) else 0
         return days * 86400 + hours * 3600 + minutes * 60 + seconds
 
+    @staticmethod
+    def _parse_stat_count(value) -> int:
+        """Parse a YouTube statistics field into an integer count."""
+        if value in (None, ""):
+            return 0
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
     @retry(3, 1.0)
     def _search_videos(self, query: str) -> List[Dict]:
         try:         
@@ -82,9 +92,9 @@ class YouTubeTool(Tool):
                 results.append({
                     'id': item['id'],
                     'title': item['snippet']['title'],
-                    'view_count': int(item['statistics'].get('viewCount', 0)),
-                    'like_count': int(item['statistics'].get('likeCount', 0)),
-                    'comment_count': int(item['statistics'].get('commentCount', 0)),
+                    'view_count': self._parse_stat_count(item['statistics'].get('viewCount')),
+                    'like_count': self._parse_stat_count(item['statistics'].get('likeCount')),
+                    'comment_count': self._parse_stat_count(item['statistics'].get('commentCount')),
                     'duration_seconds': self.parse_duration(item['contentDetails']['duration']),
                     'url': f"https://www.youtube.com/watch?v={item['id']}"
                 })
@@ -139,9 +149,9 @@ class YouTubeTool(Tool):
             return {
                 'name': channel_info['snippet']['title'],
                 'description': channel_info['snippet'].get('description', ''),
-                'subscriber_count': int(channel_info['statistics'].get('subscriberCount', 0)),
-                'total_view_count': int(channel_info['statistics'].get('viewCount', 0)),
-                'total_video_count': int(channel_info['statistics'].get('videoCount', 0)),
+                'subscriber_count': self._parse_stat_count(channel_info['statistics'].get('subscriberCount')),
+                'total_view_count': self._parse_stat_count(channel_info['statistics'].get('viewCount')),
+                'total_video_count': self._parse_stat_count(channel_info['statistics'].get('videoCount')),
                 'latest_video_list': video_list
             }
 
@@ -166,15 +176,15 @@ class YouTubeTool(Tool):
 
             results = []
             for item in response.get('items', []):
-                view_count = int(item['statistics'].get('viewCount', 0))
+                view_count = self._parse_stat_count(item['statistics'].get('viewCount'))
                 results.append({
                     'id': item['id'],
                     'title': item['snippet']['title'],
                     'channel_title': item['snippet']['channelTitle'],
                     'published_at': item['snippet']['publishedAt'],
                     'view_count': view_count,
-                    'like_count': int(item['statistics'].get('likeCount', 0)),
-                    'comment_count': int(item['statistics'].get('commentCount', 0)),
+                    'like_count': self._parse_stat_count(item['statistics'].get('likeCount')),
+                    'comment_count': self._parse_stat_count(item['statistics'].get('commentCount')),
                     'duration_seconds': self.parse_duration(item['contentDetails']['duration']),
                     'url': f"https://www.youtube.com/watch?v={item['id']}"
                 })

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
@@ -191,5 +191,11 @@ class YouTubeToolTest(unittest.TestCase):
     def test_parse_duration_rejects_partial_trailing_text(self) -> None:
         self.assertEqual(self.tool.parse_duration('PT1Mbad'), 0)
 
+    def test_parse_stat_count_handles_missing_or_malformed_values(self) -> None:
+        self.assertEqual(self.tool._parse_stat_count("123"), 123)
+        self.assertEqual(self.tool._parse_stat_count(None), 0)
+        self.assertEqual(self.tool._parse_stat_count(""), 0)
+        self.assertEqual(self.tool._parse_stat_count("hidden"), 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Add a small helper for parsing YouTube statistics counts.
- Treat missing, empty, or malformed count fields as `0` instead of raising during result formatting.
- Apply the same parsing to video, channel, and trending-video statistics.
- Add regression coverage for valid, missing, empty, and malformed count values.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/youtube_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because importing the common tool package requires `requests`, which is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.