### PR TITLE
feat(reader): add bounded concurrent BatchKnowledgeReader

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/batch_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/batch_reader.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Bounded concurrent batch reader orchestration."""
+
+# Public load_data validates user-controlled batch specifications.
+# ruff: noqa: C901, TRY003
+
+import os
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, ClassVar, cast
+from urllib.parse import urlparse
+
+from pydantic import Field, PrivateAttr
+
+from agentuniverse.agent.action.knowledge.reader.reader import Reader
+from agentuniverse.agent.action.knowledge.reader.reader_manager import ReaderManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class BatchKnowledgeReader(Reader):
+    """Load many heterogeneous sources with bounded concurrency and isolation."""
+
+    base_dir: str = "."
+    max_inputs: int = 100
+    max_workers: int = 4
+    max_documents: int = 10_000
+    max_total_chars: int = 10_000_000
+    max_source_bytes: int = 100 * 1024 * 1024
+    allow_urls: bool = False
+    default_continue_on_error: bool = True
+    default_deduplicate: bool = True
+    allowed_reader_names: list[str] = Field(default_factory=list)
+
+    _last_report: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _INPUT_FIELDS: ClassVar[set[str]] = {"source", "reader", "ext_info", "reader_kwargs"}
+
+    @property
+    def last_report(self) -> dict[str, Any]:
+        """Return a copy of the most recent batch execution report."""
+        return {
+            **self._last_report,
+            "errors": list(self._last_report.get("errors", [])),
+            "sources": list(self._last_report.get("sources", [])),
+        }
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "BatchKnowledgeReader":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "base_dir",
+            "max_inputs",
+            "max_workers",
+            "max_documents",
+            "max_total_chars",
+            "max_source_bytes",
+            "allow_urls",
+            "default_continue_on_error",
+            "default_deduplicate",
+            "allowed_reader_names",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config()
+        return self
+
+    def _validate_config(self) -> None:
+        for name in ("max_inputs", "max_workers", "max_documents", "max_total_chars", "max_source_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+        for name in ("allow_urls", "default_continue_on_error", "default_deduplicate"):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a boolean")
+        if not isinstance(self.allowed_reader_names, list) or any(
+            not isinstance(item, str) or not item for item in self.allowed_reader_names
+        ):
+            raise ValueError("allowed_reader_names must be a list of non-empty strings")
+
+    def _load_data(
+        self,
+        inputs: list[str | dict[str, Any]],
+        continue_on_error: bool | None = None,
+        deduplicate: bool | None = None,
+        deduplicate_by: str = "id",
+        max_workers: int | None = None,
+        ext_info: dict[str, Any] | None = None,
+    ) -> list[Document]:
+        """Load all sources and return documents in input order."""
+        self._validate_config()
+        specs = self._inputs(inputs, ext_info)
+        continue_on_error = self._boolean_default(
+            continue_on_error, self.default_continue_on_error, "continue_on_error"
+        )
+        deduplicate = self._boolean_default(deduplicate, self.default_deduplicate, "deduplicate")
+        if deduplicate_by not in {"id", "text"}:
+            raise ValueError("deduplicate_by must be id or text")
+        workers = self.max_workers if max_workers is None else max_workers
+        if isinstance(workers, bool) or not isinstance(workers, int) or not 1 <= workers <= self.max_workers:
+            raise ValueError(f"max_workers must be an integer from 1 to {self.max_workers}")
+
+        results: list[list[Document] | Exception] = []
+        with ThreadPoolExecutor(max_workers=min(workers, len(specs)), thread_name_prefix="au-batch-reader") as pool:
+            futures: list[Future[list[Document]]] = [pool.submit(self._load_one, spec) for spec in specs]
+            for future in futures:
+                try:
+                    results.append(future.result())
+                except Exception as exc:
+                    results.append(exc)
+
+        documents = []
+        errors = []
+        seen = set()
+        total_chars = 0
+        source_reports = []
+        for index, (spec, result) in enumerate(zip(specs, results, strict=True)):
+            if isinstance(result, Exception):
+                error = {
+                    "input_index": index,
+                    "source": spec["source_display"],
+                    "reader": spec["reader_name"],
+                    "error_type": type(result).__name__,
+                    "error": str(result),
+                }
+                errors.append(error)
+                source_reports.append({**error, "status": "error", "document_count": 0})
+                if not continue_on_error:
+                    self._set_report(specs, documents, errors, source_reports, deduplicate_by)
+                    raise RuntimeError(f"batch input {index} failed with {type(result).__name__}: {result}") from result
+                continue
+            source_count = 0
+            for document in result:
+                if not isinstance(document, Document):
+                    raise TypeError(f"reader {spec['reader_name']} returned a non-Document value")
+                copy = document.model_copy(deep=True)
+                copy.metadata = dict(copy.metadata or {})
+                copy.metadata.update(
+                    {
+                        "batch_source": spec["source_display"],
+                        "batch_input_index": index,
+                        "batch_reader": spec["reader_name"],
+                    }
+                )
+                marker = copy.id if deduplicate_by == "id" else copy.text
+                if deduplicate and marker in seen:
+                    continue
+                if deduplicate:
+                    seen.add(marker)
+                text_length = len(copy.text or "")
+                if len(documents) + 1 > self.max_documents:
+                    raise ValueError(f"batch exceeds max_documents ({self.max_documents})")
+                if total_chars + text_length > self.max_total_chars:
+                    raise ValueError(f"batch exceeds max_total_chars ({self.max_total_chars})")
+                documents.append(copy)
+                source_count += 1
+                total_chars += text_length
+            source_reports.append(
+                {
+                    "input_index": index,
+                    "source": spec["source_display"],
+                    "reader": spec["reader_name"],
+                    "status": "success",
+                    "document_count": source_count,
+                }
+            )
+        self._set_report(specs, documents, errors, source_reports, deduplicate_by)
+        return documents
+
+    def _set_report(
+        self,
+        specs: list[dict[str, Any]],
+        documents: list[Document],
+        errors: list[dict[str, Any]],
+        source_reports: list[dict[str, Any]],
+        deduplicate_by: str,
+    ) -> None:
+        self._last_report = {
+            "input_count": len(specs),
+            "successful_input_count": len(specs) - len(errors),
+            "failed_input_count": len(errors),
+            "document_count": len(documents),
+            "total_chars": sum(len(document.text or "") for document in documents),
+            "deduplicate_by": deduplicate_by,
+            "errors": errors,
+            "sources": source_reports,
+        }
+
+    @staticmethod
+    def _boolean_default(value: Any, default: bool, field: str) -> bool:
+        if value is None:
+            return default
+        if not isinstance(value, bool):
+            raise TypeError(f"{field} must be a boolean")
+        return value
+
+    def _inputs(self, value: Any, shared_ext_info: Any) -> list[dict[str, Any]]:
+        if not isinstance(value, list) or not value:
+            raise ValueError("inputs must be a non-empty list")
+        if len(value) > self.max_inputs:
+            raise ValueError(f"inputs exceeds max_inputs ({self.max_inputs})")
+        if shared_ext_info is not None and not isinstance(shared_ext_info, dict):
+            raise TypeError("ext_info must be an object")
+        output = []
+        for index, raw in enumerate(value):
+            if isinstance(raw, str):
+                raw = {"source": raw}
+            if not isinstance(raw, dict):
+                raise TypeError(f"inputs[{index}] must be a string or object")
+            unknown = set(raw) - self._INPUT_FIELDS
+            if unknown:
+                raise ValueError(f"inputs[{index}] has unknown fields: {', '.join(sorted(unknown))}")
+            source = raw.get("source")
+            if not isinstance(source, str) or not source.strip():
+                raise ValueError(f"inputs[{index}].source must be a non-empty string")
+            source = source.strip()
+            is_url = self._is_url(source)
+            if is_url:
+                if not self.allow_urls:
+                    raise ValueError("URL inputs are disabled; set allow_urls=true to enable them")
+                resolved: str | Path = source
+                default_reader = "default_web_page_reader"
+            else:
+                safe_path = cast(str, resolve_safe_path(source, self.base_dir))
+                if not os.path.isfile(safe_path):
+                    raise ValueError(f"inputs[{index}].source does not exist: {safe_path}")
+                if os.path.getsize(safe_path) > self.max_source_bytes:
+                    raise ValueError(f"inputs[{index}].source exceeds max_source_bytes ({self.max_source_bytes})")
+                extension = Path(safe_path).suffix.lower().lstrip(".")
+                default_reader = ReaderManager.DEFAULT_READER.get(extension)
+                if not default_reader:
+                    raise ValueError(f"inputs[{index}] has no default reader for .{extension or '(none)'}")
+                resolved = Path(safe_path)
+            reader_name = raw.get("reader", default_reader)
+            if not isinstance(reader_name, str) or not reader_name:
+                raise ValueError(f"inputs[{index}].reader must be a non-empty string")
+            if self.allowed_reader_names and reader_name not in self.allowed_reader_names:
+                raise ValueError(f"inputs[{index}].reader is not in allowed_reader_names")
+            item_ext_info = raw.get("ext_info")
+            if item_ext_info is not None and not isinstance(item_ext_info, dict):
+                raise TypeError(f"inputs[{index}].ext_info must be an object")
+            combined_ext_info = dict(shared_ext_info or {})
+            combined_ext_info.update(item_ext_info or {})
+            reader_kwargs = raw.get("reader_kwargs", {})
+            if not isinstance(reader_kwargs, dict) or len(reader_kwargs) > 20:
+                raise TypeError(f"inputs[{index}].reader_kwargs must be a bounded object")
+            if any(not isinstance(key, str) or key.startswith("_") for key in reader_kwargs):
+                raise ValueError(f"inputs[{index}].reader_kwargs contains an invalid key")
+            output.append(
+                {
+                    "source": resolved,
+                    "source_display": source,
+                    "reader_name": reader_name,
+                    "ext_info": combined_ext_info,
+                    "reader_kwargs": reader_kwargs,
+                }
+            )
+        return output
+
+    def _load_one(self, spec: dict[str, Any]) -> list[Document]:
+        reader = ReaderManager().get_instance_obj(spec["reader_name"])
+        if reader is None:
+            raise ValueError(f"reader is not registered: {spec['reader_name']}")
+        kwargs = dict(spec["reader_kwargs"])
+        if spec["ext_info"]:
+            kwargs["ext_info"] = spec["ext_info"]
+        documents = reader.load_data(spec["source"], **kwargs)
+        if not isinstance(documents, list):
+            raise TypeError(f"reader {spec['reader_name']} must return a list")
+        return documents
+
+    @staticmethod
+    def _is_url(value: str) -> bool:
+        parsed = urlparse(value)
+        return parsed.scheme.lower() in {"http", "https"} and bool(parsed.netloc)

--- a/agentuniverse/agent/action/knowledge/reader/batch_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/batch_reader.py
@@ -2,10 +2,10 @@
 """Bounded concurrent batch reader orchestration."""
 
 # Public load_data validates user-controlled batch specifications.
-# ruff: noqa: C901, TRY003
+# ruff: noqa: C901, TRY003, TRY301
 
 import os
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any, ClassVar, cast
 from urllib.parse import urlparse
@@ -16,6 +16,7 @@ from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.reader.reader_manager import ReaderManager
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.agent.action.tool.utils.url_safety import validate_public_http_url
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
 
 
@@ -27,6 +28,8 @@ class BatchKnowledgeReader(Reader):
     max_workers: int = 4
     max_documents: int = 10_000
     max_total_chars: int = 10_000_000
+    max_documents_per_source: int = 1_000
+    max_chars_per_source: int = 1_000_000
     max_source_bytes: int = 100 * 1024 * 1024
     allow_urls: bool = False
     default_continue_on_error: bool = True
@@ -53,6 +56,8 @@ class BatchKnowledgeReader(Reader):
             "max_workers",
             "max_documents",
             "max_total_chars",
+            "max_documents_per_source",
+            "max_chars_per_source",
             "max_source_bytes",
             "allow_urls",
             "default_continue_on_error",
@@ -65,7 +70,15 @@ class BatchKnowledgeReader(Reader):
         return self
 
     def _validate_config(self) -> None:
-        for name in ("max_inputs", "max_workers", "max_documents", "max_total_chars", "max_source_bytes"):
+        for name in (
+            "max_inputs",
+            "max_workers",
+            "max_documents",
+            "max_total_chars",
+            "max_documents_per_source",
+            "max_chars_per_source",
+            "max_source_bytes",
+        ):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{name} must be a positive integer")
@@ -101,14 +114,7 @@ class BatchKnowledgeReader(Reader):
         if isinstance(workers, bool) or not isinstance(workers, int) or not 1 <= workers <= self.max_workers:
             raise ValueError(f"max_workers must be an integer from 1 to {self.max_workers}")
 
-        results: list[list[Document] | Exception] = []
-        with ThreadPoolExecutor(max_workers=min(workers, len(specs)), thread_name_prefix="au-batch-reader") as pool:
-            futures: list[Future[list[Document]]] = [pool.submit(self._load_one, spec) for spec in specs]
-            for future in futures:
-                try:
-                    results.append(future.result())
-                except Exception as exc:
-                    results.append(exc)
+        results = self._collect_sources(specs, min(workers, len(specs)), continue_on_error)
 
         documents = []
         errors = []
@@ -168,6 +174,110 @@ class BatchKnowledgeReader(Reader):
         self._set_report(specs, documents, errors, source_reports, deduplicate_by)
         return documents
 
+    def _collect_sources(
+        self,
+        specs: list[dict[str, Any]],
+        workers: int,
+        continue_on_error: bool,
+    ) -> list[list[Document] | Exception]:
+        """Admit bounded work and validate each result as soon as it completes."""
+        pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="au-batch-reader")
+        results: list[list[Document] | Exception | None] = [None] * len(specs)
+        pending: dict[Future[list[Document]], int] = {}
+        next_index = 0
+        raw_documents = 0
+        raw_chars = 0
+        nonblocking_shutdown = False
+
+        def submit_available() -> None:
+            nonlocal next_index
+            while next_index < len(specs) and len(pending) < workers:
+                pending[pool.submit(self._load_one, specs[next_index])] = next_index
+                next_index += 1
+
+        submit_available()
+        try:
+            while pending:
+                completed, _ = wait(pending, return_when=FIRST_COMPLETED)
+                for future in completed:
+                    index = pending.pop(future)
+                    try:
+                        raw_result = future.result()
+                    except Exception as exc:
+                        results[index] = exc
+                        if not continue_on_error:
+                            nonblocking_shutdown = True
+                            for queued in pending:
+                                queued.cancel()
+                            pool.shutdown(wait=False, cancel_futures=True)
+                            self._last_report = {
+                                "input_count": len(specs),
+                                "successful_input_count": sum(isinstance(item, list) for item in results),
+                                "failed_input_count": 1,
+                                "document_count": 0,
+                                "total_chars": 0,
+                                "errors": [
+                                    {
+                                        "input_index": index,
+                                        "source": specs[index]["source_display"],
+                                        "reader": specs[index]["reader_name"],
+                                        "error_type": type(exc).__name__,
+                                        "error": str(exc),
+                                    }
+                                ],
+                                "sources": [],
+                            }
+                            raise RuntimeError(
+                                f"batch input {index} failed with {type(exc).__name__}: {exc}"
+                            ) from exc
+                        continue
+                    try:
+                        source_documents = self._validate_source_result(specs[index], raw_result)
+                        raw_documents += len(source_documents)
+                        raw_chars += sum(len(document.text or "") for document in source_documents)
+                        if raw_documents > self.max_documents:
+                            raise ValueError(f"batch exceeds max_documents ({self.max_documents})")
+                        if raw_chars > self.max_total_chars:
+                            raise ValueError(f"batch exceeds max_total_chars ({self.max_total_chars})")
+                        results[index] = source_documents
+                    except (TypeError, ValueError):
+                        nonblocking_shutdown = True
+                        for queued in pending:
+                            queued.cancel()
+                        pool.shutdown(wait=False, cancel_futures=True)
+                        raise
+                submit_available()
+        finally:
+            # The fail-fast branch already requested non-blocking shutdown.
+            if nonblocking_shutdown:
+                pass
+            elif pending or next_index < len(specs):
+                for queued in pending:
+                    queued.cancel()
+                pool.shutdown(wait=False, cancel_futures=True)
+            else:
+                pool.shutdown(wait=True)
+        return cast(list[list[Document] | Exception], results)
+
+    def _validate_source_result(self, spec: dict[str, Any], documents: Any) -> list[Document]:
+        if not isinstance(documents, list):
+            raise TypeError(f"reader {spec['reader_name']} must return a list")
+        if len(documents) > self.max_documents_per_source:
+            raise ValueError(
+                f"reader {spec['reader_name']} exceeds max_documents_per_source "
+                f"({self.max_documents_per_source})"
+            )
+        total_chars = 0
+        for document in documents:
+            if not isinstance(document, Document):
+                raise TypeError(f"reader {spec['reader_name']} returned a non-Document value")
+            total_chars += len(document.text or "")
+            if total_chars > self.max_chars_per_source:
+                raise ValueError(
+                    f"reader {spec['reader_name']} exceeds max_chars_per_source ({self.max_chars_per_source})"
+                )
+        return documents
+
     def _set_report(
         self,
         specs: list[dict[str, Any]],
@@ -219,7 +329,7 @@ class BatchKnowledgeReader(Reader):
             if is_url:
                 if not self.allow_urls:
                     raise ValueError("URL inputs are disabled; set allow_urls=true to enable them")
-                resolved: str | Path = source
+                resolved: str | Path = validate_public_http_url(source)
                 default_reader = "default_web_page_reader"
             else:
                 safe_path = cast(str, resolve_safe_path(source, self.base_dir))
@@ -237,6 +347,8 @@ class BatchKnowledgeReader(Reader):
                 raise ValueError(f"inputs[{index}].reader must be a non-empty string")
             if self.allowed_reader_names and reader_name not in self.allowed_reader_names:
                 raise ValueError(f"inputs[{index}].reader is not in allowed_reader_names")
+            if is_url and reader_name != "default_web_page_reader":
+                raise ValueError("URL inputs require default_web_page_reader so redirect safety can be enforced")
             item_ext_info = raw.get("ext_info")
             if item_ext_info is not None and not isinstance(item_ext_info, dict):
                 raise TypeError(f"inputs[{index}].ext_info must be an object")

--- a/agentuniverse/agent/action/knowledge/reader/batch_reader.yaml
+++ b/agentuniverse/agent/action/knowledge/reader/batch_reader.yaml
@@ -1,0 +1,16 @@
+name: batch_knowledge_reader
+description: Bounded concurrent orchestration across registered knowledge readers.
+metadata:
+  type: READER
+  module: agentuniverse.agent.action.knowledge.reader.batch_reader
+  class: BatchKnowledgeReader
+base_dir: .
+max_inputs: 100
+max_workers: 4
+max_documents: 10000
+max_total_chars: 10000000
+max_source_bytes: 104857600
+allow_urls: false
+default_continue_on_error: true
+default_deduplicate: true
+allowed_reader_names: []

--- a/agentuniverse/agent/action/knowledge/reader/batch_reader.yaml
+++ b/agentuniverse/agent/action/knowledge/reader/batch_reader.yaml
@@ -9,6 +9,8 @@ max_inputs: 100
 max_workers: 4
 max_documents: 10000
 max_total_chars: 10000000
+max_documents_per_source: 1000
+max_chars_per_source: 1000000
 max_source_bytes: 104857600
 allow_urls: false
 default_continue_on_error: true

--- a/agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py
@@ -1,12 +1,15 @@
 # !/usr/bin/env python3
-# -*- coding:utf-8 -*-
+
+# This legacy reader uses optional imports and layered fallbacks by design.
+# ruff: noqa: B904, PGH003, TRY003, TRY300, TRY301
 
 # @Time    : 2025/9/29
 # @FileName: web_page_reader.py
-from typing import List, Optional, Dict
+from urllib.parse import urljoin
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.tool.utils.url_safety import validate_public_http_url
 
 
 class WebPageReader(Reader):
@@ -23,7 +26,7 @@ class WebPageReader(Reader):
         - httpx or requests
     """
 
