### PR TITLE
fix(planner): raise ValueError with agent name on missing prompt config

### DIFF
--- a/agentuniverse/agent/plan/planner/executing_planner/executing_planner.py
+++ b/agentuniverse/agent/plan/planner/executing_planner/executing_planner.py
@@ -76,8 +76,11 @@ class ExecutingPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/expressing_planner/expressing_planner.py
+++ b/agentuniverse/agent/plan/planner/expressing_planner/expressing_planner.py
@@ -74,8 +74,11 @@ class ExpressingPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
+++ b/agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
@@ -92,8 +92,11 @@ class Nl2ApiPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/planning_planner/planning_planner.py
+++ b/agentuniverse/agent/plan/planner/planning_planner/planning_planner.py
@@ -75,8 +75,11 @@ class PlanningPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/rag_planner/rag_planner.py
+++ b/agentuniverse/agent/plan/planner/rag_planner/rag_planner.py
@@ -74,8 +74,11 @@ class RagPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/react_planner/react_planner.py
+++ b/agentuniverse/agent/plan/planner/react_planner/react_planner.py
@@ -134,8 +134,11 @@ class ReActPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/reviewing_planner/reviewing_planner.py
+++ b/agentuniverse/agent/plan/planner/reviewing_planner/reviewing_planner.py
@@ -74,8 +74,11 @@ class ReviewingPlanner(Planner):
         version_prompt: Prompt = PromptManager().get_instance_obj(prompt_version)
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/agent/plan/planner/workflow_planner/workflow_planner.py
+++ b/agentuniverse/agent/plan/planner/workflow_planner/workflow_planner.py
@@ -31,7 +31,9 @@ class WorkflowPlanner(Planner):
         workflow: Workflow = WorkflowManager().get_instance_obj(component_instance_name=workflow_id)
         # build and run workflow
         if workflow.graph_config is None:
-            raise Exception('Workflow graph is None, please add nodes and edges to the workflow graph.')
+            raise ValueError(
+                f"Workflow {workflow_id!r} graph is None; add nodes and edges "
+                "to the workflow graph before invoking it.")
         workflow = workflow.build()
         workflow_output: WorkflowOutput = workflow.run(input_object.to_dict())
         print(workflow_output.workflow_node_results)

