### PR TITLE
fix(store): QdrantStore dimension validation and symmetric id mapping

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/qdrant_store.py
+++ b/agentuniverse/agent/action/knowledge/store/qdrant_store.py
@@ -124,9 +124,33 @@ class QdrantStore(Store):
     def insert_document(self, documents: List[Document], **kwargs):
         self.upsert_document(documents, **kwargs)
 
+    @staticmethod
+    def _to_qdrant_point_id(document_id: str) -> str:
+        """Convert a document id to a Qdrant-compatible point id.
+
+        Qdrant point ids must be UUIDs or unsigned integers. Document ids in
+        agentUniverse are arbitrary strings, so a non-UUID id is mapped to a
+        deterministic UUID5. This MUST be applied symmetrically on insert and
+        on delete — the previous delete_document passed the raw document id,
+        which never matched the UUID5 the upsert stored, so deletes silently
+        no-op'd for every non-UUID id.
+        """
+        try:
+            return str(uuid.UUID(str(document_id)))
+        except (ValueError, AttributeError, TypeError):
+            return str(uuid.uuid5(uuid.NAMESPACE_URL, str(document_id)))
+
     def upsert_document(self, documents: List[Document], **kwargs):
         if self.client is None:
             return
+
+        # Determine the expected vector dimension up front so every point in
+        # the batch is checked against one value. The previous code called
+        # _ensure_collection(dim=len(vector)) inside the loop with each doc's
+        # own dimension; the first doc fixed the collection dimension and
+        # every later doc with a different dimension silently failed at the
+        # server side with an opaque error (or worse, was partially written).
+        expected_dim = self._infer_expected_dimension(documents)
 
         points: List[PointStruct] = []
         for document in documents:
@@ -136,14 +160,21 @@ class QdrantStore(Store):
             if not vector or len(vector) == 0:
                 continue
 
-            self._ensure_collection(dim=len(vector))
+            # Reject dimension mismatches explicitly instead of letting the
+            # server reject the whole batch with an opaque error.
+            if expected_dim is not None and len(vector) != expected_dim:
+                raise ValueError(
+                    f"Document {document.id!r} has a {len(vector)}-dimensional "
+                    f"embedding but the {self.collection_name!r} collection "
+                    f"(or another document in this batch) uses "
+                    f"{expected_dim}-dimensional vectors; a Qdrant collection "
+                    f"has a single fixed vector size. Re-embed with a "
+                    f"consistent model.")
+
+            self._ensure_collection(dim=expected_dim if expected_dim is not None else len(vector))
 
             payload = {"text": document.text, "metadata": document.metadata}
