### PR TITLE
feat(store): add OpenSearch vector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/opensearch_vector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/opensearch_vector_store.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""OpenSearch k-NN vector knowledge store."""
+
+# Dynamic mapping names are validated before request construction.
+# ruff: noqa: C901, TRY003
+
+import math
+import os
+import re
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class OpenSearchVectorStore(Store):
+    """Persistent sync/async vector store backed by OpenSearch k-NN."""
+
+    connection_args: dict[str, Any] = Field(default_factory=dict)
+    index_name: str = "agentuniverse-documents"
+    embedding_model: str | None = None
+    dimensions: int | None = None
+    distance: str = "cosine"
+    similarity_top_k: int = 10
+    create_index: bool = True
+    refresh: bool | str = False
+    filter_fields: list[str] = Field(default_factory=list)
+    ef_construction: int = 128
+    m: int = 16
+    client: Any = None
+    async_client: Any = None
+
+    _INDEX: ClassVar[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+    _FIELD: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    _SPACES: ClassVar[dict[str, str]] = {
+        "cosine": "cosinesimil",
+        "l2": "l2",
+        "inner_product": "innerproduct",
+    }
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "OpenSearchVectorStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "connection_args",
+            "index_name",
+            "embedding_model",
+            "dimensions",
+            "distance",
+            "similarity_top_k",
+            "create_index",
+            "refresh",
+            "filter_fields",
+            "ef_construction",
+            "m",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config(require_dimensions=False)
+        return self
+
+    def _validate_config(self, require_dimensions: bool = True) -> None:
+        if not isinstance(self.connection_args, dict):
+            raise TypeError("connection_args must be an object")
+        if not self._INDEX.fullmatch(self.index_name or "") or self.index_name.startswith(("_", "-", "+")):
+            raise ValueError("index_name must be a lowercase OpenSearch index identifier")
+        self.distance = (self.distance or "").lower()
+        if self.distance not in self._SPACES:
+            raise ValueError("distance must be cosine, l2, or inner_product")
+        for name in ("similarity_top_k", "ef_construction", "m"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.dimensions is not None and (
+            isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0
+        ):
+            raise ValueError("dimensions must be a positive integer")
+        if require_dimensions and self.dimensions is None:
+            raise ValueError("dimensions must be configured or inferred from the first document")
+        if not isinstance(self.filter_fields, list) or any(
+            not isinstance(field, str) or not self._FIELD.fullmatch(field) for field in self.filter_fields
+        ):
+            raise ValueError("filter_fields must contain simple identifiers")
+        if len(set(self.filter_fields)) != len(self.filter_fields):
+            raise ValueError("filter_fields must not contain duplicates")
+        if not isinstance(self.create_index, bool):
+            raise TypeError("create_index must be a boolean")
+        if not isinstance(self.refresh, (bool, str)):
+            raise TypeError("refresh must be a boolean or string")
+
+    @staticmethod
+    def _dependencies() -> tuple[Any, Any]:
+        try:
+            from opensearchpy import AsyncOpenSearch, OpenSearch
+        except ImportError as exc:
+            raise ImportError("OpenSearchVectorStore requires opensearch-py") from exc
+        return OpenSearch, AsyncOpenSearch
+
+    def _new_client(self) -> Any:
+        OpenSearch, _ = self._dependencies()
+        self._validate_config(require_dimensions=False)
+        self.client = OpenSearch(**self._resolved_connection_args())
+        self.client.info()
+        if self.create_index and self.dimensions:
+            self._ensure_index(self.dimensions)
+        return self.client
+
+    async def _new_async_client(self) -> Any:
+        _, AsyncOpenSearch = self._dependencies()
+        self._validate_config(require_dimensions=False)
+        self.async_client = AsyncOpenSearch(**self._resolved_connection_args())
+        await self.async_client.info()
+        if self.create_index and self.dimensions:
+            await self._async_ensure_index(self.dimensions)
+        return self.async_client
+
+    def _resolved_connection_args(self) -> dict[str, Any]:
+        args = dict(self.connection_args)
+        url = os.getenv("OPENSEARCH_VECTOR_URL")
+        if "hosts" not in args:
+            args["hosts"] = [url] if url else [{"host": "localhost", "port": 9200}]
+        return args
+
+    def _ensure_client(self) -> Any:
+        return self.client or self._new_client()
+
+    async def _ensure_async_client(self) -> Any:
+        return self.async_client or await self._new_async_client()
+
+    def _mapping(self, dimensions: int) -> dict[str, Any]:
+        self.dimensions = self.dimensions or dimensions
+        if dimensions != self.dimensions:
+            raise ValueError(f"embedding dimension {dimensions} does not match configured dimensions {self.dimensions}")
+        self._validate_config()
+        metadata_properties = {field: {"type": "keyword"} for field in self.filter_fields}
+        return {
+            "settings": {"index": {"knn": True}},
+            "mappings": {
+                "dynamic": "strict",
+                "properties": {
+                    "id": {"type": "keyword"},
+                    "text": {"type": "text"},
+                    "metadata": {
+                        "type": "object",
+                        "dynamic": True,
+                        "properties": metadata_properties,
+                    },
+                    "embedding": {
+                        "type": "knn_vector",
+                        "dimension": self.dimensions,
+                        "method": {
+                            "name": "hnsw",
+                            "space_type": self._SPACES[self.distance],
+                            "engine": "lucene",
+                            "parameters": {"ef_construction": self.ef_construction, "m": self.m},
+                        },
+                    },
+                },
+            },
+        }
+
+    def _ensure_index(self, dimensions: int) -> None:
+        client = self._ensure_client()
+        mapping = self._mapping(dimensions)
+        if self.create_index and not client.indices.exists(index=self.index_name):
+            client.indices.create(index=self.index_name, body=mapping)
+
+    async def _async_ensure_index(self, dimensions: int) -> None:
+        client = await self._ensure_async_client()
+        mapping = self._mapping(dimensions)
+        if self.create_index and not await client.indices.exists(index=self.index_name):
+            await client.indices.create(index=self.index_name, body=mapping)
+
+    def _embedding(self, document: Document) -> list[float]:
+        vector = document.embedding
+        if not vector and self.embedding_model:
+            model = EmbeddingManager().get_instance_obj(self.embedding_model)
+            vector = model.get_embeddings([document.text])[0]
+        return self._validate_vector(vector, "document embedding")
+
+    def _query_vector(self, query: Query) -> list[float]:
+        embeddings = query.embeddings
+        if not embeddings and self.embedding_model:
+            model = EmbeddingManager().get_instance_obj(self.embedding_model)
+            embeddings = model.get_embeddings([query.query_str], text_type="query")
+        if not embeddings:
+            raise ValueError("query requires embeddings or an embedding_model")
+        return self._validate_vector(embeddings[0], "query embedding")
+
+    def _validate_vector(self, vector: Any, field: str) -> list[float]:
+        if not isinstance(vector, list) or not vector:
+            raise ValueError(f"{field} must be a non-empty list")
+        output = []
+        for value in vector:
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+                raise ValueError(f"{field} must contain finite numbers")
+            output.append(float(value))
+        if self.dimensions is not None and len(output) != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {len(output)} does not match configured dimensions {self.dimensions}"
+            )
+        return output
+
+    def insert_document(self, documents: list[Document], **kwargs) -> Any:
+        return self.upsert_document(documents, **kwargs)
+
+    def update_document(self, documents: list[Document], **kwargs) -> Any:
+        return self.upsert_document(documents, **kwargs)
+
+    def upsert_document(self, documents: list[Document], **kwargs) -> Any:
+        prepared = self._prepare_documents(documents)
+        if not prepared:
+            return None
+        self._ensure_index(len(prepared[0][1]))
+        body = self._bulk_body(prepared)
+        result = self._ensure_client().bulk(body=body, refresh=self.refresh)
+        self._raise_bulk_errors(result)
+        return result
+
+    async def async_insert_document(self, documents: list[Document], **kwargs) -> Any:
+        return await self.async_upsert_document(documents, **kwargs)
+
+    async def async_update_document(self, documents: list[Document], **kwargs) -> Any:
+        return await self.async_upsert_document(documents, **kwargs)
+
+    async def async_upsert_document(self, documents: list[Document], **kwargs) -> Any:
+        prepared = self._prepare_documents(documents)
+        if not prepared:
+            return None
+        await self._async_ensure_index(len(prepared[0][1]))
+        result = await (await self._ensure_async_client()).bulk(body=self._bulk_body(prepared), refresh=self.refresh)
+        self._raise_bulk_errors(result)
+        return result
+
+    def _prepare_documents(self, documents: Any) -> list[tuple[Document, list[float]]]:
+        if not isinstance(documents, list):
+            raise TypeError("documents must be a list")
+        prepared = []
+        for document in documents:
+            if not isinstance(document, Document):
+                raise TypeError("documents must contain Document objects")
+            prepared.append((document, self._embedding(document)))
+        if prepared:
+            dimensions = len(prepared[0][1])
+            if any(len(vector) != dimensions for _, vector in prepared):
+                raise ValueError("all document embeddings must have the same dimensions")
+        return prepared
+
+    def _bulk_body(self, prepared: list[tuple[Document, list[float]]]) -> list[dict[str, Any]]:
+        body = []
+        for document, vector in prepared:
+            metadata = document.metadata or {}
+            if not isinstance(metadata, dict):
+                raise TypeError("document metadata must be an object")
+            body.extend(
+                (
+                    {"index": {"_index": self.index_name, "_id": str(document.id)}},
+                    {"id": str(document.id), "text": document.text or "", "metadata": metadata, "embedding": vector},
+                )
+            )
+        return body
+
+    @staticmethod
+    def _raise_bulk_errors(result: Any) -> None:
+        if isinstance(result, dict) and result.get("errors"):
+            failures = [item for item in result.get("items", []) if next(iter(item.values())).get("error")]
+            raise RuntimeError(f"OpenSearch bulk request failed for {len(failures)} document(s)")
+
+    def delete_document(self, document_id: str, **kwargs) -> Any:
+        if not isinstance(document_id, str) or not document_id:
+            raise ValueError("document_id must be a non-empty string")
+        return self._ensure_client().delete(
+            index=self.index_name,
+            id=document_id,
+            refresh=self.refresh,
+            ignore=[404],
+        )
+
+    async def async_delete_document(self, document_id: str, **kwargs) -> Any:
+        if not isinstance(document_id, str) or not document_id:
+            raise ValueError("document_id must be a non-empty string")
+        return await (await self._ensure_async_client()).delete(
+            index=self.index_name,
+            id=document_id,
+            refresh=self.refresh,
+            ignore=[404],
+        )
+
+    def query(self, query: Query, **kwargs) -> list[Document]:
+        vector, _top_k, body = self._query_request(query, kwargs.get("metadata_filter"))
+        self._ensure_index(len(vector))
+        result = self._ensure_client().search(index=self.index_name, body=body)
+        return self._to_documents(result)
+
+    async def async_query(self, query: Query, **kwargs) -> list[Document]:
+        vector, _top_k, body = self._query_request(query, kwargs.get("metadata_filter"))
+        await self._async_ensure_index(len(vector))
+        result = await (await self._ensure_async_client()).search(index=self.index_name, body=body)
+        return self._to_documents(result)
+
+    def _query_request(self, query: Any, metadata_filter: Any) -> tuple[list[float], int, dict[str, Any]]:
+        if not isinstance(query, Query):
+            raise TypeError("query must be a Query object")
+        vector = self._query_vector(query)
+        top_k = query.similarity_top_k or self.similarity_top_k
+        if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
+            raise ValueError("similarity_top_k must be a positive integer")
+        filters = self._metadata_filters(metadata_filter)
+        knn = {"knn": {"embedding": {"vector": vector, "k": top_k}}}
+        query_body: dict[str, Any] = knn if not filters else {"bool": {"must": [knn], "filter": filters}}
+        return vector, top_k, {"size": top_k, "query": query_body}
+
+    def _metadata_filters(self, value: Any) -> list[dict[str, Any]]:
+        if value is None:
+            return []
+        if not isinstance(value, dict):
+            raise TypeError("metadata_filter must be an object")
+        unknown = set(value) - set(self.filter_fields)
+        if unknown:
+            raise ValueError(f"metadata_filter fields are not indexed: {', '.join(sorted(unknown))}")
+        filters = []
+        for field, item in value.items():
+            if item is None or not isinstance(item, (str, int, float, bool)):
+                raise ValueError(f"metadata_filter.{field} must be a non-null scalar")
+            filters.append({"term": {f"metadata.{field}": item}})
+        return filters
+
+    @staticmethod
+    def _to_documents(result: Any) -> list[Document]:
+        hits = result.get("hits", {}).get("hits", []) if isinstance(result, dict) else []
+        documents = []
+        for hit in hits:
+            source = hit.get("_source", {})
+            metadata = dict(source.get("metadata") or {})
+            if hit.get("_score") is not None:
+                metadata["_opensearch_score"] = hit["_score"]
+            documents.append(
+                Document(
+                    id=str(source.get("id") or hit.get("_id")),
+                    text=source.get("text", ""),
+                    metadata=metadata,
+                    embedding=source.get("embedding") or [],
+                )
+            )
+        return documents

--- a/agentuniverse/agent/action/knowledge/store/opensearch_vector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/opensearch_vector_store.py
@@ -310,9 +310,13 @@ class OpenSearchVectorStore(Store):
         if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
             raise ValueError("similarity_top_k must be a positive integer")
         filters = self._metadata_filters(metadata_filter)
-        knn = {"knn": {"embedding": {"vector": vector, "k": top_k}}}
-        query_body: dict[str, Any] = knn if not filters else {"bool": {"must": [knn], "filter": filters}}
-        return vector, top_k, {"size": top_k, "query": query_body}
+        vector_query: dict[str, Any] = {"vector": vector, "k": top_k}
+        if filters:
+            # Filtering inside the Lucene k-NN clause selects ``k`` nearest
+            # matching documents. A surrounding bool filter is applied after
+            # candidate selection and can therefore return fewer than ``k``.
+            vector_query["filter"] = {"bool": {"filter": filters}}
+        return vector, top_k, {"size": top_k, "query": {"knn": {"embedding": vector_query}}}
 
     def _metadata_filters(self, value: Any) -> list[dict[str, Any]]:
         if value is None:

--- a/agentuniverse/agent/action/knowledge/store/opensearch_vector_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/opensearch_vector_store.yaml.example
@@ -1,0 +1,21 @@
+name: opensearch_vector_store
+description: OpenSearch HNSW vector knowledge store
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.opensearch_vector_store
+  class: OpenSearchVectorStore
+connection_args:
+  hosts:
+    - host: localhost
+      port: 9200
+  use_ssl: false
+  verify_certs: true
+index_name: agentuniverse-documents
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+create_index: true
+refresh: false
+filter_fields: [tenant, source]
+ef_construction: 128
+m: 16

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -14,7 +14,7 @@ results = store.query(
 )
 ```
 
-Supported distance metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are accepted only for fields declared in `filter_fields`. Set `OPENSEARCH_VECTOR_URL` to inject a connection URL when `connection_args.hosts` is omitted.
+Supported distance metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are accepted only for fields declared in `filter_fields`. Set `OPENSEARCH_VECTOR_URL` to inject a connection URL when `connection_args.hosts` is omitted. The optional `store_ext` extra installs the resolver-compatible OpenSearch Python client 2.8.x; this client interoperates with current OpenSearch servers without raising the core project's pinned gRPC requirement.
 
 `Store` is responsible for storing `Document` objects and providing query capabilities during the knowledge retrieval phase. The specific form of a `Store` can vary, including relational databases, vector databases, graph databases, and more. Therefore, the same `Document` can be stored in different Stores in various formats, and the retrieval methods are tied to the capabilities of the specific `Store`.
 

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -1,5 +1,21 @@
 # Store
 
+## OpenSearch vector store
+
+`OpenSearchVectorStore` persists agentUniverse `Document` embeddings in an OpenSearch k-NN HNSW index and implements synchronous and asynchronous insert, upsert, update, delete, and query operations. Copy `opensearch_vector_store.yaml.example` into an application component directory and configure the vector dimension, distance metric, index, connection arguments, and exact-match metadata fields.
+
+```python
+store.upsert_document([
+    Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2])
+])
+results = store.query(
+    Query(embeddings=[[0.1, 0.2]], similarity_top_k=5),
+    metadata_filter={"tenant": "acme"},
+)
+```
+
+Supported distance metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are accepted only for fields declared in `filter_fields`. Set `OPENSEARCH_VECTOR_URL` to inject a connection URL when `connection_args.hosts` is omitted.
+
 `Store` is responsible for storing `Document` objects and providing query capabilities during the knowledge retrieval phase. The specific form of a `Store` can vary, including relational databases, vector databases, graph databases, and more. Therefore, the same `Document` can be stored in different Stores in various formats, and the retrieval methods are tied to the capabilities of the specific `Store`.
 
 The Store is defined as follows:

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -1,5 +1,21 @@
 # Store
 
+## OpenSearch 向量存储
+
+`OpenSearchVectorStore` 将 agentUniverse `Document` 向量持久化到 OpenSearch k-NN HNSW 索引，并实现同步和异步的新增、更新、删除与查询。将 `opensearch_vector_store.yaml.example` 复制到应用组件目录，配置向量维度、距离、索引、连接参数和用于精确过滤的元数据字段。
+
+```python
+store.upsert_document([
+    Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2])
+])
+results = store.query(
+    Query(embeddings=[[0.1, 0.2]], similarity_top_k=5),
+    metadata_filter={"tenant": "acme"},
+)
+```
+
+支持 `cosine`、`l2` 和 `inner_product`。元数据过滤仅允许使用 `filter_fields` 声明的字段。当 `connection_args.hosts` 未设置时，可通过 `OPENSEARCH_VECTOR_URL` 注入连接地址。
+
 `Store`负责对`Document`进行存储，并在知识的检索阶段提供查询能力。`Store`的具体形式可以是多样的，包括关系型数据库、向量数据库、图数据库等形式。因此同一份`Document`也能在不同的`Store`中以不同的形式存储，而具体的检索方式也和`Store`的能力相绑定。
 
 Store定义如下：

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -14,7 +14,7 @@ results = store.query(
 )
 ```
 
-支持 `cosine`、`l2` 和 `inner_product`。元数据过滤仅允许使用 `filter_fields` 声明的字段。当 `connection_args.hosts` 未设置时，可通过 `OPENSEARCH_VECTOR_URL` 注入连接地址。
+支持 `cosine`、`l2` 和 `inner_product`。元数据过滤仅允许使用 `filter_fields` 声明的字段。当 `connection_args.hosts` 未设置时，可通过 `OPENSEARCH_VECTOR_URL` 注入连接地址。可选的 `store_ext` extra 安装可正常解析的 OpenSearch Python 2.8.x 客户端；该客户端可与当前 OpenSearch 服务器互操作，也不会抬高核心项目已锁定的 gRPC 版本要求。
 
 `Store`负责对`Document`进行存储，并在知识的检索阶段提供查询能力。`Store`的具体形式可以是多样的，包括关系型数据库、向量数据库、图数据库等形式。因此同一份`Document`也能在不同的`Store`中以不同的形式存储，而具体的检索方式也和`Store`的能力相绑定。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,12 @@ jsonlines = "^4.0.0"
 EbookLib = "^0.18"
 beautifulsoup4 = "^4.12.0"
 redis = { version = "^5.0.0", optional = true }
+opensearch-py = { version = "^2.8.0", optional = true }
 # qdrant-client = "^1.15.1" unsupportable version due to numpy version limit
 
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]
-store_ext = ["pymilvus", "psycopg", "pgvector", "redis"]
+store_ext = ["pymilvus", "psycopg", "pgvector", "redis", "opensearch-py"]
 pdf_ext = ["pypdf"]
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_opensearch_vector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_opensearch_vector_store.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Tests for OpenSearchVectorStore."""
+
+import asyncio
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.opensearch_vector_store import OpenSearchVectorStore
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class FakeIndices:
+    def __init__(self, exists=False):
+        self.exists_value = exists
+        self.created = []
+
+    def exists(self, index):
+        self.exists_index = index
+        return self.exists_value
+
+    def create(self, index, body):
+        self.created.append((index, body))
+        return {"acknowledged": True}
+
+
+class FakeClient:
+    def __init__(self, search_result=None, exists=False):
+        self.indices = FakeIndices(exists)
+        self.bulk_calls = []
+        self.search_calls = []
+        self.delete_calls = []
+        self.search_result = search_result or {"hits": {"hits": []}}
+
+    def bulk(self, **kwargs):
+        self.bulk_calls.append(kwargs)
+        return {"errors": False, "items": []}
+
+    def search(self, **kwargs):
+        self.search_calls.append(kwargs)
+        return self.search_result
+
+    def delete(self, **kwargs):
+        self.delete_calls.append(kwargs)
+        return {"result": "deleted"}
+
+
+class FakeAsyncIndices(FakeIndices):
+    async def exists(self, index):
+        return super().exists(index)
+
+    async def create(self, index, body):
+        return super().create(index, body)
+
+
+class FakeAsyncClient(FakeClient):
+    def __init__(self, search_result=None, exists=False):
+        super().__init__(search_result, exists)
+        self.indices = FakeAsyncIndices(exists)
+
+    async def bulk(self, **kwargs):
+        return super().bulk(**kwargs)
+
+    async def search(self, **kwargs):
+        return super().search(**kwargs)
+
+    async def delete(self, **kwargs):
+        return super().delete(**kwargs)
+
+
+class TestOpenSearchVectorStore(unittest.TestCase):
+    def test_mapping_contains_hnsw_and_keyword_filters(self):
+        store = OpenSearchVectorStore(dimensions=3, filter_fields=["tenant"], distance="cosine")
+        mapping = store._mapping(3)
+        properties = mapping["mappings"]["properties"]
+        self.assertTrue(mapping["settings"]["index"]["knn"])
+        self.assertEqual(properties["embedding"]["dimension"], 3)
+        self.assertEqual(properties["embedding"]["method"]["space_type"], "cosinesimil")
+        self.assertEqual(properties["metadata"]["properties"]["tenant"], {"type": "keyword"})
+
+    def test_rejects_unsafe_configuration(self):
+        with self.assertRaisesRegex(ValueError, "index_name"):
+            OpenSearchVectorStore(index_name="Bad Index")._validate_config(False)
+        with self.assertRaisesRegex(ValueError, "filter_fields"):
+            OpenSearchVectorStore(filter_fields=["bad-name"])._validate_config(False)
+        with self.assertRaisesRegex(ValueError, "distance"):
+            OpenSearchVectorStore(distance="unknown")._validate_config(False)
+
+    def test_rejects_dimension_mismatch_and_nonfinite_vectors(self):
+        store = OpenSearchVectorStore(dimensions=2)
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            store._validate_vector([1.0], "embedding")
+        with self.assertRaisesRegex(ValueError, "finite"):
+            store._validate_vector([float("nan"), 1.0], "embedding")
+
+    def test_index_is_created_once(self):
+        client = FakeClient(exists=False)
+        store = OpenSearchVectorStore(client=client, dimensions=2)
+        store._ensure_index(2)
+        self.assertEqual(len(client.indices.created), 1)
+        self.assertEqual(client.indices.created[0][0], "agentuniverse-documents")
+
+    def test_existing_index_is_not_recreated(self):
+        client = FakeClient(exists=True)
+        OpenSearchVectorStore(client=client, dimensions=2)._ensure_index(2)
+        self.assertEqual(client.indices.created, [])
+
+    def test_upsert_builds_bulk_index_actions(self):
+        client = FakeClient(exists=True)
+        store = OpenSearchVectorStore(client=client, dimensions=2, refresh="wait_for")
+        store.upsert_document([Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2])])
+        call = client.bulk_calls[0]
+        self.assertEqual(call["body"][0], {"index": {"_index": "agentuniverse-documents", "_id": "1"}})
+        self.assertEqual(call["body"][1]["embedding"], [0.1, 0.2])
+        self.assertEqual(call["body"][1]["metadata"], {"tenant": "acme"})
+        self.assertEqual(call["refresh"], "wait_for")
+
+    def test_bulk_failures_are_not_silenced(self):
+        result = {"errors": True, "items": [{"index": {"error": {"reason": "bad"}}}]}
+        with self.assertRaisesRegex(RuntimeError, "1 document"):
+            OpenSearchVectorStore._raise_bulk_errors(result)
+
+    def test_query_builds_knn_filter_and_converts_hits(self):
+        response = {
+            "hits": {
+                "hits": [
+                    {
+                        "_id": "1",
+                        "_score": 0.9,
+                        "_source": {
+                            "id": "1",
+                            "text": "hello",
+                            "metadata": {"tenant": "acme"},
+                            "embedding": [1.0, 0.0],
+                        },
+                    }
+                ]
+            }
+        }
+        client = FakeClient(response, exists=True)
+        store = OpenSearchVectorStore(client=client, dimensions=2, filter_fields=["tenant"])
+        documents = store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=3), metadata_filter={"tenant": "acme"})
+        body = client.search_calls[0]["body"]
+        self.assertEqual(body["size"], 3)
+        self.assertEqual(body["query"]["bool"]["filter"], [{"term": {"metadata.tenant": "acme"}}])
+        self.assertEqual(documents[0].id, "1")
+        self.assertEqual(documents[0].metadata["_opensearch_score"], 0.9)
+
+    def test_unfiltered_query_uses_direct_knn_query(self):
+        client = FakeClient(exists=True)
+        store = OpenSearchVectorStore(client=client, dimensions=2)
+        store.query(Query(embeddings=[[0.0, 1.0]]))
+        self.assertIn("knn", client.search_calls[0]["body"]["query"])
+
+    def test_rejects_unindexed_metadata_filter(self):
+        store = OpenSearchVectorStore(client=FakeClient(exists=True), dimensions=2)
+        with self.assertRaisesRegex(ValueError, "not indexed"):
+            store.query(Query(embeddings=[[1.0, 0.0]]), metadata_filter={"tenant": "acme"})
+
+    def test_invalid_top_k_fails_before_client_call(self):
+        client = FakeClient(exists=True)
+        store = OpenSearchVectorStore(client=client, dimensions=2)
+        with self.assertRaisesRegex(ValueError, "similarity_top_k"):
+            store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=-1))
+        self.assertEqual(client.search_calls, [])
+
+    def test_delete_uses_document_id_and_ignore_404(self):
+        client = FakeClient()
+        OpenSearchVectorStore(client=client).delete_document("abc")
+        self.assertEqual(client.delete_calls[0]["id"], "abc")
+        self.assertEqual(client.delete_calls[0]["ignore"], [404])
+
+    def test_managed_embeddings(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = OpenSearchVectorStore(client=FakeClient(exists=True), dimensions=2, embedding_model="embedding")
+        with patch("agentuniverse.agent.action.knowledge.store.opensearch_vector_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.upsert_document([Document(id="1", text="managed")])
+        model.get_embeddings.assert_called_once_with(["managed"])
+
+    def test_connection_url_environment_fallback(self):
+        with patch.dict("os.environ", {"OPENSEARCH_VECTOR_URL": "http://example:9200"}):
+            args = OpenSearchVectorStore()._resolved_connection_args()
+        self.assertEqual(args["hosts"], ["http://example:9200"])
+
+    def test_explicit_hosts_override_environment(self):
+        store = OpenSearchVectorStore(connection_args={"hosts": ["http://explicit:9200"]})
+        with patch.dict("os.environ", {"OPENSEARCH_VECTOR_URL": "http://environment:9200"}):
+            self.assertEqual(store._resolved_connection_args()["hosts"], ["http://explicit:9200"])
+
+    def test_missing_dependency_hint(self):
+        with patch.dict("sys.modules", {"opensearchpy": None}), self.assertRaisesRegex(ImportError, "opensearch-py"):
+            OpenSearchVectorStore._dependencies()
+
+    def test_async_crud(self):
+        response = {"hits": {"hits": [{"_id": "1", "_source": {"id": "1", "text": "async", "embedding": [0.0, 1.0]}}]}}
+        client = FakeAsyncClient(response, exists=True)
+        store = OpenSearchVectorStore(async_client=client, dimensions=2)
+
+        async def run():
+            await store.async_upsert_document([Document(id="1", text="async", embedding=[0.0, 1.0])])
+            result = await store.async_query(Query(embeddings=[[0.0, 1.0]], similarity_top_k=1))
+            await store.async_delete_document("1")
+            return result
+
+        result = asyncio.run(run())
+        self.assertEqual(result[0].text, "async")
+        self.assertEqual(client.bulk_calls[0]["body"][1]["id"], "1")
+        self.assertEqual(client.delete_calls[0]["id"], "1")
+
+    def test_component_schema(self):
+        config = Configer()
+        config.value = {
+            "name": "opensearch_vector_store",
+            "dimensions": 3,
+            "metadata": {
+                "type": "STORE",
+                "module": "agentuniverse.agent.action.knowledge.store.opensearch_vector_store",
+                "class": "OpenSearchVectorStore",
+            },
+        }
+        component = ComponentConfiger().load_by_configer(config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.STORE.value)
+        self.assertEqual(component.metadata_class, "OpenSearchVectorStore")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_opensearch_vector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_opensearch_vector_store.py
@@ -145,7 +145,10 @@ class TestOpenSearchVectorStore(unittest.TestCase):
         documents = store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=3), metadata_filter={"tenant": "acme"})
         body = client.search_calls[0]["body"]
         self.assertEqual(body["size"], 3)
