### PR TITLE
fix(llm): bound Kimi tokenizer call and guard against malformed responses

### DIFF
--- a/agentuniverse/llm/default/kimi_openai_style_llm.py
+++ b/agentuniverse/llm/default/kimi_openai_style_llm.py
@@ -5,6 +5,14 @@
 # @Author  : weizjajj
 # @Email   : weizhongjie.wzj@antgroup.com
 # @FileName: kimi_openai_style_llm.py
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : weizjajj
+# @Email   : weizhongjie.wzj@antgroup.com
+# @FileName: kimi_openai_style_llm.py
+import logging
 from typing import Optional, Any, Union, Iterator, AsyncIterator
 
 import requests
@@ -19,6 +27,13 @@ KIMI_Max_CONTEXT_LENGTH = {
     "moonshot-v1-32k": 32000,
     "moonshot-v1-128k": 128000
 }
+
+# Default per-request timeout (seconds) for the Kimi tokenizer endpoint.
+# Kimi's tokenizer is a small synchronous HTTP call on the hot path of context
+# budgeting; without a timeout a stalled endpoint hangs the whole LLM call.
+KIMI_TOKENIZER_TIMEOUT_SECONDS = 30
+
+logger = logging.getLogger(__name__)
 
 
 class KIMIOpenAIStyleLLM(OpenAIStyleLLM):
@@ -62,9 +77,46 @@ class KIMIOpenAIStyleLLM(OpenAIStyleLLM):
         return KIMI_Max_CONTEXT_LENGTH.get(self.model_name, 8000)
 
     def get_num_tokens(self, text: str) -> int:
-        # Get the token count via HTTP
+        """Estimate the token count for ``text`` via Kimi's tokenizer endpoint.
+
+        Bounded and explicit about failure modes so a stalled or malformed
+        response surfaces a clear error instead of hanging the LLM call or
+        crashing deep in a ``None.get`` chain:
+
+        - ``requests.post`` now carries a timeout, so a non-responsive
+          tokenizer cannot hang context budgeting indefinitely.
+        - A non-2xx response is raised via ``raise_for_status`` with the URL
+          and status, instead of letting ``res.json()`` fail later with a
+          cryptic ``JSONDecodeError``.
+        - The ``data`` / ``total_tokens`` fields are read defensively; a
+          response that is valid JSON but missing those fields raises a
+          clear ``RuntimeError`` instead of ``AttributeError: 'NoneType'
+          object has no attribute 'get'``.
+        """
         messages = [{"role": "user", "content": text}]
         body = {"model": self.model_name, "messages": messages}
         headers = {'Content-Type': 'application/json', 'Authorization': f'Bearer {self.api_key}'}
-        res = requests.post(f"{self.api_base}/tokenizers/estimate-token-count", headers=headers, json=body)
-        return res.json().get('data').get('total_tokens')
+        url = f"{self.api_base}/tokenizers/estimate-token-count"
+        res = requests.post(url, headers=headers, json=body,
+                            timeout=KIMI_TOKENIZER_TIMEOUT_SECONDS)
+        if not res.ok:
+            raise RuntimeError(
+                f"Kimi tokenizer request to {url} failed with status "
+                f"{res.status_code}: {res.text[:200]}") from None
+        try:
+            payload = res.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Kimi tokenizer at {url} returned a non-JSON body "
+                f"({exc}).") from exc
+        data = payload.get('data') if isinstance(payload, dict) else None
+        if not isinstance(data, dict) or 'total_tokens' not in data:
+            raise RuntimeError(
+                f"Kimi tokenizer at {url} returned an unexpected payload; "
+                f"missing data.total_tokens in {str(payload)[:200]}.")
+        total_tokens = data.get('total_tokens')
+        if not isinstance(total_tokens, int):
+            raise RuntimeError(
+                f"Kimi tokenizer at {url} returned non-integer total_tokens "
+                f"{total_tokens!r}.")
+        return total_tokens

