### PR TITLE
fix(store): three Chroma bugs (hierarchical flatten crash, search_depth None, persist_path port)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_hierarchical_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_hierarchical_store.py
@@ -27,7 +27,7 @@ class ChromaHierarchicalStore(ChromaStore):
         collection (Collection): A chroma collection object.
         persist_path (Optional[str]): Path to save the chroma database.
     """
-    search_depth: int = None
+    search_depth: Optional[int] = 1
     similarity_top_k_list: Optional[List[int]] = []
 
     def query(self, query: Query, **kwargs) -> List[Document]:
@@ -44,6 +44,8 @@ class ChromaHierarchicalStore(ChromaStore):
         Returns:
             List[Document]: List of documents retrieved by the query.
         """
+        if not self.search_depth or self.search_depth <= 0:
+            return []
 
         embedding = query.embeddings
         if self.embedding_model is not None and len(embedding) == 0:
@@ -52,16 +54,22 @@ class ChromaHierarchicalStore(ChromaStore):
             ).get_embeddings([query.query_str], text_type="query")[0]
 
         top_k_ids = []
-        current_level_ids = None
-        query_result = []
+        query_result: list[dict] = []
 
         for depth in range(self.search_depth):
             if len(top_k_ids) > 0:
-                all_results = []
-                top_k = self.similarity_top_k_list[depth] if len(
-                                self.similarity_top_k_list) >= depth + 1 else self.similarity_top_k,
+                # Flatten results across all parent_ids into a single ranked
+                # list of per-doc dicts, then keep the top-k by distance. The
+                # previous code did ``all_results.extend(results)`` on a Chroma
+                # dict (which extends with the dict's *keys*: 'ids',
+                # 'documents', ...), then ``sorted(..., key=lambda x:
+                # x['distance'])`` on those string keys — a guaranteed
+                # TypeError on every multi-parent query.
+                flat: list[dict] = []
+                top_k = (self.similarity_top_k_list[depth]
+                         if len(self.similarity_top_k_list) >= depth + 1
+                         else self.similarity_top_k)
                 for parent_id in top_k_ids:
-                    # Query for each parent_id
                     if len(embedding) > 0:
                         results = self.collection.query(
                             n_results=top_k,
@@ -74,36 +82,79 @@ class ChromaHierarchicalStore(ChromaStore):
                             query_texts=[query.query_str],
                             where={"hierarchical_parent": parent_id}
                         )
-                    all_results.extend(results)
-                sorted_results = sorted(all_results,
-                                        key=lambda x: x['distance'])
-
-                # Select the top k results
-                query_result = sorted_results[:top_k]
-
+                    flat.extend(self._flatten_chroma_results(results))
+                # Lower distance == better match in Chroma.
+                flat.sort(key=lambda x: x['distance'])
+                query_result = flat[:top_k]
             else:
                 filter_condition = {
                    "hierarchical_level": depth
                 }
+                top_k = (self.similarity_top_k_list[depth]
+                         if len(self.similarity_top_k_list) >= depth + 1
+                         else self.similarity_top_k)
                 if len(embedding) > 0:
