### PR TITLE
feat(store): add Redis Stack vector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/redis_vector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/redis_vector_store.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Redis Stack vector knowledge store."""
+
+# Dynamic identifiers are validated against strict allowlists before command construction.
+# ruff: noqa: TRY003
+
+import json
+import math
+import os
+import re
+import sys
+from array import array
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class RedisVectorStore(Store):
+    """Persistent vector store backed by Redis Stack/RediSearch."""
+
+    connection_url: str | None = None
+    index_name: str = "agentuniverse_documents"
+    key_prefix: str = "agentuniverse:document:"
+    embedding_model: str | None = None
+    dimensions: int | None = None
+    distance: str = "cosine"
+    similarity_top_k: int = 10
+    create_index: bool = True
+    filter_tag_fields: list[str] = Field(default_factory=list)
+    hnsw_m: int = 16
+    hnsw_ef_construction: int = 200
+    client: Any = None
+    async_client: Any = None
+
+    _IDENTIFIER: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    _PREFIX: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9:_-]+$")
+    _DISTANCES: ClassVar[dict[str, str]] = {"cosine": "COSINE", "l2": "L2", "inner_product": "IP"}
+    _TAG_ESCAPE: ClassVar[re.Pattern[str]] = re.compile(r"([\\,\.<>\{\}\[\]\"':;!@#$%\^&*\(\)\-\+=~|/ ])")
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "RedisVectorStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "connection_url",
+            "index_name",
+            "key_prefix",
+            "embedding_model",
+            "dimensions",
+            "distance",
+            "similarity_top_k",
+            "create_index",
+            "filter_tag_fields",
+            "hnsw_m",
+            "hnsw_ef_construction",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config(require_dimensions=False)
+        return self
+
+    def _validate_config(self, require_dimensions: bool = True) -> None:  # noqa: C901
+        if not self._IDENTIFIER.fullmatch(self.index_name or ""):
+            raise ValueError("index_name must be a simple identifier")
+        if not self._PREFIX.fullmatch(self.key_prefix or ""):
+            raise ValueError("key_prefix contains unsupported characters")
+        self.distance = (self.distance or "").lower()
+        if self.distance not in self._DISTANCES:
+            raise ValueError("distance must be cosine, l2, or inner_product")
+        for name in ("similarity_top_k", "hnsw_m", "hnsw_ef_construction"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.dimensions is not None and (
+            isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0
+        ):
+            raise ValueError("dimensions must be a positive integer")
+        if require_dimensions and self.dimensions is None:
+            raise ValueError("dimensions must be configured or inferred from the first document")
+        if not isinstance(self.filter_tag_fields, list) or any(
+            not isinstance(item, str) or not self._IDENTIFIER.fullmatch(item) for item in self.filter_tag_fields
+        ):
+            raise ValueError("filter_tag_fields must contain simple identifiers")
+        if len(set(self.filter_tag_fields)) != len(self.filter_tag_fields):
+            raise ValueError("filter_tag_fields must not contain duplicates")
+        if not isinstance(self.create_index, bool):
+            raise TypeError("create_index must be a boolean")
+
+    @staticmethod
+    def _dependencies() -> tuple[Any, Any, Any]:
+        try:
+            import redis
+            from redis import ResponseError
+            from redis.asyncio import from_url as async_from_url
+        except ImportError as exc:
+            raise ImportError("RedisVectorStore requires the redis package and Redis Stack") from exc
+        return redis, async_from_url, ResponseError
+
+    def _url(self) -> str:
+        value = self.connection_url or os.getenv("REDIS_VECTOR_URL")
+        if not value:
+            raise ValueError("connection_url is required; set it in YAML or REDIS_VECTOR_URL")
+        return value
+
+    def _new_client(self) -> Any:
+        redis, _, _ = self._dependencies()
+        self.client = redis.from_url(self._url(), decode_responses=False)
+        self.client.ping()
+        if self.create_index and self.dimensions:
+            self._ensure_index(self.dimensions)
+        return self.client
+
+    async def _new_async_client(self) -> Any:
+        _, async_from_url, _ = self._dependencies()
+        self.async_client = async_from_url(self._url(), decode_responses=False)
+        await self.async_client.ping()
+        if self.create_index and self.dimensions:
+            await self._async_ensure_index(self.dimensions)
+        return self.async_client
+
+    def _ensure_client(self) -> Any:
+        return self.client or self._new_client()
+
+    async def _ensure_async_client(self) -> Any:
+        return self.async_client or await self._new_async_client()
+
+    def _index_command(self, dimensions: int) -> list[Any]:
+        self.dimensions = self.dimensions or dimensions
+        if dimensions != self.dimensions:
+            raise ValueError(f"embedding dimension {dimensions} does not match configured dimensions {self.dimensions}")
+        self._validate_config()
+        command: list[Any] = [
+            "FT.CREATE",
+            self.index_name,
+            "ON",
+            "HASH",
+            "PREFIX",
+            1,
+            self.key_prefix,
+            "SCHEMA",
+            "id",
+            "TAG",
+            "text",
+            "TEXT",
+            "metadata",
+            "TEXT",
+            "NOINDEX",
+        ]
+        for field in self.filter_tag_fields:
+            command.extend((f"meta_{field}", "TAG", "SEPARATOR", "\x1f"))
+        command.extend(
+            (
+                "embedding",
+                "VECTOR",
+                "HNSW",
+                10,
+                "TYPE",
+                "FLOAT32",
+                "DIM",
+                self.dimensions,
+                "DISTANCE_METRIC",
+                self._DISTANCES[self.distance],
+                "M",
+                self.hnsw_m,
+                "EF_CONSTRUCTION",
+                self.hnsw_ef_construction,
+            )
+        )
+        return command
+
+    @staticmethod
+    def _already_exists(exc: Exception) -> bool:
+        return "index already exists" in str(exc).lower()
+
+    def _ensure_index(self, dimensions: int) -> None:
+        if not self.create_index:
+            self._index_command(dimensions)
+            return
+        connection = self._ensure_client()
+        try:
+            connection.execute_command(*self._index_command(dimensions))
+        except Exception as exc:
+            if not self._already_exists(exc):
+                raise
+
+    async def _async_ensure_index(self, dimensions: int) -> None:
+        if not self.create_index:
+            self._index_command(dimensions)
+            return
+        connection = await self._ensure_async_client()
+        try:
+            await connection.execute_command(*self._index_command(dimensions))
+        except Exception as exc:
+            if not self._already_exists(exc):
+                raise
+
+    def _embedding_for_query(self, query: Query) -> list[float]:
+        if query.embeddings:
+            vector = query.embeddings[0]
+        elif self.embedding_model and query.query_str:
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            vector = model.get_embeddings([query.query_str], text_type="query")[0]
+        else:
+            raise ValueError("query requires embeddings or an embedding_model plus query_str")
+        self._check_vector(vector)
+        return vector
+
+    def _vectors_for_documents(self, documents: list[Document]) -> list[list[float]]:
+        missing = [index for index, document in enumerate(documents) if not document.embedding]
+        if missing:
+            if not self.embedding_model:
+                raise ValueError("documents without embeddings require embedding_model")
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            generated = model.get_embeddings([documents[index].text or "" for index in missing])
+            for index, vector in zip(missing, generated, strict=True):
+                documents[index].embedding = vector
+        vectors = [document.embedding for document in documents]
+        for vector in vectors:
+            self._check_vector(vector)
+        return vectors
+
+    def _check_vector(self, vector: Any) -> None:
+        if (
+            not isinstance(vector, list)
+            or not vector
+            or any(
+                isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value))
+                for value in vector
+            )
+        ):
+            raise ValueError("embedding must be a non-empty list of finite numbers")
+        if self.dimensions is None:
+            self.dimensions = len(vector)
+        if len(vector) != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {len(vector)} does not match configured dimensions {self.dimensions}"
+            )
+
+    @staticmethod
+    def _vector_bytes(vector: list[float]) -> bytes:
+        values = array("f", (float(value) for value in vector))
+        if sys.byteorder != "little":
+            values.byteswap()
+        return values.tobytes()
+
+    @staticmethod
+    def _bytes_vector(value: Any) -> list[float]:
+        if value is None:
+            return []
+        raw = bytes(value)
+        if len(raw) % 4:
+            raise ValueError("Redis returned an invalid FLOAT32 vector")
+        values = array("f")
+        values.frombytes(raw)
+        if sys.byteorder != "little":
+            values.byteswap()
+        return list(values)
+
+    def _top_k(self, query: Query) -> int:
+        value = query.similarity_top_k or self.similarity_top_k
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError("similarity_top_k must be a positive integer")
+        return value
+
+    @classmethod
+    def _tag_value(cls, value: Any, field: str) -> str:
+        if isinstance(value, bool):
+            text = "true" if value else "false"
+        elif isinstance(value, (str, int, float)) and not isinstance(value, bool):
+            text = str(value)
+        else:
+            raise TypeError(f"metadata_filter.{field} must be a scalar value")
+        if not text:
+            raise ValueError(f"metadata_filter.{field} must not be empty")
+        return cls._TAG_ESCAPE.sub(r"\\\1", text)
+
+    def _filter(self, value: Any) -> str:
+        if value is None:
+            return "*"
+        if not isinstance(value, dict):
+            raise TypeError("metadata_filter must be an object")
+        unknown = set(value) - set(self.filter_tag_fields)
+        if unknown:
+            raise ValueError(f"metadata_filter fields are not indexed: {', '.join(sorted(unknown))}")
+        return " ".join(f"@meta_{field}:{{{self._tag_value(item, field)}}}" for field, item in value.items()) or "*"
+
+    def _search_command(self, vector: list[float], top_k: int, metadata_filter: Any) -> list[Any]:
+        base_filter = self._filter(metadata_filter)
+        query = f"({base_filter})=>[KNN {top_k} @embedding $query_vector AS vector_distance]"
+        return [
+            "FT.SEARCH",
+            self.index_name,
+            query,
+            "PARAMS",
+            2,
+            "query_vector",
+            self._vector_bytes(vector),
+            "SORTBY",
+            "vector_distance",
+            "RETURN",
+            5,
+            "id",
+            "text",
+            "metadata",
+            "embedding",
+            "vector_distance",
+            "LIMIT",
+            0,
+            top_k,
+            "DIALECT",
+            2,
+        ]
+
+    @staticmethod
+    def _decode(value: Any) -> str:
+        return value.decode("utf-8") if isinstance(value, bytes) else str(value)
+
+    @classmethod
+    def _rows_to_documents(cls, response: Any) -> list[Document]:
+        values = list(response or [])
+        documents = []
+        for index in range(1, len(values), 2):
+            fields = values[index + 1]
+            mapping = {cls._decode(fields[i]): fields[i + 1] for i in range(0, len(fields), 2)}
+            documents.append(
+                Document(
+                    id=cls._decode(mapping.get("id", values[index])),
+                    text=cls._decode(mapping.get("text", "")),
+                    metadata=json.loads(cls._decode(mapping.get("metadata", b"{}"))),
+                    embedding=cls._bytes_vector(mapping.get("embedding")),
+                )
+            )
+        return documents
+
+    def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        self._ensure_index(len(vector))
+        response = self._ensure_client().execute_command(
+            *self._search_command(vector, top_k, kwargs.get("metadata_filter"))
+        )
+        return self._rows_to_documents(response)
+
+    async def async_query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        await self._async_ensure_index(len(vector))
+        response = await (await self._ensure_async_client()).execute_command(
+            *self._search_command(vector, top_k, kwargs.get("metadata_filter"))
+        )
+        return self._rows_to_documents(response)
+
+    def _mapping(self, document: Document, vector: list[float]) -> dict[str, Any]:
+        metadata = document.metadata or {}
+        mapping: dict[str, Any] = {
+            "id": str(document.id),
+            "text": document.text or "",
+            "metadata": json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+            "embedding": self._vector_bytes(vector),
+        }
+        for field in self.filter_tag_fields:
+            if field in metadata:
+                value = metadata[field]
+                self._tag_value(value, field)
+                mapping[f"meta_{field}"] = str(value).lower() if isinstance(value, bool) else str(value)
+        return mapping
+
+    def upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        self._ensure_index(len(vectors[0]))
+        connection = self._ensure_client()
+        pipeline = connection.pipeline(transaction=False)
+        for document, vector in zip(documents, vectors, strict=True):
+            pipeline.hset(f"{self.key_prefix}{document.id}", mapping=self._mapping(document, vector))
+        pipeline.execute()
+
+    async def async_upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        await self._async_ensure_index(len(vectors[0]))
+        connection = await self._ensure_async_client()
+        async with connection.pipeline(transaction=False) as pipeline:
+            for document, vector in zip(documents, vectors, strict=True):
+                pipeline.hset(f"{self.key_prefix}{document.id}", mapping=self._mapping(document, vector))
+            await pipeline.execute()
+
+    def insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs: Any) -> None:
+        self._ensure_client().delete(f"{self.key_prefix}{document_id}")
+
+    async def async_delete_document(self, document_id: str, **kwargs: Any) -> None:
+        await (await self._ensure_async_client()).delete(f"{self.key_prefix}{document_id}")

--- a/agentuniverse/agent/action/knowledge/store/redis_vector_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/redis_vector_store.yaml.example
@@ -1,0 +1,16 @@
+name: redis_vector_store
+description: Redis Stack HNSW vector store
+connection_url: redis://localhost:6379/0
+index_name: agentuniverse_documents
+key_prefix: "agentuniverse:document:"
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+create_index: true
+filter_tag_fields: [tenant, category]
+hnsw_m: 16
+hnsw_ef_construction: 200
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.redis_vector_store
+  class: RedisVectorStore

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -80,3 +80,15 @@ store = ['sample_standard_app.intelligence.agentic.knowledge.store']
 - [Chroma](../../../In-Depth_Guides/Tech_Capabilities/Storage/ChromaDB.md)
 - [Milvus](../../../In-Depth_Guides/Tech_Capabilities/Storage/Milvus.md)
 - [Sqlite](../../../In-Depth_Guides/Tech_Capabilities/Storage/Sqlite.md)
+### RedisVectorStore
+
+`RedisVectorStore` uses Redis Stack/RediSearch HNSW indexes for synchronous and asynchronous vector CRUD and search. Install the optional dependency with `pip install 'agentUniverse[store_ext]'` and run Redis Stack (classic Redis without the Search module is insufficient).
+
+Copy `redis_vector_store.yaml.example` and configure the vector dimension, distance metric, key prefix, and any metadata fields that must be indexed as exact-match TAG fields. Credentials may be supplied through `REDIS_VECTOR_URL` instead of YAML.
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2])])
+results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metadata_filter={"tenant": "acme"})
+```
+
+Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are accepted only for fields declared in `filter_tag_fields`; identifiers and filter values are validated and escaped before constructing RediSearch queries.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -80,3 +80,15 @@ store = ['sample_standard_app.intelligence.agentic.knowledge.store']
 - [Chroma](../../技术组件/存储/ChromaDB.md)
 - [Milvus](../../技术组件/存储/Milvus.md)
 - [Sqlite](../../技术组件/存储/Sqlite.md)
+### RedisVectorStore
+
+`RedisVectorStore` 使用 Redis Stack/RediSearch HNSW 索引提供同步和异步向量增删改查。通过 `pip install 'agentUniverse[store_ext]'` 安装可选依赖，并使用 Redis Stack；不含 Search 模块的普通 Redis 无法使用该组件。
+
+复制 `redis_vector_store.yaml.example`，配置向量维度、距离度量、键前缀，以及需要精确过滤的 TAG 元数据字段。连接凭证也可通过 `REDIS_VECTOR_URL` 注入，避免写入 YAML。
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2])])
+results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metadata_filter={"tenant": "acme"})
+```
+
+支持 `cosine`、`l2`、`inner_product`。元数据过滤仅允许使用 `filter_tag_fields` 中声明的字段；组件会验证标识符并转义 RediSearch TAG 查询值。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,11 +73,12 @@ opentracing = ">=2.4.0,<3.0.0"
 jsonlines = "^4.0.0"
 EbookLib = "^0.18"
 beautifulsoup4 = "^4.12.0"
+redis = { version = "^5.0.0", optional = true }
 # qdrant-client = "^1.15.1" unsupportable version due to numpy version limit
 
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]
-store_ext = ["pymilvus"]
+store_ext = ["pymilvus", "redis"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_redis_vector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_redis_vector_store.py
@@ -1,0 +1,232 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+# Test doubles intentionally raise concise built-in errors.
+# ruff: noqa: TRY003
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.redis_vector_store import RedisVectorStore
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class FakePipeline:
+    def __init__(self):
+        self.calls = []
+        self.executed = False
+
+    def hset(self, key, mapping):
+        self.calls.append((key, mapping))
+        return self
+
+    def execute(self):
+        self.executed = True
+        return [1] * len(self.calls)
+
+
+class FakeAsyncPipeline(FakePipeline):
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def execute(self):
+        self.executed = True
+        return [1] * len(self.calls)
+
+
+class FakeConnection:
+    def __init__(self, search_response=None):
+        self.calls = []
+        self.deleted = []
+        self.search_response = search_response or [0]
+        self.pipeline_obj = FakePipeline()
+
+    def execute_command(self, *args):
+        self.calls.append(args)
+        return self.search_response if args[0] == "FT.SEARCH" else b"OK"
+
+    def pipeline(self, transaction=False):
+        self.transaction = transaction
+        return self.pipeline_obj
+
+    def delete(self, key):
+        self.deleted.append(key)
+        return 1
+
+
+class FakeAsyncConnection(FakeConnection):
+    def __init__(self, search_response=None):
+        super().__init__(search_response)
+        self.pipeline_obj = FakeAsyncPipeline()
+
+    async def execute_command(self, *args):
+        return super().execute_command(*args)
+
+    async def delete(self, key):
+        return super().delete(key)
+
+
+class RedisVectorStoreTest(unittest.TestCase):
+    def test_index_command_contains_hnsw_schema(self):
+        store = RedisVectorStore(dimensions=3, filter_tag_fields=["tenant"])
+        command = store._index_command(3)
+        self.assertEqual(command[:2], ["FT.CREATE", "agentuniverse_documents"])
+        self.assertIn("HNSW", command)
+        self.assertIn("FLOAT32", command)
+        self.assertIn("meta_tenant", command)
+        self.assertIn("COSINE", command)
+
+    def test_rejects_unsafe_identifiers(self):
+        with self.assertRaisesRegex(ValueError, "index_name"):
+            RedisVectorStore(index_name="idx; FLUSHALL")._validate_config(False)
+        with self.assertRaisesRegex(ValueError, "key_prefix"):
+            RedisVectorStore(key_prefix="prefix *")._validate_config(False)
+        with self.assertRaisesRegex(ValueError, "filter_tag_fields"):
+            RedisVectorStore(filter_tag_fields=["bad-name"])._validate_config(False)
+
+    def test_vector_binary_round_trip(self):
+        vector = [0.1, -0.2, 3.0]
+        decoded = RedisVectorStore._bytes_vector(RedisVectorStore._vector_bytes(vector))
+        for actual, expected in zip(decoded, vector, strict=True):
+            self.assertAlmostEqual(actual, expected, places=6)
+
+    def test_rejects_dimension_mismatch_and_nonfinite(self):
+        store = RedisVectorStore(dimensions=2)
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            store._check_vector([1.0])
+        with self.assertRaisesRegex(ValueError, "finite"):
+            store._check_vector([float("nan"), 1.0])
+
+    def test_query_and_row_conversion(self):
+        vector = RedisVectorStore._vector_bytes([1.0, 0.0])
+        response = [
+            1,
+            b"agentuniverse:document:one",
+            [b"id", b"one", b"text", b"hello", b"metadata", b'{"team":"a"}', b"embedding", vector],
+        ]
+        connection = FakeConnection(response)
+        store = RedisVectorStore(client=connection, dimensions=2, create_index=False)
+        documents = store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=1))
+        self.assertEqual(documents[0].id, "one")
+        self.assertEqual(documents[0].metadata, {"team": "a"})
+        self.assertEqual(documents[0].embedding, [1.0, 0.0])
+        self.assertEqual(connection.calls[-1][0], "FT.SEARCH")
+
+    def test_query_builds_indexed_metadata_filter(self):
+        connection = FakeConnection()
+        store = RedisVectorStore(
+            client=connection,
+            dimensions=2,
+            create_index=False,
+            filter_tag_fields=["tenant", "active"],
+        )
+        store.query(
+            Query(embeddings=[[1.0, 0.0]], similarity_top_k=3),
+            metadata_filter={"tenant": "a b", "active": True},
+        )
+        query = connection.calls[-1][2]
+        self.assertIn("@meta_tenant:{a\\ b}", query)
+        self.assertIn("@meta_active:{true}", query)
+
+    def test_query_rejects_unindexed_filter(self):
+        store = RedisVectorStore(client=FakeConnection(), dimensions=2, create_index=False)
+        with self.assertRaisesRegex(ValueError, "not indexed"):
+            store.query(Query(embeddings=[[1.0, 0.0]]), metadata_filter={"tenant": "a"})
+
+    def test_invalid_top_k_fails_before_redis(self):
+        connection = FakeConnection()
+        store = RedisVectorStore(client=connection, dimensions=2)
+        with self.assertRaisesRegex(ValueError, "similarity_top_k"):
+            store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=-1))
+        self.assertEqual(connection.calls, [])
+
+    def test_upsert_uses_pipeline_and_filter_fields(self):
+        connection = FakeConnection()
+        store = RedisVectorStore(
+            client=connection,
+            dimensions=2,
+            create_index=False,
+            filter_tag_fields=["tenant"],
+        )
+        store.upsert_document([Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2])])
+        key, mapping = connection.pipeline_obj.calls[0]
+        self.assertEqual(key, "agentuniverse:document:1")
+        self.assertEqual(mapping["meta_tenant"], "acme")
+        self.assertEqual(json.loads(mapping["metadata"]), {"tenant": "acme"})
+        self.assertTrue(connection.pipeline_obj.executed)
+
+    def test_delete_uses_prefixed_key(self):
+        connection = FakeConnection()
+        RedisVectorStore(client=connection).delete_document("abc")
+        self.assertEqual(connection.deleted, ["agentuniverse:document:abc"])
+
+    def test_missing_embeddings_require_model(self):
+        store = RedisVectorStore(client=FakeConnection(), dimensions=2, create_index=False)
+        with self.assertRaisesRegex(ValueError, "embedding_model"):
+            store.upsert_document([Document(text="hello")])
+
+    def test_managed_embeddings(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = RedisVectorStore(client=FakeConnection(), dimensions=2, create_index=False, embedding_model="embed")
+        document = Document(text="hello")
+        with patch("agentuniverse.agent.action.knowledge.store.redis_vector_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.upsert_document([document])
+        self.assertEqual(document.embedding, [0.1, 0.2])
+
+    def test_connection_url_from_environment(self):
+        with patch.dict("os.environ", {"REDIS_VECTOR_URL": "redis://test"}):
+            self.assertEqual(RedisVectorStore()._url(), "redis://test")
+
+    def test_missing_dependency_hint(self):
+        with patch.dict("sys.modules", {"redis": None}), self.assertRaisesRegex(ImportError, "redis package"):
+            RedisVectorStore._dependencies()
+
+    def test_existing_index_error_is_accepted(self):
+        class ExistingConnection(FakeConnection):
+            def execute_command(self, *args):
+                raise RuntimeError("Index already exists")
+
+        RedisVectorStore(client=ExistingConnection(), dimensions=2)._ensure_index(2)
+
+    def test_async_crud(self):
+        vector = RedisVectorStore._vector_bytes([0.0, 1.0])
+        response = [1, b"doc:1", [b"id", b"1", b"text", b"async", b"metadata", b"{}", b"embedding", vector]]
+        connection = FakeAsyncConnection(response)
+        store = RedisVectorStore(async_client=connection, dimensions=2, create_index=False)
+
+        async def run():
+            await store.async_upsert_document([Document(id="1", text="async", embedding=[0.0, 1.0])])
+            result = await store.async_query(Query(embeddings=[[0.0, 1.0]], similarity_top_k=1))
+            await store.async_delete_document("1")
+            return result
+
+        result = asyncio.run(run())
+        self.assertEqual(result[0].text, "async")
+        self.assertTrue(connection.pipeline_obj.executed)
+        self.assertEqual(connection.deleted, ["agentuniverse:document:1"])
+
+    def test_component_schema(self):
+        config = Configer()
+        config.value = {
+            "name": "redis_vector_store",
+            "dimensions": 3,
+            "metadata": {
+                "type": "STORE",
+                "module": "agentuniverse.agent.action.knowledge.store.redis_vector_store",
+                "class": "RedisVectorStore",
+            },
+        }
+        component = ComponentConfiger().load_by_configer(config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.STORE.value)
+        self.assertEqual(component.metadata_class, "RedisVectorStore")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Redis Stack/RediSearch `RedisVectorStore` backend with synchronous and asynchronous CRUD/query support
- create an HNSW vector index, infer or validate embedding dimensions, and support cosine, L2, and inner-product distance metrics
- support managed embeddings, configurable document key prefixes, exact TAG metadata filters, YAML example configuration, and environment-based connection URLs
- add the optional `redis` dependency, English/Chinese store documentation, and 17 focused tests

## Safety and compatibility

- validate index names, key prefixes, filter field identifiers, positive HNSW/query settings, vector dimensions, and finite vector values before issuing Redis commands
- restrict metadata filters to explicitly indexed `filter_tag_fields` and escape RediSearch TAG values
- encode vectors as portable FLOAT32 buffers and preserve agentUniverse `Document`, `Query`, sync, and async store interfaces
- handle an existing index idempotently while surfacing unrelated Redis errors

## Validation

macOS / Python 3.11:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_redis_vector_store
Ran 17 tests — OK

ruff check: All checks passed
ruff format --check: 2 files already formatted
```

Ubuntu 22.04 x86_64 server / Python 3.10.12:

```text
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_redis_vector_store
Ran 17 tests — OK
```

A real Redis Stack Docker integration test also passed synchronous and asynchronous upsert/query/delete workflows, HNSW search, and indexed TAG metadata filtering.

Partially addresses #259.