-    def _load_data(self, url: str, ext_info: Optional[Dict] = None) -> List[Document]:
+    def _load_data(self, url: str, ext_info: dict | None = None) -> list[Document]:
         print(f"debugging: WebPageReader start load url={url}")
         if not isinstance(url, str) or not url:
             raise ValueError("WebPageReader._load_data requires a non-empty url string")
@@ -34,7 +37,7 @@ class WebPageReader(Reader):
         text, metadata_extra = self._extract_main_text(html, url)
         print(f"debugging: WebPageReader extracted text length={len(text)}")
 
-        metadata: Dict = {"source": "web", "url": url}
+        metadata: dict = {"source": "web", "url": url}
         metadata.update(metadata_extra)
         if ext_info:
             metadata.update(ext_info)
@@ -42,6 +45,7 @@ class WebPageReader(Reader):
         return [Document(text=text, metadata=metadata)]
 
     def _fetch_html(self, url: str) -> str:
+        validate_public_http_url(url)
         try:
             import httpx  # type: ignore
             print("debugging: WebPageReader using httpx")
@@ -49,24 +53,46 @@ class WebPageReader(Reader):
                 "User-Agent": "agentUniverse/1.0 (+https://github.com/)",
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             }) as client:
-                resp = client.get(url, follow_redirects=True)
-                resp.raise_for_status()
-                return resp.text
+                current_url = url
+                for _ in range(11):
+                    validate_public_http_url(current_url)
+                    resp = client.get(current_url, follow_redirects=False)
+                    if resp.is_redirect:
+                        location = resp.headers.get("location")
+                        if not location:
+                            raise RuntimeError("redirect response has no Location header")
+                        current_url = urljoin(current_url, location)
+                        continue
+                    resp.raise_for_status()
+                    return resp.text
+                raise RuntimeError("URL exceeded 10 redirects")
+        except ValueError:
+            raise
         except Exception as e_httpx:
             print(f"debugging: WebPageReader httpx failed: {e_httpx}")
             try:
                 import requests  # type: ignore
                 print("debugging: WebPageReader using requests fallback")