-                    query_result = self.collection.query(
-                        n_results=self.similarity_top_k_list[depth] if len(
-                            self.similarity_top_k_list) >= depth + 1 else self.similarity_top_k,
+                    raw = self.collection.query(
+                        n_results=top_k,
                         query_embeddings=embedding,
                         where=filter_condition
                     )
                 else:
-                    query_result = self.collection.query(
-                        n_results=self.similarity_top_k_list[depth] if len(
-                            self.similarity_top_k_list) >= depth + 1 else self.similarity_top_k,
+                    raw = self.collection.query(
+                        n_results=top_k,
                         query_texts=[query.query_str],
                         where=filter_condition
                     )
+                query_result = self._flatten_chroma_results(raw)
 
-            documents = self.to_documents(query_result)
+            documents = self._flat_to_documents(query_result)
             top_k_ids = [doc.id for doc in documents]
 
-        return self.to_documents(query_result)
+        return self._flat_to_documents(query_result)
+
+    @staticmethod
+    def _flatten_chroma_results(results: Any) -> list[dict]:
+        """Flatten Chroma's nested-list-of-lists result dict into per-doc dicts.
+
+        Chroma returns ``{'ids': [[...]], 'documents': [[...]], 'distances':
+        [[...]], 'metadatas': [[...]], 'embeddings': [[...]] | None}``. Each
+        outer list corresponds to one query; we flatten the first query's
+        results into a list of ``{id, document, distance, metadata,
+        embedding}`` dicts that downstream sorting / pagination can use.
+        """
+        if not isinstance(results, dict):
+            return []
+        ids = results.get('ids') or []
+        documents = results.get('documents') or []
+        distances = results.get('distances') or []
+        metadatas = results.get('metadatas') or []
+        embeddings = results.get('embeddings') or []
+        if not ids or not isinstance(ids[0], list):
+            return []
+        flat: list[dict] = []
+        for i, doc_id in enumerate(ids[0]):
+            flat.append({
+                'id': doc_id,
+                'document': documents[0][i] if documents and len(documents[0]) > i else '',
+                'distance': distances[0][i] if distances and len(distances[0]) > i else 0.0,
+                'metadata': metadatas[0][i] if metadatas and len(metadatas[0]) > i else None,
+                'embedding': embeddings[0][i] if embeddings and len(embeddings[0]) > i else [],
+            })
+        return flat
+
+    @staticmethod
+    def _flat_to_documents(flat: list[dict]) -> List[Document]:
+        """Build Documents from the flattened per-doc dicts."""
+        documents: List[Document] = []
+        for item in flat:
+            metadata = item.get('metadata')
+            documents.append(Document(
+                id=item.get('id'),
+                text=item.get('document') or '',
+                embedding=item.get('embedding') or [],
+                metadata=metadata if isinstance(metadata, dict) else None,
+            ))
+        return documents
 
     def _initialize_by_component_configer(self,
                                           chroma_store_configer: ComponentConfiger) -> 'DocProcessor':

--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -41,14 +41,26 @@ class ChromaStore(Store):
 
     def _new_client(self) -> Any:
         """Initialize the chroma client."""
+        # persist_path defaults to None; a bare .startswith on None raises
+        # AttributeError before the user ever sees a helpful message. Require
+        # it explicitly so the failure is actionable.
+        if not self.persist_path:
+            raise ValueError(
+                "ChromaStore.persist_path is not set; configure a local "
+                "directory or an http(s) Chroma server URL.")
         if self.persist_path.startswith('http') or \
                 self.persist_path.startswith('https'):
             # Remote database URL
             parsed_url = urlparse(self.persist_path)
+            # urlparse returns port=None when the URL omits it; str(None) =
+            # "None" would then be passed to chromadb as the HTTP port and
+            # fail later with an opaque connection error. Fall back to the
+            # Chroma default port (8000).
+            port = parsed_url.port if parsed_url.port is not None else 8000
             settings = Settings(
                 chroma_api_impl="chromadb.api.fastapi.FastAPI",
                 chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
+                chroma_server_http_port=str(port)
             )
         else:
             settings = Settings(

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_store_bugs.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_store_bugs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for three ChromaStore / ChromaHierarchicalStore bugs.
+
+1. ChromaHierarchicalStore.query extended a Chroma result dict into a list
+   (which extends with the dict's keys) and then sorted those string keys
+   by x['distance'] — a guaranteed TypeError on every multi-parent query.
+2. ChromaHierarchicalStore.search_depth was typed ``int`` but defaulted to
+   ``None``, so ``range(self.search_depth)`` raised TypeError whenever the
+   user did not configure it.
+3. ChromaStore._new_client called ``self.persist_path.startswith(...)`` on a
+   None default, crashing before any helpful message; and a remote URL
+   without an explicit port passed ``str(None) == "None"`` as the HTTP port.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _chroma_result(ids, documents, distances, metadatas=None,
+                   embeddings=None):
+    """Build a Chroma-style nested-list-of-lists query result dict."""
+    return {
+        "ids": [list(ids)],
+        "documents": [list(documents)],
+        "distances": [list(distances)],
+        "metadatas": [list(metadatas)] if metadatas is not None else None,
+        "embeddings": [list(embeddings)] if embeddings is not None else None,
+    }
+
+
+class TestChromaHierarchicalStoreFlattening(unittest.TestCase):
+    """Multi-parent hierarchical queries must rank real documents, not crash."""
+
+    def _store(self):
+        from agentuniverse.agent.action.knowledge.store.\
+            chroma_hierarchical_store import ChromaHierarchicalStore
+        store = ChromaHierarchicalStore()
+        store.collection = MagicMock()
+        store.search_depth = 2
+        store.similarity_top_k = 2
+        store.similarity_top_k_list = []
+        return store
+
+    def test_multi_parent_query_does_not_crash_and_ranks_by_distance(self):
+        from agentuniverse.agent.action.knowledge.store.query import Query
+        store = self._store()
+        # Depth 0 (root): two parent docs.
+        store.collection.query.side_effect = [
+            # depth 0 query (root level)
+            _chroma_result(["p1", "p2"], ["parent 1", "parent 2"],
+                           [0.1, 0.2]),
+            # depth 1 query under p1
+            _chroma_result(["c1"], ["child 1"], [0.3]),
+            # depth 1 query under p2
+            _chroma_result(["c2"], ["child 2"], [0.05]),
+        ]
+        results = store.query(Query(query_str="q", embeddings=[[0.1, 0.2]]))
+        # The previous code raised TypeError: string indices must be integers
+        # on the depth-1 branch (extend(dict) then sorted(key=['distance'])).
+        ids = [r.id for r in results]
+        # c2 (distance 0.05) ranks above c1 (distance 0.3).
+        self.assertEqual(ids, ["c2", "c1"])
+
+    def test_search_depth_none_does_not_crash(self):
+        # Regression: search_depth used to default to None, and
+        # range(None) raised TypeError before the query even ran.
+        from agentuniverse.agent.action.knowledge.store.\
+            chroma_hierarchical_store import ChromaHierarchicalStore
+        from agentuniverse.agent.action.knowledge.store.query import Query
+
+        # Construct without configuring search_depth; default is now 1.
+        store = ChromaHierarchicalStore()
+        store.collection = MagicMock()
+        store.similarity_top_k = 1
+        # Sanity: the default is a usable int, not None.
+        self.assertIsNotNone(store.search_depth)
+        store.collection.query.return_value = _chroma_result(
+            ["d1"], ["doc"], [0.1])
+        results = store.query(Query(query_str="q", embeddings=[[0.1]]))
+        self.assertEqual([r.id for r in results], ["d1"])
+
+    def test_flatten_chroma_results_handles_missing_optional_fields(self):
+        from agentuniverse.agent.action.knowledge.store.\
+            chroma_hierarchical_store import ChromaHierarchicalStore
+        # Distances / metadatas / embeddings may be absent.
+        flat = ChromaHierarchicalStore._flatten_chroma_results({
+            "ids": [["a", "b"]],
+            "documents": [["da", "db"]],
+        })
+        self.assertEqual([d["id"] for d in flat], ["a", "b"])
+        self.assertEqual([d["distance"] for d in flat], [0.0, 0.0])
+        self.assertTrue(all(d["metadata"] is None for d in flat))
+
+
+class TestChromaStoreNewClientPersistPath(unittest.TestCase):
+    """_new_client must handle None persist_path and port-less URLs."""
+
+    def test_none_persist_path_raises_value_error_not_attribute_error(self):
+        from agentuniverse.agent.action.knowledge.store.chroma_store import \
+            ChromaStore
+        store = ChromaStore()  # persist_path defaults to None
+        with self.assertRaises(ValueError) as ctx:
+            store._new_client()
+        self.assertIn("persist_path", str(ctx.exception))
+
+    def test_remote_url_without_port_defaults_to_8000(self):
+        from agentuniverse.agent.action.knowledge.store.chroma_store import \
+            ChromaStore
+        store = ChromaStore(persist_path="http://chroma.example.com",
+                            collection_name="c")
+        captured_settings = []
+
+        class _FakeSettings:
+            def __init__(self, **kwargs):
+                captured_settings.append(kwargs)
+
+        with patch("agentuniverse.agent.action.knowledge.store."
+                   "chroma_store.Settings", _FakeSettings), \
+                patch("agentuniverse.agent.action.knowledge.store."
+                   "chroma_store.chromadb"):
+            store._new_client()
+        # The previous code passed str(None) == "None" as the port.
+        self.assertEqual(captured_settings[0]["chroma_server_http_port"],
+                         "8000")
+        self.assertEqual(captured_settings[0]["chroma_server_host"],
+                         "chroma.example.com")
+
+    def test_remote_url_with_explicit_port_is_preserved(self):
+        from agentuniverse.agent.action.knowledge.store.chroma_store import \
+            ChromaStore
+        store = ChromaStore(persist_path="http://chroma.example.com:9000",
+                            collection_name="c")
+        captured_settings = []
+
+        class _FakeSettings:
+            def __init__(self, **kwargs):
+                captured_settings.append(kwargs)
+
+        with patch("agentuniverse.agent.action.knowledge.store."
+                   "chroma_store.Settings", _FakeSettings), \
+                patch("agentuniverse.agent.action.knowledge.store."
+                   "chroma_store.chromadb"):
+            store._new_client()
+        self.assertEqual(captured_settings[0]["chroma_server_http_port"],
+                         "9000")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Three Chroma bugs, each a real crash or silent misconfiguration on a reachable path.

## Why (not a duplicate)

Not covered by any open or merged PR. #692 is Chroma 1.x compatibility; these are distinct logic/typing bugs.

## Changes

### 1. ChromaHierarchicalStore.query — multi-parent depth-N crash
\`agentuniverse/agent/action/knowledge/store/chroma_hierarchical_store.py\`

The depth-N branch did \`all_results.extend(results)\` where \`results\` is a Chroma dict (\`extend\` appends the dict's *keys*: 'ids', 'documents', ...), then \`sorted(all_results, key=lambda x: x['distance'])\` on those string keys — \`TypeError: string indices must be integers\` on every multi-parent query. Rewrote to flatten Chroma's nested-list-of-lists result into per-doc dicts via a new \`_flatten_chroma_results\` helper, sort by distance, slice top-k. Also fixed a comma bug making \`top_k\` a 1-tuple (\`(value,)\` instead of \`value\`).

### 2. ChromaHierarchicalStore.search_depth typed \`int\` but defaulted to \`None\`
\`range(self.search_depth)\` raised \`TypeError\` whenever the user did not configure it. Now \`Optional[int] = 1\`, and \`query()\` guards against non-positive values.

### 3. ChromaStore._new_client — None persist_path + port-less URL
\`self.persist_path.startswith(...)\` on the \`None\` default crashed with \`AttributeError\` before any helpful message; a remote URL without an explicit port passed \`str(None) == 'None'\` as \`chroma_server_http_port\`. Now raises \`ValueError\` when persist_path is unset, and falls back to port 8000 when the URL omits one.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/store/test_chroma_store_bugs.py\` — 6 regressions:
- multi-parent query ranks real documents by distance (previously TypeError)
- default \`search_depth\` is usable (previously TypeError on \`range(None)\`)
- flattening handles missing optional fields (distances/metadatas/embeddings)
- None persist_path raises ValueError (previously AttributeError)
- remote URL without port defaults to 8000 (previously "None")
- remote URL with explicit port is preserved

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_chroma_store_bugs\` — 6 passed.

## Behaviour change

- \`ChromaHierarchicalStore.query\` now works for depth >= 2 with multiple parents (previously crashed).
- \`ChromaHierarchicalStore\` defaults \`search_depth\` to 1 instead of None (previously crashed if unset).
- \`ChromaStore\` raises a clear ValueError when persist_path is unset, and uses port 8000 for port-less remote URLs.