### PR TITLE
feat(config): add versioned SQL component configuration repository

### DIFF
--- a/agentuniverse/base/agentuniverse.py
+++ b/agentuniverse/base/agentuniverse.py
@@ -21,6 +21,8 @@ from agentuniverse.base.config.component_configer.component_configer import Comp
 from agentuniverse.base.component.component_configer_util import ComponentConfigerUtil
 from agentuniverse.base.config.config_type_enum import ConfigTypeEnum
 from agentuniverse.base.config.configer import Configer
+from agentuniverse.base.config.repository.base import ConfigRepository
+from agentuniverse.base.config.repository.integration import merge_repository_configers
 from agentuniverse.base.config.custom_configer.default_llm_configer import DefaultLLMConfiger
 from agentuniverse.base.config.custom_configer.custom_key_configer import CustomKeyConfiger
 from agentuniverse.base.component.component_enum import ComponentEnum
@@ -60,11 +62,24 @@ class AgentUniverse(object):
         self.__system_default_memory_storage_package = ['agentuniverse.agent.memory.memory_storage']
         self.__system_default_work_pattern_package = ['agentuniverse.agent.work_pattern']
         self.__system_default_log_sink_package = ['agentuniverse.base.util.logging.log_sink.log_sink']
+        self.__component_config_repository = None
+        self.__component_config_environment = 'default'
 
-    def start(self, config_path: str = None, core_mode: bool = False):
+    def start(self, config_path: str = None, core_mode: bool = False,
+              component_config_repository: ConfigRepository = None,
+              config_environment: str = 'default'):
         """Start the agentUniverse framework.
 
+        Args:
+            config_path: Main application TOML path.
+            core_mode: Execute post-fork hooks immediately.
+            component_config_repository: Optional versioned source whose values
+                overlay YAML components and may define database-only components.
+            config_environment: Repository environment to load.
+
         """
+        self.__component_config_repository = component_config_repository
+        self.__component_config_environment = config_environment
         character_util.show_au_start_banner()
         # get default config path
         project_root_path = get_project_root_path()
@@ -216,7 +231,11 @@ class AgentUniverse(object):
         for component_enum, package_list in component_package_map.items():
             if not package_list:
                 continue
-            component_configer_list = self.scan(package_list, ConfigTypeEnum.YAML, component_enum)
+            component_configer_list = self.scan(
+                package_list, ConfigTypeEnum.YAML, component_enum,
+                self.__component_config_repository,
+                self.__component_config_environment,
+            )
             component_configer_list_map[component_enum] = component_configer_list
 
         for component_enum, component_configer_list in component_configer_list_map.items():
