### PR TITLE
fix(processor): skip invalid Dashscope rerank indexes

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/dashscope_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/dashscope_reranker.py
@@ -70,7 +70,7 @@ class DashscopeReranker(DocProcessor):
         rerank_docs = []
         for _result in results:
             index = _result.index
-            if not isinstance(index, int) or index < 0 or index >= len(origin_docs):
+            if type(index) is not int or index < 0 or index >= len(origin_docs):
                 continue
             if origin_docs[index].metadata:
                 origin_docs[index].metadata["relevance_score"] = _result.relevance_score

--- a/agentuniverse/agent/action/knowledge/doc_processor/dashscope_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/dashscope_reranker.py
@@ -70,6 +70,8 @@ class DashscopeReranker(DocProcessor):
         rerank_docs = []
         for _result in results:
             index = _result.index
+            if not isinstance(index, int) or index < 0 or index >= len(origin_docs):
+                continue
             if origin_docs[index].metadata:
                 origin_docs[index].metadata["relevance_score"] = _result.relevance_score
             else:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_dashscope_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_dashscope_reranker.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+
+
+class TestDashscopeReranker(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        fake_dashscope = types.SimpleNamespace(
+            TextReRank=types.SimpleNamespace(
+                Models=types.SimpleNamespace(gte_rerank="gte_rerank"),
+                call=MagicMock()
+            )
+        )
+        sys.modules["dashscope"] = fake_dashscope
+        module_name = (
+            "agentuniverse.agent.action.knowledge.doc_processor."
+            "dashscope_reranker"
+        )
+        cls.module = importlib.reload(importlib.import_module(module_name))
+
+    def test_process_docs_skips_out_of_range_results(self):
+        docs = [
+            Document(text="first", metadata={}),
+            Document(text="second", metadata={})
+        ]
+        self.module.dashscope.TextReRank.call.return_value = MagicMock(
+            status_code=self.module.HTTPStatus.OK,
+            output=MagicMock(results=[
+                MagicMock(index=5, relevance_score=0.9),
+                MagicMock(index=1, relevance_score=0.8),
+                MagicMock(index=-1, relevance_score=0.7),
+                MagicMock(index=None, relevance_score=0.6),
+            ])
+        )
+
+        reranker = self.module.DashscopeReranker()
+        reranked = reranker._process_docs(docs, Query(query_str="query"))
+
+        self.assertEqual(len(reranked), 1)
+        self.assertEqual(reranked[0].text, "second")
+        self.assertEqual(reranked[0].metadata["relevance_score"], 0.8)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_dashscope_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_dashscope_reranker.py
@@ -34,15 +34,20 @@ class TestDashscopeReranker(unittest.TestCase):
             status_code=self.module.HTTPStatus.OK,
             output=MagicMock(results=[
                 MagicMock(index=5, relevance_score=0.9),
+                MagicMock(index=0, relevance_score=0.85),
                 MagicMock(index=1, relevance_score=0.8),
                 MagicMock(index=-1, relevance_score=0.7),
                 MagicMock(index=None, relevance_score=0.6),
+                MagicMock(index=True, relevance_score=0.5),
+                MagicMock(index=False, relevance_score=0.4),
             ])
         )
 
         reranker = self.module.DashscopeReranker()
         reranked = reranker._process_docs(docs, Query(query_str="query"))
 
-        self.assertEqual(len(reranked), 1)
-        self.assertEqual(reranked[0].text, "second")
-        self.assertEqual(reranked[0].metadata["relevance_score"], 0.8)
+        self.assertEqual(len(reranked), 2)
+        self.assertEqual(reranked[0].text, "first")
+        self.assertEqual(reranked[0].metadata["relevance_score"], 0.85)
+        self.assertEqual(reranked[1].text, "second")
+        self.assertEqual(reranked[1].metadata["relevance_score"], 0.8)


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Skip Dashscope rerank results whose index is not an integer or is outside the original document list.
- Prevent malformed API result entries from raising `IndexError` during result assembly.
- Add regression coverage for negative, `None`, and out-of-range indexes while keeping valid results.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_dashscope_reranker.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/doc_processor/dashscope_reranker.py tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_dashscope_reranker.py` passed.
- `git diff --check` passed.
- Focused unittest could not run in my local lightweight Python environment because `langchain_core` is not installed there. `pytest` is also not installed in that environment.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.