### PR TITLE
fix: silent exceptions (context compression, memory retrieval) + reader size guard

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/txt_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/txt_reader.py
@@ -11,6 +11,9 @@ class LineTxtReader(Reader):
     def _load_data(self, fpath: Path, ext_info: Optional[Dict] = None) -> List[Document]:
         dlist: List[Document] = []
         encoding = detect_file_encoding(fpath)
+        # Bound the input: a crafted large file would otherwise accumulate an
+        # unbounded list of line Documents in memory.
+        self._check_file_size(fpath)
 
         with open(fpath, 'r', encoding=encoding) as file:
             metadata = {"file_name": Path(file.name).name}
@@ -28,6 +31,9 @@ class TxtReader(Reader):
 
     def _load_data(self, fpath: Path, ext_info: Optional[Dict] = None) -> List[Document]:
         encoding = detect_file_encoding(fpath)
+        # Bound the input: file.read() materialises the whole file at once,
+        # so a 10 GB file would OOM the process before any Document is built.
+        self._check_file_size(fpath)
 
         with open(fpath, 'r', encoding=encoding) as file:
             metadata = {"file_name": Path(file.name).name}

--- a/agentuniverse/agent/action/knowledge/reader/reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/reader.py
@@ -19,6 +19,12 @@ class Reader(ComponentBase):
     component_type: ComponentEnum = ComponentEnum.READER
     name: Optional[str] = None
     description: Optional[str] = None
+    # Soft upper bound (bytes) on a single file a reader will fully ingest.
+    # Readers that stream can ignore it; readers that materialise the whole
+    # file into memory (TxtReader, JsonReader, ...) check the on-disk size
+    # before reading so a maliciously large input cannot OOM the process.
+    # Defaults to 256 MB; override per-reader via the component configer.
+    max_read_bytes: int = 256 * 1024 * 1024
 
     def load_data(self, *args: Any, **kwargs: Any) -> List[Document]:
         """Load data from the input params."""
@@ -27,6 +33,26 @@ class Reader(ComponentBase):
     @abstractmethod
     def _load_data(self, *args: Any, **kwargs: Any) -> List[Document]:
         """Load data from the input params."""
+
+    def _check_file_size(self, fpath: Any) -> None:
+        """Raise ValueError if ``fpath`` exceeds ``max_read_bytes``.
+
+        Called by readers that materialise the whole file. A no-op when the
+        path does not expose a size (e.g. a stream), so callers that already
+        stream do not need to change anything.
+        """
+        try:
+            size = fpath.stat().st_size if hasattr(fpath, "stat") else None
+            if size is None and isinstance(fpath, str):
+                import os
+                size = os.path.getsize(fpath)
+        except OSError:
+            return
+        if size is not None and size > self.max_read_bytes:
+            raise ValueError(
+                f"File {fpath!r} is {size} bytes which exceeds the reader's "
+                f"max_read_bytes ({self.max_read_bytes}); raise the limit on "
+                f"the reader component or split the input.")
 
     def _initialize_by_component_configer(self,
                                          reader_configer: ComponentConfiger) \
@@ -37,8 +63,10 @@ class Reader(ComponentBase):
             reader_configer(ComponentConfiger): A configer contains reader
             basic info.
         Returns:
