### PR TITLE
fix(tool): make APITool redirect following opt-in and bounded

### DIFF
--- a/agentuniverse/agent/action/tool/api_tool.py
+++ b/agentuniverse/agent/action/tool/api_tool.py
@@ -20,8 +20,21 @@ class APITool(Tool):
 
     Attributes:
         openapi_spec(str): The openapi schema of the api tool.
+        allow_redirects (bool): Whether to follow HTTP redirects. Defaults to
+            ``False``: an OpenAPI-described endpoint is expected to answer at
+            the configured URL, and silently following redirects is a known
+            SSRF escape hatch (an external 30x can redirect the request to an
+            internal metadata service or link-local address). Integrators who
+            genuinely need redirect handling can opt in by setting
+            ``allow_redirects: true`` in the tool yaml; ``max_redirects``
+            still bounds the chain.
+        max_redirects (int): Upper bound on the redirect chain length when
+            ``allow_redirects`` is enabled. Defaults to ``5`` to mirror the
+            project's bounded-by-default stance and prevent redirect loops.
     """
     openapi_spec: Optional[dict] = None
+    allow_redirects: bool = False
+    max_redirects: int = 5
 
     def execute(self, tool_input: ToolInput):
         res = self.do_http_request(self.openapi_spec.get('url'), self.openapi_spec.get('method'), {},
@@ -199,8 +212,19 @@ class APITool(Tool):
             else:
                 body = body
         if method in ('get', 'head', 'post', 'put', 'delete', 'patch'):
-            response = getattr(ssrf_proxy, method)(url, params=params, headers=headers, data=body,
-                                                   follow_redirects=True)
+            # follow_redirects is opt-in (see allow_redirects). Defaulting to
+            # False closes an SSRF escape hatch: an OpenAPI-described endpoint
+            # is expected to answer at the configured URL, but a 30x from a
+            # compromised or attacker-controlled endpoint could redirect the
+            # authenticated request to an internal metadata service or a
+            # link-local address. When redirects are enabled, max_redirects
+            # still bounds the chain so a redirect loop cannot exhaust the
+            # tool call.
+            response = getattr(ssrf_proxy, method)(
+                url, params=params, headers=headers, data=body,
+                follow_redirects=self.allow_redirects,
+                max_redirects=self.max_redirects if self.allow_redirects else 0,
+            )
             return response
         else:
             raise ValueError(f'Invalid http method')

--- a/agentuniverse/agent/action/tool/utils/ssrf_proxy.py
+++ b/agentuniverse/agent/action/tool/utils/ssrf_proxy.py
@@ -19,11 +19,30 @@ proxies = {
 
 
 def make_request(method, url, **kwargs):
+    """Issue an HTTP request through the configured SSRF proxy.
+
+    When the caller asks to follow redirects, route through a short-lived
+    ``httpx.Client`` so that ``max_redirects`` can bound the chain — the
+    top-level ``httpx.request`` does not accept ``max_redirects`` and would
+    otherwise follow up to the default of 20, which is large enough for a
+    redirect loop to consume a tool call. When redirects are not followed
+    (the safe default), the request goes through the top-level helper as
+    before.
+    """
     kwargs.setdefault("timeout", 20)
+    follow_redirects = kwargs.get("follow_redirects", False)
+    max_redirects = kwargs.pop("max_redirects", None)
+    proxy_kwargs = {}
     if SSRF_PROXY_ALL_URL:
-        kwargs["proxy"] = SSRF_PROXY_ALL_URL
+        proxy_kwargs["proxy"] = SSRF_PROXY_ALL_URL
     elif proxies:
-        kwargs["proxies"] = proxies
+        proxy_kwargs["proxies"] = proxies
+    if follow_redirects and max_redirects is not None:
+        with httpx.Client(follow_redirects=True, max_redirects=max_redirects,
+                          **proxy_kwargs) as client:
+            return client.request(method=method, url=url, **kwargs)
+    if proxy_kwargs:
+        kwargs.update(proxy_kwargs)
     return httpx.request(method=method, url=url, **kwargs)
 
 

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_redirect_guard.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_redirect_guard.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for APITool redirect / SSRF defaults.
+
+Locks in the contract that APITool does NOT follow redirects by default
+(closing an SSRF escape hatch where a 30x from an attacker-controlled
+endpoint could redirect an authenticated request to an internal metadata
+service), and that redirects are a deliberate opt-in bounded by
+``max_redirects``.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from agentuniverse.agent.action.tool.api_tool import APITool
+from agentuniverse.agent.action.tool.tool import ToolInput
+
+
+def _make_tool(allow_redirects=None, max_redirects=None) -> APITool:
+    tool = APITool()
+    tool.openapi_spec = {
+        "url": "https://api.example.com/v1/items",
+        "method": "GET",
+        "operation": {"parameters": []},
+    }
+    if allow_redirects is not None:
+        tool.allow_redirects = allow_redirects
+    if max_redirects is not None:
+        tool.max_redirects = max_redirects
+    return tool
+
+
+class TestAPIToolRedirectDefaults(unittest.TestCase):
+    """The defaults are part of the security contract; pin them."""
+
+    def test_default_disallows_redirects(self) -> None:
+        tool = APITool()
+        self.assertFalse(tool.allow_redirects,
+                         "APITool must not follow redirects by default; it is "
+                         "an SSRF escape hatch.")
+
+    def test_default_max_redirects_is_bounded(self) -> None:
+        tool = APITool()
+        self.assertEqual(tool.max_redirects, 5)
+        self.assertGreater(tool.max_redirects, 0)
+
+
+class TestAPIToolRequestRedirectBehavior(unittest.TestCase):
+    """The do_http_request path passes the configured redirect contract."""
+
+    def test_default_request_does_not_follow_redirects(self) -> None:
+        tool = _make_tool()
+        with patch("agentuniverse.agent.action.tool.api_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = MagicMock(text="ok")
+            tool.do_http_request(tool.openapi_spec["url"], "GET", {}, {})
+        # follow_redirects=False is passed explicitly so the contract is
+        # observable in the call.
+        self.assertFalse(proxy.get.call_args.kwargs["follow_redirects"])
+        # max_redirects is 0 when redirects are off (defensive; never used).
+        self.assertEqual(proxy.get.call_args.kwargs["max_redirects"], 0)
+
+    def test_opting_into_redirects_passes_bounded_max_redirects(self) -> None:
+        tool = _make_tool(allow_redirects=True, max_redirects=3)
+        with patch("agentuniverse.agent.action.tool.api_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = MagicMock(text="ok")
+            tool.do_http_request(tool.openapi_spec["url"], "GET", {}, {})
+        self.assertTrue(proxy.get.call_args.kwargs["follow_redirects"])
+        self.assertEqual(proxy.get.call_args.kwargs["max_redirects"], 3)
+
+    def test_opting_into_redirects_uses_configured_max_not_default(self) -> None:
+        tool = _make_tool(allow_redirects=True, max_redirects=10)
+        with patch("agentuniverse.agent.action.tool.api_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = MagicMock(text="ok")
+            tool.do_http_request(tool.openapi_spec["url"], "GET", {}, {})
+        self.assertEqual(proxy.get.call_args.kwargs["max_redirects"], 10)
+
+    def test_post_method_also_respects_redirect_default(self) -> None:
+        # All methods share the same redirect contract.
+        tool = _make_tool()
+        tool.openapi_spec["method"] = "POST"
+        with patch("agentuniverse.agent.action.tool.api_tool.ssrf_proxy") as proxy:
+            proxy.post.return_value = MagicMock(text="ok")
+            tool.do_http_request(tool.openapi_spec["url"], "POST", {}, {})
+        self.assertFalse(proxy.post.call_args.kwargs["follow_redirects"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from agentuniverse.agent.action.tool.utils import ssrf_proxy
 
@@ -46,6 +46,48 @@ class TestSSRFProxy(unittest.TestCase):
             timeout=3,
             proxy="http://proxy.local",
         )
+
+    def test_no_redirects_uses_top_level_request_without_max_redirects(self):
+        # Default path: follow_redirects is False (or unset). The request goes
+        # through httpx.request directly, with no max_redirects key (the
+        # top-level helper does not accept it).
+        with patch.object(ssrf_proxy, "SSRF_PROXY_ALL_URL", ""):
+            with patch.object(ssrf_proxy, "proxies", None):
+                with patch.object(ssrf_proxy.httpx, "request", return_value="ok") as request:
+                    result = ssrf_proxy.get("https://example.com",
+                                            follow_redirects=False, max_redirects=5)
+
+        self.assertEqual(result, "ok")
+        request.assert_called_once_with(
+            method="GET",
+            url="https://example.com",
+            timeout=20,
+            follow_redirects=False,
+        )
+        # max_redirects must not leak into the top-level httpx.request kwargs.
+        self.assertNotIn("max_redirects", request.call_args.kwargs)
+
+    def test_redirects_with_max_redirects_route_through_client(self):
+        # When redirects are followed AND a bound is supplied, the request goes
+        # through a short-lived httpx.Client so the chain is bounded; the
+        # top-level httpx.request would otherwise follow up to 20.
+        fake_client = MagicMock()
+        fake_client.request.return_value = "redirected-ok"
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = fake_client
+        fake_cm.__exit__.return_value = False
+        with patch.object(ssrf_proxy, "SSRF_PROXY_ALL_URL", ""):
+            with patch.object(ssrf_proxy, "proxies", None):
+                with patch.object(ssrf_proxy.httpx, "Client", return_value=fake_cm) as client_cls:
+                    result = ssrf_proxy.get("https://example.com",
+                                            follow_redirects=True, max_redirects=3)
+
+        self.assertEqual(result, "redirected-ok")
+        client_cls.assert_called_once_with(
+            follow_redirects=True, max_redirects=3)
+        fake_client.request.assert_called_once_with(
+            method="GET", url="https://example.com",
+            follow_redirects=True, timeout=20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`APITool.do_http_request` followed HTTP redirects unconditionally (`follow_redirects=True` hardcoded). Redirect following is now opt-in and bounded.

## Why (not a duplicate)

An OpenAPI-described endpoint is expected to answer at the configured URL, but a 30x from a compromised or attacker-controlled endpoint could redirect an authenticated request to an internal metadata service or a link-local address — a classic SSRF escape hatch. Same spirit as the merged #658 (Jina TLS verification by default) and #657 (RunCommandTool opt-in): make the safe behaviour the default and require an explicit opt-in for the risky one.

## Changes

- New `allow_redirects` attribute on `APITool` (default `False`). Integrators who genuinely need redirect handling set `allow_redirects: true` in the tool yaml.
- New `max_redirects` attribute (default `5`) bounds the chain so a redirect loop cannot exhaust the tool call when redirects are enabled.
- `ssrf_proxy.make_request` now routes redirect-following requests through a short-lived `httpx.Client` when `max_redirects` is supplied, because the top-level `httpx.request` does not accept `max_redirects` and would otherwise follow up to 20. The default no-redirect path is unchanged.

## Tests

`tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_redirect_guard.py` (6 tests):
- `APITool` default `allow_redirects=False` (security contract pinned)
- default `max_redirects=5`
- default request passes `follow_redirects=False` + `max_redirects=0`
- opt-in passes `follow_redirects=True` + configured `max_redirects`
- opt-in respects a non-default `max_redirects`
- POST method shares the same contract

`tests/test_agentuniverse/unit/agent/action/tool/test_ssrf_proxy.py` extended (2 new tests):
- no-redirect path still uses top-level `httpx.request` and does not leak `max_redirects`
- redirect + `max_redirects` routes through `httpx.Client(follow_redirects=True, max_redirects=N)`

All mock httpx; no network. `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_ssrf_proxy tests.test_agentuniverse.unit.agent.action.tool.test_api_tool_redirect_guard` — 11 passed.

## ⚠️ Behaviour change (intentional)

`APITool` no longer follows redirects by default. An endpoint that relied on a 30x to reach its handler will now return the 3xx response to the agent. Integrators who need the old behaviour set `allow_redirects: true` (and optionally `max_redirects`) in the tool yaml.