@@ -225,7 +244,9 @@ class AgentUniverse(object):
     def scan(self,
              package_list: [str],
              config_type_enum: ConfigTypeEnum,
-             component_enum: ComponentEnum) -> list:
+             component_enum: ComponentEnum,
+             component_config_repository: ConfigRepository = None,
+             config_environment: str = 'default') -> list:
         """Scan the component directory and return certain component configer list.
 
         Args:
@@ -267,6 +288,16 @@ class AgentUniverse(object):
                 component_config_type = component_configer.get_component_config_type()
                 if component_config_type == component_enum.value:
                     component_configer_list.append(component_configer)
+        if component_config_repository is not None:
+            file_configers = [item.configer for item in component_configer_list]
+            merged = merge_repository_configers(
+                file_configers, component_config_repository,
+                component_enum.value, config_environment,
+            )
+            component_configer_list = [
+                ComponentConfiger().load_by_configer(configer)
+                for configer in merged
+            ]
         return component_configer_list
 
     def __register(self, component_enum: ComponentEnum, component_configer_list: list[ComponentConfiger]):

--- a/agentuniverse/base/config/repository/__init__.py
+++ b/agentuniverse/base/config/repository/__init__.py
@@ -1,0 +1,22 @@
+from agentuniverse.base.config.repository.base import ConfigRecord, ConfigRepository
+from agentuniverse.base.config.repository.integration import merge_repository_configers
+from agentuniverse.base.config.repository.layered import LayeredConfigResolver, deep_merge
+from agentuniverse.base.config.repository.migration import (
+    MigrationReport,
+    export_yaml_directory,
+    import_yaml_files,
+)
+from agentuniverse.base.config.repository.sql_repository import (
+    ConfigConflictError,
+    ConfigNotFoundError,
+    SQLConfigRepository,
+    validate_secret_references,
+)
+
+__all__ = [
+    "ConfigConflictError", "ConfigNotFoundError", "ConfigRecord",
+    "ConfigRepository", "LayeredConfigResolver", "MigrationReport",
+    "SQLConfigRepository", "deep_merge", "export_yaml_directory",
+    "import_yaml_files", "merge_repository_configers",
+    "validate_secret_references",
+]

--- a/agentuniverse/base/config/repository/base.py
+++ b/agentuniverse/base/config/repository/base.py
@@ -1,0 +1,48 @@
+"""Contracts shared by component-configuration repositories."""
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from agentuniverse.base.config.configer import Configer
+
+
+@dataclass(frozen=True)
+class ConfigRecord:
+    """A versioned component configuration stored outside the source tree."""
+
+    component_type: str
+    name: str
+    environment: str
+    value: dict
+    revision: int
+    updated_at: datetime
+    updated_by: str
+
+    def as_configer(self) -> Configer:
+        """Return a regular ``Configer`` understood by component configurers."""
+        configer = Configer(
+            path=(f"db://{self.environment}/{self.component_type}/"
+                  f"{self.name}@{self.revision}")
+        )
+        configer.value = copy.deepcopy(self.value)
+        return configer
+
+
+class ConfigRepository(Protocol):
+    """Minimal repository contract required by the agentUniverse loader."""
+
+    def get(self, component_type: str, name: str,
+            environment: str = "default") -> ConfigRecord:
+        ...
+
+    def list(self, component_type: str | None = None,
+             environment: str = "default") -> list[ConfigRecord]:
+        ...
+
+    def put(self, component_type: str, name: str, value: dict, *,
+            environment: str = "default", expected_revision: int | None = None,
+            updated_by: str = "system") -> ConfigRecord:
+        ...

--- a/agentuniverse/base/config/repository/integration.py
+++ b/agentuniverse/base/config/repository/integration.py
@@ -1,0 +1,64 @@
+"""Bridge versioned repository records into the existing YAML loader."""
+# ruff: noqa: TRY003
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+from agentuniverse.base.config.configer import Configer, PlaceholderResolver
+from agentuniverse.base.config.repository.base import ConfigRecord, ConfigRepository
+from agentuniverse.base.config.repository.layered import deep_merge
+
+
+def component_config_name(configer: Configer) -> str:
+    """Return the stable repository key for a file-backed configuration."""
+    name = (configer.value or {}).get("name")
+    if name:
+        return str(name)
+    return Path(configer.path or "unnamed").stem
+
+
+def _record_configer(record: ConfigRecord, base: Configer | None = None) -> Configer:
+    value = deep_merge(base.value, record.value) if base else copy.deepcopy(record.value)
+    value.setdefault("name", record.name)
+    metadata_type = (value.get("metadata") or {}).get("type")
+    if metadata_type and metadata_type != record.component_type:
+        raise ValueError(
+            f"database record {record.component_type}/{record.name} contains "
+            f"metadata.type={metadata_type}"
+        )
+    value = PlaceholderResolver().resolve(value)
+    configer = Configer(path=(
+        f"db://{record.environment}/{record.component_type}/"
+        f"{record.name}@{record.revision}"
+    ))
+    configer.value = value
+    return configer
+
+
+def merge_repository_configers(
+        file_configers: list[Configer], repository: ConfigRepository,
+        component_type: str, environment: str = "default") -> list[Configer]:
+    """Overlay database records onto YAML and append database-only components.
+
+    YAML remains the compatibility baseline. A matching database record wins at
+    every key it defines, while omitted keys continue to come from YAML. A
+    repository error is deliberately propagated so startup cannot silently run
+    with a partially applied configuration set.
+    """
+    records = repository.list(component_type=component_type,
+                              environment=environment)
+    records_by_name = {record.name: record for record in records}
+    result: list[Configer] = []
+    consumed: set[str] = set()
+    for configer in file_configers:
+        name = component_config_name(configer)
+        record = records_by_name.get(name)
+        if record is None:
+            result.append(configer)
+            continue
+        result.append(_record_configer(record, configer))
+        consumed.add(name)
+    for name in sorted(records_by_name.keys() - consumed):
+        result.append(_record_configer(records_by_name[name]))
+    return result

--- a/agentuniverse/base/config/repository/layered.py
+++ b/agentuniverse/base/config/repository/layered.py
@@ -1,0 +1,22 @@
+"""Deterministic defaults -> YAML -> database -> runtime configuration precedence."""
+from __future__ import annotations
+
+import copy
+
+
+def deep_merge(base: dict, overlay: dict) -> dict:
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+class LayeredConfigResolver:
+    def resolve(self, *, defaults=None, yaml=None, database=None, runtime=None) -> dict:
+        result = {}
+        for layer in (defaults or {}, yaml or {}, database or {}, runtime or {}):
+            result = deep_merge(result, layer)
+        return result

--- a/agentuniverse/base/config/repository/migration.py
+++ b/agentuniverse/base/config/repository/migration.py
@@ -1,0 +1,76 @@
+"""Import/export helpers for migrating YAML component configuration."""
+# ruff: noqa: TRY003, TRY301
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from agentuniverse.base.config.repository.base import ConfigRepository
+from agentuniverse.base.config.repository.sql_repository import ConfigNotFoundError
+
+
+@dataclass
+class MigrationReport:
+    imported: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def import_yaml_files(repository: ConfigRepository, paths: Iterable[str | Path], *,
+                      environment: str = "default", updated_by: str = "migration",
+                      overwrite: bool = False, dry_run: bool = False) -> MigrationReport:
+    """Import component YAML without resolving environment placeholders."""
+    report = MigrationReport()
+    for raw_path in paths:
+        path = Path(raw_path)
+        try:
+            value = yaml.safe_load(path.read_text(encoding="utf-8"))
+            if not isinstance(value, dict):
+                raise TypeError("component YAML must contain a mapping")
+            component_type = (value.get("metadata") or {}).get("type")
+            if not component_type:
+                raise ValueError("metadata.type is required")
+            name = str(value.get("name") or path.stem)
+            key = f"{component_type}/{name}"
+            expected_revision = 0
+            try:
+                current = repository.get(component_type, name, environment)
+            except ConfigNotFoundError:
+                current = None
+            if current is not None and not overwrite:
+                report.skipped.append(key)
+                continue
+            if current is not None:
+                expected_revision = current.revision
+            if not dry_run:
+                repository.put(component_type, name, value,
+                               environment=environment,
+                               expected_revision=expected_revision,
+                               updated_by=updated_by)
+            report.imported.append(key)
+        except Exception as exc:  # collect all invalid files for one migration run
+            report.errors.append(f"{path}: {exc}")
+    return report
+
+
+def export_yaml_directory(repository: ConfigRepository, target: str | Path, *,
+                          environment: str = "default",
+                          overwrite: bool = False) -> list[Path]:
+    """Export current records into ``TYPE/name.yaml`` files."""
+    target = Path(target)
+    written: list[Path] = []
+    for record in repository.list(environment=environment):
+        component_dir = target / record.component_type.lower()
+        component_dir.mkdir(parents=True, exist_ok=True)
+        path = component_dir / f"{record.name}.yaml"
+        if path.exists() and not overwrite:
+            raise FileExistsError(path)
+        path.write_text(
+            yaml.safe_dump(record.value, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+        written.append(path)
+    return written

--- a/agentuniverse/base/config/repository/sql_repository.py
+++ b/agentuniverse/base/config/repository/sql_repository.py
@@ -1,0 +1,245 @@
+"""Versioned database-backed component configuration repository."""
+# ruff: noqa: TRY003
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    and_,
+    create_engine,
+    func,
+    select,
+)
+from sqlalchemy.engine import Engine
+
+from agentuniverse.base.config.configer import Configer
+from agentuniverse.base.config.repository.base import ConfigRecord
+
+
+class ConfigConflictError(RuntimeError):
+    pass
+
+
+class ConfigNotFoundError(KeyError):
+    pass
+
+
+_SENSITIVE = ("password", "secret", "token", "api_key", "private_key", "credential")
+_REFERENCE_PREFIXES = ("env://", "secret://", "vault://", "kms://")
+
+
+def _is_secret_reference(value: Any) -> bool:
+    if isinstance(value, dict):
+        reference = value.get("secret_ref")
+        return isinstance(reference, str) and (
+            "://" in reference or reference.startswith("${")
+        )
+    if isinstance(value, str):
+        return ((value.startswith("${") and value.endswith("}"))
+                or value.startswith(_REFERENCE_PREFIXES))
+    return False
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return any(normalized == marker or normalized.endswith(f"_{marker}")
+               for marker in _SENSITIVE)
+
+
+def validate_secret_references(value: Any, path: str = "config") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "secret_ref":
+                if not _is_secret_reference({"secret_ref": child}):
+                    raise ValueError(f"{path}.secret_ref must be a URI-like reference")
+                continue
+            if _is_sensitive_key(key):
+                if not _is_secret_reference(child):
+                    raise ValueError(f"{path}.{key} must contain a secret_ref instead of a raw value")
+                continue
+            validate_secret_references(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            validate_secret_references(child, f"{path}[{index}]")
+
+
+class SQLConfigRepository:
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        self.metadata = MetaData()
+        self.configs = Table(
+            "au_component_config", self.metadata,
+            Column("component_type", String(64), primary_key=True),
+            Column("name", String(255), primary_key=True),
+            Column("environment", String(64), primary_key=True),
+            Column("value", JSON, nullable=False),
+            Column("revision", Integer, nullable=False),
+            Column("updated_at", DateTime(timezone=True), nullable=False),
+            Column("updated_by", String(255), nullable=False),
+        )
+        self.audit = Table(
+            "au_component_config_audit", self.metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("component_type", String(64), nullable=False),
+            Column("name", String(255), nullable=False),
+            Column("environment", String(64), nullable=False),
+            Column("value", JSON, nullable=False),
+            Column("revision", Integer, nullable=False),
+            Column("action", String(32), nullable=False),
+            Column("updated_at", DateTime(timezone=True), nullable=False),
+            Column("updated_by", String(255), nullable=False),
+        )
+        self.metadata.create_all(engine)
+
+    @classmethod
+    def from_uri(cls, uri: str) -> SQLConfigRepository:
+        return cls(create_engine(uri))
+
+    @classmethod
+    def from_sqldb_wrapper(cls, wrapper) -> SQLConfigRepository:
+        return cls(wrapper.sql_database._engine)
+
+    @staticmethod
+    def _record(row) -> ConfigRecord:
+        data = row._mapping
+        updated = data["updated_at"]
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=timezone.utc)
+        return ConfigRecord(data["component_type"], data["name"], data["environment"],
+                            copy.deepcopy(data["value"]), data["revision"], updated, data["updated_by"])
+
+    def get(self, component_type: str, name: str, environment: str = "default") -> ConfigRecord:
+        query = select(self.configs).where(and_(
+            self.configs.c.component_type == component_type,
+            self.configs.c.name == name,
+            self.configs.c.environment == environment,
+        ))
+        with self.engine.begin() as connection:
+            row = connection.execute(query).first()
+        if row is None:
+            raise ConfigNotFoundError((component_type, name, environment))
+        return self._record(row)
+
+    def put(self, component_type: str, name: str, value: dict, *, environment: str = "default",
+            expected_revision: int | None = None, updated_by: str = "system") -> ConfigRecord:
+        if not component_type.strip() or not name.strip() or not environment.strip():
+            raise ValueError("component_type, name and environment are required")
+        if not isinstance(value, dict):
+            raise TypeError("configuration value must be a dictionary")
+        validate_secret_references(value)
+        now = datetime.now(timezone.utc)
+        key = and_(self.configs.c.component_type == component_type,
+                   self.configs.c.name == name, self.configs.c.environment == environment)
+        with self.engine.begin() as connection:
+            current = connection.execute(select(self.configs).where(key)).first()
+            if current is None:
+                if expected_revision not in (None, 0):
+                    raise ConfigConflictError("configuration does not exist at expected revision")
+                last_revision = connection.execute(
+                    select(func.max(self.audit.c.revision)).where(and_(
+                        self.audit.c.component_type == component_type,
+                        self.audit.c.name == name,
+                        self.audit.c.environment == environment,
+                    ))
+                ).scalar_one_or_none() or 0
+                revision = last_revision + 1
+                action = "create" if last_revision == 0 else "recreate"
+                connection.execute(self.configs.insert().values(
+                    component_type=component_type, name=name, environment=environment,
+                    value=copy.deepcopy(value), revision=revision, updated_at=now, updated_by=updated_by,
+                ))
+            else:
+                actual = current._mapping["revision"]
+                if expected_revision is not None and expected_revision != actual:
+                    raise ConfigConflictError(f"expected revision {expected_revision}, found {actual}")
+                revision, action = actual + 1, "update"
+                result = connection.execute(self.configs.update().where(and_(key, self.configs.c.revision == actual)).values(
+                    value=copy.deepcopy(value), revision=revision, updated_at=now, updated_by=updated_by,
+                ))
+                if result.rowcount != 1:
+                    raise ConfigConflictError("configuration changed concurrently")
+            connection.execute(self.audit.insert().values(
+                component_type=component_type, name=name, environment=environment,
+                value=copy.deepcopy(value), revision=revision, action=action,
+                updated_at=now, updated_by=updated_by,
+            ))
+        return self.get(component_type, name, environment)
+
+    def list(self, component_type: str | None = None,
+             environment: str = "default") -> list[ConfigRecord]:
+        """List one environment's current records in deterministic order."""
+        query = select(self.configs).where(self.configs.c.environment == environment)
+        if component_type is not None:
+            query = query.where(self.configs.c.component_type == component_type)
+        query = query.order_by(self.configs.c.component_type, self.configs.c.name)
+        with self.engine.begin() as connection:
+            rows = connection.execute(query).all()
+        return [self._record(row) for row in rows]
+
+    def delete(self, component_type: str, name: str, *, environment: str = "default",
+               expected_revision: int | None = None,
+               updated_by: str = "system") -> None:
+        """Delete a record while retaining its last value in the audit log."""
+        key = and_(self.configs.c.component_type == component_type,
+                   self.configs.c.name == name,
+                   self.configs.c.environment == environment)
+        now = datetime.now(timezone.utc)
+        with self.engine.begin() as connection:
+            current = connection.execute(select(self.configs).where(key)).first()
+            if current is None:
+                raise ConfigNotFoundError((component_type, name, environment))
+            data = current._mapping
+            actual = data["revision"]
+            if expected_revision is not None and expected_revision != actual:
+                raise ConfigConflictError(
+                    f"expected revision {expected_revision}, found {actual}"
+                )
+            connection.execute(self.audit.insert().values(
+                component_type=component_type, name=name, environment=environment,
+                value=copy.deepcopy(data["value"]), revision=actual + 1,
+                action="delete", updated_at=now, updated_by=updated_by,
+            ))
+            result = connection.execute(
+                self.configs.delete().where(and_(key, self.configs.c.revision == actual))
+            )
+            if result.rowcount != 1:
+                raise ConfigConflictError("configuration changed concurrently")
+
+    def history(self, component_type: str, name: str, environment: str = "default") -> list[ConfigRecord]:
+        query = select(self.audit).where(and_(
+            self.audit.c.component_type == component_type, self.audit.c.name == name,
+            self.audit.c.environment == environment,
+        )).order_by(self.audit.c.revision)
+        with self.engine.begin() as connection:
+            rows = connection.execute(query).all()
+        return [self._record(row) for row in rows]
+
+    def rollback(self, component_type: str, name: str, revision: int, *, environment: str = "default",
+                 expected_revision: int | None = None, updated_by: str = "system") -> ConfigRecord:
+        history = self.history(component_type, name, environment)
+        target = next((item for item in history if item.revision == revision), None)
+        if target is None:
+            raise ConfigNotFoundError((component_type, name, environment, revision))
+        return self.put(component_type, name, target.value, environment=environment,
+                        expected_revision=expected_revision, updated_by=updated_by)
+
+    def export(self, environment: str | None = None) -> list[dict]:
+        query = select(self.configs)
+        if environment:
+            query = query.where(self.configs.c.environment == environment)
+        query = query.order_by(self.configs.c.component_type, self.configs.c.name, self.configs.c.environment)
+        with self.engine.begin() as connection:
+            rows = connection.execute(query).all()
+        return [{**self._record(row).__dict__} for row in rows]
+
+    def as_configer(self, component_type: str, name: str, environment: str = "default") -> Configer:
+        return self.get(component_type, name, environment).as_configer()