-                resp = requests.get(url, timeout=20, headers={
-                    "User-Agent": "agentUniverse/1.0 (+https://github.com/)",
-                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                })
-                resp.raise_for_status()
-                return resp.text
+                current_url = url
+                for _ in range(11):
+                    validate_public_http_url(current_url)
+                    resp = requests.get(current_url, timeout=20, allow_redirects=False, headers={
+                        "User-Agent": "agentUniverse/1.0 (+https://github.com/)",
+                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    })
+                    if resp.is_redirect:
+                        location = resp.headers.get("location")
+                        if not location:
+                            raise RuntimeError("redirect response has no Location header")
+                        current_url = urljoin(current_url, location)
+                        continue
+                    resp.raise_for_status()
+                    return resp.text
+                raise RuntimeError("URL exceeded 10 redirects")
             except Exception as e_requests:
                 raise RuntimeError(f"Failed to fetch url: {url}. httpx_error={e_httpx}, requests_error={e_requests}")
 
-    def _extract_main_text(self, html: str, url: str) -> (str, Dict):
+    def _extract_main_text(self, html: str, url: str) -> (str, dict):
         # Try trafilatura
         try:
             import trafilatura  # type: ignore
@@ -79,8 +105,8 @@ class WebPageReader(Reader):
 
         # Fallback to readability
         try:
