### PR TITLE
fix(monitor): preserve LLM inputs during token counting

### DIFF
--- a/agentuniverse/base/util/monitor/monitor.py
+++ b/agentuniverse/base/util/monitor/monitor.py
@@ -291,7 +291,7 @@ class Monitor(BaseModel):
 
             if llm_obj is None or llm_input is None:
                 return {}
-            messages = llm_input.get('kwargs', {}).pop('messages', None)
+            messages = llm_input.get('kwargs', {}).get('messages')
 
             input_str = ''
             if messages is not None and isinstance(messages, list):

--- a/tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py
+++ b/tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py
@@ -1,0 +1,30 @@
+from copy import deepcopy
+
+from agentuniverse.base.util.monitor.monitor import Monitor
+from agentuniverse.llm.llm_output import LLMOutput
+
+
+class _StubLLM:
+    @staticmethod
+    def get_num_tokens(text: str) -> int:
+        return len(text)
+
+
+def test_get_llm_token_usage_preserves_llm_input():
+    llm_input = {
+        "kwargs": {
+            "messages": [
+                {"role": "user", "content": "hello"},
+            ]
+        }
+    }
+    original_input = deepcopy(llm_input)
+
+    usage = Monitor.get_llm_token_usage(
+        _StubLLM(),
+        llm_input,
+        LLMOutput(text="response"),
+    )
+
+    assert usage["total_tokens"] > 0
+    assert llm_input == original_input


### PR DESCRIPTION
## Summary

- read LLM messages without removing them from the caller-provided input
- keep fallback token counting behavior and returned usage unchanged
- add a regression test proving token accounting is side-effect free

## Problem

`Monitor.get_llm_token_usage` used `pop("messages")` on the nested `kwargs` mapping. Enabling token accounting therefore silently removed messages from the original LLM input object, allowing observability code to change request state.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py -q` (1 passed)
- `ruff check --no-fix tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py`
- `ruff format --check tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py`
- `python -m py_compile agentuniverse/base/util/monitor/monitor.py tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py`
- `git diff --check`

No dependencies or public APIs are changed.