### PR TITLE
fix(planner,llm): operator-priority background drop, None.get guards, WenXin TokenModelList typo

### DIFF
--- a/agentuniverse/agent/plan/planner/planner.py
+++ b/agentuniverse/agent/plan/planner/planner.py
@@ -135,7 +135,15 @@ class Planner(ComponentBase):
                                             for key in agent.output_keys()
                                             if output_object.get_data(key) is not None]))
 
-        planner_input['background'] = planner_input['background'] or '' + "\n".join(action_result)
+        # NOTE: ``+`` binds tighter than ``or`` in Python, so the previous
+        # form ``planner_input['background'] or '' + "\n".join(...)`` parsed
+        # as ``background or ('' + join)`` — when background was already
+        # non-empty the entire action_result was silently dropped. The
+        # intended behaviour is to *append* the new action results to any
+        # existing background; parenthesise to make that explicit and use
+        # ``.get`` so a missing key does not KeyError.
+        existing_background = planner_input.get('background') or ''
+        planner_input['background'] = existing_background + "\n".join(action_result)
 
     def handle_prompt(self, agent_model: AgentModel, planner_input: dict):
         """Prompt module processing.
@@ -156,7 +164,7 @@ class Planner(ComponentBase):
         Returns:
             LLM: The language model.
         """
-        llm_name = agent_model.profile.get('llm_model').get('name')
+        llm_name = agent_model.profile.get('llm_model', {}).get('name')
         llm: LLM = LLMManager().get_instance_obj(component_instance_name=llm_name)
         return llm
 

--- a/agentuniverse/agent/plan/planner/react_planner/react_planner.py
+++ b/agentuniverse/agent/plan/planner/react_planner/react_planner.py
@@ -70,7 +70,7 @@ class ReActPlanner(Planner):
         agent_executor = AgentExecutor(agent=agent, tools=tools,
                                        verbose=True,
                                        handle_parsing_errors=True,
-                                       max_iterations=agent_model.plan.get('planner').get("max_iterations", 15))
+                                       max_iterations=(agent_model.plan.get('planner') or {}).get("max_iterations", 15))
 
         return agent_executor.invoke(input=planner_input, memory=memory.as_langchain() if memory else None,
                                      chat_history=planner_input.get(memory.memory_key) if memory else '',
@@ -83,7 +83,7 @@ class ReActPlanner(Planner):
         output_stream = input_object.get_data('output_stream')
         callbacks.append(StreamOutPutCallbackHandler(output_stream, agent_info=agent_model.info))
         callbacks.append(InvokeCallbackHandler(source=agent_model.info.get('name'),
-                                               llm_name=agent_model.profile.get('llm_model').get('name')))
+                                               llm_name=agent_model.profile.get('llm_model', {}).get('name')))
         config.setdefault("callbacks", callbacks)
         return config
 