--- a/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Database_Backend_Configuration.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Database_Backend_Configuration.md
@@ -1,0 +1,63 @@
+# Database-backed configuration repository
+
+`SQLConfigRepository` stores versioned component dictionaries on any SQLAlchemy engine,
+including the existing `SQLDBWrapper` engine. Writes are transactional and use optimistic
+revision checks; every revision has an audit row and rollback creates another visible revision.
+Environments are isolated. Raw secret-like fields are rejected in favor of `secret_ref` values.
+
+`as_configer()` returns the existing `Configer` contract, so component configurers do not need a
+second parsing architecture. `LayeredConfigResolver` applies defaults, YAML, database and runtime
+overrides in that order, preserving YAML compatibility during migration.
+
+## Runtime integration
+
+Pass the repository to the normal bootstrap. Matching records overlay YAML by component `name`;
+records that do not have a YAML counterpart are also loaded. Repository failures abort startup
+rather than silently producing a partially overridden component graph.
+
+```python
+from sqlalchemy import create_engine
+from agentuniverse.base.agentuniverse import AgentUniverse
+from agentuniverse.base.config.repository import SQLConfigRepository
+
+repository = SQLConfigRepository(create_engine("sqlite:///components.db"))
+repository.put(
+    "LLM", "default_openai_llm",
+    {"temperature": 0.2, "api_key": "${OPENAI_API_KEY}"},
+    environment="production", expected_revision=0,
+)
+AgentUniverse().start(
+    component_config_repository=repository,
+    config_environment="production",
+)
+```
+
+Database values may be partial overlays. Database-only values must include enough `metadata`
+(`type`, `module`, and `class`) to initialize the component. Secret-like values accept structured
+`secret_ref` objects, `env://`/`vault://` URIs, or existing `${ENV_VAR}` placeholders; literal
+secrets are rejected.
+
+## Migration and rollback
+
+```python
+from pathlib import Path
+from agentuniverse.base.config.repository import (
+    export_yaml_directory, import_yaml_files,
+)
+
+report = import_yaml_files(
+    repository, Path("intelligence").rglob("*.yaml"),
+    environment="staging", dry_run=True,
+)
+assert not report.errors
+
+# Run again without dry_run, then keep the generated audit revision.
+import_yaml_files(repository, Path("intelligence").rglob("*.yaml"),
+                  environment="staging")
+repository.rollback("TOOL", "search", revision=1,
+                    environment="staging", expected_revision=2)
+export_yaml_directory(repository, "config-export", environment="staging")
+```
+
+Use `expected_revision` on updates and deletes to prevent lost updates. Imports preserve
+`${ENV_VAR}` placeholders instead of resolving them on the migration host.