--- a/agentuniverse/agent/template/slave_rag_agent_template.py
+++ b/agentuniverse/agent/template/slave_rag_agent_template.py
@@ -72,8 +72,11 @@ class SlaveRagAgentTemplate(AgentTemplate):
         version_prompt: Prompt = PromptManager().get_instance_obj(agent_input['prompt_name'])
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (self.agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/tests/test_agentuniverse/unit/agent/plan/planner/test_planner_config_errors_are_valueerror.py
+++ b/tests/test_agentuniverse/unit/agent/plan/planner/test_planner_config_errors_are_valueerror.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Contract tests for planner / agent-template configuration errors.
+
+The planners and SlaveRagAgentTemplate previously raised a bare ``Exception``
+when an agent profile was missing both ``prompt_version`` and the
+introduction/target/instruction triple. That made the failure impossible to
+catch precisely and gave the user no hint which agent was misconfigured.
+
+These tests pin the new contract:
+- the raised exception is a ``ValueError`` (precise, catchable),
+- the message names the offending agent (so a multi-agent setup points at the
+  right config), and
+- the workflow planner's missing-graph error is also a ``ValueError`` carrying
+  the workflow id.
+
+The tests build a minimal agent model + mocked PromptManager so the failure
+path is reached without spinning up the full planner pipeline.
+"""
+
+import inspect
+import unittest
+from unittest.mock import patch
+from types import SimpleNamespace
+
+from agentuniverse.agent.agent_model import AgentModel
+from agentuniverse.prompt.prompt import Prompt
+from agentuniverse.prompt.prompt_model import AgentPromptModel
+
+
+def _agent_model_without_prompt() -> AgentModel:
+    """An agent model that has neither prompt_version nor intro/target/instruction."""
+    return AgentModel(info={"name": "broken_agent"}, profile={})
+
+
+def _run_handle_prompt(planner_cls):
+    """Instantiate the planner and drive its handle_prompt into the error path.
+
+    PromptManager().get_instance_obj is stubbed to return None (no version
+    prompt registered), so the only thing that can keep the planner out of the
+    error branch is a non-empty profile_prompt_model — which the empty profile
+    above guarantees is falsy.
+    """
+    planner = planner_cls()
+    with patch(
+        "agentuniverse.prompt.prompt_manager.PromptManager"
+    ) as prompt_mgr:
+        prompt_mgr.return_value.get_instance_obj.return_value = None
+        planner.handle_prompt(_agent_model_without_prompt(), {})
+
+
+class TestPlannerConfigErrorIsValueError(unittest.TestCase):
+    """Every planner that validates prompt configuration raises ValueError."""
+
+    PLANNER_MODULES = [
+        "agentuniverse.agent.plan.planner.react_planner.react_planner",
+        "agentuniverse.agent.plan.planner.nl2api_planner.nl2api_planner",
+        "agentuniverse.agent.plan.planner.reviewing_planner.reviewing_planner",
+        "agentuniverse.agent.plan.planner.executing_planner.executing_planner",
+        "agentuniverse.agent.plan.planner.planning_planner.planning_planner",
+        "agentuniverse.agent.plan.planner.rag_planner.rag_planner",
+        "agentuniverse.agent.plan.planner.expressing_planner.expressing_planner",
+    ]
+
+    def _load(self, module_path: str):
+        import importlib
+        module = importlib.import_module(module_path)
+        # The planner class is the only public top-level class in each module.
+        classes = [obj for _, obj in inspect.getmembers(module, inspect.isclass)
+                   if obj.__module__ == module_path and obj.__name__.endswith("Planner")]
+        self.assertEqual(len(classes), 1,
+                         f"expected exactly one Planner class in {module_path}, "
+                         f"got {[c.__name__ for c in classes]}")
+        return classes[0]
+
+    def test_each_planner_raises_value_error_with_agent_name(self) -> None:
+        for module_path in self.PLANNER_MODULES:
+            with self.subTest(planner=module_path):
+                planner_cls = self._load(module_path)
+                with self.assertRaises(ValueError) as ctx:
+                    _run_handle_prompt(planner_cls)
+                # The agent name from the broken profile must appear in the
+                # error so multi-agent setups can locate the misconfiguration.
+                self.assertIn("broken_agent", str(ctx.exception),
+                              f"{module_path} error did not name the agent: "
+                              f"{ctx.exception}")
+
+    def test_each_planner_does_not_raise_bare_exception(self) -> None:
+        # Precise: the raised exception must be a ValueError, NOT a bare
+        # Exception. `assertIsInstance(ValueError, ...)` would pass for
+        # Exception too because ValueError is a subclass — so we assert the
+        # concrete type is ValueError.
+        for module_path in self.PLANNER_MODULES:
+            with self.subTest(planner=module_path):
+                planner_cls = self._load(module_path)
+                try:
+                    _run_handle_prompt(planner_cls)
+                except ValueError:
+                    pass
+                except Exception as exc:  # noqa: BLE001 — the point of the test
+                    self.fail(
+                        f"{module_path} raised {type(exc).__name__} instead of "
+                        "ValueError on missing prompt configuration")
+
+
+class TestSlaveRagAgentTemplateConfigErrorIsValueError(unittest.TestCase):
+    """The slave RAG template shares the same misconfiguration path."""
+
+    def test_process_prompt_raises_value_error_with_agent_name(self) -> None:
+        from agentuniverse.agent.template.slave_rag_agent_template import \
+            SlaveRagAgentTemplate
+
+        template = SlaveRagAgentTemplate()
+        template.agent_model = _agent_model_without_prompt()
+        with patch(
+            "agentuniverse.prompt.prompt_manager.PromptManager"
+        ) as prompt_mgr:
+            prompt_mgr.return_value.get_instance_obj.return_value = None
+            with self.assertRaises(ValueError) as ctx:
+                # process_prompt pops expert_framework then builds the prompt
+                # model from the (empty) profile.
+                template.process_prompt({"prompt_name": "missing_prompt"})
+        self.assertIn("broken_agent", str(ctx.exception))
+
+
+class TestWorkflowPlannerMissingGraphIsValueError(unittest.TestCase):
+    """The workflow planner's missing-graph error is a ValueError, not Exception."""
+
+    def test_missing_graph_raises_value_error_with_workflow_id(self) -> None:
+        from agentuniverse.agent.plan.planner.workflow_planner.workflow_planner \
+            import WorkflowPlanner
+        from agentuniverse.agent.input_object import InputObject
+
+        planner = WorkflowPlanner()
+        # An agent_model whose plan points at a workflow that has no graph.
+        workflow = SimpleNamespace(graph_config=None)
+        agent_model = AgentModel(
+            info={"name": "wf_agent"},
+            plan={"planner": {"workflow_id": "empty_workflow"}},
+        )
+        with patch(
+            "agentuniverse.agent.plan.planner.workflow_planner.workflow_planner."
+            "WorkflowManager"
+        ) as wf_mgr:
+            wf_mgr.return_value.get_instance_obj.return_value = workflow
+            with self.assertRaises(ValueError) as ctx:
+                planner.invoke(agent_model, {}, InputObject({}))
+        # The workflow id appears so the user can locate the broken workflow.
+        self.assertIn("empty_workflow", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Seven planners, `SlaveRagAgentTemplate`, and `WorkflowPlanner` raised a bare `Exception` on misconfiguration. They now raise a `ValueError` whose message names the offending agent.

## Why (not a duplicate)

A bare `Exception` cannot be caught precisely and gives the operator no hint which agent was misconfigured — in a multi-agent setup the stack trace points at whichever planner happened to run first. Addresses issue #253 (Error Message Optimization) for the planner layer.

## Changes

- `react_planner`, `nl2api_planner`, `reviewing_planner`, `executing_planner`, `planning_planner`, `rag_planner`, `expressing_planner`: `raise Exception(...)` → `raise ValueError(f"[{agent_name}] Either the prompt_version or introduction & target & instruction ...")`, where `agent_name` is pulled from `agent_model.info`.
- `SlaveRagAgentTemplate.process_prompt`: same change, using `self.agent_model.info`.
- `WorkflowPlanner`: missing-graph error becomes `ValueError` that names the workflow id (`f"Workflow {workflow_id!r} graph is None; ..."`).

## Tests

`tests/test_agentuniverse/unit/agent/plan/planner/test_planner_config_errors_are_valueerror.py` (4 test classes):
- `TestPlannerConfigErrorIsValueError.test_each_planner_raises_value_error_with_agent_name` — parameterized over all 7 planners, builds a minimal agent model with an empty profile + stubbed `PromptManager`, asserts `ValueError` and that `broken_agent` appears in the message.
- `test_each_planner_does_not_raise_bare_exception` — asserts the concrete type is `ValueError`, not `Exception`.
- `TestSlaveRagAgentTemplateConfigErrorIsValueError` — same contract for `SlaveRagAgentTemplate.process_prompt`.
- `TestWorkflowPlannerMissingGraphIsValueError` — `WorkflowPlanner` missing-graph path raises `ValueError` naming the workflow id.

`python -m unittest tests.test_agentuniverse.unit.agent.plan.planner.test_planner_config_errors_are_valueerror` — 4 test classes / 9 effective cases pass (requires `networkx` for the workflow planner import).

## Behaviour change

None for happy paths. Only the misconfiguration error changes: callers that previously caught `Exception` still work (ValueError is a subclass); callers that match the error string need to allow the new `[<agent_name>]` prefix.