### PR TITLE
fix(store): SQLiteStore BM25 correctness — stale index, top_k, None rows

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/sqlite_store.py
+++ b/agentuniverse/agent/action/knowledge/store/sqlite_store.py
@@ -128,6 +128,15 @@ class SQLiteStore(Store):
                     'INSERT OR REPLACE INTO documents (id, text, word_count, metadata) VALUES (?, ?, ?, ?)',
                     (document.id, document.text, len(jieba.lcut(document.text)), metadata)
                 )
+                # Clear any stale inverted-index rows for this id so a re-insert
+                # of the same id (e.g. re-running ingest) does not accumulate
+                # old keywords alongside the new ones. Matches upsert_document
+                # semantics; without this the BM25 term-frequency / IDF counts
+                # get polluted and stale keywords keep recalling the document.
+                self.conn.execute(
+                    'DELETE FROM inverted_index WHERE doc_id = ?',
+                    (document.id,)
+                )
                 self._get_document_keyword(document)
                 for term in set(document.keywords):
                     self.conn.execute(
@@ -197,16 +206,26 @@ class SQLiteStore(Store):
             cursor = self.conn.cursor()
             cursor.execute('SELECT text FROM documents WHERE id = ?',
                            (doc_id,))
-            doc_text = cursor.fetchone()[0]
+            row = cursor.fetchone()
             cursor.close()
+            # The inverted index can reference a doc_id whose row was since
+            # replaced or removed (INSERT OR REPLACE does not touch the index,
+            # and a stale entry should not crash the whole query).
+            if row is None:
+                continue
+            doc_text = row[0]
 
             bm25_score = self.compute_bm25(query.query_str, doc_text,
                                            inverted_index, total_doc_count, total_word_count)
             doc_scores.append((doc_id, bm25_score))
 
-        # Order the docs with bm25, and return top k.
+        # Order the docs with bm25, and return top k. Honour the per-query
+        # similarity_top_k when the caller supplied one; otherwise fall back to
+        # the store default. The previous code always used the store default,
+        # silently truncating caller-requested recall.
+        top_k = query.similarity_top_k if query.similarity_top_k else self.similarity_top_k
         doc_scores.sort(key=lambda x: x[1], reverse=True)
-        top_docs = doc_scores[:self.similarity_top_k]
+        top_docs = doc_scores[:top_k]
         results = []
         for doc_id, score in top_docs:
             cursor = self.conn.cursor()
@@ -214,24 +233,59 @@ class SQLiteStore(Store):
                            (doc_id,))
             doc_row = cursor.fetchone()
             cursor.close()
+            if doc_row is None:
+                continue
 
+            # metadata is stored as JSON or NULL; json.loads(None) would raise
+            # TypeError, so guard it explicitly.
+            raw_metadata = doc_row[3]
+            metadata = json.loads(raw_metadata) if raw_metadata else None
             document = Document(id=doc_row[0], text=doc_row[1],
                                 word_count=doc_row[2],
-                                metadata=json.loads(doc_row[3]))
+                                metadata=metadata)
             results.append(document)
 
         return results
 
     @staticmethod
     def to_documents(query_result) -> List[Document]:
-        """Convert the query results of sqlite to the agentUniverse(aU) document format."""
+        """Convert rows from the documents table to aU Documents.
 
+        Accepts either a Chroma-style dict (``{'ids': [[...]], 'documents': [[...]],
+        'metadatas': [[...]]}``) for cross-store compatibility, or a list of
+        tuples shaped like ``(id, text, word_count, metadata_json)`` as produced
+        by the SQLiteStore query path. Returns an empty list for ``None`` or an
+        unrecognised shape, rather than crashing on a missing key.
+        """
         if query_result is None:
             return []