--- a/agentuniverse/llm/default/wenxin_llm.py
+++ b/agentuniverse/llm/default/wenxin_llm.py
@@ -21,8 +21,8 @@ from agentuniverse.llm.llm_output import LLMOutput
 from agentuniverse.llm.wenxin_langchain_instance import WenXinLangChainInstance
 
 TokenModelList = [
-    'ernie-4.5-turbo-32k'
-    'ernie-4.5-8k-preview'
+    'ernie-4.5-turbo-32k',
+    'ernie-4.5-8k-preview',
     'ernie-4.0-8k',
     'ernie-3.5-8k',
     'ernie-speed-8k',

--- a/tests/test_agentuniverse/unit/agent/plan/planner/test_planner_priority_and_none_guard.py
+++ b/tests/test_agentuniverse/unit/agent/plan/planner/test_planner_priority_and_none_guard.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for planner operator-priority bug, None.get guards, and WenXin typo.
+
+1. planner.run_all_actions built ``background or '' + "\n".join(results)``.
+   Python's ``+`` binds tighter than ``or``, so this parsed as
+   ``background or ('' + join)`` — when background was already non-empty,
+   the entire action_result was silently dropped. Verified at the source
+   level (the fix parenthesises / appends explicitly).
+
+2. planner.handle_llm and react_planner.get_run_config did
+   ``profile.get('llm_model').get('name')`` and
+   ``plan.get('planner').get('max_iterations', 15)``. When the config omits
+   the ``llm_model`` / ``planner`` sub-key (a common minimal-config case),
+   these crashed with AttributeError: 'NoneType' object has no attribute
+   'get'. Verified at the source level (the fix uses ``{}, {})`` defaults).
+
+3. WenXinLLM TokenModelList was missing commas between the first three
+   model strings, so Python's implicit string concatenation produced a
+   single garbage entry; get_num_tokens never matched ernie-4.5/4.0
+   models. Verified behaviourally.
+"""
+
+import unittest
+
+
+class TestPlannerBackgroundPriorityFix(unittest.TestCase):
+    """The action_result must be appended to background, not dropped."""
+
+    def test_background_construction_appends_not_drops(self):
+        # Behavioural check of the exact expression the fix uses, so the
+        # priority bug cannot regress. ``background or '' + join`` would
+        # keep the old background and discard join; the fix is
+        # ``(background or '') + join``.
+        def build_background(existing, action_results):
+            # Mirror the fixed line in planner.run_all_actions.
+            existing_background = existing or ''
+            return existing_background + "\n".join(action_results)
+
+        # When background already has content, action results are APPENDED.
+        result = build_background("prior context", ["r1", "r2"])
+        self.assertEqual(result, "prior contextr1\nr2")
+        # The old (buggy) form would have returned just "prior context".
+        self.assertIn("r1", result)
+        self.assertIn("r2", result)
+
+        # When background is empty, action results are the whole content.
+        result = build_background("", ["r1", "r2"])
+        self.assertEqual(result, "r1\nr2")
+
+        # When background key is missing entirely (None), still works.
+        result = build_background(None, ["r1"])
+        self.assertEqual(result, "r1")
+
+    def test_source_uses_safe_background_construction(self):
+        import inspect
+        from agentuniverse.agent.plan.planner.planner import Planner
+
+        src = inspect.getsource(Planner.run_all_actions)
+        # The fixed form assigns an explicit append; the buggy form was a
+        # bare assignment ``planner_input['background'] = planner_input['background'] or '' + ...``.
+        # Look for the fixed assignment line.
+        self.assertIn(
+            "planner_input['background'] = existing_background +",
+            src,
+            "run_all_actions must append action results to the existing "
+            "background via an explicit `existing_background + join`, not "
+            "the operator-priority-buggy `background or '' + join`")
+
+
+class TestPlannerNoneGetGuards(unittest.TestCase):
+    """handle_llm / get_run_config must not crash on missing config sub-keys."""
+
+    def test_handle_llm_source_uses_safe_get(self):
+        import inspect
+        from agentuniverse.agent.plan.planner.planner import Planner
+
+        src = inspect.getsource(Planner.handle_llm)
+        # Must use the safe ``.get('llm_model', {})`` form, not the bare
+        # ``.get('llm_model').get('name')`` chain.
+        self.assertIn("profile.get('llm_model', {})", src)
+        self.assertNotIn("profile.get('llm_model').get('name')", src)
+
+    def test_react_planner_max_iterations_source_uses_safe_get(self):
+        import inspect
+        from agentuniverse.agent.plan.planner.react_planner.react_planner \
+            import ReActPlanner
+
+        src = inspect.getsource(ReActPlanner.invoke)
+        # Must guard ``plan.get('planner')`` against None before .get().
+        self.assertIn("(agent_model.plan.get('planner') or {})", src)
+
+    def test_react_planner_get_run_config_source_uses_safe_get(self):
+        import inspect
+        from agentuniverse.agent.plan.planner.react_planner.react_planner \
+            import ReActPlanner
+
+        src = inspect.getsource(ReActPlanner.get_run_config)
+        self.assertIn("profile.get('llm_model', {})", src)
+        self.assertNotIn("profile.get('llm_model').get('name')", src)
+
+
+class TestWenXinTokenModelList(unittest.TestCase):
+    """TokenModelList must list each model as a separate entry."""
+
+    def test_each_model_is_a_separate_list_entry(self):
+        from agentuniverse.llm.default.wenxin_llm import TokenModelList
+
+        # The bug: implicit string concatenation merged the first three
+        # entries into one garbage string. Assert each known model is its
+        # own entry.
+        expected_models = [
+            'ernie-4.5-turbo-32k',
+            'ernie-4.5-8k-preview',
+            'ernie-4.0-8k',
+            'ernie-3.5-8k',
+        ]
+        for model in expected_models:
+            self.assertIn(model, TokenModelList,
+                          f"{model!r} must appear as its own entry in "
+                          "TokenModelList; the previous missing-comma bug "
+                          "merged it into a garbage string")
+
+    def test_no_concatenated_garbage_entries(self):
+        from agentuniverse.llm.default.wenxin_llm import TokenModelList
+
+        for entry in TokenModelList:
+            # Each entry should be a single model name, not a concatenation
+            # of multiple model names.
+            self.assertFalse(
+                entry.count('ernie-') > 1,
+                f"entry {entry!r} looks like a missing-comma concatenation "
+                "of multiple model names")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Four independent bugs, each silently breaking a real path. Three in the planner layer, one in WenXinLLM.

## Why (not a duplicate)

None covered by an open or merged PR. #702 fixed planner `raise Exception → ValueError`; #706 fixed react_planner `stop_sequence` namespace. These are distinct bugs in nearby code.

## Changes

### 1. planner.run_all_actions — operator-priority bug silently dropped action results

`agentuniverse/agent/plan/planner/planner.py:138`

`planner_input['background'] = planner_input['background'] or '' + "\n".join(action_result)`. Python's `+` binds tighter than `or`, so this parsed as `background or ('' + join)` — when background was already non-empty (the common case after the first action), the ENTIRE action_result was silently dropped and the prompt never saw the latest tool/knowledge/agent output. Now appends explicitly: `existing_background + join`.

### 2. planner.handle_llm — None.get crash on missing llm_model

`profile.get('llm_model').get('name')` crashed with `AttributeError: 'NoneType' object has no attribute 'get'` when the agent config omitted the `llm_model` sub-key. Affects every planner. Now uses `.get('llm_model', {})`, matching the existing `handle_memory` safe form.

### 3. react_planner — two None.get crashes

- `max_iterations`: `plan.get('planner').get('max_iterations', 15)` crashed when the `planner` sub-key was absent.
- `InvokeCallbackHandler llm_name`: `profile.get('llm_model').get('name')`.
Both now guard against None.

### 4. WenXinLLM TokenModelList — missing commas

`TokenModelList` was missing commas between the first three model strings, so Python's implicit string concatenation merged them into one garbage entry (`'ernie-4.5-turbo-32kernie-4.5-8k-previewernie-4.0-8k'`). `get_num_tokens` never matched ernie-4.5/4.0 models. Added the missing commas.

## Tests

`tests/test_agentuniverse/unit/agent/plan/planner/test_planner_priority_and_none_guard.py` — 7 regressions: behavioural background-append check, source contracts for the three None.get fixes, and WenXin list integrity (each model is its own entry, no concatenated garbage).

`python -m unittest tests.test_agentuniverse.unit.agent.plan.planner.test_planner_priority_and_none_guard` — 7 passed.

## Behaviour change

- `run_all_actions` now actually includes action results in the prompt background (previously dropped when background was non-empty).
- Minimal agent configs without `llm_model` / `planner` sub-keys no longer crash.
- WenXin token counting now matches ernie-4.5/4.0 models correctly.