--- a/docs/guidebook/zh/In-Depth_Guides/技术组件/数据库配置仓库.md
+++ b/docs/guidebook/zh/In-Depth_Guides/技术组件/数据库配置仓库.md
@@ -1,0 +1,49 @@
+# 数据库配置仓库
+
+`SQLConfigRepository` 复用 SQLAlchemy/SQLDBWrapper，支持事务、乐观锁、版本历史、回滚、
+环境隔离和导出。疑似密钥字段必须使用 `secret_ref`。`as_configer()` 返回现有 Configer，
+分层解析按默认值、YAML、数据库、运行时覆盖顺序执行，因此迁移期间保留 YAML 兼容性。
+
+## 接入启动流程
+
+```python
+from sqlalchemy import create_engine
+from agentuniverse.base.agentuniverse import AgentUniverse
+from agentuniverse.base.config.repository import SQLConfigRepository
+
+repository = SQLConfigRepository(create_engine("sqlite:///components.db"))
+repository.put(
+    "LLM", "default_openai_llm",
+    {"temperature": 0.2, "api_key": "${OPENAI_API_KEY}"},
+    environment="production", expected_revision=0,
+)
+AgentUniverse().start(
+    component_config_repository=repository,
+    config_environment="production",
+)
+```
+
+数据库记录按组件 `name` 覆盖 YAML；没有对应 YAML 的完整数据库记录也会注册。数据库读取
+失败会中止启动，不会静默生成只应用了一部分覆盖项的组件图。数据库值可以是局部覆盖；
+纯数据库组件必须提供 `metadata.type/module/class`。密钥可使用 `secret_ref`、`env://`、
+`vault://` 或 `${ENV_VAR}`，明文密钥会被拒绝。
+
+## 迁移、导出和回滚
+
+```python
+from pathlib import Path
+from agentuniverse.base.config.repository import import_yaml_files, export_yaml_directory
+
+files = Path("intelligence").rglob("*.yaml")
+report = import_yaml_files(repository, files, environment="staging", dry_run=True)
+assert not report.errors
+
+import_yaml_files(repository, Path("intelligence").rglob("*.yaml"),
+                  environment="staging")
+repository.rollback("TOOL", "search", 1,
+                    environment="staging", expected_revision=2)
+export_yaml_directory(repository, "config-export", environment="staging")
+```
+
+更新和删除时使用 `expected_revision` 可避免覆盖并发修改。迁移会保留 `${ENV_VAR}`，不会在
+迁移机器上提前解析环境变量。

