### PR TITLE
feat: support Python 3.12 and Chroma 1.x (#549)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_client_factory.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_client_factory.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Version-stable Chroma client construction helpers."""
+
+# Public helpers intentionally use concise built-in validation exceptions.
+# ruff: noqa: TRY003
+
+from typing import Any
+from urllib.parse import urlparse
+
+
+def create_chroma_client(persist_path: str | None, *, anonymized_telemetry: bool = False) -> Any:
+    """Create a current Chroma HTTP or persistent client.
+
+    This uses the public ``HttpClient`` and ``PersistentClient`` constructors
+    available in Chroma 1.x rather than configuring its internal FastAPI class.
+    """
+    try:
+        import chromadb
+        from chromadb.config import Settings
+    except ImportError as exc:
+        raise ImportError("chromadb is required; install it with: pip install chromadb") from exc
+
+    settings = Settings(anonymized_telemetry=anonymized_telemetry)
+    value = persist_path or "./chroma"
+    parsed = urlparse(value)
+    if parsed.scheme.lower() in {"http", "https"}:
+        if not parsed.hostname:
+            raise ValueError(f"invalid Chroma server URL: {value}")
+        if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+            raise ValueError("Chroma server URL must not contain a path, query, or fragment")
+        return chromadb.HttpClient(
+            host=parsed.hostname,
+            port=parsed.port or (443 if parsed.scheme.lower() == "https" else 8000),
+            ssl=parsed.scheme.lower() == "https",
+            settings=settings,
+        )
+    if parsed.scheme:
+        raise ValueError("persist_path must be a local path or an http(s) URL")
+    return chromadb.PersistentClient(path=value, settings=settings)

--- a/agentuniverse/agent/action/knowledge/store/chroma_client_factory.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_client_factory.py
@@ -4,6 +4,7 @@
 # Public helpers intentionally use concise built-in validation exceptions.
 # ruff: noqa: TRY003
 
+import re
 from typing import Any
 from urllib.parse import urlparse
 
@@ -22,6 +23,11 @@ def create_chroma_client(persist_path: str | None, *, anonymized_telemetry: bool
 
     settings = Settings(anonymized_telemetry=anonymized_telemetry)
     value = persist_path or "./chroma"
+    # ``urlparse`` treats the drive prefix in ``C:\\data`` as a URI scheme.
+    # Recognize Windows drive and UNC paths before URL parsing so the same
+    # configuration remains portable across supported operating systems.
+    if re.match(r"^[A-Za-z]:[\\/]", value) or value.startswith("\\\\"):
+        return chromadb.PersistentClient(path=value, settings=settings)
     parsed = urlparse(value)
     if parsed.scheme.lower() in {"http", "https"}:
         if not parsed.hostname:

--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -5,19 +5,17 @@
 # @Author  : wangchongshi
 # @Email   : wangchongshi.wcs@antgroup.com
 # @FileName: chroma_store.py
-from urllib.parse import urlparse
 from typing import List, Any, Optional
 from pydantic import SkipValidation
 
-import chromadb
 from chromadb import QueryResult
-from chromadb.config import Settings
 from chromadb.api.models.Collection import Collection
 
 from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.knowledge.store.query import Query
 from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.agent.action.knowledge.store.chroma_client_factory import create_chroma_client
 from agentuniverse.base.config.component_configer.component_configer import \
     ComponentConfiger
 
@@ -41,22 +39,7 @@ class ChromaStore(Store):
 
     def _new_client(self) -> Any:
         """Initialize the chroma client."""
-        if self.persist_path.startswith('http') or \
-                self.persist_path.startswith('https'):
-            # Remote database URL
-            parsed_url = urlparse(self.persist_path)
-            settings = Settings(
-                chroma_api_impl="chromadb.api.fastapi.FastAPI",
-                chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
-            )
-        else:
-            settings = Settings(
-                is_persistent=True,
-                persist_directory=self.persist_path
-            )
-
-        client = chromadb.Client(settings)
+        client = create_chroma_client(self.persist_path)
         if self.collection is None:
             # default to create a new collection or get an existed collection.
             self.collection = client.get_or_create_collection(
@@ -133,7 +116,7 @@ class ChromaStore(Store):
             self.collection.upsert(
                 documents=[document.text],
                 metadatas=[document.metadata],
-                embeddings=[embedding] if embedding is not None else None,
+                embeddings=[embedding] if len(embedding) > 0 else None,
                 ids=[document.id]
             )
 
@@ -148,7 +131,7 @@ class ChromaStore(Store):
             self.collection.update(
                 documents=[document.text],
                 metadatas=[document.metadata],
-                embeddings=[embedding] if embedding is not None else None,
+                embeddings=[embedding] if len(embedding) > 0 else None,
                 ids=[document.id]
             )
 

--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -26,6 +26,7 @@ from agentuniverse.agent.context.context_model import (
     ContextType,
     ContextPriority,
 )
+from agentuniverse.agent.action.knowledge.store.chroma_client_factory import create_chroma_client
 
 
 class ChromaContextStore(ContextStore):
@@ -62,14 +63,10 @@ class ChromaContextStore(ContextStore):
 
         # Initialize Chroma client
         try:
-            import chromadb
-            from chromadb.config import Settings
-
-            # Create persistent client
-            self._chroma_client = chromadb.Client(Settings(
-                persist_directory=self.persist_directory,
-                anonymized_telemetry=False
-            ))
+            self._chroma_client = create_chroma_client(
+                self.persist_directory,
+                anonymized_telemetry=False,
+            )
 
             # Get or create collection with embedding function
             self._setup_embedding_function()

--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -8,12 +8,9 @@ import json
 
 import uuid
 from datetime import datetime
-from urllib.parse import urlparse
 from typing import Optional, List, Any
 
-import chromadb
 from pydantic import SkipValidation
-from chromadb.config import Settings
 from chromadb.api.models.Collection import Collection
 
 from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
@@ -21,6 +18,7 @@ from agentuniverse.agent.memory.conversation_memory.conversation_message import 
 from agentuniverse.agent.memory.conversation_memory.enum import ConversationMessageEnum, ConversationMessageSourceType
 from agentuniverse.agent.memory.memory_storage.memory_storage import MemoryStorage
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.agent.action.knowledge.store.chroma_client_factory import create_chroma_client
 
 
 class ChromaConversationMemoryStorage(MemoryStorage):
@@ -57,19 +55,7 @@ class ChromaConversationMemoryStorage(MemoryStorage):
 
     def _init_collection(self) -> Any:
         """Initialize the ChromaDB collection."""
-        if self.persist_path.startswith('http') or self.persist_path.startswith('https'):
-            parsed_url = urlparse(self.persist_path)
-            settings = Settings(
-                chroma_api_impl="chromadb.api.fastapi.FastAPI",
-                chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
-            )
-        else:
-            settings = Settings(
-                is_persistent=True,
-                persist_directory=self.persist_path
-            )
-        client = chromadb.Client(settings)
+        client = create_chroma_client(self.persist_path)
         self._collection = client.get_or_create_collection(name=self.collection_name)
         return client
 

--- a/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
@@ -7,18 +7,16 @@
 # @FileName: chroma_memory_storage.py
 import uuid
 from datetime import datetime
-from urllib.parse import urlparse
 from typing import Optional, List, Any
 
-import chromadb
 from pydantic import SkipValidation
-from chromadb.config import Settings
 from chromadb.api.models.Collection import Collection
 
 from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
 from agentuniverse.agent.memory.memory_storage.memory_storage import MemoryStorage
 from agentuniverse.agent.memory.message import Message
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.agent.action.knowledge.store.chroma_client_factory import create_chroma_client
 
 
 class ChromaMemoryStorage(MemoryStorage):
@@ -55,19 +53,7 @@ class ChromaMemoryStorage(MemoryStorage):
 
     def _init_collection(self) -> Any:
         """Initialize the ChromaDB collection."""
-        if self.persist_path.startswith('http') or self.persist_path.startswith('https'):
-            parsed_url = urlparse(self.persist_path)
-            settings = Settings(
-                chroma_api_impl="chromadb.api.fastapi.FastAPI",
-                chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
-            )
-        else:
-            settings = Settings(
-                is_persistent=True,
-                persist_directory=self.persist_path
-            )
-        client = chromadb.Client(settings)
+        client = create_chroma_client(self.persist_path)
         self._collection = client.get_or_create_collection(name=self.collection_name)
         return client
 

--- a/docs/guidebook/en/Get_Start/0.Installation_and_Initialization.md
+++ b/docs/guidebook/en/Get_Start/0.Installation_and_Initialization.md
@@ -1,8 +1,10 @@
 # Installation
 ## Python version requirements
-- python 3.10+
+- Python 3.10, 3.11, or 3.12
 
-We recommend using python 3.10 or later to ensure optimal performance and functionality. The entire project has successfully passed all tests on Python 3.10.0 and later versions. If you are using a Python version lower than 3.10, we cannot guarantee that the project will run correctly.
+We recommend Python 3.10–3.12. Python versions below 3.10 are unsupported.
+
+agentUniverse accepts NumPy 1.26 and 2.x. Chroma-backed stores use Chroma 1.x and its public `PersistentClient`/`HttpClient` constructors. Existing local persistence paths remain valid; remote configurations should use a root URL such as `http://localhost:8000` without an API path, query, or fragment.
 
 
 

--- a/docs/guidebook/en/Get_Start/0.Installation_and_Initialization.md
+++ b/docs/guidebook/en/Get_Start/0.Installation_and_Initialization.md
@@ -4,7 +4,7 @@
 
 We recommend Python 3.10–3.12. Python versions below 3.10 are unsupported.
 
-agentUniverse accepts NumPy 1.26 and 2.x. Chroma-backed stores use Chroma 1.x and its public `PersistentClient`/`HttpClient` constructors. Existing local persistence paths remain valid; remote configurations should use a root URL such as `http://localhost:8000` without an API path, query, or fragment.
+agentUniverse supports Python 3.10 through 3.12. Chroma-backed stores use Chroma 1.x and its public `PersistentClient`/`HttpClient` constructors. Existing local persistence paths, including Windows drive and UNC paths, remain valid; remote configurations should use a root URL such as `http://localhost:8000` without an API path, query, or fragment. NumPy remains on the 1.26 line because the current LangChain dependency set does not yet support NumPy 2.
 
 
 

--- a/docs/guidebook/zh/开始使用/0.安装及创建标准工程.md
+++ b/docs/guidebook/zh/开始使用/0.安装及创建标准工程.md
@@ -1,8 +1,10 @@
 # 安装
-## python版本要求
-- python 3.10+
+## Python 版本要求
+- Python 3.10、3.11 或 3.12
 
-我们推荐您使用python 3.10+版本，以便获得最佳性能和功能。目前整个项目已经在python 3.10.0版本上通过了所有测试。若您使用的是低于3.10的python版本，我们无法保证项目能够完全正常运行。
+推荐使用 Python 3.10–3.12，低于 3.10 的版本不受支持。
+
+agentUniverse 支持 NumPy 1.26 和 2.x。Chroma 存储升级为 Chroma 1.x，并使用公开的 `PersistentClient`/`HttpClient` 构造方式。原有本地持久化目录可以继续使用；远程配置应使用不包含 API 路径、查询参数和片段的根地址，例如 `http://localhost:8000`。
 
 ## 安装方式
 推荐通过pip安装或通过poetry等包版本管理工具安装

--- a/docs/guidebook/zh/开始使用/0.安装及创建标准工程.md
+++ b/docs/guidebook/zh/开始使用/0.安装及创建标准工程.md
@@ -4,7 +4,7 @@
 
 推荐使用 Python 3.10–3.12，低于 3.10 的版本不受支持。
 
-agentUniverse 支持 NumPy 1.26 和 2.x。Chroma 存储升级为 Chroma 1.x，并使用公开的 `PersistentClient`/`HttpClient` 构造方式。原有本地持久化目录可以继续使用；远程配置应使用不包含 API 路径、查询参数和片段的根地址，例如 `http://localhost:8000`。
+agentUniverse 支持 Python 3.10 至 3.12。Chroma 存储升级为 Chroma 1.x，并使用公开的 `PersistentClient`/`HttpClient` 构造方式。原有本地持久化目录（包括 Windows 盘符和 UNC 路径）可以继续使用；远程配置应使用不包含 API 路径、查询参数和片段的根地址，例如 `http://localhost:8000`。由于当前 LangChain 依赖组合尚不支持 NumPy 2，NumPy 仍保持在 1.26 系列。
 
 ## 安装方式
 推荐通过pip安装或通过poetry等包版本管理工具安装

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ packages = [
 include = ["*.yaml"]
 classifiers = [
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
@@ -37,7 +39,7 @@ SQLAlchemy = '2.0.25'
 pydantic = "^2.6.4"
 gunicorn = "^22.0.0"
 grpcio = "1.63.0"
-chromadb = "0.4.24"
+chromadb = "^1.5.9"
 opentelemetry-api = "^1.25.0"
 opentelemetry-sdk = "^1.25.0"
 opentelemetry-semantic-conventions = ">=0.48b0"

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_1x_compatibility.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_1x_compatibility.py
@@ -5,7 +5,13 @@ import importlib.util
 import sys
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
+
+try:
+    import tomllib
+except ImportError:  # Python 3.10
+    import tomli as tomllib
 
 if importlib.util.find_spec("chromadb") is None:
     chromadb_stub = types.ModuleType("chromadb")
@@ -137,6 +143,19 @@ class TestChromaAdapters(unittest.TestCase):
                 returned = storage._init_collection()
             factory.assert_called_once_with("https://chroma.example")
             self.assertIs(returned, client)
+
+
+class TestCompatibilityMetadata(unittest.TestCase):
+    def test_python312_numpy2_and_chroma1_constraints(self):
+        project_file = next(
+            parent / "pyproject.toml" for parent in Path(__file__).parents if (parent / "pyproject.toml").is_file()
+        )
+        with project_file.open("rb") as stream:
+            project = tomllib.load(stream)["tool"]["poetry"]
+        self.assertIn("Programming Language :: Python :: 3.12", project["classifiers"])
+        dependencies = project["dependencies"]
+        self.assertEqual(dependencies["numpy"], ">=1.26.0,<3.0.0")
+        self.assertEqual(dependencies["chromadb"], "^1.5.9")
 
 
 if __name__ == "__main__":

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_1x_compatibility.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_1x_compatibility.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Chroma 1.x client construction and adapter compatibility tests."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+if importlib.util.find_spec("chromadb") is None:
+    chromadb_stub = types.ModuleType("chromadb")
+    chromadb_stub.QueryResult = dict
+    api_stub = types.ModuleType("chromadb.api")
+    models_stub = types.ModuleType("chromadb.api.models")
+    collection_stub = types.ModuleType("chromadb.api.models.Collection")
+    collection_stub.Collection = object
+    sys.modules.update(
+        {
+            "chromadb": chromadb_stub,
+            "chromadb.api": api_stub,
+            "chromadb.api.models": models_stub,
+            "chromadb.api.models.Collection": collection_stub,
+        }
+    )
+
+from agentuniverse.agent.action.knowledge.store.chroma_client_factory import create_chroma_client
+from agentuniverse.agent.action.knowledge.store.chroma_store import ChromaStore
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.memory.conversation_memory.memory_storage.chroma_conversation_memory_storage import (
+    ChromaConversationMemoryStorage,
+)
+from agentuniverse.agent.memory.memory_storage.chroma_memory_storage import ChromaMemoryStorage
+
+
+class FakeSettings:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class FakeChroma(types.ModuleType):
+    def __init__(self):
+        super().__init__("chromadb")
+        self.calls = []
+
+    def PersistentClient(self, **kwargs):
+        self.calls.append(("persistent", kwargs))
+        return "persistent-client"
+
+    def HttpClient(self, **kwargs):
+        self.calls.append(("http", kwargs))
+        return "http-client"
+
+
+class TestChromaClientFactory(unittest.TestCase):
+    def call_with_fake(self, path, telemetry=False):
+        chroma = FakeChroma()
+        config = types.ModuleType("chromadb.config")
+        config.Settings = FakeSettings
+        with patch.dict(sys.modules, {"chromadb": chroma, "chromadb.config": config}):
+            result = create_chroma_client(path, anonymized_telemetry=telemetry)
+        return result, chroma.calls[0]
+
+    def test_persistent_client_uses_public_constructor(self):
+        result, call = self.call_with_fake("data/chroma", telemetry=True)
+        self.assertEqual(result, "persistent-client")
+        self.assertEqual(call[0], "persistent")
+        self.assertEqual(call[1]["path"], "data/chroma")
+        self.assertTrue(call[1]["settings"].kwargs["anonymized_telemetry"])
+
+    def test_none_path_has_stable_local_default(self):
+        _result, call = self.call_with_fake(None)
+        self.assertEqual(call[1]["path"], "./chroma")
+
+    def test_http_client_default_port(self):
+        result, call = self.call_with_fake("http://chroma.internal")
+        self.assertEqual(result, "http-client")
+        self.assertEqual(call[1]["host"], "chroma.internal")
+        self.assertEqual(call[1]["port"], 8000)
+        self.assertFalse(call[1]["ssl"])
+
+    def test_https_client_default_port_and_ssl(self):
+        _result, call = self.call_with_fake("https://chroma.internal")
+        self.assertEqual(call[1]["port"], 443)
+        self.assertTrue(call[1]["ssl"])
+
+    def test_explicit_server_port(self):
+        _result, call = self.call_with_fake("http://localhost:9000")
+        self.assertEqual(call[1]["port"], 9000)
+
+    def test_rejects_server_url_path_query_and_unknown_scheme(self):
+        for path in ("http://localhost:8000/api", "https://localhost/?x=1", "ftp://localhost/db"):
+            with self.subTest(path=path), self.assertRaises(ValueError):
+                self.call_with_fake(path)
+
+    def test_missing_dependency_has_install_hint(self):
+        with patch.dict(sys.modules, {"chromadb": None}), self.assertRaisesRegex(ImportError, "pip install"):
+            create_chroma_client("./chroma")
+
+
+class TestChromaAdapters(unittest.TestCase):
+    def test_chroma_store_delegates_client_creation(self):
+        client = Mock()
+        client.get_or_create_collection.return_value = Mock()
+        store = ChromaStore(persist_path="./data")
+        with patch(
+            "agentuniverse.agent.action.knowledge.store.chroma_store.create_chroma_client",
+            return_value=client,
+        ) as factory:
+            returned = store._new_client()
+        factory.assert_called_once_with("./data")
+        self.assertIs(returned, client)
+
+    def test_empty_embeddings_are_omitted_on_upsert_and_update(self):
+        collection = Mock()
+        store = ChromaStore(collection=collection)
+        document = Document(id="1", text="hello", embedding=[])
+        store.upsert_document([document])
+        store.update_document([document])
+        self.assertIsNone(collection.upsert.call_args.kwargs["embeddings"])
+        self.assertIsNone(collection.update.call_args.kwargs["embeddings"])
+
+    def test_memory_storages_use_shared_factory(self):
+        for module, storage_class in (
+            (
+                "agentuniverse.agent.memory.memory_storage.chroma_memory_storage",
+                ChromaMemoryStorage,
+            ),
+            (
+                "agentuniverse.agent.memory.conversation_memory.memory_storage.chroma_conversation_memory_storage",
+                ChromaConversationMemoryStorage,
+            ),
+        ):
+            client = Mock()
+            client.get_or_create_collection.return_value = Mock()
+            storage = storage_class(persist_path="https://chroma.example")
+            with patch(f"{module}.create_chroma_client", return_value=client) as factory:
+                returned = storage._init_collection()
+            factory.assert_called_once_with("https://chroma.example")
+            self.assertIs(returned, client)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_1x_compatibility.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_1x_compatibility.py
@@ -77,6 +77,18 @@ class TestChromaClientFactory(unittest.TestCase):
         _result, call = self.call_with_fake(None)
         self.assertEqual(call[1]["path"], "./chroma")
 
+    def test_windows_drive_path_uses_persistent_client(self):
+        path = r"C:\agentuniverse\chroma"
+        result, call = self.call_with_fake(path)
+        self.assertEqual(result, "persistent-client")
+        self.assertEqual(call[1]["path"], path)
+
+    def test_windows_unc_path_uses_persistent_client(self):
+        path = r"\\server\share\chroma"
+        result, call = self.call_with_fake(path)
+        self.assertEqual(result, "persistent-client")
+        self.assertEqual(call[1]["path"], path)
+
     def test_http_client_default_port(self):
         result, call = self.call_with_fake("http://chroma.internal")
         self.assertEqual(result, "http-client")
@@ -146,7 +158,7 @@ class TestChromaAdapters(unittest.TestCase):
 
 
 class TestCompatibilityMetadata(unittest.TestCase):
-    def test_python312_numpy2_and_chroma1_constraints(self):
+    def test_python312_and_chroma1_constraints(self):
         project_file = next(
             parent / "pyproject.toml" for parent in Path(__file__).parents if (parent / "pyproject.toml").is_file()
         )
@@ -154,7 +166,9 @@ class TestCompatibilityMetadata(unittest.TestCase):
             project = tomllib.load(stream)["tool"]["poetry"]
         self.assertIn("Programming Language :: Python :: 3.12", project["classifiers"])
         dependencies = project["dependencies"]
-        self.assertEqual(dependencies["numpy"], ">=1.26.0,<3.0.0")
+        # NumPy 2 requires a coordinated LangChain upgrade and is intentionally
+        # outside this compatibility change.
+        self.assertEqual(dependencies["numpy"], "^1.26.0")
         self.assertEqual(dependencies["chromadb"], "^1.5.9")
 
 


### PR DESCRIPTION
## Summary
- declare Python 3.11/3.12 support while retaining the existing NumPy 1.26 constraint
- update the optional Chroma dependency to current Chroma 1.x
- replace internal/deprecated Chroma FastAPI configuration with public `PersistentClient` and `HttpClient` constructors
- share client creation across knowledge, context, memory, and conversation-memory adapters
- omit empty embedding arrays on Chroma upsert/update so server-side embedding remains possible
- document the compatibility range in English and Chinese

## Validation
### Local (macOS, Python 3.11)
- `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_chroma_1x_compatibility` — **11 passed**
- targeted Ruff check and format verification — **passed**

### Linux server
- Python 3.10.12 combined branch unit module — **11 passed**
- ChromaDB 1.5.9 compatibility round trip — **passed**
- NumPy 2 is intentionally excluded because the current `langchain-community==0.0.38` dependency requires NumPy `<2`

Addresses the Python 3.12/Chroma compatibility portion of #549; it does **not** claim NumPy 2 support or address #548.

## Review follow-up (2026-07-20)
- removed the unsatisfiable NumPy 2 claim and retained the honest `numpy = ^1.26.0` constraint
- added Windows drive (`C:\\...`) and UNC (`\\\\server\\share`) persistent-path handling before URL parsing
- current targeted result: **13 tests passed; Ruff passed**
- Ubuntu server (Python 3.10.12): **13 tests passed** against the pushed review-fix head
- Poetry is not installed in the local runner, so clean resolver verification remains a CI check
