### PR TITLE
fix(reader): keep Google Docs credentials out of metadata

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud/google_docs_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud/google_docs_reader.py
@@ -29,8 +29,18 @@ class GoogleDocsReader(Reader):
 
         metadata: Dict = {"source": "google_docs", "doc_id": doc_id}
         if ext_info:
-            metadata.update(ext_info)
+            metadata.update(self._public_metadata(ext_info))
         return [Document(text=text, metadata=metadata)]
+
+    @staticmethod
+    def _public_metadata(ext_info: Dict) -> Dict:
+        sensitive_keys = {
+            "GOOGLE_SERVICE_ACCOUNT_JSON",
+            "google_service_account_json",
+            "service_account_json",
+            "credentials",
+        }
+        return {key: value for key, value in ext_info.items() if key not in sensitive_keys}
 
     def _build_drive_service(self, ext_info: Optional[Dict]):
         try:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.reader.cloud.google_docs_reader import GoogleDocsReader
+
+
+class FakeGoogleDocsReader(GoogleDocsReader):
+    def _build_drive_service(self, ext_info):
+        return object()
+
+    def _export_html(self, drive, file_id: str) -> str:
+        return "<html><body>Hello</body></html>"
+
+    def _html_to_text(self, html: str) -> str:
+        return "Hello"
+
+
+class TestGoogleDocsReader(unittest.TestCase):
+    def test_service_account_path_is_not_copied_to_metadata(self):
+        reader = FakeGoogleDocsReader()
+
+        docs = reader._load_data(
+            "doc-1",
+            ext_info={
+                "GOOGLE_SERVICE_ACCOUNT_JSON": "/tmp/service-account.json",
+                "project": "demo",
+            },
+        )
+
+        metadata = docs[0].metadata
+        self.assertEqual(metadata["project"], "demo")
+        self.assertNotIn("GOOGLE_SERVICE_ACCOUNT_JSON", metadata)
+
+    def test_public_metadata_filters_known_secret_keys(self):
+        metadata = GoogleDocsReader._public_metadata({
+            "service_account_json": "secret.json",
+            "credentials": "secret",
+            "source_name": "docs",
+        })
+
+        self.assertEqual(metadata, {"source_name": "docs"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Avoid copying Google Docs service-account credential fields into returned document metadata.
- Keep non-sensitive caller metadata available on generated `Document` objects.
- Add regression coverage for filtering service-account JSON while preserving public metadata.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/cloud/google_docs_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because `langchain_core` is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.