### PR TITLE
fix(llm): surface Ollama error responses instead of crashing on None

### DIFF
--- a/agentuniverse/llm/default/default_ollama_llm.py
+++ b/agentuniverse/llm/default/default_ollama_llm.py
@@ -14,6 +14,35 @@ from agentuniverse.llm.llm_output import LLMOutput
 from agentuniverse.llm.ollama_langchain_instance import OllamaLangchainInstance
 
 
+def _extract_ollama_message(response: Any) -> dict:
+    """Return the ``message`` dict from an Ollama chat response.
+
+    Ollama returns a top-level ``error`` field instead of ``message`` when the
+    model is missing, the request is malformed, or the server hits an internal
+    error. The previous code did ``res.get("message").get("content")``, which
+    crashed with ``AttributeError: 'NoneType' object has no attribute 'get'``
+    in that case — masking the real cause (often a model-not-found or context
+    overflow) behind a generic NoneType error.
+
+    This helper surfaces the Ollama error verbatim when present and only falls
+    back to a clear ValueError when the response shape is unexpected, so
+    callers see an actionable error instead of a NoneType crash.
+    """
+    if not isinstance(response, dict):
+        raise ValueError(
+            f"Ollama returned an unexpected response type {type(response).__name__}; "
+            f"expected a dict, got {response!r}.")
+    if "error" in response:
+        raise RuntimeError(
+            f"Ollama chat call failed: {response['error']}")
+    message = response.get("message")
+    if not isinstance(message, dict):
+        raise ValueError(
+            f"Ollama response is missing the 'message' object; "
+            f"got response: {str(response)[:200]}.")
+    return message
+
+
 class OllamaLLM(LLM):
     base_url: Optional[str] = Field(
         default_factory=lambda: get_from_env("OLLAMA_BASE_URL") if get_from_env(
@@ -56,7 +85,8 @@ class OllamaLLM(LLM):
         if should_stream:
             return self.generate_result(res)
         else:
-            return LLMOutput(text=res.get("message").get('content'), raw=json.dumps(res))
+            message = _extract_ollama_message(res)
+            return LLMOutput(text=message.get('content', ''), raw=json.dumps(res))
 
     async def _acall(self, messages, stop=None, **kwargs) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
         client = self._new_async_client()
@@ -65,17 +95,20 @@ class OllamaLLM(LLM):
         options.setdefault("stop", stop)
         res = await client.chat(model=self.model_name, messages=messages, options=options, stream=should_stream)
         if not should_stream:
-            return LLMOutput(text=res.get("message").get('content'), raw=json.dumps(res))
+            message = _extract_ollama_message(res)
+            return LLMOutput(text=message.get('content', ''), raw=json.dumps(res))
         if should_stream:
             return self.agenerate_result(res)
 
     def generate_result(self, data):
         for line in data:
-            yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line))
+            message = _extract_ollama_message(line)
+            yield LLMOutput(text=message.get('content', ''), raw=json.dumps(line))
 
     async def agenerate_result(self, data):
         async for line in data:
-            yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line))
+            message = _extract_ollama_message(line)
+            yield LLMOutput(text=message.get('content', ''), raw=json.dumps(line))
 
     def as_langchain(self) -> BaseLanguageModel:
         self.init_channel()

--- a/agentuniverse/llm/llm_channel/ollama_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/ollama_llm_channel.py
@@ -13,6 +13,7 @@ from ollama import Options
 
 from agentuniverse.agent.memory.message import Message
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.llm.default.default_ollama_llm import _extract_ollama_message
 from agentuniverse.llm.llm_channel.langchain_instance.ollama_channel_langchain_instance import \
     OllamaChannelLangchainInstance
 from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
@@ -63,8 +64,9 @@ class OllamaLLMChannel(LLMChannel):
         if should_stream:
             return self.generate_result(res)
         else:
-            return LLMOutput(text=res.get("message").get('content'), raw=json.dumps(res),
-                             message=Message.from_dict(res.get("message")))
+            message = _extract_ollama_message(res)
+            return LLMOutput(text=message.get('content', ''), raw=json.dumps(res),
+                             message=Message.from_dict(message))
 
     async def _acall(self, messages, stop=None, **kwargs) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
         client = self._new_async_client()
@@ -73,17 +75,20 @@ class OllamaLLMChannel(LLMChannel):
         options.setdefault("stop", stop)
         res = await client.chat(model=self.channel_model_name, messages=messages, options=options, stream=should_stream)
         if not should_stream:
