### PR TITLE
feat(tool): add bounded SecureArchiveTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/__init__.py
+++ b/agentuniverse/agent/action/tool/common_tool/__init__.py
@@ -8,8 +8,10 @@
 
 from .github_tool import GitHubTool
 from .yahoo_finance_tool import YahooFinanceTool
+from .secure_archive_tool import SecureArchiveTool
 
 __all__ = [
     'GitHubTool',
     'YahooFinanceTool',
+    'SecureArchiveTool',
 ]

--- a/agentuniverse/agent/action/tool/common_tool/secure_archive_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/secure_archive_tool.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Bounded ZIP and TAR archive operations for agents."""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from pathlib import PurePosixPath
+from typing import Any, ClassVar, cast
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class SecureArchiveTool(Tool):
+    """Create, list, inspect, and safely extract ZIP/TAR archives."""
+
+    base_dir: str = "."
+    max_read_bytes: int = 100 * 1024 * 1024
+    max_write_bytes: int = 100 * 1024 * 1024
+    max_entries: int = 5_000
+    max_member_bytes: int = 100 * 1024 * 1024
+    max_uncompressed_bytes: int = 500 * 1024 * 1024
+    max_compression_ratio: float = 200.0
+    max_input_files: int = 1_000
+
+    _FORMATS: ClassVar[tuple[str, ...]] = (".zip", ".tar", ".tar.gz", ".tgz")
+
+    def execute(
+        self,
+        mode: str,
+        file_path: str,
+        input_paths: list[str] | None = None,
+        output_dir: str | None = None,
+        members: list[str] | None = None,
+        overwrite: bool = False,
+        compression: str = "deflated",
+    ) -> dict[str, Any]:
+        try:
+            self._validate_config()
+            operation = self._mode(mode)
+            archive = self._archive_path(file_path)
+            if operation == "create":
+                return self._create(archive, input_paths, overwrite, compression)
+            self._check_archive_file(archive)
+            entries = self._entries(archive)
+            if operation == "list":
+                return self._list(archive, entries)
+            if operation == "info":
+                return self._info(archive, entries)
+            return self._extract(archive, entries, output_dir, members, overwrite)
+        except (TypeError, ValueError) as exc:
+            return self._error(file_path, "validation_error", str(exc))
+        except Exception as exc:
+            return self._error(file_path, "operation_error", f"Archive operation failed: {exc}")
+
+    @staticmethod
+    def _error(path: Any, kind: str, message: str) -> dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message, "file_path": path}
+
+    def _validate_config(self) -> None:
+        for name in (
+            "max_read_bytes",
+            "max_write_bytes",
+            "max_entries",
+            "max_member_bytes",
+            "max_uncompressed_bytes",
+            "max_input_files",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if (
+            isinstance(self.max_compression_ratio, bool)
+            or not isinstance(self.max_compression_ratio, (int, float))
+            or self.max_compression_ratio <= 0
+        ):
+            raise ValueError("max_compression_ratio must be positive")
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+
+    @staticmethod
+    def _mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"create", "list", "extract", "info"}:
+            raise ValueError("mode must be create, list, extract, or info")
+        return mode
+
+    def _archive_path(self, value: Any) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("file_path must be a non-empty string")
+        if not value.lower().endswith(self._FORMATS):
+            raise ValueError("file_path must end with .zip, .tar, .tar.gz, or .tgz")
+        return cast(str, resolve_safe_path(value, self.base_dir))
+
+    def _directory(self, value: Any) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("output_dir must be a non-empty string")
+        return cast(str, resolve_safe_path(value, self.base_dir))
+
+    def _check_archive_file(self, path: str) -> None:
+        if not os.path.isfile(path):
+            raise ValueError(f"file_path does not exist: {path}")
+        if os.path.getsize(path) > self.max_read_bytes:
+            raise ValueError(f"archive exceeds max_read_bytes ({self.max_read_bytes})")
+
+    @staticmethod
+    def _kind(path: str) -> str:
+        return "zip" if path.lower().endswith(".zip") else "tar"
+
+    @staticmethod
+    def _safe_member_name(raw: str) -> str:
+        if not isinstance(raw, str) or not raw or "\x00" in raw:
+            raise ValueError("archive contains an invalid member name")
+        normalized = raw.replace("\\", "/")
+        path = PurePosixPath(normalized)
+        if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+            raise ValueError(f"unsafe archive member path: {raw}")
+        if path.parts and path.parts[0].endswith(":"):
+            raise ValueError(f"unsafe archive member path: {raw}")
+        return path.as_posix().rstrip("/")
+
+    def _entries(self, path: str) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        if self._kind(path) == "zip":
+            try:
+                with zipfile.ZipFile(path) as archive:
+                    for item in archive.infolist():
+                        mode = item.external_attr >> 16
+                        if stat.S_ISLNK(mode):
+                            raise ValueError(f"archive symlink is not supported: {item.filename}")
+                        if item.flag_bits & 0x1:
+                            raise ValueError("encrypted archives are not supported")
+                        entries.append(
+                            {
+                                "name": self._safe_member_name(item.filename),
+                                "size": item.file_size,
+                                "compressed_size": item.compress_size,
+                                "is_dir": item.is_dir(),
+                            }
+                        )
+            except zipfile.BadZipFile as exc:
+                raise ValueError("file_path is not a valid ZIP archive") from exc
+        else:
+            try:
+                with tarfile.open(path, mode="r:*") as archive:
+                    for item in archive.getmembers():
+                        if not (item.isfile() or item.isdir()):
+                            raise ValueError(f"archive links and special files are not supported: {item.name}")
+                        entries.append(
+                            {
+                                "name": self._safe_member_name(item.name),
+                                "size": item.size,
+                                "compressed_size": None,
+                                "is_dir": item.isdir(),
+                            }
+                        )
+            except tarfile.TarError as exc:
+                raise ValueError("file_path is not a valid TAR archive") from exc
+        self._validate_entries(entries, os.path.getsize(path))
+        return entries
+
+    def _validate_entries(self, entries: list[dict[str, Any]], archive_size: int) -> None:
+        if len(entries) > self.max_entries:
+            raise ValueError(f"archive exceeds max_entries ({self.max_entries})")
+        names: set[str] = set()
+        total = 0
+        for entry in entries:
+            if entry["name"] in names:
+                raise ValueError(f"archive contains duplicate member: {entry['name']}")
+            names.add(entry["name"])
+            if entry["size"] > self.max_member_bytes:
+                raise ValueError(f"archive member exceeds max_member_bytes: {entry['name']}")
+            total += entry["size"]
+            compressed = entry["compressed_size"]
+            if not entry["is_dir"] and compressed is not None:
+                ratio = entry["size"] / max(compressed, 1)
+                if ratio > self.max_compression_ratio:
+                    raise ValueError(f"archive member exceeds max_compression_ratio: {entry['name']}")
+        if total > self.max_uncompressed_bytes:
+            raise ValueError(f"archive exceeds max_uncompressed_bytes ({self.max_uncompressed_bytes})")
+        if total and total / max(archive_size, 1) > self.max_compression_ratio:
+            raise ValueError("archive exceeds max_compression_ratio")
+
+    def _collect_inputs(self, values: Any, archive_path: str) -> list[tuple[str, str]]:  # noqa: C901
+        if not isinstance(values, list) or not values:
+            raise ValueError("input_paths must be a non-empty list")
+        base = os.path.realpath(os.path.abspath(self.base_dir))
+        files: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for index, value in enumerate(values):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"input_paths[{index}] must be a non-empty string")
+            path = cast(str, resolve_safe_path(value, self.base_dir))
+            if not os.path.exists(path):
+                raise ValueError(f"input path does not exist: {path}")
+            candidates = [path]
+            if os.path.isdir(path):
+                candidates = [os.path.join(root, name) for root, _, names in os.walk(path) for name in names]
+            for candidate in candidates:
+                resolved = os.path.realpath(candidate)
+                if resolved == archive_path:
+                    raise ValueError("archive output cannot also be an input")
+                if not os.path.isfile(resolved) or resolved in seen:
+                    continue
+                seen.add(resolved)
+                arcname = os.path.relpath(resolved, base).replace(os.sep, "/")
+                files.append((resolved, self._safe_member_name(arcname)))
+                if len(files) > self.max_input_files:
+                    raise ValueError(f"inputs exceed max_input_files ({self.max_input_files})")
+        total = sum(os.path.getsize(path) for path, _ in files)
+        if not files:
+            raise ValueError("input_paths contain no regular files")
+        if total > self.max_uncompressed_bytes:
+            raise ValueError(f"inputs exceed max_uncompressed_bytes ({self.max_uncompressed_bytes})")
+        if any(os.path.getsize(path) > self.max_member_bytes for path, _ in files):
+            raise ValueError("an input exceeds max_member_bytes")
+        return files
+
+    def _create(self, path: str, values: Any, overwrite: Any, compression: Any) -> dict[str, Any]:
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        if os.path.exists(path) and not overwrite:
+            raise ValueError("file exists; set overwrite=true to replace it")
+        if not isinstance(compression, str) or compression not in {"deflated", "stored"}:
+            raise ValueError("compression must be deflated or stored")
+        files = self._collect_inputs(values, path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        temporary = None
+        try:
+            suffix = ".zip" if self._kind(path) == "zip" else ".tar"
+            with tempfile.NamedTemporaryFile(
+                prefix=".archive-", suffix=suffix, dir=os.path.dirname(path), delete=False
+            ) as out:
+                temporary = out.name
+            if self._kind(path) == "zip":
+                method = zipfile.ZIP_DEFLATED if compression == "deflated" else zipfile.ZIP_STORED
+                with zipfile.ZipFile(temporary, "w", compression=method, allowZip64=True) as archive:
+                    for source, name in files:
+                        archive.write(source, name)
+            else:
+                mode = "w:gz" if path.lower().endswith((".tar.gz", ".tgz")) else "w"
+                with tarfile.open(temporary, mode=mode) as archive:
+                    for source, name in files:
+                        archive.add(source, arcname=name, recursive=False)
+            if os.path.getsize(temporary) > self.max_write_bytes:
+                raise ValueError(f"generated archive exceeds max_write_bytes ({self.max_write_bytes})")
+            entries = self._entries(temporary)
+            os.replace(temporary, path)
+            temporary = None
+        finally:
+            if temporary and os.path.exists(temporary):
+                os.unlink(temporary)
+        return {
+            "status": "success",
+            "mode": "create",
+            "file_path": path,
+            "entry_count": len(entries),
+            "uncompressed_size": sum(item["size"] for item in entries),
+            "file_size": os.path.getsize(path),
+        }
+
+    @staticmethod
+    def _list(path: str, entries: list[dict[str, Any]]) -> dict[str, Any]:
+        return {"status": "success", "mode": "list", "file_path": path, "entries": entries, "entry_count": len(entries)}
+
+    def _info(self, path: str, entries: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "status": "success",
+            "mode": "info",
+            "file_path": path,
+            "format": self._kind(path),
+            "entry_count": len(entries),
+            "file_count": sum(not item["is_dir"] for item in entries),
+            "uncompressed_size": sum(item["size"] for item in entries),
+            "file_size": os.path.getsize(path),
+        }
+
+    def _selected(self, entries: list[dict[str, Any]], members: Any) -> list[dict[str, Any]]:
+        if members is None:
+            return entries
+        if not isinstance(members, list) or not members or any(not isinstance(item, str) for item in members):
+            raise ValueError("members must be a non-empty list of strings")
+        requested = {self._safe_member_name(item) for item in members}
+        available = {item["name"] for item in entries}
+        missing = requested - available
+        if missing:
+            raise ValueError(f"archive members not found: {', '.join(sorted(missing))}")
+        return [item for item in entries if item["name"] in requested]
+
+    def _extract(
+        self,
+        path: str,
+        entries: list[dict[str, Any]],
+        output_dir: Any,
+        members: Any,
+        overwrite: Any,
+    ) -> dict[str, Any]:
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        directory = self._directory(output_dir)
+        selected = self._selected(entries, members)
+        destinations = [(item, cast(str, resolve_safe_path(item["name"], directory))) for item in selected]
+        for item, destination in destinations:
+            if not item["is_dir"] and os.path.exists(destination) and not overwrite:
+                raise ValueError(f"file exists: {destination}; set overwrite=true")
+        os.makedirs(directory, exist_ok=True)
+        extracted: list[str] = []
+        if self._kind(path) == "zip":
+            with zipfile.ZipFile(path) as archive:
+                for item, destination in destinations:
+                    if item["is_dir"]:
+                        os.makedirs(destination, exist_ok=True)
+                        continue
+                    with archive.open(item["name"]) as source:
+                        self._atomic_copy(source, destination, item["size"])
+                    extracted.append(destination)
+        else:
+            with tarfile.open(path, mode="r:*") as archive:
+                for item, destination in destinations:
+                    if item["is_dir"]:
+                        os.makedirs(destination, exist_ok=True)
+                        continue
+                    source = archive.extractfile(item["name"])
+                    if source is None:
+                        raise ValueError(f"unable to read archive member: {item['name']}")
+                    with source:
+                        self._atomic_copy(source, destination, item["size"])
+                    extracted.append(destination)
+        return {
+            "status": "success",
+            "mode": "extract",
+            "file_path": path,
+            "output_dir": directory,
+            "output_paths": extracted,
+            "entry_count": len(selected),
+        }
+
+    @staticmethod
+    def _atomic_copy(source: Any, destination: str, expected_size: int) -> None:
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=".extract-", dir=os.path.dirname(destination), delete=False
+            ) as output:
+                temporary = output.name
+                shutil.copyfileobj(source, output, length=1024 * 1024)
+            if os.path.getsize(temporary) != expected_size:
+                raise ValueError(f"archive member size changed while extracting: {destination}")
+            os.replace(temporary, destination)
+            temporary = None
+        finally:
+            if temporary and os.path.exists(temporary):
+                os.unlink(temporary)

--- a/agentuniverse/agent/action/tool/common_tool/secure_archive_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/secure_archive_tool.yaml
@@ -1,0 +1,40 @@
+name: secure_archive_tool
+description: Create, list, inspect, and safely extract bounded ZIP and TAR archives.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.secure_archive_tool
+  class: SecureArchiveTool
+input_keys:
+  - mode
+  - file_path
+base_dir: .
+max_read_bytes: 104857600
+max_write_bytes: 104857600
+max_entries: 5000
+max_member_bytes: 104857600
+max_uncompressed_bytes: 524288000
+max_compression_ratio: 200
+max_input_files: 1000
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: [create, list, extract, info]
+    file_path:
+      type: string
+    input_paths:
+      type: array
+      items: {type: string}
+    output_dir: {type: string}
+    members:
+      type: array
+      items: {type: string}
+    overwrite: {type: boolean, default: false}
+    compression:
+      type: string
+      enum: [deflated, stored]
+      default: deflated
+  required: [mode, file_path]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -202,3 +202,17 @@ Parameter Description:
     response_content_type: the output format for the HTTP request result. If set to 'json', the result will be returned in JSON format; if set to 'text', it will be returned as plain text.
 This tool can be used directly without  requiring any keys.
 
+
+## SecureArchiveTool
+
+`SecureArchiveTool` provides bounded archive operations for agent workflows without external dependencies. It supports ZIP, TAR, TAR.GZ, and TGZ files with four modes: `create`, `list`, `extract`, and `info`.
+
+```python
+from agentuniverse.agent.action.tool.common_tool.secure_archive_tool import SecureArchiveTool
+
+tool = SecureArchiveTool(base_dir="/srv/agent-files")
+tool.execute(mode="create", file_path="reports.zip", input_paths=["reports"])
+tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", members=["reports/q2.txt"])
+```
+
+All paths are confined to `base_dir`. Extraction rejects absolute/traversal paths, links, special TAR files, encrypted ZIPs, duplicate members, excessive compression ratios, and configured size/count limits. Destinations are preflighted before extraction and files are written through same-directory temporary files.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -356,3 +356,17 @@ metadata:
     json_parse 输入参数是否需要是要HTTP解析，POST请求时需要设置为True,GET请求需要设置为False
     response_content_type http请求结果的解析方式，设置为json时，会返回json结果，设置为text时会返回text结果
 该工具可以直接使用，无需任何keys
+
+## SecureArchiveTool
+
+`SecureArchiveTool` 为智能体工作流提供无需额外依赖、带资源边界的压缩包操作，支持 ZIP、TAR、TAR.GZ 和 TGZ，以及 `create`、`list`、`extract`、`info` 四种模式。
+
+```python
+from agentuniverse.agent.action.tool.common_tool.secure_archive_tool import SecureArchiveTool
+
+tool = SecureArchiveTool(base_dir="/srv/agent-files")
+tool.execute(mode="create", file_path="reports.zip", input_paths=["reports"])
+tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", members=["reports/q2.txt"])
+```
+
+所有路径均限制在 `base_dir` 内。解压会拒绝绝对路径和路径穿越、链接、TAR 特殊文件、加密 ZIP、重复成员、异常压缩率以及超过配置的文件数量和大小。工具会在写入前预检全部目标，并通过同目录临时文件完成原子写入。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_secure_archive_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_secure_archive_tool.py
@@ -1,0 +1,164 @@
+import os
+import stat
+import tempfile
+import unittest
+import zipfile
+
+from agentuniverse.agent.action.tool.common_tool import secure_archive_tool as archive_module
+from agentuniverse.agent.action.tool.common_tool.secure_archive_tool import SecureArchiveTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = os.path.join(os.path.dirname(archive_module.__file__), "secure_archive_tool.yaml")
+
+
+class SecureArchiveToolTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.tool = SecureArchiveTool(base_dir=self.directory.name)
+        self.write("a.txt", b"alpha")
+        self.write("nested/b.txt", b"beta")
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def write(self, name, data):
+        path = os.path.join(self.directory.name, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as output:
+            output.write(data)
+        return path
+
+    def test_zip_round_trip(self):
+        created = self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt", "nested"])
+        self.assertEqual(created["status"], "success")
+        self.assertEqual(created["entry_count"], 2)
+        listed = self.tool.execute(mode="list", file_path="bundle.zip")
+        self.assertEqual({item["name"] for item in listed["entries"]}, {"a.txt", "nested/b.txt"})
+        extracted = self.tool.execute(mode="extract", file_path="bundle.zip", output_dir="out")
+        self.assertEqual(extracted["status"], "success")
+        with open(os.path.join(self.directory.name, "out/nested/b.txt"), "rb") as stream:
+            self.assertEqual(stream.read(), b"beta")
+
+    def test_tar_gz_round_trip(self):
+        result = self.tool.execute(mode="create", file_path="bundle.tar.gz", input_paths=["nested"])
+        self.assertEqual(result["status"], "success")
+        info = self.tool.execute(mode="info", file_path="bundle.tar.gz")
+        self.assertEqual(info["format"], "tar")
+        self.assertEqual(info["file_count"], 1)
+        extracted = self.tool.execute(mode="extract", file_path="bundle.tar.gz", output_dir="tar-out")
+        self.assertEqual(extracted["entry_count"], 1)
+
+    def test_selective_extract(self):
+        self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt", "nested/b.txt"])
+        result = self.tool.execute(mode="extract", file_path="bundle.zip", output_dir="out", members=["nested/b.txt"])
+        self.assertEqual(len(result["output_paths"]), 1)
+        self.assertFalse(os.path.exists(os.path.join(self.directory.name, "out/a.txt")))
+
+    def test_create_refuses_overwrite(self):
+        self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt"])
+        result = self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["nested/b.txt"])
+        self.assertIn("overwrite=true", result["error"])
+
+    def test_extract_preflights_destinations(self):
+        self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt", "nested/b.txt"])
+        self.write("out/nested/b.txt", b"existing")
+        result = self.tool.execute(mode="extract", file_path="bundle.zip", output_dir="out")
+        self.assertIn("overwrite=true", result["error"])
+        self.assertFalse(os.path.exists(os.path.join(self.directory.name, "out/a.txt")))
+
+    def test_rejects_zip_slip(self):
+        with zipfile.ZipFile(os.path.join(self.directory.name, "evil.zip"), "w") as archive:
+            archive.writestr("../escape.txt", "bad")
+        result = self.tool.execute(mode="list", file_path="evil.zip")
+        self.assertIn("unsafe archive member", result["error"])
+
+    def test_rejects_zip_symlink(self):
+        info = zipfile.ZipInfo("link")
+        info.create_system = 3
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        with zipfile.ZipFile(os.path.join(self.directory.name, "link.zip"), "w") as archive:
+            archive.writestr(info, "target")
+        result = self.tool.execute(mode="list", file_path="link.zip")
+        self.assertIn("symlink", result["error"])
+
+    def test_rejects_duplicate_members(self):
+        with zipfile.ZipFile(os.path.join(self.directory.name, "duplicate.zip"), "w") as archive:
+            archive.writestr("same.txt", "one")
+            archive.writestr("same.txt", "two")
+        result = self.tool.execute(mode="info", file_path="duplicate.zip")
+        self.assertIn("duplicate", result["error"])
+
+    def test_rejects_compression_bomb_ratio(self):
+        with zipfile.ZipFile(os.path.join(self.directory.name, "ratio.zip"), "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("large.txt", "x" * 100_000)
+        self.tool.max_compression_ratio = 2
+        result = self.tool.execute(mode="info", file_path="ratio.zip")
+        self.assertIn("max_compression_ratio", result["error"])
+
+    def test_rejects_too_many_entries(self):
+        with zipfile.ZipFile(os.path.join(self.directory.name, "many.zip"), "w") as archive:
+            archive.writestr("one", "1")
+            archive.writestr("two", "2")
+        self.tool.max_entries = 1
+        result = self.tool.execute(mode="list", file_path="many.zip")
+        self.assertIn("max_entries", result["error"])
+
+    def test_input_and_output_path_escape(self):
+        result = self.tool.execute(mode="create", file_path="../bundle.zip", input_paths=["a.txt"])
+        self.assertIn("escapes the allowed directory", result["error"])
+        self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt"])
+        result = self.tool.execute(mode="extract", file_path="bundle.zip", output_dir="../out")
+        self.assertIn("escapes the allowed directory", result["error"])
+
+    def test_invalid_extension(self):
+        result = self.tool.execute(mode="info", file_path="bundle.rar")
+        self.assertIn(".zip", result["error"])
+
+    def test_generated_size_limit_preserves_destination(self):
+        self.write("bundle.zip", b"existing")
+        self.tool.max_write_bytes = 1
+        result = self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt"], overwrite=True)
+        self.assertIn("max_write_bytes", result["error"])
+        with open(os.path.join(self.directory.name, "bundle.zip"), "rb") as stream:
+            self.assertEqual(stream.read(), b"existing")
+
+    def test_missing_member(self):
+        self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt"])
+        result = self.tool.execute(mode="extract", file_path="bundle.zip", output_dir="out", members=["missing.txt"])
+        self.assertIn("not found", result["error"])
+
+
+class SecureArchiveRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=os.path.abspath(YAML_PATH)).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "SecureArchiveTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, SecureArchiveTool)
+        self.assertEqual(tool.input_keys, ["mode", "file_path"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `SecureArchiveTool` with structured `create`, `list`, `extract`, and `info` modes
- support ZIP, TAR, TAR.GZ, and TGZ using the Python standard library only
- support selective extraction, configurable compression, explicit overwrite, YAML registration, and English/Chinese documentation
- add 16 tests covering real archive round trips, registration, path confinement, selective extraction, and bounded failure behavior

## Safety and reliability

- confine archive, input, and extraction paths to the configured `base_dir`
- reject absolute/traversal member names, ZIP symlinks, TAR links and special files, encrypted ZIP members, and duplicate destinations
- bound archive size, member count, member size, expanded size, compression ratio, input count, and generated output size
- preflight every extraction destination before writing and use same-directory temporary files so failed writes preserve existing files
- refuse implicit create/extract overwrites

## Validation

macOS / Python 3.11:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_secure_archive_tool
Ran 16 tests — OK

ruff check: All checks passed
ruff format --check: 2 files already formatted
```

Ubuntu 22.04 x86_64 server / Python 3.10.12:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_secure_archive_tool
Ran 16 tests — OK
```

Partially addresses #252.
