### PR TITLE
fix(reader): isolate line text metadata

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/txt_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/txt_reader.py
@@ -18,7 +18,7 @@ class LineTxtReader(Reader):
                 metadata.update(ext_info)
 
             for line in file:
-                dlist.append(Document(text=line, metadata=metadata or {}))
+                dlist.append(Document(text=line, metadata=metadata.copy()))
 
         return dlist
 

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_txt_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_txt_reader.py
@@ -1,0 +1,12 @@
+from agentuniverse.agent.action.knowledge.reader.file.txt_reader import LineTxtReader
+
+
+def test_line_txt_reader_uses_independent_metadata(tmp_path):
+    file_path = tmp_path / "lines.txt"
+    file_path.write_text("first\nsecond\n", encoding="utf-8")
+
+    documents = LineTxtReader().load_data(file_path, ext_info={"source": "test"})
+
+    assert len(documents) == 2
+    documents[0].metadata["source"] = "changed"
+    assert documents[1].metadata["source"] == "test"


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Give each `LineTxtReader` output document its own metadata dictionary.
- Prevent later mutation of one line document's metadata from affecting other line documents produced by the same read.
- Add regression coverage that mutates one document and verifies the next document keeps its original metadata.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_txt_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/txt_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_txt_reader.py` passed.
- `git diff --check` passed.
- Focused pytest could not run in my local lightweight Python environment because `pytest` is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.