### PR TITLE
fix(processor): bound Jina reranker requests

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py
@@ -26,6 +26,7 @@ class JinaReranker(DocProcessor):
     api_key: Optional[str] = None
     model_name: str = "jina-reranker-v2-base-multilingual"
     top_n: int = 10
+    timeout: int = 30
 
     def _process_docs(self, origin_docs: List[Document], query: Query = None) -> List[Document]:
         """Rerank documents based on their relevance to the query.
@@ -61,7 +62,9 @@ class JinaReranker(DocProcessor):
         }
 
         try:
-            response = requests.post(api_base, headers=headers, json=payload)
+            response = requests.post(
+                api_base, headers=headers, json=payload, timeout=self.timeout
+            )
             response.raise_for_status()
             results = response.json().get("results", [])
         except requests.exceptions.RequestException as e:
@@ -103,5 +106,7 @@ class JinaReranker(DocProcessor):
             self.model_name = doc_processor_configer.model_name
         if hasattr(doc_processor_configer, "top_n"):
             self.top_n = doc_processor_configer.top_n
+        if hasattr(doc_processor_configer, "timeout"):
+            self.timeout = doc_processor_configer.timeout
 
         return self

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
@@ -25,7 +25,8 @@ class TestJinaReranker(unittest.TestCase):
             'description': 'reranker use jina api',
             'api_key': 'test_api_key',
             'model_name': 'test_model',
-            'top_n': 5
+            'top_n': 5,
+            'timeout': 12
         }
         self.configer = ComponentConfiger()
         self.configer.load_by_configer(cfg)
@@ -50,6 +51,7 @@ class TestJinaReranker(unittest.TestCase):
             self.assertEqual(self.reranker.api_key, 'test_api_key')
             self.assertEqual(self.reranker.model_name, 'test_model')
             self.assertEqual(self.reranker.top_n, 5)
+            self.assertEqual(self.reranker.timeout, 12)
 
     @patch('requests.post')
     def test_process_docs(self, mock_post):
@@ -80,7 +82,8 @@ class TestJinaReranker(unittest.TestCase):
                 'query': 'test query',
                 'documents': [doc.text for doc in self.test_docs],
                 'top_n': 10
-            }
+            },
+            timeout=30
         )
 
         self.assertEqual(len(result_docs), 5)
@@ -116,7 +119,8 @@ class TestJinaReranker(unittest.TestCase):
                 'query': 'test query',
                 'documents': [doc.text for doc in self.test_docs],
                 'top_n': 2
-            }
+            },
+            timeout=30
         )
 
         self.assertEqual(len(result_docs), 2)


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Add a configurable timeout for Jina reranker HTTP requests.
- Pass the timeout to `requests.post()` so a slow or stalled remote request cannot block indefinitely.
- Allow component configuration to override the timeout value.
- Update existing Jina reranker tests to cover the timeout field and request argument.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/doc_processor/jina_reranker.py tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because `requests` is not installed there. `pytest` is also not installed in that environment.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.