### PR TITLE
fix(reader): lazy load Feishu Selenium dependency

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/feishu_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/feishu_reader.py
@@ -6,8 +6,6 @@
 # @Email   : 2179709293@qq.com
 # @FileName: feishu_reader.py
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from bs4 import BeautifulSoup
 import time
 from typing import Dict,List
@@ -24,6 +22,15 @@ class PublicFeishuReader:
 
     def __init__(self):
         """Initialize Selenium WebDriver with headless configuration"""
+        try:
+            from selenium import webdriver
+            from selenium.webdriver.chrome.options import Options
+        except ImportError as exc:
+            raise ImportError(
+                "selenium is required to read public Feishu documents: "
+                "please run `pip install selenium`"
+            ) from exc
+
         chrome_options = Options()
         chrome_options.add_argument("--headless")
         chrome_options.add_argument("--disable-gpu")

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud_file_reader/test_feishu_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud_file_reader/test_feishu_reader.py
@@ -1,0 +1,12 @@
+import importlib
+import sys
+
+
+def test_feishu_reader_imports_without_selenium(monkeypatch):
+    monkeypatch.setitem(sys.modules, "selenium", None)
+    module = importlib.import_module(
+        "agentuniverse.agent.action.knowledge.reader.cloud_file_reader."
+        "feishu_reader"
+    )
+
+    assert module.PublicFeishuReader is not None


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for duplicate features related to this request and communicated with the project maintainers if needed. | 我已检查没有与此请求重复的功能，并在需要时与项目维护者沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results. | 我已经提交了测试文件并可提供测试结果。
- [ ] I have added or modified the documentation related to this PR. | 本次修复不需要文档变更。
- [ ] I have added examples and notes if needed. | 本次修复不需要示例变更。

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Move Selenium imports from module import time into `PublicFeishuReader.__init__()`.
- Keep the cloud file reader module importable when the optional Selenium dependency is not installed.
- Raise a clear dependency error only when Feishu browser rendering is actually requested.
- Add regression coverage for importing the Feishu reader module without Selenium installed.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud_file_reader/test_feishu_reader.py`
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/cloud_file_reader/feishu_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud_file_reader/test_feishu_reader.py` passed.
- `git diff --check` passed.
- Focused pytest could not run in my local lightweight Python environment because `pytest` is not installed there.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.