-        self.assertEqual(body["query"]["bool"]["filter"], [{"term": {"metadata.tenant": "acme"}}])
+        self.assertEqual(
+            body["query"]["knn"]["embedding"]["filter"],
+            {"bool": {"filter": [{"term": {"metadata.tenant": "acme"}}]}},
+        )
         self.assertEqual(documents[0].id, "1")
         self.assertEqual(documents[0].metadata["_opensearch_score"], 0.9)
 

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_opensearch_vector_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_opensearch_vector_store.py
@@ -3,7 +3,13 @@
 
 import asyncio
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
+
+try:
+    import tomllib
+except ImportError:  # Python 3.10
+    import tomli as tomllib
 
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.knowledge.store.opensearch_vector_store import OpenSearchVectorStore
@@ -72,6 +78,15 @@ class FakeAsyncClient(FakeClient):
 
 
 class TestOpenSearchVectorStore(unittest.TestCase):
+    def test_optional_dependency_is_resolver_compatible(self):
+        project_file = next(
+            parent / "pyproject.toml" for parent in Path(__file__).parents if (parent / "pyproject.toml").is_file()
+        )
+        with project_file.open("rb") as stream:
+            poetry = tomllib.load(stream)["tool"]["poetry"]
+        self.assertEqual(poetry["dependencies"]["opensearch-py"], {"version": "^2.8.0", "optional": True})
+        self.assertIn("opensearch-py", poetry["extras"]["store_ext"])
+
     def test_mapping_contains_hnsw_and_keyword_filters(self):
         store = OpenSearchVectorStore(dimensions=3, filter_fields=["tenant"], distance="cosine")
         mapping = store._mapping(3)


