### PR TITLE
fix(store): prevent Milvus filter injection and prefer native upsert

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/milvus_store.py
+++ b/agentuniverse/agent/action/knowledge/store/milvus_store.py
@@ -223,20 +223,49 @@ class MilvusStore(Store):
                     max_length=max_length,
                     index_params=index_params
                 )
-            expr = f'id == "{document.id}"'
-            existing_docs = self.collection.query(expr)
             entities = [
                 [document.id],
                 [embedding],
                 [document.text],
                 [document.metadata]
             ]
-            if existing_docs:
-                self.collection.delete(expr)
-                self.collection.insert(entities)
+            # Prefer the native upsert when available: it is atomic and
+            # sidesteps the query/delete/insert race in the manual path below.
+            # The previous code built the existence-check expression with an
+            # f-string (f'id == "{document.id}"'), which let a document id
+            # containing a double-quote escape the Milvus expression and inject
+            # arbitrary predicates (or just crash the query).
+            if hasattr(self.collection, "upsert"):
+                self.collection.upsert(entities)
             else:
+                # Fallback for pymilvus versions without Collection.upsert:
+                # validate the id before interpolating it into the filter
+                # expression so it cannot escape the string literal.
+                self._validate_filterable_id(document.id)
+                expr = f'id == "{document.id}"'
+                existing_docs = self.collection.query(expr)
+                if existing_docs:
+                    self.collection.delete(expr)
                 self.collection.insert(entities)
             self.collection.load()
+
+    @staticmethod
+    def _validate_filterable_id(document_id: str) -> None:
+        """Reject ids that can escape a Milvus filter string literal.
+
+        Milvus filter expressions embed string values inside double quotes.
+        An id containing a double-quote or backslash can break out of the
+        literal and inject arbitrary predicates. The native upsert path
+        does not build such an expression, so this only guards the legacy
+        query/delete/insert fallback.
+        """
+        if not isinstance(document_id, str) or not document_id:
+            raise ValueError("document id must be a non-empty string")
+        if '"' in document_id or "\\" in document_id:
+            raise ValueError(
+                f"document id {document_id!r} contains a character that can "
+                "escape the Milvus filter expression; use a safe id or "
+                "upgrade pymilvus to a version with Collection.upsert.")
 
     def insert_document(self,
                          documents: List[Document],

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_milvus_store_upsert.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_milvus_store_upsert.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for MilvusStore upsert injection and native-upsert preference.
+
+The previous upsert_document built the existence-check expression with an
+f-string: ``f'id == "{document.id}"'``. A document id containing a double
+quote could escape the Milvus filter literal and inject arbitrary predicates
+(or crash the query). Also, the manual query/delete/insert sequence is
+non-atomic; modern pymilvus exposes a native ``Collection.upsert`` that
+sidesteps both problems.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestMilvusValidateFilterableId(unittest.TestCase):
+    """The legacy fallback path must reject ids that escape the filter literal."""
+
+    def test_safe_id_is_accepted(self):
+        from agentuniverse.agent.action.knowledge.store.milvus_store import \
+            MilvusStore
+        # Should not raise.
+        MilvusStore._validate_filterable_id("doc-123")
+        MilvusStore._validate_filterable_id("a" * 64)
+
+    def test_id_with_double_quote_is_rejected(self):
+        from agentuniverse.agent.action.knowledge.store.milvus_store import \
+            MilvusStore
+        with self.assertRaises(ValueError):
+            MilvusStore._validate_filterable_id('a" or id != "')
+
+    def test_id_with_backslash_is_rejected(self):
+        from agentuniverse.agent.action.knowledge.store.milvus_store import \
+            MilvusStore
+        with self.assertRaises(ValueError):
+            MilvusStore._validate_filterable_id("a\\b")
+
+    def test_empty_or_non_string_id_is_rejected(self):
+        from agentuniverse.agent.action.knowledge.store.milvus_store import \
+            MilvusStore
+        with self.assertRaises(ValueError):
+            MilvusStore._validate_filterable_id("")
+        with self.assertRaises(ValueError):
+            MilvusStore._validate_filterable_id(None)
+
+
+class TestMilvusUpsertUsesNativeWhenAvailable(unittest.TestCase):
+    """When Collection.upsert exists, use it (atomic + no filter expression)."""
+
+    def _store_with_collection(self, has_upsert: bool):
+        from agentuniverse.agent.action.knowledge.store.milvus_store import \
+            MilvusStore
+        store = MilvusStore()
+        collection = MagicMock()
+        if not has_upsert:
+            del collection.upsert
+        store.collection = collection
+        return store, collection
+
+    def test_native_upsert_called_when_available(self):
+        store, collection = self._store_with_collection(has_upsert=True)
+        store.upsert_document(
+            [Document(id="d1", text="a", embedding=[0.1, 0.2, 0.3])])
+        collection.upsert.assert_called_once()
+        # The query/delete path must NOT run when native upsert is available.
+        collection.query.assert_not_called()
+        collection.delete.assert_not_called()
+
+    def test_fallback_path_validates_id_before_querying(self):
+        store, collection = self._store_with_collection(has_upsert=False)
+        collection.query.return_value = []
+        # A safe id goes through query/insert.
+        store.upsert_document(
+            [Document(id="safe-id", text="a", embedding=[0.1, 0.2, 0.3])])
+        collection.query.assert_called_once_with('id == "safe-id"')
+
+    def test_fallback_path_rejects_injection_id(self):
+        store, collection = self._store_with_collection(has_upsert=False)
+        # An id that would escape the filter literal must be rejected before
+        # it ever reaches query().
+        with self.assertRaises(ValueError):
+            store.upsert_document(
+                [Document(id='x" or "1" == "1', text="a",
+                          embedding=[0.1, 0.2, 0.3])])
+        collection.query.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

\`MilvusStore.upsert_document\` built its existence-check expression with an f-string interpolating the raw document id, allowing filter-literal escape and a non-atomic query/delete/insert sequence.

## Why (not a duplicate)

Not covered by any open or merged PR. #664 fixed the analogous Cypher-injection bug in Neo4j; this is the Milvus equivalent.

## Changes

\`upsert_document\` now:
- prefers the native \`Collection.upsert\` when the installed pymilvus exposes it (atomic, and no filter expression is built at all);
- falls back to the query/delete/insert path only on older pymilvus, after validating the id via \`_validate_filterable_id\` — ids containing a double quote or backslash are rejected with a clear \`ValueError\` before they reach the filter expression.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/store/test_milvus_store_upsert.py\` — 7 regressions:
- safe id accepted
- double-quote / backslash / empty / non-string ids rejected
- native \`upsert\` preferred over the manual query/delete/insert path
- fallback path still works for safe ids (query called with the sanitised expr)
- fallback path rejects injection ids before calling query

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_milvus_store_upsert\` — 7 passed (mocks the collection; no Milvus server).

## Behaviour change

- Modern pymilvus installs use the atomic native \`upsert\` (no behaviour change for callers, but no race window).
- Older pymilvus installs now reject ids containing \`"\` or \`\\\` with a clear error instead of letting them escape the filter literal.