--- a/tests/test_agentuniverse/unit/base/config/repository/test_sql_config_repository.py
+++ b/tests/test_agentuniverse/unit/base/config/repository/test_sql_config_repository.py
@@ -1,0 +1,138 @@
+import pytest
+from sqlalchemy import create_engine
+
+from agentuniverse.base.config.configer import Configer
+from agentuniverse.base.config.repository import (
+    ConfigConflictError,
+    ConfigNotFoundError,
+    LayeredConfigResolver,
+    SQLConfigRepository,
+    export_yaml_directory,
+    import_yaml_files,
+    merge_repository_configers,
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return SQLConfigRepository(create_engine(f"sqlite:///{tmp_path / 'config.db'}"))
+
+
+def test_create_update_history_and_optimistic_lock(repo):
+    first = repo.put("TOOL", "search", {"name": "search", "timeout": 3}, expected_revision=0, updated_by="alice")
+    second = repo.put("TOOL", "search", {"name": "search", "timeout": 5}, expected_revision=1, updated_by="bob")
+    assert (first.revision, second.revision) == (1, 2)
+    assert [item.value["timeout"] for item in repo.history("TOOL", "search")] == [3, 5]
+    with pytest.raises(ConfigConflictError, match="expected revision"):
+        repo.put("TOOL", "search", {"timeout": 9}, expected_revision=1)
+    assert repo.get("TOOL", "search").value["timeout"] == 5
+
+
+def test_rollback_creates_auditable_new_revision(repo):
+    repo.put("LLM", "model", {"temperature": 0.1})
+    repo.put("LLM", "model", {"temperature": 0.9})
+    rolled = repo.rollback("LLM", "model", 1, expected_revision=2, updated_by="operator")
+    assert rolled.revision == 3 and rolled.value == {"temperature": 0.1}
+    assert len(repo.history("LLM", "model")) == 3
+
+
+def test_environments_are_isolated_and_export_is_deterministic(repo):
+    repo.put("AGENT", "a", {"name": "dev"}, environment="dev")
+    repo.put("AGENT", "a", {"name": "prod"}, environment="prod")
+    assert repo.get("AGENT", "a", "dev").value["name"] == "dev"
+    assert [item["environment"] for item in repo.export()] == ["dev", "prod"]
+
+
+def test_raw_secrets_are_rejected_but_references_are_allowed(repo):
+    with pytest.raises(ValueError, match="secret_ref"):
+        repo.put("LLM", "x", {"api_key": "raw"})
+    record = repo.put("LLM", "x", {"api_key": {"secret_ref": "env://OPENAI_API_KEY"}})
+    assert record.value["api_key"]["secret_ref"].startswith("env://")
+    placeholder = repo.put("LLM", "placeholder", {"api_key": "${OPENAI_API_KEY}"})
+    assert placeholder.value["api_key"] == "${OPENAI_API_KEY}"
+    ordinary = repo.put("LLM", "ordinary", {"max_tokens": 4096})
+    assert ordinary.value["max_tokens"] == 4096
+
+
+def test_repository_record_becomes_existing_configer(repo):
+    repo.put("TOOL", "search", {"name": "search", "metadata": {"type": "TOOL"}})
+    configer = repo.as_configer("TOOL", "search")
+    assert configer.path == "db://default/TOOL/search@1"
+    assert configer.value["name"] == "search"
+
+
+def test_layered_precedence_and_copy_isolation():
+    resolver = LayeredConfigResolver()
+    result = resolver.resolve(
+        defaults={"timeout": 1, "nested": {"a": 1, "b": 1}},
+        yaml={"nested": {"b": 2}}, database={"timeout": 3}, runtime={"nested": {"a": 4}},
+    )
+    assert result == {"timeout": 3, "nested": {"a": 4, "b": 2}}
+
+
+def test_list_delete_and_delete_audit(repo):
+    repo.put("TOOL", "b", {"name": "b"})
+    repo.put("TOOL", "a", {"name": "a"})
+    assert [record.name for record in repo.list("TOOL")] == ["a", "b"]
+    repo.delete("TOOL", "a", expected_revision=1, updated_by="operator")
+    with pytest.raises(ConfigNotFoundError):
+        repo.get("TOOL", "a")
+    history = repo.history("TOOL", "a")
+    assert [record.revision for record in history] == [1, 2]
+    recreated = repo.put("TOOL", "a", {"name": "a2"}, expected_revision=0)
+    assert recreated.revision == 3
+    with pytest.raises(ConfigConflictError):
+        repo.delete("TOOL", "b", expected_revision=9)
+
+
+def test_database_overlay_and_database_only_component(repo, monkeypatch, tmp_path):
+    yaml_configer = Configer(path=str(tmp_path / "search.yaml"))
+    yaml_configer.value = {
+        "name": "search", "timeout": 3, "nested": {"keep": True},
+        "metadata": {"type": "TOOL", "module": "pkg.tool", "class": "Search"},
+    }
+    repo.put("TOOL", "search", {"timeout": 8, "nested": {"db": True}})
+    repo.put("TOOL", "database_only", {
+        "description": "from db",
+        "metadata": {"type": "TOOL", "module": "pkg.tool", "class": "Search"},
+    })
+    merged = merge_repository_configers([yaml_configer], repo, "TOOL")
+    assert [item.value["name"] for item in merged] == ["search", "database_only"]
+    assert merged[0].value["timeout"] == 8
+    assert merged[0].value["nested"] == {"keep": True, "db": True}
+    assert merged[0].path == "db://default/TOOL/search@1"
+
+    monkeypatch.setenv("DB_MODEL", "resolved-model")
+    repo.put("LLM", "model", {
+        "model_name": "${DB_MODEL}",
+        "metadata": {"type": "LLM"},
+    })
+    assert merge_repository_configers([], repo, "LLM")[0].value["model_name"] == "resolved-model"
+
+
+def test_database_metadata_type_must_match_repository_key(repo):
+    repo.put("TOOL", "bad", {"metadata": {"type": "LLM"}})
+    with pytest.raises(ValueError, match=r"metadata\.type=LLM"):
+        merge_repository_configers([], repo, "TOOL")
+
+
+def test_yaml_migration_round_trip_and_dry_run(repo, tmp_path):
+    source = tmp_path / "search.yaml"
+    source.write_text(
+        "name: search\napi_key: '${SEARCH_KEY}'\n"
+        "metadata:\n  type: TOOL\n  module: pkg.tool\n  class: Search\n",
+        encoding="utf-8",
+    )
+    report = import_yaml_files(repo, [source], environment="staging")
+    assert report.imported == ["TOOL/search"] and not report.errors
+    assert repo.get("TOOL", "search", "staging").value["api_key"] == "${SEARCH_KEY}"
+
+    skipped = import_yaml_files(repo, [source], environment="staging")
+    assert skipped.skipped == ["TOOL/search"]
+    output = export_yaml_directory(repo, tmp_path / "export", environment="staging")
+    assert output == [tmp_path / "export" / "tool" / "search.yaml"]
+    assert "${SEARCH_KEY}" in output[0].read_text(encoding="utf-8")
+
+    dry_repo = SQLConfigRepository(create_engine("sqlite:///:memory:"))
+    dry = import_yaml_files(dry_repo, [source], dry_run=True)
+    assert dry.imported == ["TOOL/search"] and dry_repo.list() == []


### PR DESCRIPTION
## Summary

This PR introduces a versioned SQL-backed repository for agentUniverse component configuration and connects it to the existing component scan path.

It is a backward-compatible foundation for #179: YAML remains supported, while database records can overlay YAML components or define complete database-only components.

## What changed

- added a provider-neutral ConfigRepository contract and ConfigRecord;
- added SQLConfigRepository for any SQLAlchemy engine, including the existing SQLDBWrapper engine;
- added transactional writes, optimistic revision checks, audit history, rollback, deletion, and revision-safe recreation;
- added isolated configuration environments;
- added deterministic YAML-to-database import, dry-run, and YAML export helpers;
- added layered YAML/database resolution with database precedence;
- integrated the repository into AgentUniverse.start() through optional component_config_repository and config_environment arguments;
- added placeholder-aware secret validation for environment and vault references while rejecting literal secret-like values;
- added English and Chinese migration/runtime documentation.

Repository failures are intentionally propagated during startup so the framework does not silently run with only part of the intended database configuration.

## Scope boundary

This PR does not remove the application TOML bootstrap or force existing projects to migrate. It establishes the component-storage and loading contract first; admin APIs/UI can build on this contract separately.

Addresses #179.

## Checklist

- [x] I have read and understood the contributor guidelines.
- [x] I checked the current repository and linked work for duplicates.
- [x] I accept maintainer suggestions to revise or close this PR.
- [x] Test files are included and reproducible results are listed below.
- [x] English and Chinese documentation is included.
- [x] Migration and runtime examples are included.

## Validation

Local:

    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/base/config
    19 passed

Independent Ubuntu/Python 3.10.12 server:

    tests/test_agentuniverse/unit/base/config
    19 passed

A real AgentUniverse.start() integration experiment also passed on the server:

    database override: max_citations=2
    component path: db://test/TOOL/financial_evidence_tool@1
    registered components: FinancialEvidenceTool, FinancialIndicatorExtractor, MMRProcessor

Test file:

- tests/test_agentuniverse/unit/base/config/repository/test_sql_config_repository.py

## Documentation

- docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Database_Backend_Configuration.md
- docs/guidebook/zh/In-Depth_Guides/技术组件/数据库配置仓库.md