-        documents = []
-        for i in range(len(query_result['ids'][0])):
-            documents.append(Document(id=query_result['ids'][0][i],
-                                      text=query_result['documents'][0][i],
-                                      embedding=[],
-                                      metadata=json.loads(query_result[2]) if query_result[2] else None))
+
+        documents: List[Document] = []
+
+        # Chroma-style nested-list-of-lists dict.
+        if isinstance(query_result, dict) and 'ids' in query_result:
+            ids = query_result.get('ids') or [[]]
+            texts = query_result.get('documents') or [[]]
+            metadatas = query_result.get('metadatas') or [[]]
+            if not ids or not isinstance(ids[0], list):
+                return []
+            for i, doc_id in enumerate(ids[0]):
+                text = texts[0][i] if texts and len(texts[0]) > i else ''
+                meta = metadatas[0][i] if metadatas and len(metadatas[0]) > i else None
+                documents.append(Document(id=doc_id, text=text, embedding=[],
+                                          metadata=meta if isinstance(meta, dict) else None))
+            return documents
+
+        # SQLite row tuples: (id, text, word_count, metadata_json).
+        if isinstance(query_result, list):
+            for row in query_result:
+                if not row or len(row) < 2:
+                    continue
+                raw_metadata = row[3] if len(row) > 3 else None
+                try:
+                    metadata = json.loads(raw_metadata) if raw_metadata else None
+                except (TypeError, ValueError):
+                    metadata = None
+                documents.append(Document(id=row[0], text=row[1], embedding=[],
+                                          metadata=metadata))
         return documents

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_sqlite_store_bm25.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_sqlite_store_bm25.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for SQLiteStore BM25 correctness.
+
+Covers three bugs that each silently distorted recall:
+
+1. ``insert_document`` did not clear stale inverted-index rows for a re-inserted
+   id, so re-running ingest accumulated old keywords alongside new ones,
+   polluting BM25 term-frequency / IDF and recalling stale keywords.
+2. ``query`` always used the store default ``similarity_top_k``, ignoring a
+   caller-supplied ``Query.similarity_top_k``.
+3. ``query`` dereferenced ``fetchone()[0]`` and ``json.loads(doc_row[3])``
+   without guarding None, so a stale inverted-index entry or a NULL metadata
+   column crashed the whole query.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.sqlite_store import SQLiteStore
+
+
+def _identity_keyword_extractor(document):
+    """A keyword extractor that uses whitespace tokens as keywords.
+
+    Used in place of a real DocProcessor so tests can exercise the
+    insert/query path without registering a keyword-extraction component.
+    """
+    document.keywords = list(set((document.text or "").split()))
+    return document
+
+
+class _SQLiteStoreTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.store = SQLiteStore(db_path=self.tmp.name, keyword_extractor="test")
+        self.store._new_client()
+        # Patch DocProcessorManager so _get_document_keyword uses our
+        # identity extractor instead of requiring a registered component.
+        fake_mgr = type("M", (), {"get_instance_obj":
+                                  staticmethod(lambda name: type(
+                                      "P", (), {"process_docs":
+                                                staticmethod(
+                                                    lambda docs: [
+                                                        _identity_keyword_extractor(d)
+                                                        for d in docs])})())})
+        self._patcher = patch(
+            "agentuniverse.agent.action.knowledge.store.sqlite_store."
+            "DocProcessorManager", return_value=fake_mgr())
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        self.store.conn.close()
+        if os.path.exists(self.tmp.name):
+            os.unlink(self.tmp.name)
+
+    def _insert(self, doc_id: str, text: str, metadata=None):
+        self.store.insert_document([
+            Document(id=doc_id, text=text, metadata=metadata or {}),
+        ])
+
+
+class TestInsertClearsStaleInvertedIndex(_SQLiteStoreTestBase):
+    """insert_document must clear stale keywords for a re-inserted id."""
+
+    def test_re_insert_replaces_keywords_not_accumulates(self) -> None:
+        # First insert: doc has keywords "alpha" and "beta".
+        self._insert("d1", "alpha beta", metadata={"v": 1})
+        cursor = self.store.conn.cursor()
+        cursor.execute(
+            "SELECT COUNT(*) FROM inverted_index WHERE doc_id = ?", ("d1",))
+        before = cursor.fetchone()[0]
+        cursor.close()
+        self.assertEqual(before, 2)
+
+        # Re-insert the SAME id with different text/keywords.
+        self._insert("d1", "gamma delta", metadata={"v": 2})
+
+        cursor = self.store.conn.cursor()
+        # Stale rows for "alpha" and "beta" must be gone; only "gamma" and
+        # "delta" remain.
+        cursor.execute(
+            "SELECT term FROM inverted_index WHERE doc_id = ? ORDER BY term",
+            ("d1",))
+        terms = [row[0] for row in cursor.fetchall()]
+        cursor.close()
+        self.assertEqual(terms, ["delta", "gamma"])
+
+    def test_re_insert_does_not_pollute_bm25_term_frequency(self) -> None:
+        # Insert d1 with "alpha", then re-insert d1 with "beta". A query for
+        # "alpha" must NOT recall d1 anymore.
+        self._insert("d1", "alpha")
+        self._insert("d1", "beta")  # re-insert replaces the document
+
+        # d2 still has "alpha" as a real keyword.
+        self._insert("d2", "alpha gamma")
+
+        results = self.store.query(Query(query_str="alpha",
+                                         keywords=["alpha"],
+                                         similarity_top_k=10))
+        ids = [r.id for r in results]
+        self.assertIn("d2", ids)
+        self.assertNotIn(
+            "d1", ids,
+            "stale 'alpha' keyword from the first insert of d1 must not "
+            "recall d1 after it was re-inserted with different text")
+
+
+class TestQueryHonoursPerQueryTopK(_SQLiteStoreTestBase):
+    """query must honour Query.similarity_top_k, not just the store default."""
+
+    def test_query_returns_more_than_default_when_top_k_requested(self) -> None:
+        # Insert 5 docs that all share a keyword so they are all candidates.
+        for i in range(5):
+            self._insert(f"d{i}", f"shared term {i}")
+
+        # Store default is 10; ask for only 2.
+        results = self.store.query(Query(query_str="shared",
+                                         keywords=["shared"],
+                                         similarity_top_k=2))
+        self.assertEqual(len(results), 2)
+
+    def test_query_respects_store_default_when_top_k_not_set(self) -> None:
+        for i in range(15):
+            self._insert(f"d{i}", f"shared term {i}")
+        # Query without similarity_top_k; store default is 10.
+        original_default = self.store.similarity_top_k
+        self.store.similarity_top_k = 3
+        try:
+            results = self.store.query(Query(query_str="shared",
+                                             keywords=["shared"]))
+            self.assertEqual(len(results), 3)
+        finally:
+            self.store.similarity_top_k = original_default
+
+
+class TestQueryGuardsAgainstMissingRows(_SQLiteStoreTestBase):
+    """query must not crash on a stale inverted-index entry or NULL metadata."""
+
+    def test_stale_inverted_index_entry_is_skipped_not_crash(self) -> None:
+        # Manually plant an inverted_index row pointing at a doc that does not
+        # exist in the documents table.
+        with self.store.conn:
+            self.store.conn.execute(
+                "INSERT INTO inverted_index (term, doc_id) VALUES (?, ?)",
+                ("ghost", "missing_doc"),
+            )
+        # Also insert a real doc that matches "ghost" so we can tell the query
+        # completed and returned the real one.
+        self._insert("real", "ghost story")
+
+        # Previously: cursor.fetchone()[0] on the missing_doc row raised
+        # TypeError: 'NoneType' object is not subscriptable.
+        results = self.store.query(Query(query_str="ghost",
+                                         keywords=["ghost"],
+                                         similarity_top_k=10))
+        ids = [r.id for r in results]
+        self.assertIn("real", ids)
+        self.assertNotIn("missing_doc", ids)
+
+    def test_null_metadata_does_not_crash_query(self) -> None:
+        # Insert a doc whose metadata ends up NULL in the DB (metadata=None).
+        self.store.insert_document([Document(id="d1", text="alpha beta",
+                                             metadata=None)])
+        # Previously: json.loads(None) raised TypeError.
+        results = self.store.query(Query(query_str="alpha",
+                                         keywords=["alpha"],
+                                         similarity_top_k=10))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, "d1")
+        # metadata must round-trip as None, not crash.
+        self.assertIsNone(results[0].metadata)
+
+
+class TestToDocumentsHandlesShapesSafely(unittest.TestCase):
+    """to_documents must not crash on the shapes it can actually receive."""
+
+    def test_none_returns_empty(self) -> None:
+        self.assertEqual(SQLiteStore.to_documents(None), [])
+
+    def test_unrecognised_shape_returns_empty(self) -> None:
+        # Previously this would have raised KeyError or TypeError.
+        self.assertEqual(SQLiteStore.to_documents("not a dict or list"), [])
+        self.assertEqual(SQLiteStore.to_documents({"no_ids_key": []}), [])
+
+    def test_sqlite_row_tuples_round_trip(self) -> None:
+        rows = [
+            ("d1", "text one", 2, json.dumps({"k": "v"})),
+            ("d2", "text two", 2, None),  # NULL metadata
+        ]
+        docs = SQLiteStore.to_documents(rows)
+        self.assertEqual([d.id for d in docs], ["d1", "d2"])
+        self.assertEqual(docs[0].metadata, {"k": "v"})
+        self.assertIsNone(docs[1].metadata)
+
+    def test_chroma_style_dict_round_trip(self) -> None:
+        # Cross-store compatibility: a Chroma-style nested-list-of-lists dict.
+        result = {
+            "ids": [["c1", "c2"]],
+            "documents": [["a text", "b text"]],
+            "metadatas": [[{"x": 1}, {"x": 2}]],
+        }
+        docs = SQLiteStore.to_documents(result)
+        self.assertEqual([d.id for d in docs], ["c1", "c2"])
+        self.assertEqual(docs[0].metadata, {"x": 1})
+
+    def test_corrupt_metadata_json_does_not_crash(self) -> None:
+        rows = [("d1", "text", 1, "not-valid-json{")]
+        docs = SQLiteStore.to_documents(rows)
+        self.assertEqual(len(docs), 1)
+        self.assertIsNone(docs[0].metadata)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Three bugs in \`SQLiteStore\` that each silently distorted BM25 recall, plus a rewrite of a broken \`to_documents\` static method.

## Why (not a duplicate)

Not covered by any open or merged PR. SQLiteStore is the built-in keyword/BM25 store; these are core recall-correctness bugs.

## Changes

### 1. `insert_document` accumulated stale inverted-index rows
\`insert_document\` used \`INSERT OR REPLACE\` on the documents table but never cleared the old \`(term, doc_id)\` rows. Re-running ingest for a document left stale keywords recalling it AND polluted the BM25 counts (\`compute_bm25\` reads \`len(inverted_index[term])\` for \`num_docs_with_term\`). \`upsert_document\` already did this delete; \`insert_document\` now matches it.

### 2. `query` ignored `Query.similarity_top_k`
\`query\` sliced with the store default (\`self.similarity_top_k\`) and ignored a caller-supplied \`Query.similarity_top_k\`. A caller asking for 100 results silently got 10. Now honours \`query.similarity_top_k\` when set.

### 3. `query` crashed on None rows / NULL metadata
\`fetchone()[0]\` and \`json.loads(doc_row[3])\` had no None guard. A stale inverted-index entry pointing at a missing doc, or a row with NULL metadata, raised \`TypeError\` and crashed the whole query instead of degrading. Both are now None-guarded.

### 4. `to_documents` rewritten
The previous staticmethod was a copy-paste of Chroma's result shape but indexed the dict as a tuple (\`query_result[2]\`) and had no internal caller. It now safely handles \`None\`, unrecognised shapes, Chroma-style dicts, SQLite row tuples, and corrupt metadata JSON.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/store/test_sqlite_store_bm25.py\` — 11 regressions across all four fixes:
- re-insert replaces keywords (not accumulates)
- re-insert does not pollute BM25 term frequency (stale keyword no longer recalls)
- query honours per-query \`similarity_top_k\`
- query falls back to store default when not set
- stale inverted-index entry is skipped, not crashed
- NULL metadata does not crash query
- \`to_documents\` handles None / unrecognised shape / SQLite row tuples / Chroma-style dict / corrupt JSON

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_sqlite_store_bm25\` — 11 passed (uses a temp SQLite DB + stubbed keyword extractor; no network).

## Behaviour change

- \`insert_document\` now clears stale keywords on re-insert (previously silently accumulated them).
- \`query\` honours caller-supplied \`similarity_top_k\` (previously ignored it).
- \`query\` skips missing rows / NULL metadata instead of raising \`TypeError\`.