-            Reader: A reader instance.
+            Reader instance.
         """
         self.name = reader_configer.name
         self.description = reader_configer.description
+        if hasattr(reader_configer, "max_read_bytes"):
+            self.max_read_bytes = reader_configer.max_read_bytes
         return self

--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -16,6 +16,7 @@ The ContextManager is responsible for:
 
 from typing import Dict, List, Optional, Any
 from datetime import datetime, timedelta
+import logging
 
 from agentuniverse.base.component.component_base import ComponentBase
 from agentuniverse.base.component.component_enum import ComponentEnum
@@ -26,6 +27,8 @@ from agentuniverse.agent.context.context_model import (
     ContextPriority,
 )
 from agentuniverse.agent.context.context_store import ContextStore
+
+logger = logging.getLogger(__name__)
 
 
 class ContextManager(ComponentBase):
@@ -438,9 +441,27 @@ class ContextManager(ComponentBase):
                     preserve_types=[ContextType.SYSTEM, ContextType.TASK]  # Never compress these
                 )
 
-                # Replace segments in storage
+                # Replace segments in storage. If the add fails after the
+                # delete, restore the original segments so the hot store is
+                # not left empty — the previous code's bare ``except: pass``
+                # silently dropped the entire session history when compression
+                # produced output that the store rejected.
                 self._hot_store.delete(window.session_id)  # Clear old segments
-                self._hot_store.add(compressed, session_id=window.session_id)  # Add compressed
+                try:
+                    self._hot_store.add(compressed, session_id=window.session_id)  # Add compressed
+                except Exception:
+                    # Restore the originals we just deleted so the window is
+                    # not silently emptied; the eviction fallback below still
+                    # runs to actually free the requested tokens.
+                    try:
+                        self._hot_store.add(segments, session_id=window.session_id)
+                    except Exception:
+                        logger.exception(
+                            "ContextManager: compression add failed AND the "
+                            "rollback add of the original segments failed; "
+                            "session %s hot store may be empty.",
+                            window.session_id)
+                    raise
 
                 # Update window tracking
                 window.total_tokens = sum(seg.tokens for seg in compressed)
@@ -452,8 +473,13 @@ class ContextManager(ComponentBase):
                 return  # Compression successful
 
             except Exception as e:
-                # Compression failed, fall back to simple eviction
-                pass
+                # Compression failed; log it so operators can see why the
+                # context switched to eviction (LLM timeout, rate limit, store
+                # rejection, ...), then fall back to simple eviction below.
+                logger.warning(
+                    "ContextManager: compression failed for session %s, "
+                    "falling back to eviction: %s", window.session_id, e,
+                    exc_info=True)
 
         # Strategy 3: Fallback - Simple eviction by priority and decay
         segments = self._hot_store.get(window.session_id)

--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -21,6 +21,7 @@ from agentuniverse.base.component.component_base import ComponentBase
 from agentuniverse.base.component.component_enum import ComponentEnum
 from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
 from agentuniverse.base.config.component_configer.configers.memory_configer import MemoryConfiger
+from agentuniverse.base.util.logging.logging_util import LOGGER
 from agentuniverse.base.util.memory_util import get_memory_tokens, get_memory_string
 
 
@@ -189,7 +190,15 @@ class Memory(ComponentBase):
 
                     return selected_messages
 
-            except Exception:
+            except Exception as e:
+                # Log the failure so operators can tell why the context-aware
+                # retrieval fell back to traditional pruning (segment-to-message
+                # conversion failure, missing metadata, ...). Previously this
+                # was a bare ``except: pass`` that silently hid the error and
+                # made the memory look empty.
+                LOGGER.warning(
+                    f"Context-budget retrieval failed, falling back to "
+                    f"traditional retrieval: {e}")
                 pass  # Fall back to traditional retrieval
 
         # Fallback: Original pruning logic (backward compatible)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_reader_size_and_silent_exceptions.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_reader_size_and_silent_exceptions.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for silent-exception and reader-size-guard fixes.
+
+1. ContextManager._make_room: a compression add-failure after delete used to
+   silently drop the session history; now it restores the original segments
+   and logs.
+2. Memory.get_with_context_budget: a bare ``except: pass`` hid context
+   retrieval failures; now logs a warning before falling back.
+3. Reader base + TxtReader/LineTxtReader: file.read() on an unbounded input
+   could OOM; now bounded by ``max_read_bytes``.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestReaderSizeGuard(unittest.TestCase):
+    """Readers must refuse inputs larger than max_read_bytes."""
+
+    def _large_file(self, size_bytes: int) -> str:
+        fd, path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "wb") as f:
+            # Write a sparse-ish file: actual bytes so stat() reports size.
+            f.write(b"x" * size_bytes)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_txt_reader_rejects_file_over_limit(self):
+        from agentuniverse.agent.action.knowledge.reader.file.txt_reader \
+            import TxtReader
+        reader = TxtReader()
+        reader.max_read_bytes = 128
+        big = self._large_file(1024)  # 1 KB > 128 byte limit
+        with self.assertRaises(ValueError) as ctx:
+            reader.load_data(Path(big))
+        self.assertIn("max_read_bytes", str(ctx.exception))
+
+    def test_txt_reader_accepts_file_under_limit(self):
+        from agentuniverse.agent.action.knowledge.reader.file.txt_reader \
+            import TxtReader
+        reader = TxtReader()
+        reader.max_read_bytes = 1024
+        small = self._large_file(64)
+        docs = reader.load_data(Path(small))
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].text, "x" * 64)
+
+    def test_line_txt_reader_rejects_file_over_limit(self):
+        from agentuniverse.agent.action.knowledge.reader.file.txt_reader \
+            import LineTxtReader
+        reader = LineTxtReader()
+        reader.max_read_bytes = 64
+        big = self._large_file(256)
+        with self.assertRaises(ValueError):
+            reader.load_data(Path(big))
+
+    def test_max_read_bytes_default_is_set(self):
+        from agentuniverse.agent.action.knowledge.reader.file.txt_reader \
+            import TxtReader
+        # The default must be a sane positive value (not None / 0). Access
+        # via a concrete subclass instance because the Reader base is a
+        # pydantic V1 model whose class-level field is not directly readable.
+        reader = TxtReader()
+        self.assertGreater(reader.max_read_bytes, 0)
+
+
+class TestContextManagerCompressionRollback(unittest.TestCase):
+    """A compression add-failure must restore the original segments, not drop them silently."""
+
+    def test_source_restores_originals_and_logs_on_add_failure(self):
+        # Source-level contract: the compression branch must (a) wrap the
+        # post-delete add in its own try/except that re-adds the original
+        # segments, and (b) log the failure via logger.warning instead of a
+        # bare ``except: pass``. Driving the full _make_room path requires
+        # building a complete ContextWindow + hot_store + compressor graph,
+        # which is unrelated to this regression.
+        import inspect
+        from agentuniverse.agent.context import context_manager as cm_module
+
+        src = inspect.getsource(cm_module.ContextManager._make_room)
+
+        # Rollback: the originals must be re-added on add failure.
+        self.assertIn("self._hot_store.add(segments", src,
+                      "compression rollback must restore the original segments "
+                      "when the compressed add fails")
+        # Logging: the failure must be visible, not a bare ``except: pass``.
+        self.assertIn("logger.warning", src,
+                      "compression failure must be logged so operators can "
+                      "tell why context fell back to eviction")
+        # The bare-pass bug must be gone.
+        self.assertNotIn("except Exception as e:\n                pass", src,
+                         "the bare except-pass that silently dropped session "
+                         "history must be removed")
+
+
+class TestMemoryContextBudgetLogsFallback(unittest.TestCase):
+    """A context-budget retrieval failure must be logged, not silent."""
+
+    def test_source_logs_warning_instead_of_bare_pass(self):
+        # Source-level contract: the except clause must reference LOGGER and
+        # must NOT be a bare ``except: pass``. The previous bug silently hid
+        # every context-retrieval failure.
+        import inspect
+        from agentuniverse.agent.memory import memory as memory_module
+
+        src = inspect.getsource(memory_module.Memory.get_with_context_budget)
+        # The fix surfaces the exception via LOGGER.warning. The bug was a
+        # bare ``except Exception: pass`` with no logging.
+        self.assertIn("LOGGER.warning", src,
+                      "context-budget fallback must log the failure so "
+                      "operators can diagnose why recall fell back")
+        # And it must still fall back (the original pruning path runs after).
+        self.assertIn("Fall back to traditional retrieval", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Three silent-failure / unbounded-input bugs across context, memory, and reader layers.

## Why (not a duplicate)

None covered by an open or merged PR. All three hide real failures from operators or expose the process to OOM.

## Changes

### 1. ContextManager._make_room — compression failure silently dropped session history
\`agentuniverse/agent/context/context_manager.py\`

The compression branch deleted the original segments then added the compressed ones. If the add raised, a bare \`except Exception: pass\` swallowed the error and left the hot store empty for that session — the entire history was silently dropped. The add is now wrapped in its own try/except that re-adds the original segments on failure (so the window is never silently emptied), and the outer except logs the failure via \`logger.warning\` with \`exc_info\` before falling back to eviction.

### 2. Memory.get_with_context_budget — bare \`except: pass\`
\`agentuniverse/agent/memory/memory.py\`

A bare \`except: pass\` hid every context-aware retrieval failure (segment-to-message conversion error, missing metadata, ...) and silently made the memory look empty. Now logs a \`LOGGER.warning\` naming the failure before falling back to the traditional pruning path.

### 3. Reader base + TxtReader/LineTxtReader — unbounded file read
\`agentuniverse/agent/action/knowledge/reader/reader.py\` + \`file/txt_reader.py\`

\`file.read()\` and the line-by-line accumulate materialised an unbounded input into memory; a crafted large file could OOM the process. Added a \`max_read_bytes\` field (default 256 MB, configurable via the component configer) and a \`_check_file_size\` helper; \`TxtReader\` and \`LineTxtReader\` call it before reading. Streaming readers are unaffected.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_reader_size_and_silent_exceptions.py\` — 6 regressions:
- TxtReader rejects a file over the limit
- TxtReader accepts a file under the limit
- LineTxtReader rejects over-limit
- default \`max_read_bytes\` is a positive value
- ContextManager source contract: restores originals + logs (no bare except-pass)
- Memory source contract: logs the fallback before traditional retrieval

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.test_reader_size_and_silent_exceptions\` — 6 passed.

## Behaviour change

- Context compression no longer silently empties a session's hot store on add failure.
- Context-budget retrieval failures are now visible in logs.
- Readers refuse inputs larger than \`max_read_bytes\` (default 256 MB) instead of OOM-ing.