### PR TITLE
feat(tool): add structured EmailDocumentTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/__init__.py
+++ b/agentuniverse/agent/action/tool/common_tool/__init__.py
@@ -8,8 +8,10 @@
 
 from .github_tool import GitHubTool
 from .yahoo_finance_tool import YahooFinanceTool
+from .email_document_tool import EmailDocumentTool
 
 __all__ = [
     'GitHubTool',
     'YahooFinanceTool',
+    'EmailDocumentTool',
 ]

--- a/agentuniverse/agent/action/tool/common_tool/email_document_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/email_document_tool.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Bounded RFC 5322 email document operations."""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import mimetypes
+import os
+import tempfile
+from email import policy
+from email.message import EmailMessage, Message
+from email.parser import BytesParser
+from typing import Any, ClassVar, cast
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class EmailDocumentTool(Tool):
+    """Create, read, inspect, and extract attachments from EML files."""
+
+    base_dir: str = "."
+    max_read_bytes: int = 25 * 1024 * 1024
+    max_write_bytes: int = 25 * 1024 * 1024
+    max_body_chars: int = 200_000
+    max_headers: int = 100
+    max_attachments: int = 50
+    max_attachment_bytes: int = 20 * 1024 * 1024
+    max_total_attachment_bytes: int = 50 * 1024 * 1024
+
+    _CREATE_HEADERS: ClassVar[dict[str, str]] = {
+        "from": "From",
+        "to": "To",
+        "cc": "Cc",
+        "bcc": "Bcc",
+        "subject": "Subject",
+        "reply_to": "Reply-To",
+        "date": "Date",
+        "message_id": "Message-ID",
+    }
+    _READ_HEADERS: ClassVar[tuple[str, ...]] = (
+        "From",
+        "To",
+        "Cc",
+        "Bcc",
+        "Subject",
+        "Reply-To",
+        "Date",
+        "Message-ID",
+    )
+
+    def execute(
+        self,
+        mode: str,
+        file_path: str,
+        headers: dict[str, str] | None = None,
+        text_body: str | None = None,
+        html_body: str | None = None,
+        attachments: list[str] | None = None,
+        output_dir: str | None = None,
+        attachment_names: list[str] | None = None,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        try:
+            self._validate_config()
+            operation = self._mode(mode)
+            path = self._eml_path(file_path, "file_path")
+            if operation == "create":
+                return self._create(path, headers, text_body, html_body, attachments, overwrite)
+            message = self._message(path)
+            if operation == "read":
+                return self._read(path, message)
+            if operation == "info":
+                return self._info(path, message)
+            return self._extract(path, message, output_dir, attachment_names, overwrite)
+        except (TypeError, ValueError) as exc:
+            return self._error(file_path, "validation_error", str(exc))
+        except Exception as exc:
+            return self._error(file_path, "operation_error", f"Email operation failed: {exc}")
+
+    @staticmethod
+    def _error(path: Any, kind: str, message: str) -> dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message, "file_path": path}
+
+    def _validate_config(self) -> None:
+        for name in (
+            "max_read_bytes",
+            "max_write_bytes",
+            "max_body_chars",
+            "max_headers",
+            "max_attachments",
+            "max_attachment_bytes",
+            "max_total_attachment_bytes",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+
+    @staticmethod
+    def _mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"create", "read", "info", "extract"}:
+            raise ValueError("mode must be create, read, info, or extract")
+        return mode
+
+    def _eml_path(self, value: Any, field: str) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{field} must be a non-empty string")
+        if os.path.splitext(value)[1].lower() != ".eml":
+            raise ValueError(f"{field} must have a .eml extension")
+        return cast(str, resolve_safe_path(value, self.base_dir))
+
+    def _directory(self, value: Any) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("output_dir must be a non-empty string")
+        return cast(str, resolve_safe_path(value, self.base_dir))
+
+    def _message(self, path: str) -> EmailMessage:
+        if not os.path.isfile(path):
+            raise ValueError(f"file_path does not exist: {path}")
+        if os.path.getsize(path) > self.max_read_bytes:
+            raise ValueError(f"file_path exceeds max_read_bytes ({self.max_read_bytes})")
+        with open(path, "rb") as stream:
+            message = BytesParser(policy=policy.default).parse(stream)
+        if len(message.items()) > self.max_headers:
+            raise ValueError(f"email exceeds max_headers ({self.max_headers})")
+        self._attachment_parts(message)
+        return cast(EmailMessage, message)
+
+    @staticmethod
+    def _safe_header(value: Any, field: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"headers.{field} must be a non-empty string")
+        if "\r" in value or "\n" in value or len(value) > 2_000:
+            raise ValueError(f"headers.{field} contains invalid characters or is too long")
+        return value.strip()
+
+    def _headers(self, value: Any) -> dict[str, str]:
+        if not isinstance(value, dict):
+            raise TypeError("headers must be an object")
+        unknown = set(value) - set(self._CREATE_HEADERS)
+        if unknown:
+            raise ValueError(f"headers contain unknown fields: {', '.join(sorted(unknown))}")
+        output = {key: self._safe_header(item, key) for key, item in value.items()}
+        for required in ("from", "to"):
+            if required not in output:
+                raise ValueError(f"headers.{required} is required")
+        return output
+
+    def _body(self, value: Any, field: str) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError(f"{field} must be a string")
+        if len(value) > self.max_body_chars:
+            raise ValueError(f"{field} exceeds max_body_chars ({self.max_body_chars})")
+        return value
+
+    @staticmethod
+    def _safe_filename(value: Any) -> str:
+        if not isinstance(value, str) or not value or "\x00" in value:
+            raise ValueError("attachment has an invalid filename")
+        if value in {".", ".."} or os.path.basename(value) != value or "/" in value or "\\" in value:
+            raise ValueError(f"unsafe attachment filename: {value}")
+        return value
+
+    def _attachment_inputs(self, values: Any) -> list[tuple[str, str, str, str]]:
+        if values is None:
+            return []
+        if not isinstance(values, list):
+            raise TypeError("attachments must be a list")
+        if len(values) > self.max_attachments:
+            raise ValueError(f"attachments exceed max_attachments ({self.max_attachments})")
+        output: list[tuple[str, str, str, str]] = []
+        names: set[str] = set()
+        total = 0
+        for index, value in enumerate(values):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"attachments[{index}] must be a non-empty string")
+            path = cast(str, resolve_safe_path(value, self.base_dir))
+            if not os.path.isfile(path):
+                raise ValueError(f"attachment does not exist: {path}")
+            size = os.path.getsize(path)
+            if size > self.max_attachment_bytes:
+                raise ValueError(f"attachment exceeds max_attachment_bytes: {path}")
+            total += size
+            name = self._safe_filename(os.path.basename(path))
+            if name in names:
+                raise ValueError(f"duplicate attachment filename: {name}")
+            names.add(name)
+            content_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
+            maintype, subtype = content_type.split("/", 1)
+            output.append((path, name, maintype, subtype))
+        if total > self.max_total_attachment_bytes:
+            raise ValueError("attachments exceed max_total_attachment_bytes")
+        return output
+
+    def _create(
+        self,
+        path: str,
+        headers: Any,
+        text_body: Any,
+        html_body: Any,
+        attachments: Any,
+        overwrite: Any,
+    ) -> dict[str, Any]:
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        if os.path.exists(path) and not overwrite:
+            raise ValueError("file exists; set overwrite=true to replace it")
+        normalized_headers = self._headers(headers)
+        text = self._body(text_body, "text_body")
+        html = self._body(html_body, "html_body")
+        if text is None and html is None:
+            raise ValueError("text_body or html_body is required")
+        files = self._attachment_inputs(attachments)
+        message = EmailMessage(policy=policy.default)
+        for key, value in normalized_headers.items():
+            message[self._CREATE_HEADERS[key]] = value
+        message.set_content(text or "")
+        if html is not None:
+            message.add_alternative(html, subtype="html")
+        for source, name, maintype, subtype in files:
+            with open(source, "rb") as stream:
+                message.add_attachment(stream.read(), maintype=maintype, subtype=subtype, filename=name)
+        self._atomic_write(path, message.as_bytes())
+        return {
+            "status": "success",
+            "mode": "create",
+            "file_path": path,
+            "attachment_count": len(files),
+            "file_size": os.path.getsize(path),
+        }
+
+    def _attachment_parts(self, message: Message) -> list[dict[str, Any]]:
+        output = []
+        total = 0
+        names: set[str] = set()
+        for part in message.walk():
+            filename = part.get_filename()
+            if not filename:
+                continue
+            name = self._safe_filename(str(filename))
+            payload = part.get_payload(decode=True) or b""
+            size = len(payload)
+            if size > self.max_attachment_bytes:
+                raise ValueError(f"attachment exceeds max_attachment_bytes: {name}")
+            if name in names:
+                raise ValueError(f"duplicate attachment filename: {name}")
+            names.add(name)
+            total += size
+            output.append({"name": name, "size": size, "content_type": part.get_content_type(), "part": part})
+        if len(output) > self.max_attachments:
+            raise ValueError(f"email exceeds max_attachments ({self.max_attachments})")
+        if total > self.max_total_attachment_bytes:
+            raise ValueError("email attachments exceed max_total_attachment_bytes")
+        return output
+
+    def _body_parts(self, message: Message) -> tuple[str, str, bool]:
+        text_parts: list[str] = []
+        html_parts: list[str] = []
+        for part in message.walk():
+            if part.get_filename() or part.get_content_maintype() == "multipart":
+                continue
+            if part.get_content_type() not in {"text/plain", "text/html"}:
+                continue
+            try:
+                content = part.get_content()
+            except (KeyError, LookupError, UnicodeError) as exc:
+                raise ValueError(f"unable to decode email body: {exc}") from exc
+            (html_parts if part.get_content_type() == "text/html" else text_parts).append(str(content))
+        text = "\n".join(text_parts).strip()
+        html = "\n".join(html_parts).strip()
+        total = len(text) + len(html)
+        if total <= self.max_body_chars:
+            return text, html, False
+        remaining = self.max_body_chars
+        text, remaining = text[:remaining], max(0, remaining - len(text))
+        html = html[:remaining]
+        return text, html, True
+
+    def _header_output(self, message: Message) -> dict[str, str]:
+        return {name.lower().replace("-", "_"): str(message.get(name, "")) for name in self._READ_HEADERS}
+
+    def _read(self, path: str, message: Message) -> dict[str, Any]:
+        text, html, truncated = self._body_parts(message)
+        attachments = self._attachment_parts(message)
+        return {
+            "status": "success",
+            "mode": "read",
+            "file_path": path,
+            "headers": self._header_output(message),
+            "text_body": text,
+            "html_body": html,
+            "truncated": truncated,
+            "attachments": [{key: item[key] for key in ("name", "size", "content_type")} for item in attachments],
+        }
+
+    def _info(self, path: str, message: Message) -> dict[str, Any]:
+        text, html, truncated = self._body_parts(message)
+        attachments = self._attachment_parts(message)
+        return {
+            "status": "success",
+            "mode": "info",
+            "file_path": path,
+            "file_size": os.path.getsize(path),
+            "headers": self._header_output(message),
+            "header_count": len(message.items()),
+            "attachment_count": len(attachments),
+            "attachment_bytes": sum(item["size"] for item in attachments),
+            "text_chars": len(text),
+            "html_chars": len(html),
+            "truncated": truncated,
+        }
+
+    def _extract(
+        self,
+        path: str,
+        message: Message,
+        output_dir: Any,
+        names: Any,
+        overwrite: Any,
+    ) -> dict[str, Any]:
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        directory = self._directory(output_dir)
+        attachments = self._attachment_parts(message)
+        if names is not None:
+            if not isinstance(names, list) or not names or any(not isinstance(item, str) for item in names):
+                raise ValueError("attachment_names must be a non-empty list of strings")
+            requested = {self._safe_filename(item) for item in names}
+            missing = requested - {item["name"] for item in attachments}
+            if missing:
+                raise ValueError(f"attachments not found: {', '.join(sorted(missing))}")
+            attachments = [item for item in attachments if item["name"] in requested]
+        destinations = [(item, cast(str, resolve_safe_path(item["name"], directory))) for item in attachments]
+        for _, destination in destinations:
+            if os.path.exists(destination) and not overwrite:
+                raise ValueError(f"file exists: {destination}; set overwrite=true")
+        os.makedirs(directory, exist_ok=True)
+        outputs = []
+        for item, destination in destinations:
+            self._atomic_write(destination, item["part"].get_payload(decode=True) or b"")
+            outputs.append(destination)
+        return {
+            "status": "success",
+            "mode": "extract",
+            "file_path": path,
+            "output_dir": directory,
+            "output_paths": outputs,
+            "attachment_count": len(outputs),
+        }
+
+    def _atomic_write(self, destination: str, content: bytes) -> None:
+        if len(content) > self.max_write_bytes:
+            raise ValueError(f"generated file exceeds max_write_bytes ({self.max_write_bytes})")
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=".email-", dir=os.path.dirname(destination), delete=False
+            ) as output:
+                temporary = output.name
+                output.write(content)
+            os.replace(temporary, destination)
+            temporary = None
+        finally:
+            if temporary and os.path.exists(temporary):
+                os.unlink(temporary)

--- a/agentuniverse/agent/action/tool/common_tool/email_document_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/email_document_tool.yaml
@@ -1,0 +1,36 @@
+name: email_document_tool
+description: Create, read, inspect, and safely extract attachments from bounded RFC 5322 EML files.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.email_document_tool
+  class: EmailDocumentTool
+input_keys:
+  - mode
+  - file_path
+base_dir: .
+max_read_bytes: 26214400
+max_write_bytes: 26214400
+max_body_chars: 200000
+max_headers: 100
+max_attachments: 50
+max_attachment_bytes: 20971520
+max_total_attachment_bytes: 52428800
+args_model_schema:
+  type: object
+  properties:
+    mode: {type: string, enum: [create, read, info, extract]}
+    file_path: {type: string}
+    headers: {type: object}
+    text_body: {type: string}
+    html_body: {type: string}
+    attachments:
+      type: array
+      items: {type: string}
+    output_dir: {type: string}
+    attachment_names:
+      type: array
+      items: {type: string}
+    overwrite: {type: boolean, default: false}
+  required: [mode, file_path]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -202,3 +202,22 @@ Parameter Description:
     response_content_type: the output format for the HTTP request result. If set to 'json', the result will be returned in JSON format; if set to 'text', it will be returned as plain text.
 This tool can be used directly without  requiring any keys.
 
+
+## EmailDocumentTool
+
+`EmailDocumentTool` provides offline RFC 5322 `.eml` workflows with `create`, `read`, `info`, and `extract` modes. It can build multipart text/HTML messages, attach files, inspect headers and bodies, and extract selected attachments.
+
+```python
+from agentuniverse.agent.action.tool.common_tool.email_document_tool import EmailDocumentTool
+
+tool = EmailDocumentTool(base_dir="/srv/agent-files")
+tool.execute(
+    mode="create",
+    file_path="report.eml",
+    headers={"from": "agent@example.com", "to": "user@example.com", "subject": "Report"},
+    text_body="The report is attached.",
+    attachments=["report.pdf"],
+)
+```
+
+The tool performs no network or mailbox access. It confines paths to `base_dir`, rejects header injection and unsafe/duplicate attachment names, bounds headers, bodies, attachment counts and bytes, preflights extraction destinations, and uses atomic writes.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -356,3 +356,22 @@ metadata:
     json_parse 输入参数是否需要是要HTTP解析，POST请求时需要设置为True,GET请求需要设置为False
     response_content_type http请求结果的解析方式，设置为json时，会返回json结果，设置为text时会返回text结果
 该工具可以直接使用，无需任何keys
+
+## EmailDocumentTool
+
+`EmailDocumentTool` 提供离线 RFC 5322 `.eml` 工作流，支持 `create`、`read`、`info`、`extract`。它可以创建纯文本/HTML 多部分邮件、添加附件、检查邮件头和正文，并安全提取指定附件。
+
+```python
+from agentuniverse.agent.action.tool.common_tool.email_document_tool import EmailDocumentTool
+
+tool = EmailDocumentTool(base_dir="/srv/agent-files")
+tool.execute(
+    mode="create",
+    file_path="report.eml",
+    headers={"from": "agent@example.com", "to": "user@example.com", "subject": "Report"},
+    text_body="报告见附件。",
+    attachments=["report.pdf"],
+)
+```
+
+该工具不会访问网络或邮箱。所有路径限制在 `base_dir` 内，并拒绝邮件头注入、不安全或重复的附件名；邮件头、正文、附件数量和大小均有边界；提取前会预检全部目标并采用原子写入。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_email_document_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_email_document_tool.py
@@ -1,0 +1,181 @@
+import os
+import tempfile
+import unittest
+from email import policy
+from email.message import EmailMessage
+
+from agentuniverse.agent.action.tool.common_tool import email_document_tool as email_module
+from agentuniverse.agent.action.tool.common_tool.email_document_tool import EmailDocumentTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = os.path.join(os.path.dirname(email_module.__file__), "email_document_tool.yaml")
+
+
+class EmailDocumentToolTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.tool = EmailDocumentTool(base_dir=self.directory.name)
+        self.write("files/report.txt", b"quarterly data")
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def write(self, name, content):
+        path = os.path.join(self.directory.name, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as output:
+            output.write(content)
+        return path
+
+    def create(self, name="message.eml", **kwargs):
+        params = {
+            "mode": "create",
+            "file_path": name,
+            "headers": {"from": "sender@example.com", "to": "user@example.com", "subject": "Report"},
+            "text_body": "Hello 世界",
+        }
+        params.update(kwargs)
+        return self.tool.execute(**params)
+
+    def save_message(self, name, message):
+        self.write(name, message.as_bytes(policy=policy.default))
+
+    def test_create_read_info_round_trip(self):
+        result = self.create(html_body="<p>Hello</p>", attachments=["files/report.txt"])
+        self.assertEqual(result["status"], "success")
+        read = self.tool.execute(mode="read", file_path="message.eml")
+        self.assertEqual(read["headers"]["subject"], "Report")
+        self.assertIn("Hello 世界", read["text_body"])
+        self.assertIn("<p>Hello</p>", read["html_body"])
+        self.assertEqual(read["attachments"][0]["name"], "report.txt")
+        info = self.tool.execute(mode="info", file_path="message.eml")
+        self.assertEqual(info["attachment_count"], 1)
+
+    def test_extract_attachment(self):
+        self.create(attachments=["files/report.txt"])
+        result = self.tool.execute(mode="extract", file_path="message.eml", output_dir="out")
+        self.assertEqual(result["status"], "success")
+        with open(os.path.join(self.directory.name, "out/report.txt"), "rb") as stream:
+            self.assertEqual(stream.read(), b"quarterly data")
+
+    def test_selective_extract(self):
+        self.write("files/other.bin", b"other")
+        self.create(attachments=["files/report.txt", "files/other.bin"])
+        result = self.tool.execute(
+            mode="extract", file_path="message.eml", output_dir="out", attachment_names=["other.bin"]
+        )
+        self.assertEqual(len(result["output_paths"]), 1)
+        self.assertTrue(result["output_paths"][0].endswith("other.bin"))
+
+    def test_extract_preflights_overwrite(self):
+        self.write("files/other.bin", b"other")
+        self.create(attachments=["files/report.txt", "files/other.bin"])
+        self.write("out/other.bin", b"existing")
+        result = self.tool.execute(mode="extract", file_path="message.eml", output_dir="out")
+        self.assertIn("overwrite=true", result["error"])
+        self.assertFalse(os.path.exists(os.path.join(self.directory.name, "out/report.txt")))
+
+    def test_rejects_unsafe_attachment_filename(self):
+        message = EmailMessage()
+        message["From"] = "a@example.com"
+        message["To"] = "b@example.com"
+        message.set_content("hello")
+        message.add_attachment(b"bad", maintype="application", subtype="octet-stream", filename="../evil.txt")
+        self.save_message("evil.eml", message)
+        result = self.tool.execute(mode="read", file_path="evil.eml")
+        self.assertIn("unsafe attachment filename", result["error"])
+
+    def test_rejects_duplicate_attachment_names(self):
+        message = EmailMessage()
+        message["From"] = "a@example.com"
+        message["To"] = "b@example.com"
+        message.set_content("hello")
+        for payload in (b"one", b"two"):
+            message.add_attachment(payload, maintype="application", subtype="octet-stream", filename="same.bin")
+        self.save_message("duplicate.eml", message)
+        result = self.tool.execute(mode="info", file_path="duplicate.eml")
+        self.assertIn("duplicate attachment", result["error"])
+
+    def test_rejects_header_injection(self):
+        result = self.create(headers={"from": "a@example.com\nBcc: x@example.com", "to": "b@example.com"})
+        self.assertIn("invalid characters", result["error"])
+
+    def test_requires_sender_and_recipient(self):
+        result = self.create(headers={"from": "a@example.com"})
+        self.assertIn("headers.to is required", result["error"])
+
+    def test_requires_a_body(self):
+        result = self.create(text_body=None, html_body=None)
+        self.assertIn("text_body or html_body", result["error"])
+
+    def test_read_truncates_body(self):
+        self.create(text_body="abcdefgh")
+        self.tool.max_body_chars = 4
+        result = self.tool.execute(mode="read", file_path="message.eml")
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["text_body"], "abcd")
+
+    def test_attachment_size_limit(self):
+        self.tool.max_attachment_bytes = 3
+        result = self.create(attachments=["files/report.txt"])
+        self.assertIn("max_attachment_bytes", result["error"])
+
+    def test_create_refuses_overwrite(self):
+        self.create()
+        result = self.create(text_body="replacement")
+        self.assertIn("overwrite=true", result["error"])
+
+    def test_write_limit_preserves_existing(self):
+        self.write("message.eml", b"existing")
+        self.tool.max_write_bytes = 1
+        result = self.create(overwrite=True)
+        self.assertIn("max_write_bytes", result["error"])
+        with open(os.path.join(self.directory.name, "message.eml"), "rb") as stream:
+            self.assertEqual(stream.read(), b"existing")
+
+    def test_path_and_extension_validation(self):
+        self.assertIn("escapes", self.tool.execute(mode="info", file_path="../message.eml")["error"])
+        self.assertIn(".eml", self.tool.execute(mode="info", file_path="message.txt")["error"])
+
+    def test_missing_requested_attachment(self):
+        self.create(attachments=["files/report.txt"])
+        result = self.tool.execute(
+            mode="extract", file_path="message.eml", output_dir="out", attachment_names=["missing.bin"]
+        )
+        self.assertIn("not found", result["error"])
+
+
+class EmailDocumentRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=os.path.abspath(YAML_PATH)).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "EmailDocumentTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, EmailDocumentTool)
+        self.assertEqual(tool.input_keys, ["mode", "file_path"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `EmailDocumentTool` with structured `create`, `read`, `info`, and `extract` modes for RFC 5322 `.eml` documents
- support plain-text and HTML multipart bodies, standard headers, file attachments, selective attachment extraction, and explicit overwrite
- register the tool through YAML and the common-tool package and add English/Chinese documentation
- add 17 tests covering real EML round trips, MIME attachments, component registration, Unicode/body truncation, and bounded failure paths

## Safety and reliability

- confine EML, attachment input, and extraction paths to the configured `base_dir`
- reject header injection, unsafe/duplicate attachment filenames, unexpected header fields, and missing sender/recipient/body data
- bound source/generated file size, header count, body output, attachment count, individual attachment size, and total attachment bytes
- preflight all extraction destinations and preserve existing files when validation or atomic write fails
- refuse implicit create/extract overwrites

## Validation

macOS / Python 3.11:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_email_document_tool
Ran 17 tests — OK

ruff check: All checks passed
ruff format --check: 2 files already formatted
```

Ubuntu 22.04 x86_64 server / Python 3.10.12:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_email_document_tool
Ran 17 tests — OK
```

Partially addresses #252.