-            from readability import Document as ReadabilityDocument  # type: ignore
             from bs4 import BeautifulSoup  # type: ignore
+            from readability import Document as ReadabilityDocument  # type: ignore
             print("debugging: WebPageReader using readability-lxml")
             article_html = ReadabilityDocument(html).summary(html_partial=True)
             soup = BeautifulSoup(article_html, "lxml")
@@ -101,7 +127,7 @@ class WebPageReader(Reader):
             text = soup.get_text("\n")
             text = "\n".join([line.strip() for line in text.splitlines() if line.strip()])
             return text, {"extractor": "bs4"}
-        except Exception as e_bs:
+        except Exception:
             raise RuntimeError(
                 "Install one of the extractors: `pip install trafilatura` or "
                 "`pip install readability-lxml beautifulsoup4 lxml`"

--- a/agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/web/web_page_reader.py
@@ -5,11 +5,14 @@
 
 # @Time    : 2025/9/29
 # @FileName: web_page_reader.py
+import logging
 from urllib.parse import urljoin
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.tool.utils.url_safety import validate_public_http_url
+
+logger = logging.getLogger(__name__)
 
 
 class WebPageReader(Reader):
@@ -27,15 +30,11 @@ class WebPageReader(Reader):
     """
 
     def _load_data(self, url: str, ext_info: dict | None = None) -> list[Document]:
-        print(f"debugging: WebPageReader start load url={url}")
         if not isinstance(url, str) or not url:
             raise ValueError("WebPageReader._load_data requires a non-empty url string")
 
         html = self._fetch_html(url)
-        print(f"debugging: WebPageReader fetched html length={len(html)}")
-
         text, metadata_extra = self._extract_main_text(html, url)
-        print(f"debugging: WebPageReader extracted text length={len(text)}")
 
         metadata: dict = {"source": "web", "url": url}
         metadata.update(metadata_extra)
@@ -48,7 +47,6 @@ class WebPageReader(Reader):
         validate_public_http_url(url)
         try:
             import httpx  # type: ignore
-            print("debugging: WebPageReader using httpx")
             with httpx.Client(timeout=20.0, headers={
                 "User-Agent": "agentUniverse/1.0 (+https://github.com/)",
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -69,10 +67,14 @@ class WebPageReader(Reader):
         except ValueError:
             raise
         except Exception as e_httpx:
-            print(f"debugging: WebPageReader httpx failed: {e_httpx}")
+            logger.debug(
+                "httpx fetch failed for %s, falling back to requests: %s",
+                url,
+                e_httpx,
+                exc_info=True,
+            )
             try:
                 import requests  # type: ignore
-                print("debugging: WebPageReader using requests fallback")
                 current_url = url
                 for _ in range(11):
                     validate_public_http_url(current_url)
@@ -96,39 +98,48 @@ class WebPageReader(Reader):
         # Try trafilatura
         try:
             import trafilatura  # type: ignore
-            print("debugging: WebPageReader using trafilatura")
             extracted = trafilatura.extract(html, include_links=False, include_images=False)
             if extracted and extracted.strip():
                 return extracted.strip(), {"extractor": "trafilatura"}
-        except Exception as e_traf:
-            print(f"debugging: WebPageReader trafilatura failed: {e_traf}")
+            logger.debug("trafilatura returned no content for %s; trying next extractor", url)
+        except Exception as exc:
+            logger.debug(
+                "trafilatura extraction failed for %s, trying next extractor: %s",
+                url,
+                exc,
+                exc_info=True,
+            )
 
         # Fallback to readability
         try:
             from bs4 import BeautifulSoup  # type: ignore
             from readability import Document as ReadabilityDocument  # type: ignore
-            print("debugging: WebPageReader using readability-lxml")
             article_html = ReadabilityDocument(html).summary(html_partial=True)
             soup = BeautifulSoup(article_html, "lxml")
             text = soup.get_text("\n")
             text = "\n".join([line.strip() for line in text.splitlines() if line.strip()])
             if text:
                 return text, {"extractor": "readability"}
-        except Exception as e_read:
-            print(f"debugging: WebPageReader readability failed: {e_read}")
+            logger.debug("readability returned no content for %s; trying next extractor", url)
+        except Exception as exc:
+            logger.debug(
+                "readability extraction failed for %s, trying next extractor: %s",
+                url,
+                exc,
+                exc_info=True,
+            )
 
         # Last resort: BeautifulSoup plain text
         try:
             from bs4 import BeautifulSoup  # type: ignore
-            print("debugging: WebPageReader using BeautifulSoup fallback")
             soup = BeautifulSoup(html, "lxml")
             for tag in soup(["script", "style", "noscript"]):
                 tag.extract()
             text = soup.get_text("\n")
             text = "\n".join([line.strip() for line in text.splitlines() if line.strip()])
             return text, {"extractor": "bs4"}
-        except Exception:
+        except Exception as exc:
             raise RuntimeError(
                 "Install one of the extractors: `pip install trafilatura` or "
                 "`pip install readability-lxml beautifulsoup4 lxml`"
-            )
+            ) from exc

--- a/agentuniverse/agent/action/tool/utils/url_safety.py
+++ b/agentuniverse/agent/action/tool/utils/url_safety.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Network destination validation for server-side HTTP requests."""
+
+# Validation errors intentionally describe the rejected destination.
+# ruff: noqa: TRY003
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+def validate_public_http_url(url: str) -> str:
+    """Reject non-HTTP and non-public destinations after DNS resolution."""
+    if not isinstance(url, str) or not url:
+        raise ValueError("URL must be a non-empty string")
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("URL must use http or https and include a hostname")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("URL credentials are not allowed")
+    try:
+        addresses = {
+            info[4][0]
+            for info in socket.getaddrinfo(
+                parsed.hostname,
+                parsed.port or (443 if parsed.scheme.lower() == "https" else 80),
+                type=socket.SOCK_STREAM,
+            )
+        }
+    except socket.gaierror as exc:
+        raise ValueError(f"URL hostname could not be resolved: {parsed.hostname}") from exc
+    if not addresses:
+        raise ValueError(f"URL hostname could not be resolved: {parsed.hostname}")
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if not ip.is_global:
+            raise ValueError(f"URL resolves to a non-public address: {address}")
+    return url

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Reader.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Reader.md
@@ -1,5 +1,25 @@
 # Reader
 
+## BatchKnowledgeReader
+
+`BatchKnowledgeReader` dispatches a bounded list of local files to registered readers, runs independent inputs concurrently, preserves input order, isolates per-source failures, optionally deduplicates documents, and records source provenance in every returned document.
+
+```python
+reader = BatchKnowledgeReader(base_dir="/srv/knowledge", max_workers=4)
+documents = reader.load_data(
+    inputs=[
+        "handbook.md",
+        {"source": "policy.pdf", "ext_info": {"tenant": "acme"}},
+        {"source": "records.csv", "reader_kwargs": {"delimiter": ";"}},
+    ],
+    continue_on_error=True,
+    deduplicate=True,
+)
+print(reader.last_report)
+```
+
+Local paths are confined to `base_dir`. Input count, workers, source size, resulting document count, and aggregate text are bounded. URL loading is disabled by default and custom readers can be restricted with `allowed_reader_names`.
+
 The Reader is responsible for extracting information from various sources into the Document format used within agentUniverse. These sources can range from local files to web pages or even an I/O interface.
 
 The Reader is defined as follows:

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Reader.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Reader.md
@@ -18,7 +18,7 @@ documents = reader.load_data(
 print(reader.last_report)
 ```
 
-Local paths are confined to `base_dir`. Input count, workers, source size, resulting document count, and aggregate text are bounded. URL loading is disabled by default and custom readers can be restricted with `allowed_reader_names`.
+Local paths are confined to `base_dir`. Input count, workers, source size, per-source documents/text, and aggregate documents/text are bounded and checked as futures complete. `continue_on_error=false` stops admitting new work, cancels queued futures, and returns immediately on the first completed failure; already-running Python threads cannot be forcibly terminated. URL loading is disabled by default. When enabled, only the built-in web reader is accepted, and both the initial destination and every redirect are DNS-resolved and rejected if any address is loopback, private, link-local, reserved, or otherwise non-public.
 
 The Reader is responsible for extracting information from various sources into the Document format used within agentUniverse. These sources can range from local files to web pages or even an I/O interface.
 

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Reader.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Reader.md
@@ -1,5 +1,25 @@
 # Reader
 
+## BatchKnowledgeReader
+
+`BatchKnowledgeReader` 将有数量限制的本地文件分发给已注册 Reader，并发处理彼此独立的输入，保持输入顺序，隔离单个来源错误，可选文档去重，并在每个返回文档中记录来源信息。
+
+```python
+reader = BatchKnowledgeReader(base_dir="/srv/knowledge", max_workers=4)
+documents = reader.load_data(
+    inputs=[
+        "handbook.md",
+        {"source": "policy.pdf", "ext_info": {"tenant": "acme"}},
+        {"source": "records.csv", "reader_kwargs": {"delimiter": ";"}},
+    ],
+    continue_on_error=True,
+    deduplicate=True,
+)
+print(reader.last_report)
+```
+
+本地路径限制在 `base_dir` 内，同时限制输入数量、并发数、来源文件大小、文档数量和总文本量。URL 默认关闭，也可以通过 `allowed_reader_names` 限制可调用的 Reader。
+
 Reader负责从各式各样的信息源中将信息抽取成agentUniverse中的Document形式。这些信息源可以是各种本地文件，也可以是网页或者一个IO接口，
 
 Reader的定义如下:

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Reader.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Reader.md
@@ -18,7 +18,7 @@ documents = reader.load_data(
 print(reader.last_report)
 ```
 
-本地路径限制在 `base_dir` 内，同时限制输入数量、并发数、来源文件大小、文档数量和总文本量。URL 默认关闭，也可以通过 `allowed_reader_names` 限制可调用的 Reader。
+本地路径限制在 `base_dir` 内，同时限制输入数量、并发数、来源文件大小、单来源文档/文本量以及批次总文档/文本量，并在 Future 完成时立即检查。`continue_on_error=false` 会停止接收新工作、取消已排队 Future，并在首个已完成失败出现时立即返回；已运行的 Python 线程无法被强制终止。URL 默认关闭。开启后只接受内置网页 Reader，初始地址和每次重定向都会解析 DNS；如果任一地址属于回环、私有、链路本地、保留或其他非公网范围，请求将被拒绝。
 
 Reader负责从各式各样的信息源中将信息抽取成agentUniverse中的Document形式。这些信息源可以是各种本地文件，也可以是网页或者一个IO接口，
 

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_batch_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_batch_reader.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Tests for BatchKnowledgeReader."""
+
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.batch_reader import BatchKnowledgeReader
+from agentuniverse.agent.action.knowledge.reader.reader_manager import ReaderManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = Path(__file__).parents[7] / "agentuniverse/agent/action/knowledge/reader/batch_reader.yaml"
+
+
+class FakeReader:
+    def __init__(self, documents=None, error=None, delay=0, capture=None):
+        self.documents = documents or []
+        self.error = error
+        self.delay = delay
+        self.capture = capture
+
+    def load_data(self, source, **kwargs):
+        if self.capture is not None:
+            self.capture.append((source, kwargs))
+        if self.delay:
+            time.sleep(self.delay)
+        if self.error:
+            raise self.error
+        return [document.model_copy(deep=True) for document in self.documents]
+
+
+class FakeManagerFactory:
+    DEFAULT_READER = ReaderManager.DEFAULT_READER
+
+    def __init__(self, readers):
+        self.readers = readers
+
+    def __call__(self):
+        return self
+
+    def get_instance_obj(self, name):
+        return self.readers.get(name)
+
+
+class BatchReaderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.context = tempfile.TemporaryDirectory()
+        self.base_dir = self.context.name
+        self.reader = BatchKnowledgeReader(base_dir=self.base_dir)
+
+    def tearDown(self):
+        self.context.cleanup()
+
+    def file(self, name, content="content"):
+        path = Path(self.base_dir, name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    @staticmethod
+    def manager(readers):
+        return patch(
+            "agentuniverse.agent.action.knowledge.reader.batch_reader.ReaderManager",
+            new=FakeManagerFactory(readers),
+        )
+
+
+class TestBatchReaderOperations(BatchReaderTestCase):
+    def test_auto_dispatch_preserves_order_and_adds_provenance(self):
+        self.file("slow.txt")
+        self.file("fast.md")
+        readers = {
+            "default_txt_reader": FakeReader([Document(id="1", text="slow")], delay=0.02),
+            "default_markdown_reader": FakeReader([Document(id="2", text="fast")]),
+        }
+        with self.manager(readers):
+            documents = self.reader.load_data(["slow.txt", "fast.md"])
+        self.assertEqual([document.text for document in documents], ["slow", "fast"])
+        self.assertEqual(documents[0].metadata["batch_source"], "slow.txt")
+        self.assertEqual(documents[1].metadata["batch_input_index"], 1)
+        self.assertEqual(self.reader.last_report["successful_input_count"], 2)
+
+    def test_custom_reader_receives_kwargs_and_combined_ext_info(self):
+        source = self.file("data.csv")
+        capture = []
+        readers = {"custom_csv": FakeReader([Document(text="csv")], capture=capture)}
+        with self.manager(readers):
+            self.reader.load_data(
+                [
+                    {
+                        "source": "data.csv",
+                        "reader": "custom_csv",
+                        "ext_info": {"source_type": "finance"},
+                        "reader_kwargs": {"delimiter": ";"},
+                    }
+                ],
+                ext_info={"tenant": "acme"},
+            )
+        self.assertEqual(capture[0][0].resolve(), source.resolve())
+        self.assertEqual(capture[0][1]["delimiter"], ";")
+        self.assertEqual(capture[0][1]["ext_info"], {"tenant": "acme", "source_type": "finance"})
+
+    def test_continue_on_error_isolates_failed_input(self):
+        self.file("bad.txt")
+        self.file("good.md")
+        readers = {
+            "default_txt_reader": FakeReader(error=ValueError("cannot parse")),
+            "default_markdown_reader": FakeReader([Document(text="good")]),
+        }
+        with self.manager(readers):
+            documents = self.reader.load_data(["bad.txt", "good.md"], continue_on_error=True)
+        self.assertEqual([document.text for document in documents], ["good"])
+        report = self.reader.last_report
+        self.assertEqual(report["failed_input_count"], 1)
+        self.assertEqual(report["errors"][0]["error_type"], "ValueError")
+
+    def test_fail_fast_mode_raises_descriptive_error(self):
+        self.file("bad.txt")
+        with (
+            self.manager({"default_txt_reader": FakeReader(error=RuntimeError("boom"))}),
+            self.assertRaisesRegex(RuntimeError, "batch input 0 failed.*boom"),
+        ):
+            self.reader.load_data(["bad.txt"], continue_on_error=False)
+
+    def test_deduplicate_by_id(self):
+        self.file("one.txt")
+        self.file("two.txt")
+        reader = FakeReader([Document(id="same", text="same text")])
+        with self.manager({"default_txt_reader": reader}):
+            documents = self.reader.load_data(["one.txt", "two.txt"], deduplicate=True)
+        self.assertEqual(len(documents), 1)
+
+    def test_deduplicate_can_be_disabled(self):
+        self.file("one.txt")
+        self.file("two.txt")
+        reader = FakeReader([Document(id="same", text="same text")])
+        with self.manager({"default_txt_reader": reader}):
+            documents = self.reader.load_data(["one.txt", "two.txt"], deduplicate=False)
+        self.assertEqual(len(documents), 2)
+
+    def test_deduplicate_by_text(self):
+        self.file("one.txt")
+        self.file("two.txt")
+        readers = {
+            "default_txt_reader": FakeReader([Document(id="1", text="same")]),
+            "default_markdown_reader": FakeReader([Document(id="2", text="same")]),
+        }
+        Path(self.base_dir, "two.txt").rename(Path(self.base_dir, "two.md"))
+        with self.manager(readers):
+            documents = self.reader.load_data(["one.txt", "two.md"], deduplicate_by="text")
+        self.assertEqual(len(documents), 1)
+
+    def test_url_requires_explicit_opt_in(self):
+        with self.assertRaisesRegex(ValueError, "URL inputs are disabled"):
+            self.reader.load_data(["https://example.com/article"])
+
+    def test_url_dispatch_when_enabled(self):
+        self.reader.allow_urls = True
+        readers = {"default_web_page_reader": FakeReader([Document(text="web")])}
+        with self.manager(readers):
+            documents = self.reader.load_data(["https://example.com/article"])
+        self.assertEqual(documents[0].metadata["batch_source"], "https://example.com/article")
+
+
+class TestBatchReaderValidation(BatchReaderTestCase):
+    def test_rejects_empty_and_oversized_input_list(self):
+        with self.assertRaisesRegex(ValueError, "non-empty list"):
+            self.reader.load_data([])
+        self.reader.max_inputs = 1
+        with self.assertRaisesRegex(ValueError, "max_inputs"):
+            self.reader.load_data(["one.txt", "two.txt"])
+
+    def test_rejects_path_escape_and_missing_file(self):
+        with self.assertRaisesRegex(ValueError, "escapes the allowed directory"):
+            self.reader.load_data(["../outside.txt"])
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            self.reader.load_data(["missing.txt"])
+
+    def test_rejects_unknown_extension(self):
+        self.file("data.unknown")
+        with self.assertRaisesRegex(ValueError, "no default reader"):
+            self.reader.load_data(["data.unknown"])
+
+    def test_source_size_limit(self):
+        self.file("large.txt", "x" * 20)
+        self.reader.max_source_bytes = 10
+        with self.assertRaisesRegex(ValueError, "max_source_bytes"):
+            self.reader.load_data(["large.txt"])
+
+    def test_reader_allowlist(self):
+        self.file("data.txt")
+        self.reader.allowed_reader_names = ["approved_reader"]
+        with self.assertRaisesRegex(ValueError, "allowed_reader_names"):
+            self.reader.load_data(["data.txt"])
+
+    def test_worker_limit(self):
+        self.file("data.txt")
+        with self.assertRaisesRegex(ValueError, "max_workers"):
+            self.reader.load_data(["data.txt"], max_workers=self.reader.max_workers + 1)
+
+    def test_document_and_character_limits(self):
+        self.file("data.txt")
+        self.reader.max_documents = 1
+        fake = FakeReader([Document(text="one"), Document(text="two")])
+        with self.manager({"default_txt_reader": fake}), self.assertRaisesRegex(ValueError, "max_documents"):
+            self.reader.load_data(["data.txt"], deduplicate=False)
+        self.reader.max_documents = 10
+        self.reader.max_total_chars = 2
+        with self.manager({"default_txt_reader": fake}), self.assertRaisesRegex(ValueError, "max_total_chars"):
+            self.reader.load_data(["data.txt"], deduplicate=False)
+
+    def test_non_document_reader_result_is_rejected(self):
+        self.file("data.txt")
+
+        class InvalidReader:
+            @staticmethod
+            def load_data(_source, **_kwargs):
+                return ["not a document"]
+
+        with self.manager({"default_txt_reader": InvalidReader()}), self.assertRaisesRegex(TypeError, "non-Document"):
+            self.reader.load_data(["data.txt"])
+
+    def test_invalid_configuration(self):
+        self.reader.max_workers = True
+        with self.assertRaisesRegex(ValueError, "max_workers must be a positive integer"):
+            self.reader.load_data(["data.txt"])
+
+
+class TestBatchReaderRegistration(unittest.TestCase):
+    def test_yaml_component_schema(self):
+        component = ComponentConfiger().load_by_configer(Configer(path=str(YAML_PATH)).load())
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.READER.value)
+        self.assertEqual(component.metadata_class, "BatchKnowledgeReader")
+        self.assertEqual(component.max_workers, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_batch_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_batch_reader.py
@@ -5,10 +5,11 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from agentuniverse.agent.action.knowledge.reader.batch_reader import BatchKnowledgeReader
 from agentuniverse.agent.action.knowledge.reader.reader_manager import ReaderManager
+from agentuniverse.agent.action.knowledge.reader.web.web_page_reader import WebPageReader
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.base.component.component_enum import ComponentEnum
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
@@ -127,6 +128,18 @@ class TestBatchReaderOperations(BatchReaderTestCase):
         ):
             self.reader.load_data(["bad.txt"], continue_on_error=False)
 
+    def test_fail_fast_does_not_wait_for_unrelated_slow_work(self):
+        self.file("slow.txt")
+        self.file("bad.md")
+        readers = {
+            "default_txt_reader": FakeReader([Document(text="slow")], delay=0.25),
+            "default_markdown_reader": FakeReader(error=RuntimeError("boom")),
+        }
+        started = time.monotonic()
+        with self.manager(readers), self.assertRaisesRegex(RuntimeError, "boom"):
+            self.reader.load_data(["slow.txt", "bad.md"], continue_on_error=False, max_workers=2)
+        self.assertLess(time.monotonic() - started, 0.15)
+
     def test_deduplicate_by_id(self):
         self.file("one.txt")
         self.file("two.txt")
@@ -162,9 +175,21 @@ class TestBatchReaderOperations(BatchReaderTestCase):
     def test_url_dispatch_when_enabled(self):
         self.reader.allow_urls = True
         readers = {"default_web_page_reader": FakeReader([Document(text="web")])}
-        with self.manager(readers):
+        with (
+            self.manager(readers),
+            patch(
+                "agentuniverse.agent.action.knowledge.reader.batch_reader.validate_public_http_url",
+                side_effect=lambda value: value,
+            ),
+        ):
             documents = self.reader.load_data(["https://example.com/article"])
         self.assertEqual(documents[0].metadata["batch_source"], "https://example.com/article")
+
+    def test_url_rejects_private_and_link_local_destinations(self):
+        self.reader.allow_urls = True
+        for url in ("http://127.0.0.1/", "http://169.254.169.254/latest/meta-data/", "http://[::1]/"):
+            with self.subTest(url=url), self.assertRaisesRegex(ValueError, "non-public"):
+                self.reader.load_data([url])
 
 
 class TestBatchReaderValidation(BatchReaderTestCase):
@@ -214,6 +239,15 @@ class TestBatchReaderValidation(BatchReaderTestCase):
         with self.manager({"default_txt_reader": fake}), self.assertRaisesRegex(ValueError, "max_total_chars"):
             self.reader.load_data(["data.txt"], deduplicate=False)
 
+    def test_per_source_limits_are_enforced_at_completion(self):
+        self.file("data.txt")
+        fake = FakeReader([Document(text="one"), Document(text="two")])
+        self.reader.max_documents_per_source = 1
+        with self.manager({"default_txt_reader": fake}), self.assertRaisesRegex(
+            ValueError, "max_documents_per_source"
+        ):
+            self.reader.load_data(["data.txt"], continue_on_error=False)
+
     def test_non_document_reader_result_is_rejected(self):
         self.file("data.txt")
 
@@ -237,6 +271,35 @@ class TestBatchReaderRegistration(unittest.TestCase):
         self.assertEqual(component.get_component_config_type(), ComponentEnum.READER.value)
         self.assertEqual(component.metadata_class, "BatchKnowledgeReader")
         self.assertEqual(component.max_workers, 4)
+
+
+class TestSafeWebRedirects(unittest.TestCase):
+    def test_redirect_destination_is_revalidated(self):
+        class RedirectResponse:
+            def __init__(self):
+                self.is_redirect = True
+                self.headers = {"location": "http://127.0.0.1/admin"}
+
+        client = MagicMock()
+        client.__enter__.return_value.get.return_value = RedirectResponse()
+        checked = []
+
+        def validate(url):
+            checked.append(url)
+            if "127.0.0.1" in url:
+                raise ValueError("non-public")
+            return url
+
+        with (
+            patch("httpx.Client", return_value=client),
+            patch(
+                "agentuniverse.agent.action.knowledge.reader.web.web_page_reader.validate_public_http_url",
+                side_effect=validate,
+            ),
+            self.assertRaisesRegex(ValueError, "non-public"),
+        ):
+            WebPageReader()._fetch_html("https://example.com/start")
+        self.assertEqual(checked[-1], "http://127.0.0.1/admin")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `BatchKnowledgeReader` for bounded concurrent ingestion of heterogeneous sources
- auto-dispatch registered readers by extension while allowing explicit reader/kwargs overrides
- preserve input order, isolate per-source errors, optionally fail fast, deduplicate by id/text, and attach source provenance
- expose a structured execution report and enforce source/input/worker/document/character/allowlist limits
- keep URL ingestion disabled by default and enforce safe local paths
- add English/Chinese docs, YAML configuration, and unit coverage

## Validation
### Local (macOS, Python 3.11)
- `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.test_batch_reader` — **19 passed**
- targeted Ruff check and format verification — **passed**

### Linux server (Ubuntu, Python 3.10.12)
- same unit module — **19 passed**
- 100-source concurrency/provenance/order stress run with 8 worker threads — **passed** (`BATCH_READER_STRESS_OK 100 8 0.174`)

This is a standalone proposal and no longer claims to implement the reserved/non-goal scope in #602.

## Review follow-up (2026-07-20)
- redesigned scheduling around bounded admission and `FIRST_COMPLETED`; fail-fast now cancels queued work and returns without waiting for unrelated running threads
- validate per-source and aggregate document/text budgets as each future completes
- added public-destination validation for URL inputs and manual redirect revalidation in the built-in web reader; private, loopback, link-local, and reserved destinations are rejected
- added elapsed-time fail-fast, per-source budget, private-address, and unsafe-redirect tests
- current targeted result: **23 tests passed; Ruff passed**
- Ubuntu server (Python 3.10.12): **23 tests passed** against the pushed review-fix head
