### PR TITLE
fix(reader): preserve empty CSV fields

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/csv_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/csv_reader.py
@@ -64,7 +64,7 @@ class CSVReader(Reader):
                     if any(cell.strip() for cell in row):
                         while row and not row[-1].strip():
                             row.pop()
-                        csv_content.append(", ".join(filter(None, row)))
+                        csv_content.append(", ".join(row))
             finally:
                 if should_close:
                     text_stream.close()

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_text_encoding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_text_encoding.py
@@ -36,3 +36,13 @@ def test_csv_reader_handles_utf8_bom(tmp_path):
     assert len(documents) == 1
     assert "值1" in documents[0].text
     assert documents[0].metadata["file_name"] == file_path.name
+
+
+def test_csv_reader_preserves_empty_middle_fields(tmp_path):
+    file_path = tmp_path / "empty_middle.csv"
+    file_path.write_text("name,middle,last\nAlice,,Smith\n", encoding="utf-8")
+
+    reader = CSVReader()
+    documents = reader.load_data(file_path)
+
+    assert "Alice, , Smith" in documents[0].text


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Preserve empty fields that appear in the middle of CSV rows.
- Continue trimming trailing empty cells so the previous output remains compact.
- Add regression coverage for a row such as `Alice,,Smith`, which should keep the missing middle column visible in the parsed text.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_text_encoding.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/csv_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_text_encoding.py` passed.
- `git diff --check` passed.
- Focused pytest could not run in my local lightweight Python environment because `pytest` is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.