### PR TITLE
fix(reader): keep Notion credentials out of metadata

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
@@ -59,8 +59,19 @@ class NotionReader(Reader):
 
         text = "\n\n".join([b for b in text_blocks if b and b.strip()])
         if ext_info:
-            metadata.update(ext_info)
+            metadata.update(self._public_metadata(ext_info))
         return [Document(text=text, metadata=metadata)]
+
+    @staticmethod
+    def _public_metadata(ext_info: Dict) -> Dict:
+        sensitive_keys = {
+            "NOTION_TOKEN",
+            "notion_token",
+            "token",
+            "auth",
+            "authorization",
+        }
+        return {key: value for key, value in ext_info.items() if key not in sensitive_keys}
 
     def _export_page(self, client, page_id: str) -> List[str]:
         blocks: List[str] = []

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.reader.cloud.notion_reader import NotionReader
+
+
+class TestNotionReader(unittest.TestCase):
+    def test_public_metadata_filters_token_fields(self):
+        metadata = NotionReader._public_metadata({
+            "NOTION_TOKEN": "secret",
+            "notion_token": "secret-2",
+            "token": "secret-3",
+            "source_name": "notion",
+        })
+
+        self.assertEqual(metadata, {"source_name": "notion"})
+
+    def test_public_metadata_keeps_non_secret_fields(self):
+        metadata = NotionReader._public_metadata({
+            "workspace": "team-space",
+            "page_title": "Roadmap",
+        })
+
+        self.assertEqual(
+            metadata,
+            {"workspace": "team-space", "page_title": "Roadmap"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Avoid copying Notion token/auth fields into returned document metadata.
- Preserve ordinary public metadata values provided by callers.
- Add regression coverage for token filtering and public metadata preservation.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because `langchain_core` is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.