### PR DESCRIPTION
## Summary
- add an `OpenSearchVectorStore` backend with synchronous and asynchronous CRUD/query operations
- create bounded HNSW `knn_vector` mappings for cosine, L2, and inner-product distance
- support exact allowlisted metadata filters and optional managed embeddings
- validate index/field names, vector dimensions, finite values, bulk failures, and connection configuration
- add an optional `opensearch-py` dependency group plus English/Chinese configuration docs and YAML example

## Validation
### Local (macOS, Python 3.11)
- `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_opensearch_vector_store` — **18 passed**
- targeted Ruff check and format verification — **passed**

### Linux server (Ubuntu, Python 3.10.12)
- same unit module — **18 passed**
- real `opensearchproject/opensearch:3.2.0` Docker integration with index creation, sync/async upsert-query-delete, update, missing delete, and exact metadata filtering — **passed**
- the real integration exposed post-filter candidate loss; the implementation was corrected to place filters inside the Lucene k-NN clause and was revalidated (`OPENSEARCH_3_2_INTEGRATION_OK`)

Partially addresses #259.

## Review follow-up (2026-07-20)
- pin optional `opensearch-py` to resolver-compatible `^2.8.0`; unlike 3.x it does not raise the project's pinned `grpcio` requirement
- added manifest regression coverage for both the version and `store_ext` membership
- `pip install --dry-run 'opensearch-py>=2.8,<3'` resolves cleanly
- current targeted result: **19 tests passed; Ruff passed**
- Ubuntu server (Python 3.10.12): **19 tests passed** against the pushed review-fix head
