### PR TITLE
fix(trace): preserve parent chain for async agents

### DIFF
--- a/agentuniverse/base/annotation/trace.py
+++ b/agentuniverse/base/annotation/trace.py
@@ -209,7 +209,6 @@ async def _default_agent_wrapper_async(func, *args, **kwargs):
                                                          result,
                                                          start_info,
                                                          pair_id)
-        Monitor.pop_invocation_chain()
         return result
 
 

--- a/tests/test_agentuniverse/unit/base/annotation/test_trace.py
+++ b/tests/test_agentuniverse/unit/base/annotation/test_trace.py
@@ -1,0 +1,50 @@
+import asyncio
+import importlib
+
+from agentuniverse.base.context.framework_context_manager import FrameworkContextManager
+
+
+class _StubConversationMemoryModule:
+    def add_agent_input_info(self, *args, **kwargs):
+        pass
+
+    def add_agent_result_info(self, *args, **kwargs):
+        pass
+
+
+class _StubAgent:
+    agent_model = None
+
+
+async def _run_agent(self, **kwargs):
+    return "done"
+
+
+def test_async_agent_wrapper_restores_parent_invocation_chain(monkeypatch):
+    trace_module = importlib.import_module("agentuniverse.base.annotation.trace")
+    monkeypatch.setattr(
+        trace_module,
+        "ConversationMemoryModule",
+        _StubConversationMemoryModule,
+    )
+
+    async def run_in_parent_context():
+        context_manager = FrameworkContextManager()
+        context_manager.clear_all_contexts()
+        parent = {"source": "parent-agent", "type": "agent"}
+        trace_module.Monitor.init_invocation_chain()
+        trace_module.Monitor.add_invocation_chain(parent)
+
+        try:
+            result = await trace_module._default_agent_wrapper_async(
+                _run_agent,
+                _StubAgent(),
+            )
+
+            assert result == "done"
+            assert trace_module.Monitor.get_invocation_chain() == [parent]
+        finally:
+            trace_module.Monitor.clear_invocation_chain()
+            context_manager.clear_all_contexts()
+
+    asyncio.run(run_in_parent_context())


### PR DESCRIPTION
## Summary

- remove the redundant invocation-chain pop from the async agent wrapper
- rely on `InvocationChainContext.__exit__` for the same balanced cleanup used by the sync wrapper
- add a regression test that runs the wrapper inside a parent async trace context

## Problem

`_default_agent_wrapper_async` popped its child chain explicitly and then popped again when the surrounding `InvocationChainContext` exited. A nested async agent invocation could therefore remove its parent trace entry.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/base/annotation/test_trace.py -q` (1 passed)
- `ruff check --no-fix tests/test_agentuniverse/unit/base/annotation/test_trace.py`
- `ruff format --check tests/test_agentuniverse/unit/base/annotation/test_trace.py`
- `python -m py_compile agentuniverse/base/annotation/trace.py tests/test_agentuniverse/unit/base/annotation/test_trace.py`
- `git diff --check`

No dependencies or public APIs are changed.