### PR TITLE
fix(doc_processor): SemanticDeduplicator None text + dimension mismatch; JiebaKeywordExtractor None text

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/jieba_keyword_extractor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/jieba_keyword_extractor.py
@@ -66,8 +66,12 @@ class JiebaKeywordExtractor(DocProcessor):
         Returns:
             The original documents with keywords added to their metadata.
         """
+        if not origin_docs:
+            return []
         for _doc in origin_docs:
-            words = jieba.lcut(_doc.text)
+            # Document.text is Optional[str]; jieba.lcut(None) raises TypeError.
+            text = _doc.text or ''
+            words = jieba.lcut(text)
             filtered_words = [word for word in words if word not in
                               chinese_stopwords and word.lower() not in stop_words]
             keywords = jieba.analyse.extract_tags(" ".join(filtered_words),

--- a/agentuniverse/agent/action/knowledge/doc_processor/semantic_deduplicator.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/semantic_deduplicator.py
@@ -199,7 +199,10 @@ class SemanticDeduplicator(DocProcessor):
         Returns:
             Hex string of hash.
         """
-        return hashlib.sha256(text.encode('utf-8')).hexdigest()
+        # Document.text is Optional[str]; None would crash .encode(). Treat
+        # None and empty as the same hash so empty docs dedupe together
+        # instead of raising AttributeError mid-pipeline.
+        return hashlib.sha256((text or '').encode('utf-8')).hexdigest()
 
     def _compute_similarity(self, embedding1: List[float], embedding2: List[float]) -> float:
         """Compute cosine similarity between two embeddings.
@@ -211,6 +214,16 @@ class SemanticDeduplicator(DocProcessor):
         Returns:
             Cosine similarity score (0.0-1.0).
         """
+        # Vectors from different embedding models / stores may have different
+        # dimensions. zip() silently truncates to the shorter one and returns
+        # a plausible-looking but meaningless score (the same hole the
+        # MMRProcessor was hardened against). Require equal length; if a
+        # caller hands mismatched vectors, treat them as non-similar rather
+        # than silently ranking on garbage.
+        if not embedding1 or not embedding2:
+            return 0.0
+        if len(embedding1) != len(embedding2):
+            return 0.0
         # Compute dot product
         dot_product = sum(a * b for a, b in zip(embedding1, embedding2))
 

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_doc_processor_none_guard.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_doc_processor_none_guard.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for None.text / dimension-mismatch guards in doc processors.
+
+1. SemanticDeduplicator._compute_hash crashed on None text (Document.text is
+   Optional[str]); now treats None as ''.
+2. SemanticDeduplicator._compute_similarity used zip() across mismatched
+   dimensions, silently truncating and returning a meaningless score (same
+   hole MMRProcessor was hardened against); now returns 0.0 on mismatch.
+3. JiebaKeywordExtractor._process_docs crashed on None text (jieba.lcut(None)
+   TypeError) and had no empty-input short-circuit; both fixed.
+"""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestSemanticDeduplicatorsNoneAndDimensionGuards(unittest.TestCase):
+
+    def _processor(self):
+        from agentuniverse.agent.action.knowledge.doc_processor.\
+            semantic_deduplicator import SemanticDeduplicator
+        return SemanticDeduplicator()
+
+    def test_compute_hash_handles_none_text(self):
+        proc = self._processor()
+        # Previously: None.encode() raised AttributeError.
+        h = proc._compute_hash(None)
+        self.assertEqual(h, proc._compute_hash(''))
+        self.assertEqual(len(h), 64)  # sha256 hex length
+
+    def test_compute_hash_handles_empty_text(self):
+        proc = self._processor()
+        h = proc._compute_hash('')
+        self.assertEqual(len(h), 64)
+
+    def test_compute_similarity_rejects_mismatched_dimensions(self):
+        proc = self._processor()
+        # Previously: zip() silently truncated to length 2 and produced a
+        # plausible-looking but meaningless score.
+        score = proc._compute_similarity([1.0, 0.0], [1.0, 0.0, 0.0])
+        self.assertEqual(score, 0.0,
+                         "mismatched-dimension vectors must not be compared; "
+                         "they come from different embedding spaces")
+
+    def test_compute_similarity_returns_zero_on_empty_vector(self):
+        proc = self._processor()
+        self.assertEqual(proc._compute_similarity([], [1.0, 0.0]), 0.0)
+        self.assertEqual(proc._compute_similarity([1.0, 0.0], []), 0.0)
+
+    def test_compute_similarity_matches_equal_dimensions(self):
+        proc = self._processor()
+        # Same direction → similarity 1.0.
+        score = proc._compute_similarity([1.0, 0.0], [1.0, 0.0])
+        self.assertAlmostEqual(score, 1.0, places=6)
+
+
+class TestJiebaKeywordExtractorNoneGuard(unittest.TestCase):
+
+    def _processor(self):
+        from agentuniverse.agent.action.knowledge.doc_processor.\
+            jieba_keyword_extractor import JiebaKeywordExtractor
+        return JiebaKeywordExtractor()
+
+    def test_process_docs_handles_none_text(self):
+        proc = self._processor()
+        # Previously: jieba.lcut(None) raised TypeError.
+        docs = [Document(id="d1", text=None),
+                Document(id="d2", text="正常中文文本")]
+        result = proc._process_docs(docs)
+        self.assertEqual(len(result), 2)
+
+    def test_process_docs_empty_input_returns_empty(self):
+        proc = self._processor()
+        # Previously: no short-circuit; the loop just didn't run, returning
+        # the empty list. Pin the explicit return.
+        self.assertEqual(proc._process_docs([]), [])
+
+    def test_process_docs_extracts_keywords_from_normal_text(self):
+        proc = self._processor()
+        docs = [Document(id="d1", text="人工智能是未来")]
+        result = proc._process_docs(docs)
+        # Some keywords should be extracted (sanity — we are not asserting
+        # the exact set, which depends on the jieba dictionary).
+        # keywords is a set on Document; just assert it ran without crashing
+        # and returned the doc.
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, "d1")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Three None.text / dimension-mismatch bugs in two doc processors.

## Why (not a duplicate)

Not covered by any open or merged PR. #248 series covers SummarizationProcessor/MMR/RRF/SensitiveDataRedactor/ContextBudgetCompressor; these are distinct processors.

## Changes

### 1. SemanticDeduplicator._compute_hash — None text crash
\`text.encode('utf-8')\` without a None guard; \`Document.text\` is \`Optional[str]\`, so a recalled doc with \`text=None\` crashed mid-deduplication. Now treats None as ''.

### 2. SemanticDeduplicator._compute_similarity — dimension mismatch silent truncation
\`zip(embedding1, embedding2)\` without a length check. Vectors from different embedding models/stores can have different dimensions; \`zip()\` silently truncates to the shorter and produces a plausible but meaningless score (same hole \`MMRProcessor\` was hardened against). Now returns 0.0 on length mismatch or empty vectors.

### 3. JiebaKeywordExtractor._process_docs — None text crash + no empty short-circuit
\`jieba.lcut(_doc.text)\` with no None guard (\`jieba.lcut(None)\` raises TypeError) and no empty-input short-circuit. Both fixed.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_doc_processor_none_guard.py\` — 8 regressions:
- hash on None / empty text
- similarity on mismatched dimensions / empty vectors / matching vectors
- jieba on None text / empty input / normal text

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_doc_processor_none_guard\` — 8 passed.

## Behaviour change

- None/empty text no longer crashes deduplication or keyword extraction.
- Mismatched-dimension embeddings are treated as non-similar (score 0.0) instead of silently ranked on truncated garbage.