### PR TITLE
fix(memory): raise precise exceptions in Elasticsearch memory storage

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
@@ -57,7 +57,10 @@ class ElasticsearchMemoryStorage(MemoryStorage):
         if getattr(memory_storage_config, 'es_timeout', None):
             self.timeout = memory_storage_config.es_timeout
         if self.es_url is None:
-            raise Exception('`es_url` is not set')
+            raise ValueError(
+                "`es_url` is not set; configure the Elasticsearch server URL "
+                "on the ElasticsearchMemoryStorage component (yaml field "
+                "`es_url`) or via the component configer.")
         # initialize the memory converter if not set
         if self.memory_converter is None:
             self.memory_converter = DefaultMemoryConverter(self.index_name)
@@ -98,7 +101,9 @@ class ElasticsearchMemoryStorage(MemoryStorage):
                 json=settings
             )
             if response.status_code != 200:
-                raise Exception(f"Failed to create index: {response.text}")
+                raise RuntimeError(
+                    f"Failed to create Elasticsearch index {self.index_name!r}: "
+                    f"status {response.status_code}, body: {response.text}")
 
     def delete(self, session_id: str = None, agent_id: str = None, trace_id: str = None, **kwargs) -> None:
         """Delete the memory from Elasticsearch.
@@ -131,7 +136,10 @@ class ElasticsearchMemoryStorage(MemoryStorage):
             query['query']['bool']['must'].append({"term": {"trace_id": trace_id}})
         response = self.client.post(url, json=query)
         if response.status_code != 200:
-            raise Exception(f"Failed to delete documents: {response.text}")
+            raise RuntimeError(
+                f"Failed to delete documents from Elasticsearch index "
+                f"{self.index_name!r} at {url}: status {response.status_code}, "
+                f"body: {response.text}")
 
     def add(self, message_list: List[ConversationMessage], session_id: str = None, agent_id: str = None,
             **kwargs) -> None:
@@ -155,7 +163,10 @@ class ElasticsearchMemoryStorage(MemoryStorage):
             headers={'Content-Type': 'application/x-ndjson'}
         )
         if response.status_code != 200:
-            raise Exception(f"Failed to add documents: {response.text}")
+            raise RuntimeError(
+                f"Failed to add documents to Elasticsearch index "
+                f"{self.index_name!r} (bulk): status {response.status_code}, "
+                f"body: {response.text}")
 
     def get(self, session_id: str = None, agent_id: str = None, top_k=50, trace_id: str = None, **kwargs) -> List[
         ConversationMessage]:
@@ -221,7 +232,10 @@ class ElasticsearchMemoryStorage(MemoryStorage):
             json=query
         )
         if response.status_code != 200:
-            raise Exception(f"Failed to retrieve documents: {response.text}")
+            raise RuntimeError(
+                f"Failed to retrieve documents from Elasticsearch index "
+                f"{self.index_name!r} (_search): status {response.status_code}, "
+                f"body: {response.text}")
 
         hits = response.json()['hits']['hits']
         messages = []

--- a/tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_es_conversation_memory_storage_errors.py
+++ b/tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_es_conversation_memory_storage_errors.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for ElasticsearchMemoryStorage error contracts.
+
+The storage previously raised a bare \`Exception\` for every failure: a
+missing es_url, a non-200 index creation, a failed delete, a failed bulk
+add, and a failed search. Each now raises a precise exception that names
+the index, the operation, the HTTP status, and the Elasticsearch error
+body, so an operator can tell configuration errors (ValueError) from
+runtime failures (RuntimeError) and locate the offending index.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.memory.conversation_memory.memory_storage.es_conversation_memory_storage import \
+    ElasticsearchMemoryStorage
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+
+def _make_storage() -> ElasticsearchMemoryStorage:
+    """A storage whose client is mocked so we never touch ES.
+
+    Built via the configer so the memory_converter is set up the same way as
+    in production (DefaultMemoryConverter for ES does not subclass
+    BaseMemoryConverter, so direct constructor assignment fails pydantic
+    validation — the configer path is the supported way to set it).
+    """
+    from types import SimpleNamespace
+    configer = SimpleNamespace(
+        es_url="http://localhost:9200",
+        es_index_name="memory",
+        es_user=None, es_password=None, es_timeout=60,
+    )
+    storage = ElasticsearchMemoryStorage()
+    # Patch _new_client / _init_es_index so construction does not touch ES.
+    with patch.object(ElasticsearchMemoryStorage, "_new_client"):
+        storage._initialize_by_component_configer(configer)
+    storage.client = MagicMock()
+    return storage
+
+
+def _response(status_code: int, text: str = "error body", json_body=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    if json_body is not None:
+        response.json.return_value = json_body
+    return response
+
+
+class TestElasticsearchMemoryStorageConfigErrors(unittest.TestCase):
+    """Configuration problems raise ValueError, not a bare Exception."""
+
+    def test_missing_es_url_raises_value_error(self) -> None:
+        storage = ElasticsearchMemoryStorage(es_url=None, index_name="memory")
+        configer = ComponentConfiger()
+        # Patch _new_client so we isolate the configuration check.
+        with patch.object(ElasticsearchMemoryStorage, "_new_client"):
+            with self.assertRaises(ValueError) as ctx:
+                storage._initialize_by_component_configer(configer)
+        self.assertIn("es_url", str(ctx.exception))
+
+
+class TestElasticsearchMemoryStorageRuntimeErrors(unittest.TestCase):
+    """ES non-200 responses raise RuntimeError naming the index + status."""
+
+    def test_create_index_failure_raises_runtime_error_with_status(self) -> None:
+        storage = _make_storage()
+        # First GET returns 404 (index missing), PUT to create returns 500.
+        storage.client.get.return_value = _response(404)
+        storage.client.put.return_value = _response(500, text="mapping error")
+        with self.assertRaises(RuntimeError) as ctx:
+            storage._init_es_index()
+        msg = str(ctx.exception)
+        self.assertIn("memory", msg)
+        self.assertIn("500", msg)
+        self.assertIn("mapping error", msg)
+
+    def test_delete_failure_raises_runtime_error_with_url_and_status(self) -> None:
+        storage = _make_storage()
+        storage.client.post.return_value = _response(400, text="bad query")
+        with self.assertRaises(RuntimeError) as ctx:
+            storage.delete(session_id="s1")
+        msg = str(ctx.exception)
+        self.assertIn("memory", msg)
+        self.assertIn("400", msg)
+        self.assertIn("bad query", msg)
+        self.assertIn("_delete_by_query", msg)
+
+    def test_add_failure_raises_runtime_error_with_status(self) -> None:
+        storage = _make_storage()
+        storage.client.post.return_value = _response(413, text="too large")
+        with patch(
+            "agentuniverse.agent.memory.conversation_memory."
+            "memory_storage.es_conversation_memory_storage.ConversationMessage"
+        ) as conv:
+            conv.check_and_convert_message.return_value = []
+            with self.assertRaises(RuntimeError) as ctx:
+                storage.add(message_list=[], session_id="s1")
+        msg = str(ctx.exception)
+        self.assertIn("memory", msg)
+        self.assertIn("413", msg)
+        self.assertIn("too large", msg)
+
+    def test_retrieve_failure_raises_runtime_error_with_status(self) -> None:
+        storage = _make_storage()
+        storage.client.post.return_value = _response(401, text="unauthorized")
+        with self.assertRaises(RuntimeError) as ctx:
+            storage.get(session_id="s1")
+        msg = str(ctx.exception)
+        self.assertIn("memory", msg)
+        self.assertIn("401", msg)
+        self.assertIn("unauthorized", msg)
+        self.assertIn("_search", msg)
+
+    def test_errors_are_not_bare_exception(self) -> None:
+        # The concrete type must be ValueError / RuntimeError, not Exception.
+        storage = _make_storage()
+        storage.client.post.return_value = _response(500)
+        with patch(
+            "agentuniverse.agent.memory.conversation_memory."
+            "memory_storage.es_conversation_memory_storage.ConversationMessage"
+        ) as conv:
+            conv.check_and_convert_message.return_value = []
+            try:
+                storage.add(message_list=[], session_id="s1")
+            except ValueError:
+                pass
+            except RuntimeError:
+                pass
+            except Exception as exc:  # noqa: BLE001 — the point of the test
+                self.fail(
+                    f"add() raised bare {type(exc).__name__}; expected "
+                    "ValueError or RuntimeError")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`ElasticsearchMemoryStorage` raised a bare `Exception` on every failure (missing es_url, non-200 index creation, failed delete, failed bulk add, failed search). It now raises precise exceptions that name the index, operation, HTTP status, and ES error body.

## Why (not a duplicate)

A bare `Exception` cannot be caught precisely, and the original messages did not name the index, the operation, or the HTTP status — an operator saw only the raw Elasticsearch body and had to guess which call failed. Addresses #253 (Error Message Optimization) for the ES conversation memory layer. Same direction as the merged work on planner/agent error messages.

## Changes

The exception types now reflect the failure class:
- **missing `es_url`** → `ValueError` (configuration problem), with a hint pointing at the yaml field.
- **any ES non-200 response** → `RuntimeError` naming the index, the operation (`create` / `delete` / `bulk` / `_search`), the HTTP status code, and the ES error body.

Five call sites updated: `_initialize_by_component_configer` (es_url check), `_init_es_index` (create), `delete`, `add` (bulk), `get` (_search).

## Tests

`tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_es_conversation_memory_storage_errors.py` — 6 unit tests:
- `test_missing_es_url_raises_value_error`
- `test_create_index_failure_raises_runtime_error_with_status` — asserts index name, status code (500), ES body
- `test_delete_failure_raises_runtime_error_with_url_and_status` — asserts `_delete_by_query` URL appears
- `test_add_failure_raises_runtime_error_with_status`
- `test_retrieve_failure_raises_runtime_error_with_status` — asserts `_search` appears
- `test_errors_are_not_bare_exception` — concrete type is ValueError/RuntimeError, not Exception

All mock the httpx client; no ES instance needed. `python -m unittest tests.test_agentuniverse.unit.agent.memory.conversation_memory.test_es_conversation_memory_storage_errors` — 6 passed.

## Behaviour change

Narrow: callers that caught `Exception` still work (ValueError/RuntimeError are subclasses). Callers that matched the error string need to allow the new index/operation/status prefixes.