-            return LLMOutput(text=res.get("message").get('content'), raw=json.dumps(res),
-                             message=Message.from_dict(res.get("message")))
+            message = _extract_ollama_message(res)
+            return LLMOutput(text=message.get('content', ''), raw=json.dumps(res),
+                             message=Message.from_dict(message))
         if should_stream:
             return self.agenerate_result(res)
 
     def generate_result(self, data):
         for line in data:
-            yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line),
-                            message=Message.from_dict(line.get("message")))
+            message = _extract_ollama_message(line)
+            yield LLMOutput(text=message.get('content', ''), raw=json.dumps(line),
+                            message=Message.from_dict(message))
 
     async def agenerate_result(self, data):
         async for line in data:
-            yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line),
-                            message=Message.from_dict(line.get("message")))
+            message = _extract_ollama_message(line)
+            yield LLMOutput(text=message.get('content', ''), raw=json.dumps(line),
+                            message=Message.from_dict(message))

--- a/tests/test_agentuniverse/unit/llm/test_ollama_llm_none_response.py
+++ b/tests/test_agentuniverse/unit/llm/test_ollama_llm_none_response.py
@@ -1,0 +1,155 @@
+# !/usr/bin/env python3
+
+# @Time    : 2026/07/20
+# @FileName: test_ollama_llm_none_response.py
+
+"""Unit tests for Ollama LLM error-response handling.
+
+Ollama returns a top-level ``error`` field (instead of ``message``) when the
+model is missing, the request is malformed, or the server hits an internal
+error. The previous code crashed deep in a ``None.get`` chain with no hint of
+the real cause; these tests lock in the contract that the Ollama error is
+surfaced verbatim and unexpected shapes raise a clear ValueError.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.llm.default.default_ollama_llm import (
+    OllamaLLM,
+    _extract_ollama_message,
+)
+
+
+async def _async_value(value):
+    """Wrap a value in an awaitable for mocking async client methods."""
+    return value
+
+
+class TestExtractOllamaMessage(unittest.TestCase):
+    """The shared helper is the contract every call site now depends on."""
+
+    def test_happy_path_returns_message_dict(self) -> None:
+        message = _extract_ollama_message({"message": {"role": "assistant", "content": "hi"}})
+        self.assertEqual(message, {"role": "assistant", "content": "hi"})
+
+    def test_error_field_surfaces_as_runtime_error(self) -> None:
+        # The most common real-world failure: model not found / context
+        # overflow. Ollama returns {"error": "..."} with no "message".
+        with self.assertRaises(RuntimeError) as ctx:
+            _extract_ollama_message({"error": "model 'llama-99x' not found"})
+        self.assertIn("model 'llama-99x' not found", str(ctx.exception))
+
+    def test_missing_message_raises_clear_value_error(self) -> None:
+        # Regression: previously raised
+        # AttributeError: 'NoneType' object has no attribute 'get'.
+        with self.assertRaises(ValueError) as ctx:
+            _extract_ollama_message({"done": True, "eval_count": 0})
+        self.assertIn("missing the 'message' object", str(ctx.exception))
+
+    def test_non_dict_response_raises_clear_value_error(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            _extract_ollama_message("not-a-dict")
+        self.assertIn("unexpected response type", str(ctx.exception))
+
+    def test_message_wrong_type_raises_clear_value_error(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            _extract_ollama_message({"message": "wrong-type"})
+        self.assertIn("missing the 'message' object", str(ctx.exception))
+
+
+class TestOllamaLLMCallSurfacesErrors(unittest.TestCase):
+    """_call and _acall must surface the Ollama error instead of NoneType."""
+
+    def setUp(self) -> None:
+        # Stub client so we never touch the network. We patch _new_client /
+        # _new_async_client to return a MagicMock whose .chat returns the
+        # response we configure per test.
+        self.llm = OllamaLLM(
+            model_name="test-model",
+            base_url="http://localhost:11434",
+            streaming=False,
+            max_context_length=2048,
+            max_tokens=16,
+            temperature=0.0,
+            request_timeout=10,
+        )
+
+    def _patch_client(self, response):
+        client = MagicMock()
+        client.chat.return_value = response
+        # _options() in the real code returns an ollama.Options pydantic object
+        # whose setdefault behaviour is unrelated to this PR; return a plain
+        # dict so we exercise only the error-handling path under test.
+        options_patch = patch.object(self.llm, "_options", return_value={})
+        client_patch = patch.object(self.llm, "_new_client", return_value=client)
+        return client_patch, options_patch
+
+    def _call_with_response(self, response):
+        client_patch, options_patch = self._patch_client(response)
+        with client_patch, options_patch:
+            return self.llm._call(messages=[{"role": "user", "content": "hi"}])
+
+    def _call_expect_error(self, response, exc_type):
+        client_patch, options_patch = self._patch_client(response)
+        with client_patch, options_patch, self.assertRaises(exc_type) as ctx:
+            self.llm._call(messages=[{"role": "user", "content": "hi"}])
+        return ctx
+
+    def test_call_with_error_response_raises_runtime_error(self) -> None:
+        ctx = self._call_expect_error({"error": "model 'x' not found"}, RuntimeError)
+        self.assertIn("model 'x' not found", str(ctx.exception))
+
+    def test_call_with_missing_message_raises_value_error(self) -> None:
+        ctx = self._call_expect_error({"done": True}, ValueError)
+        self.assertIn("missing the 'message' object", str(ctx.exception))
+
+    def test_call_happy_path_returns_llm_output(self) -> None:
+        output = self._call_with_response({"message": {"role": "assistant", "content": "hello"}})
+        self.assertEqual(output.text, "hello")
+
+    def test_call_with_empty_content_returns_empty_string_not_crash(self) -> None:
+        # A well-formed response whose content is empty must not crash; it
+        # yields an empty-string LLMOutput.
+        output = self._call_with_response({"message": {"role": "assistant", "content": ""}})
+        self.assertEqual(output.text, "")
+
+    def test_async_call_with_error_response_raises_runtime_error(self) -> None:
+        import asyncio
+
+        async_client = MagicMock()
+        # client.chat is awaited, so it must return an awaitable resolving to
+        # the Ollama error response.
+        async_client.chat = MagicMock(return_value=_async_value({"error": "internal error"}))
+
+        with (
+            patch.object(self.llm, "_new_async_client", return_value=async_client),
+            patch.object(self.llm, "_options", return_value={}),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            asyncio.new_event_loop().run_until_complete(self.llm._acall(messages=[{"role": "user", "content": "hi"}]))
+        self.assertIn("internal error", str(ctx.exception))
+
+
+class TestOllamaChannelUsesSameHelperContract(unittest.TestCase):
+    """The channel layer imports and uses the same shared helper.
+
+    We assert the import directly rather than reconstructing a V1-style
+    LLMChannel subclass (which has stricter field requirements); the helper-
+    level tests above already lock in the contract the channel depends on.
+    """
+
+    def test_channel_module_imports_shared_helper(self) -> None:
+        from agentuniverse.llm.llm_channel import ollama_llm_channel as channel_module
+
+        # The channel must source its error-handling from the same helper as
+        # the default LLM, so the two cannot drift.
+        self.assertIs(
+            channel_module._extract_ollama_message,
+            _extract_ollama_message,
+            "OllamaLLMChannel must import _extract_ollama_message from agentuniverse.llm.default.default_ollama_llm",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Both `default_ollama_llm.py` (`OllamaLLM`) and `ollama_llm_channel.py` (`OllamaLLMChannel`) crashed with `AttributeError: 'NoneType' object has no attribute 'get'` whenever Ollama returned an error response.

## Why (not a duplicate)

Ollama returns a top-level `error` field (and no `message`) when the model is missing, the request is malformed, or the server hits an internal error. The previous code did `res.get("message").get("content")` on every call and every streaming line, which crashed with no hint of the real cause (typically model-not-found or context overflow).

## Changes

A shared `_extract_ollama_message` helper now:
- surfaces the Ollama error verbatim as a `RuntimeError`,
- raises a clear `ValueError` when the response is missing the `message` object or is the wrong type,
- returns the `message` dict on the happy path.

The channel imports the same helper from the default module so the two layers cannot drift. All four call sites in each file (sync `_call`, async `_acall`, `generate_result`, `agenerate_result`) now go through the helper.

## Tests

`tests/test_agentuniverse/unit/llm/test_ollama_llm_none_response.py` — 11 unit tests covering:
- helper contract: error field, missing message, non-dict response, message-wrong-type, happy path
- sync `_call`: error → RuntimeError, missing message → ValueError, happy path, empty content
- async `_acall`: error → RuntimeError
- channel imports the shared helper (no drift)

All mock the Ollama client; no network. `python -m unittest tests.test_agentuniverse.unit.llm.test_ollama_llm_none_response` — 11 passed.

## Behaviour change

Narrow and intentional: callers that previously saw `AttributeError: 'NoneType' object has no attribute 'get'` on an Ollama error response now see a `RuntimeError` carrying the actual Ollama error message (e.g. `"model 'x' not found"`), or a `ValueError` describing the unexpected response shape. No change to the happy path.