-            try:
-                point_id = str(uuid.UUID(str(document.id)))
-            except Exception:
-                # fallback to deterministic UUID5 if document id is not UUID
-                point_id = str(uuid.uuid5(uuid.NAMESPACE_URL, str(document.id)))
+            point_id = self._to_qdrant_point_id(document.id)
             points.append(
                 PointStruct(
                     id=point_id,
@@ -155,13 +186,39 @@ class QdrantStore(Store):
         if points:
             self.client.upsert(collection_name=self.collection_name, points=points)
 
+    def _infer_expected_dimension(self, documents: List[Document]) -> Optional[int]:
+        """Return the dimension every vector in this batch must agree on.
+
+        Prefers the dimension of the collection if it already exists; falls
+        back to the first non-empty embedding in the batch so the first
+        insert creates the collection with a concrete size. Returns None
+        only when neither is available (e.g. all vectors will be computed
+        on demand and no collection exists yet).
+        """
+        if self.client is not None and self.client.collection_exists(self.collection_name):
+            try:
+                info = self.client.get_collection(self.collection_name)
+                cfg = (info.config.params.vectors or {}).get(self.VECTOR_NAME)
+                if cfg is not None and getattr(cfg, "size", None) is not None:
+                    return cfg.size
+            except Exception:
+                pass
+        for doc in documents:
+            if doc.embedding and len(doc.embedding) > 0:
+                return len(doc.embedding)
+        return None
+
     def update_document(self, documents: List[Document], **kwargs):
         self.upsert_document(documents, **kwargs)
 
     def delete_document(self, document_id: str, **kwargs):
         if self.client is None:
             return
-        self.client.delete(collection_name=self.collection_name, points_selector=[document_id])
+        # Apply the SAME id mapping as upsert; otherwise a non-UUID document
+        # id never matches the UUID5 point id stored by upsert, and the delete
+        # silently no-ops.
+        point_id = self._to_qdrant_point_id(document_id)
+        self.client.delete(collection_name=self.collection_name, points_selector=[point_id])
 
     @staticmethod
     def to_documents(results) -> List[Document]:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store_bugs.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store_bugs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for two QdrantStore bugs.
+
+1. Dimension mismatch was not validated: the first document's embedding fixed
+   the collection dimension, and every later document with a different
+   dimension was rejected by the Qdrant server with an opaque error (or
+   worse, partially written in a batch upsert).
+
+2. delete_document passed the raw document id to Qdrant, but upsert had
+   stored it under a UUID5 derived from that id. For every non-UUID document
+   id the delete silently no-op'd because the ids never matched.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestQdrantDimensionMismatch(unittest.TestCase):
+    """Upsert must reject mixed-dimension batches explicitly."""
+
+    def _store(self):
+        from agentuniverse.agent.action.knowledge.store.qdrant_store import \
+            QdrantStore
+        store = QdrantStore()
+        store.client = MagicMock()
+        # Collection does not exist yet — dimension is inferred from the batch.
+        store.client.collection_exists.return_value = False
+        return store
+
+    def test_mixed_dimensions_in_one_batch_raises_value_error(self):
+        store = self._store()
+        docs = [
+            Document(id="d1", text="a", embedding=[0.1, 0.2, 0.3]),
+            Document(id="d2", text="b", embedding=[0.1, 0.2]),  # dim 2 vs 3
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            store.upsert_document(docs)
+        self.assertIn("dimension", str(ctx.exception).lower())
+        self.assertIn("d2", str(ctx.exception))
+
+    def test_consistent_dimensions_are_accepted(self):
+        store = self._store()
+        docs = [
+            Document(id="d1", text="a", embedding=[0.1, 0.2]),
+            Document(id="d2", text="b", embedding=[0.3, 0.4]),
+        ]
+        store.upsert_document(docs)
+        store.client.upsert.assert_called_once()
+        points = store.client.upsert.call_args.kwargs["points"]
+        self.assertEqual(len(points), 2)
+
+    def test_existing_collection_dimension_enforced_on_new_doc(self):
+        from agentuniverse.agent.action.knowledge.store.qdrant_store import \
+            QdrantStore
+        store = QdrantStore()
+        store.client = MagicMock()
+        store.client.collection_exists.return_value = True
+        # Existing collection is 3-dimensional.
+        vector_cfg = MagicMock(size=3)
+        info = MagicMock()
+        info.config.params.vectors = {store.VECTOR_NAME: vector_cfg}
+        store.client.get_collection.return_value = info
+
+        # A 2-dim doc must be rejected against the 3-dim collection.
+        with self.assertRaises(ValueError):
+            store.upsert_document(
+                [Document(id="d1", text="a", embedding=[0.1, 0.2])])
+
+
+class TestQdrantDeleteIdMapping(unittest.TestCase):
+    """delete must apply the same UUID5 mapping as upsert."""
+
+    def test_non_uuid_id_uses_uuid5_on_both_upsert_and_delete(self):
+        from agentuniverse.agent.action.knowledge.store.qdrant_store import \
+            QdrantStore
+        store = QdrantStore()
+        store.client = MagicMock()
+        store.client.collection_exists.return_value = False
+
+        doc_id = "my-business-id-123"
+        store.upsert_document(
+            [Document(id=doc_id, text="a", embedding=[0.1, 0.2])])
+        upserted_point_ids = [
+            p.id for p in store.client.upsert.call_args.kwargs["points"]
+        ]
+        self.assertEqual(len(upserted_point_ids), 1)
+        stored_id = upserted_point_ids[0]
+        # The stored id is a UUID5, not the raw business id.
+        self.assertNotEqual(stored_id, doc_id)
+
+        # delete must send the SAME mapped id, not the raw business id.
+        store.delete_document(doc_id)
+        selector = store.client.delete.call_args.kwargs["points_selector"]
+        self.assertEqual(selector, [stored_id],
+                         "delete must map the document id the same way upsert "
+                         "did; otherwise non-UUID ids silently fail to delete.")
+
+    def test_uuid_id_is_preserved_on_both_paths(self):
+        from agentuniverse.agent.action.knowledge.store.qdrant_store import \
+            QdrantStore
+        store = QdrantStore()
+        store.client = MagicMock()
+        store.client.collection_exists.return_value = False
+
+        uuid_id = "12345678-1234-1234-1234-123456789abc"
+        store.upsert_document(
+            [Document(id=uuid_id, text="a", embedding=[0.1, 0.2])])
+        stored_id = store.client.upsert.call_args.kwargs["points"][0].id
+        self.assertEqual(stored_id, uuid_id)
+
+        store.delete_document(uuid_id)
+        selector = store.client.delete.call_args.kwargs["points_selector"]
+        self.assertEqual(selector, [uuid_id])
+
+    def test_point_id_helper_is_deterministic(self):
+        from agentuniverse.agent.action.knowledge.store.qdrant_store import \
+            QdrantStore
+        # Same input always maps to same UUID5 — required so re-inserts
+        # overwrite rather than create duplicates.
+        a = QdrantStore._to_qdrant_point_id("consistent-id")
+        b = QdrantStore._to_qdrant_point_id("consistent-id")
+        self.assertEqual(a, b)
+        # Different inputs map to different ids.
+        c = QdrantStore._to_qdrant_point_id("other-id")
+        self.assertNotEqual(a, c)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Two QdrantStore bugs: missing dimension validation on upsert, and an asymmetric id mapping between upsert and delete that silently broke deletion for every non-UUID document id.

## Why (not a duplicate)

Not covered by any open or merged PR.

## Changes

### 1. Dimension mismatch not validated
\`_ensure_collection(dim=...)\` ran inside the per-document loop with each document's own dimension; the first document fixed the collection size and every later document with a different dimension was rejected by the Qdrant server with an opaque error (or partially written in a batch upsert). \`upsert_document\` now infers the expected dimension once (existing collection size via \`get_collection\`, or the first non-empty embedding in the batch) via \`_infer_expected_dimension\`, and raises a clear \`ValueError\` naming the offending document when any vector disagrees.

### 2. delete_document id mapping asymmetric with upsert
\`delete_document\` passed the raw document id to Qdrant, but \`upsert\` had stored non-UUID ids under \`uuid5(NAMESPACE_URL, id)\`. For every non-UUID document id the delete silently no-op'd because the ids never matched. Extracted the mapping into \`_to_qdrant_point_id\` and applied it symmetrically on both paths.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store_bugs.py\` — 6 regressions:
- mixed-dimension batch raises ValueError naming the offending doc
- consistent dimensions accepted
- existing collection dimension enforced on a new doc
- non-UUID id mapped symmetrically across upsert + delete (delete sends the stored UUID5, not the raw id)
- UUID id preserved on both paths
- helper is deterministic (re-inserts overwrite, not duplicate)

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_qdrant_store_bugs\` — 6 passed (mocks the qdrant client; no server).

## Behaviour change

- Mixed-dimension batches now raise a clear \`ValueError\` instead of failing opaquely at the server.
- \`delete_document\` now actually deletes non-UUID-id documents (previously silently no-op'd).