### PR TITLE
fix(tool): verify Jina requests by default

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
@@ -34,6 +34,7 @@ class JinaAITool(Tool):
     api_key: Optional[str] = Field(default_factory=lambda: get_from_env("JINA_API_KEY"))
     max_read_content_length: int = Field(10000, description="Maximum content length in characters")
     remove_image: bool = Field(True, description="Remove image from content")
+    verify_ssl: bool = Field(True, description="Verify SSL certificates for Jina API requests")
     headers: Dict[str, str] = None
     def execute(self,
                 input: str = None,
@@ -42,6 +43,7 @@ class JinaAITool(Tool):
                 api_key: str = None,
                 max_read_content_length: int = None,
                 remove_image: bool = None,
+                verify_ssl: bool = None,
                 headers: Dict[str, str] = None
                 ):
         if not input:
@@ -58,6 +60,8 @@ class JinaAITool(Tool):
             self.max_read_content_length = max_read_content_length
         if remove_image is not None:
             self.remove_image = remove_image
+        if verify_ssl is not None:
+            self.verify_ssl = verify_ssl
         if headers:
             self.headers = headers
 
@@ -93,7 +97,7 @@ class JinaAITool(Tool):
                 response = requests.get(
                     url, 
                     headers=self._get_headers(), 
-                    verify=False, 
+                    verify=self.verify_ssl,
                     timeout=timeout
                 )
                 response.raise_for_status()

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
@@ -10,6 +10,32 @@ from agentuniverse.agent.action.tool.common_tool.jina_ai_tool import JinaAITool
 
 
 class JinaAIToolTest(unittest.TestCase):
+    def test_make_api_request_verifies_ssl_by_default(self):
+        tool = JinaAITool()
+
+        with patch(
+            'agentuniverse.agent.action.tool.common_tool.jina_ai_tool.requests.get',
+            side_effect=requests.Timeout()
+        ) as get_mock, patch(
+            'agentuniverse.agent.action.tool.common_tool.jina_ai_tool.time.sleep'
+        ):
+            tool._make_api_request(
+                'https://r.jina.ai/https://example.com',
+                timeout=1,
+                error_prefix='Error reading URL'
+            )
+
+        self.assertTrue(get_mock.call_args.kwargs["verify"])
+
+    def test_execute_can_disable_ssl_verification_explicitly(self):
+        tool = JinaAITool()
+
+        with patch.object(tool, "read_url", return_value="ok"):
+            result = tool.execute("https://example.com", verify_ssl=False)
+
+        self.assertEqual(result, "ok")
+        self.assertFalse(tool.verify_ssl)
+
     def test_make_api_request_handles_http_error_without_response(self):
         tool = JinaAITool()
 


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Verify TLS certificates for Jina API requests by default instead of disabling verification unconditionally.
- Add an explicit `verify_ssl` option for callers that need to override the default.
- Keep timeout and retry behavior unchanged.
- Add tests for the default verified request path and the explicit opt-out path.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py`
- `python -m py_compile agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because `requests` is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.