### PR TITLE
fix(store): default LangChain metadata

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/document.py
+++ b/agentuniverse/agent/action/knowledge/store/document.py
@@ -48,7 +48,12 @@ class Document(BaseModel):
         if document_list is None:
             return langchain_document_list
         for document in document_list:
-            langchain_document_list.append(LCDocument(page_content=document.text, metadata=document.metadata))
+            langchain_document_list.append(
+                LCDocument(
+                    page_content=document.text,
+                    metadata=document.metadata or {}
+                )
+            )
         return langchain_document_list
 
     @staticmethod

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_document.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_document.py
@@ -1,0 +1,19 @@
+import unittest
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestDocument(unittest.TestCase):
+
+    def test_as_langchain_list_handles_empty_metadata(self):
+        langchain_docs = Document.as_langchain_list([
+            Document(text="plain text", metadata=None)
+        ])
+
+        self.assertEqual(len(langchain_docs), 1)
+        self.assertEqual(langchain_docs[0].metadata, {})
+        self.assertEqual(langchain_docs[0].page_content, "plain text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Make `Document.as_langchain_list()` pass an empty metadata dict when an agentUniverse `Document` has `metadata=None`.
- This matches the behavior of `Document.as_langchain()` and avoids passing `None` into LangChain document metadata.
- Add regression coverage for list conversion with empty metadata.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_document.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/store/document.py tests/test_agentuniverse/unit/agent/action/knowledge/store/test_document.py`: passed.
- `python -m unittest tests/test_agentuniverse/unit/agent/action/knowledge/store/test_document.py`: not run to completion locally because this environment is missing project dependency `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.