--- a/tests/test_agentuniverse/unit/llm/test_kimi_openai_style_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_kimi_openai_style_llm.py
@@ -1,0 +1,122 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/20
+# @FileName: test_kimi_openai_style_llm.py
+
+"""Unit tests for KIMIOpenAIStyleLLM.get_num_tokens failure handling.
+
+The tokenizer endpoint is a synchronous HTTP call on the LLM hot path. These
+tests lock in the failure contract added alongside the timeout: a stalled or
+malformed response surfaces a clear ``RuntimeError`` instead of hanging the
+call or crashing deep in a ``None.get`` chain.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from agentuniverse.llm.default.kimi_openai_style_llm import KIMIOpenAIStyleLLM
+
+
+def _make_response(status_code: int = 200, json_body=None, text: str = "") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.text = text or (str(json_body) if json_body is not None else "")
+    if json_body is not None:
+        response.json.return_value = json_body
+    else:
+        def _raise():
+            raise ValueError("not JSON")
+        response.json.side_effect = _raise
+    return response
+
+
+class TestKimiGetNumTokensFailureHandling(unittest.TestCase):
+    """get_num_tokens must surface clear errors for every non-happy path."""
+
+    def setUp(self) -> None:
+        # A minimal instance; we never hit the network because requests.post
+        # is patched in each test.
+        self.llm = KIMIOpenAIStyleLLM(model_name="moonshot-v1-8k",
+                                      api_key="test-key",
+                                      api_base="https://tokenizer.example/v1")
+
+    def test_happy_path_returns_total_tokens(self) -> None:
+        response = _make_response(json_body={"data": {"total_tokens": 42}})
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response) as posted:
+            result = self.llm.get_num_tokens("hello")
+        self.assertEqual(result, 42)
+        # Timeout was actually passed through.
+        self.assertIn("timeout", posted.call_args.kwargs)
+        self.assertIsNotNone(posted.call_args.kwargs["timeout"])
+
+    def test_non_2xx_response_raises_runtime_error_with_status(self) -> None:
+        # Previously: res.json() would raise JSONDecodeError with no context.
+        response = _make_response(status_code=503, text="service unavailable")
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.llm.get_num_tokens("hello")
+        self.assertIn("503", str(ctx.exception))
+        self.assertIn("tokenizer.example", str(ctx.exception))
+
+    def test_non_json_body_raises_runtime_error_with_url(self) -> None:
+        # A gateway HTML error page instead of JSON.
+        response = _make_response(json_body=None, text="<html>gateway error</html>")
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.llm.get_num_tokens("hello")
+        self.assertIn("non-JSON", str(ctx.exception))
+
+    def test_missing_data_field_raises_clear_error(self) -> None:
+        # Regression: previously this hit ``None.get('total_tokens')`` and
+        # raised AttributeError: 'NoneType' object has no attribute 'get'.
+        response = _make_response(json_body={"unexpected": "shape"})
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.llm.get_num_tokens("hello")
+        self.assertIn("total_tokens", str(ctx.exception))
+
+    def test_missing_total_tokens_raises_clear_error(self) -> None:
+        response = _make_response(json_body={"data": {"some_other_field": 1}})
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.llm.get_num_tokens("hello")
+        self.assertIn("total_tokens", str(ctx.exception))
+
+    def test_non_integer_total_tokens_raises_clear_error(self) -> None:
+        response = _make_response(json_body={"data": {"total_tokens": "not-a-number"}})
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.llm.get_num_tokens("hello")
+        self.assertIn("non-integer", str(ctx.exception))
+
+    def test_request_timeout_is_passed_through(self) -> None:
+        # A stalled tokenizer must not hang the call indefinitely. The timeout
+        # is the contract; this test pins it so it cannot silently regress.
+        response = _make_response(json_body={"data": {"total_tokens": 0}})
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   return_value=response) as posted:
+            self.llm.get_num_tokens("hello")
+        timeout = posted.call_args.kwargs["timeout"]
+        self.assertIsNotNone(timeout)
+        self.assertGreater(timeout, 0)
+
+    def test_connection_error_propagates(self) -> None:
+        # requests itself raises on connection failure / timeout; that should
+        # propagate unchanged rather than being swallowed into a RuntimeError.
+        import requests as requests_module
+        with patch("agentuniverse.llm.default.kimi_openai_style_llm.requests.post",
+                   side_effect=requests_module.ConnectionError("dns failure")):
+            with self.assertRaises(requests_module.ConnectionError):
+                self.llm.get_num_tokens("hello")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`KIMIOpenAIStyleLLM.get_num_tokens` had two real failure modes that surfaced as cryptic errors instead of actionable ones.

## Why (not a duplicate)

Touches code no other open or merged PR covers. Sibling direction to the merged #646 (JinaReranker request timeout / non-JSON guard) — same class of bug in the LLM layer.

## Changes

1. **No timeout** — `requests.post` carried no timeout, so a stalled Kimi tokenizer endpoint hung the whole LLM call indefinitely on the context-budgeting hot path. Now bounded at 30 s.
2. **NoneType crash on bad responses** — a 4xx/5xx response, a non-JSON gateway page, or a payload missing the `data.total_tokens` field all eventually crashed inside a `None.get` chain with `'NoneType' object has no attribute 'get'`, with no hint that the tokenizer endpoint was the cause. The call now:
   - raises for status with the URL and status code,
   - validates the JSON shape explicitly,
   - surfaces each failure mode as a `RuntimeError` that names the endpoint.

A connection-level error from `requests` itself (DNS failure, TCP reset, read timeout) still propagates unchanged so retries / transport errors are not swallowed.

## Tests

`tests/test_agentuniverse/unit/llm/test_kimi_openai_style_llm.py` — 8 unit tests covering the happy path plus every failure mode: non-2xx, non-JSON body, missing `data` field, missing `total_tokens`, non-integer `total_tokens`, timeout pass-through, and connection-error propagation. All mock `requests.post`; no network.

`python -m unittest tests.test_agentuniverse.unit.llm.test_kimi_openai_style_llm` — 8 passed.

## Behaviour change

Intentional and narrow: callers that previously saw an `AttributeError: 'NoneType' object has no attribute 'get'` (or a hung process) on a bad tokenizer response now see a `RuntimeError` naming the endpoint and the specific shape problem. No change to the happy path or to transport-level errors.