### PR TITLE
feat(example): add auditable financial research workspace

### DIFF
--- a/docs/guidebook/en/Examples/Financial_Research_Workspace.md
+++ b/docs/guidebook/en/Examples/Financial_Research_Workspace.md
@@ -1,0 +1,7 @@
+# Financial research workspace example
+
+See `examples/sample_apps/financial_research_app`. It demonstrates reproducible local ingestion,
+bounded retrieval, citations, provenance, tenant isolation and resumable jobs. The evidence is
+converted into native `Document`/`Query` objects, processed by `FinancialIndicatorExtractor` and
+`MMRProcessor`, and can be passed to a registered PEER `WorkPattern`. The included YAML also
+registers the workspace as `FinancialEvidenceTool`; all automated tests run without network calls.

--- a/examples/sample_apps/financial_research_app/README.md
+++ b/examples/sample_apps/financial_research_app/README.md
@@ -1,0 +1,75 @@
+# Auditable financial research workspace
+
+This sample is an offline-first financial research application built on agentUniverse's native
+`Tool`, `DocProcessor`, `Document`, `Query`, and `WorkPattern` contracts. It adds the operational
+boundaries commonly missing from a notebook demo:
+
+- tenant-isolated SQLite ingestion and jobs;
+- bounded deterministic retrieval with stable citation and source hashes;
+- a persisted retrieval checkpoint, so interrupted jobs resume without changing evidence;
+- built-in `FinancialIndicatorExtractor` and `MMRProcessor` execution;
+- optional registered `WorkPattern` execution (including a configured PEER pattern);
+- citation precision/recall helpers and network-free fixtures/tests.
+
+## Architecture
+
+```text
+local reports -> FinancialResearchWorkspace -> cited evidence
+                                               |
+                                               v
+                          agentUniverse Document / Query
+                                               |
+                         FinancialIndicatorExtractor -> MMRProcessor
+                                               |
+                              optional registered WorkPattern (PEER)
+```
+
+`FinancialEvidenceTool` exposes ingestion and research through the normal agentUniverse tool
+interface. Its YAML lives in `intelligence/agentic/tool/financial_evidence_tool.yaml`.
+
+## Offline quick start
+
+No model key or network call is needed:
+
+```bash
+python -m examples.sample_apps.financial_research_app.cli \
+  --db /tmp/financial-research.db \
+  --tenant demo \
+  --ingest examples/sample_apps/financial_research_app/data/sample_company_report.txt \
+  --question 'How did revenue and margin change?'
+```
+
+The JSON output includes the original citations/provenance and the documents enhanced by the
+native financial indicator processor and MMR reranker.
+
+## Registered component mode
+
+Start agentUniverse with the included configuration and resolve the processors through their
+managers:
+
+```bash
+python -m examples.sample_apps.financial_research_app.cli \
+  --config examples/sample_apps/financial_research_app/config/config.toml \
+  --db /tmp/financial-research.db --tenant demo \
+  --ingest examples/sample_apps/financial_research_app/data/sample_company_report.txt \
+  --question 'How did revenue and margin change?'
+```
+
+A project that configures planning/executing/expressing/reviewing agents can additionally pass its
+registered work-pattern name with `--work-pattern`. The evidence and stable citations are inserted
+into the pattern's `InputObject`.
+
+## Tests
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q \
+  examples/sample_apps/financial_research_app/intelligence/test/test_workspace.py
+```
+
+Tests cover tenant isolation, bounds, checkpoint resume, metric extraction, MMR, work-pattern
+input, YAML component configuration, and the `FinancialEvidenceTool` adapter. They never call a
+hosted model or market-data service.
+
+For production, replace the local retriever with an agentUniverse `Store`, keep the citation and
+tenant boundaries, use an authenticated service, and configure a PEER work pattern plus approved
+market-data tools such as `YahooFinanceTool`.

--- a/examples/sample_apps/financial_research_app/README_zh.md
+++ b/examples/sample_apps/financial_research_app/README_zh.md
@@ -1,0 +1,47 @@
+# 可审计金融研究工作区
+
+这是一个基于 agentUniverse 原生 `Tool`、`DocProcessor`、`Document`、`Query` 和
+`WorkPattern` 接口的离线优先金融研究应用，包含：
+
+- SQLite 租户隔离的数据摄取和任务；
+- 有上限的确定性检索、稳定引用 ID 和来源哈希；
+- 持久化检索检查点，中断恢复时不会悄悄更换证据；
+- 内置 `FinancialIndicatorExtractor` 与 `MMRProcessor`；
+- 可选的已注册 `WorkPattern`（包括项目配置好的 PEER）；
+- 引用 precision/recall 评估和完全离线的测试数据。
+
+## 离线运行
+
+```bash
+python -m examples.sample_apps.financial_research_app.cli \
+  --db /tmp/financial-research.db --tenant demo \
+  --ingest examples/sample_apps/financial_research_app/data/sample_company_report.txt \
+  --question 'How did revenue and margin change?'
+```
+
+无需模型密钥和网络。输出同时保留原始引用/来源信息，以及经过 agentUniverse 金融指标处理器
+和 MMR 重排后的分析文档。
+
+## 组件注册模式
+
+```bash
+python -m examples.sample_apps.financial_research_app.cli \
+  --config examples/sample_apps/financial_research_app/config/config.toml \
+  --db /tmp/financial-research.db --tenant demo \
+  --ingest examples/sample_apps/financial_research_app/data/sample_company_report.txt \
+  --question 'How did revenue and margin change?'
+```
+
+此模式通过 agentUniverse Manager 获取处理器。项目若已经配置 PEER 的 planning、executing、
+expressing、reviewing 智能体，可再传 `--work-pattern`；证据和稳定引用会放进其 `InputObject`。
+
+## 测试
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q \
+  examples/sample_apps/financial_research_app/intelligence/test/test_workspace.py
+```
+
+测试覆盖租户隔离、输入上限、检查点恢复、金融指标提取、MMR、WorkPattern 输入、YAML 组件
+配置和 `FinancialEvidenceTool`，不会访问托管模型或行情服务。生产环境可将本地检索替换为
+agentUniverse `Store`，并接入认证服务、配置完整 PEER 和批准的行情工具。

--- a/examples/sample_apps/financial_research_app/__init__.py
+++ b/examples/sample_apps/financial_research_app/__init__.py
@@ -1,0 +1,1 @@
+"""Offline-first auditable financial research sample."""

--- a/examples/sample_apps/financial_research_app/application.py
+++ b/examples/sample_apps/financial_research_app/application.py
@@ -1,0 +1,128 @@
+"""Framework-native research pipeline built from agentUniverse components."""
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import DocProcessor
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor_manager import DocProcessorManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.work_pattern.work_pattern import WorkPattern
+from agentuniverse.agent.work_pattern.work_pattern_manager import WorkPatternManager
+from examples.sample_apps.financial_research_app.workspace import FinancialResearchWorkspace
+
+
+def _embedding(text: str, dimensions: int = 64) -> list[float]:
+    """Create a deterministic offline vector used only by the sample's MMR."""
+    vector = [0.0] * dimensions
+    for token in re.findall(r"[a-z0-9_]+", text.lower()):
+        digest = hashlib.sha256(token.encode()).digest()
+        index = int.from_bytes(digest[:2], "big") % dimensions
+        vector[index] += -1.0 if digest[2] & 1 else 1.0
+    return vector
+
+
+class FinancialResearchApplication:
+    """Compose workspace evidence, native doc processors, and a work pattern."""
+
+    def __init__(self, workspace: FinancialResearchWorkspace, *,
+                 processors: Iterable[DocProcessor] | None = None,
+                 work_pattern: WorkPattern | None = None) -> None:
+        self.workspace = workspace
+        self.processors = list(processors or [])
+        self.work_pattern = work_pattern
+
+    @classmethod
+    def with_native_defaults(cls, workspace: FinancialResearchWorkspace, *,
+                             work_pattern: WorkPattern | None = None):
+        """Build an offline pipeline from built-in agentUniverse processors."""
+        from agentuniverse.agent.action.knowledge.doc_processor.financial_indicator_extractor import (
+            FinancialIndicatorExtractor,
+        )
+        from agentuniverse.agent.action.knowledge.doc_processor.mmr_processor import MMRProcessor
+
+        return cls(
+            workspace,
+            processors=[
+                FinancialIndicatorExtractor(use_llm=False),
+                MMRProcessor(lambda_coef=0.7, top_n=5),
+            ],
+            work_pattern=work_pattern,
+        )
+
+    @classmethod
+    def from_registry(cls, workspace: FinancialResearchWorkspace, *,
+                      processor_names: Iterable[str] = (
+                          "financial_indicator_extractor", "mmr_processor",
+                      ), work_pattern_name: str | None = None):
+        """Resolve components registered by ``AgentUniverse.start``."""
+        processors = [
+            DocProcessorManager().get_instance_obj(name, strict=True)
+            for name in processor_names
+        ]
+        work_pattern = None
+        if work_pattern_name:
+            work_pattern = WorkPatternManager().get_instance_obj(
+                work_pattern_name, strict=True
+            )
+        return cls(workspace, processors=processors, work_pattern=work_pattern)
+
+    def ingest(self, tenant_id: str, title: str, content: str, *,
+               metadata: dict | None = None) -> str:
+        return self.workspace.ingest(
+            tenant_id, title, content, metadata=metadata
+        )
+
+    def research(self, tenant_id: str, question: str, *,
+                 job_id: str | None = None, top_k: int = 5,
+                 retry_count: int = 1, eval_threshold: float = 0.8) -> dict:
+        job_id = job_id or self.workspace.create_job(tenant_id, question)
+        report = self.workspace.run(tenant_id, job_id, top_k=top_k)
+        documents = [
+            Document(
+                id=item["citation_id"], text=item["excerpt"],
+                metadata={**item, "citation_id": item["citation_id"]},
+                embedding=_embedding(item["excerpt"]),
+            )
+            for item in report["citations"]
+        ]
+        query = Query(query_str=question, embeddings=[_embedding(question)])
+        for processor in self.processors:
+            documents = processor.process_docs(documents, query)
+
+        report["agentuniverse"] = {
+            "doc_processors": [
+                processor.name or processor.__class__.__name__
+                for processor in self.processors
+            ],
+            "analysis_documents": [
+                {"id": document.id, "text": document.text,
+                 "metadata": document.metadata or {}}
+                for document in documents
+            ],
+        }
+        if self.work_pattern is not None:
+            pattern_input = {
+                "input": question,
+                "retry_count": retry_count,
+                "jump_step": "planning",
+                "eval_threshold": eval_threshold,
+            }
+            input_object = InputObject({
+                "input": question,
+                "question": question,
+                "tenant_id": tenant_id,
+                "job_id": job_id,
+                "evidence": report["agentuniverse"]["analysis_documents"],
+                "citations": report["citations"],
+            })
+            report["agentuniverse"]["work_pattern"] = (
+                self.work_pattern.name or self.work_pattern.__class__.__name__
+            )
+            report["agentuniverse"]["work_pattern_result"] = (
+                self.work_pattern.invoke(input_object, pattern_input)
+            )
+        return report

--- a/examples/sample_apps/financial_research_app/cli.py
+++ b/examples/sample_apps/financial_research_app/cli.py
@@ -1,0 +1,51 @@
+"""CLI for the auditable financial research sample."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from examples.sample_apps.financial_research_app.application import FinancialResearchApplication
+from examples.sample_apps.financial_research_app.workspace import FinancialResearchWorkspace
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default="financial-research.db")
+    parser.add_argument("--tenant", required=True)
+    parser.add_argument("--ingest", type=Path, action="append", default=[])
+    parser.add_argument("--question", required=True)
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument(
+        "--config", type=Path,
+        help="Optional agentUniverse config.toml; resolves processors from the registry.",
+    )
+    parser.add_argument(
+        "--work-pattern", help="Optional registered work-pattern name, for example peer_work_pattern.",
+    )
+    args = parser.parse_args(argv)
+
+    workspace = FinancialResearchWorkspace(args.db)
+    if args.config:
+        from agentuniverse.base.agentuniverse import AgentUniverse
+
+        AgentUniverse().start(config_path=str(args.config), core_mode=True)
+        application = FinancialResearchApplication.from_registry(
+            workspace, work_pattern_name=args.work_pattern,
+        )
+    else:
+        application = FinancialResearchApplication.with_native_defaults(workspace)
+
+    for path in args.ingest:
+        application.ingest(
+            args.tenant, path.name, path.read_text(encoding="utf-8"),
+            metadata={"path": str(path)},
+        )
+    report = application.research(
+        args.tenant, args.question, top_k=args.top_k,
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sample_apps/financial_research_app/components.py
+++ b/examples/sample_apps/financial_research_app/components.py
@@ -1,0 +1,46 @@
+"""agentUniverse Tool adapter for the financial research workspace."""
+# ruff: noqa: TRY003
+from __future__ import annotations
+
+import json
+
+from pydantic import Field, PrivateAttr
+
+from agentuniverse.agent.action.tool.tool import Tool
+from examples.sample_apps.financial_research_app.application import FinancialResearchApplication
+from examples.sample_apps.financial_research_app.workspace import FinancialResearchWorkspace
+
+
+class FinancialEvidenceTool(Tool):
+    """Ingest local evidence or prepare a cited research package."""
+
+    name: str = "financial_evidence_tool"
+    description: str = (
+        "Tenant-isolated financial evidence ingestion and cited retrieval tool."
+    )
+    database_path: str = "financial-research.db"
+    max_citations: int = 5
+    input_keys: list[str] = Field(
+        default_factory=lambda: ["mode", "tenant_id"]
+    )
+    _workspace: FinancialResearchWorkspace | None = PrivateAttr(default=None)
+
+    def _get_workspace(self) -> FinancialResearchWorkspace:
+        if self._workspace is None:
+            self._workspace = FinancialResearchWorkspace(self.database_path)
+        return self._workspace
+
+    def execute(self, mode: str, tenant_id: str, question: str = "", title: str = "",
+                content: str = "", job_id: str = "") -> str:
+        workspace = self._get_workspace()
+        if mode == "ingest":
+            source_id = workspace.ingest(tenant_id, title, content)
+            return json.dumps({"source_id": source_id}, sort_keys=True)
+        if mode != "research":
+            raise ValueError("mode must be 'ingest' or 'research'")
+        application = FinancialResearchApplication.with_native_defaults(workspace)
+        report = application.research(
+            tenant_id, question, job_id=job_id or None,
+            top_k=self.max_citations,
+        )
+        return json.dumps(report, ensure_ascii=False, sort_keys=True)

--- a/examples/sample_apps/financial_research_app/config/config.toml
+++ b/examples/sample_apps/financial_research_app/config/config.toml
@@ -1,0 +1,26 @@
+[BASE_INFO]
+appname = 'financial_research_app'
+
+[PACKAGE_PATH_INFO]
+ROOT_PACKAGE = 'examples.sample_apps.financial_research_app'
+
+[CORE_PACKAGE]
+default = ['${ROOT_PACKAGE}.intelligence.agentic']
+tool = ['${ROOT_PACKAGE}.intelligence.agentic.tool']
+doc_processor = []
+work_pattern = []
+
+[SUB_CONFIG_PATH]
+log_config_path = './log_config.toml'
+
+[DB]
+system_db_uri = 'sqlite:///financial-research-system.db'
+
+[GUNICORN]
+activate = 'false'
+
+[GRPC]
+activate = 'false'
+
+[MONITOR]
+activate = false

--- a/examples/sample_apps/financial_research_app/config/log_config.toml
+++ b/examples/sample_apps/financial_research_app/config/log_config.toml
@@ -1,0 +1,10 @@
+[LOG_CONFIG]
+
+[LOG_CONFIG.BASIC_CONFIG]
+log_level = "INFO"
+log_path = "./.financial_research_logs"
+log_rotation = "100 MB"
+log_retention = "7 days"
+
+[LOG_CONFIG.EXTEND_MODULE]
+sls_log = "False"

--- a/examples/sample_apps/financial_research_app/data/sample_company_report.txt
+++ b/examples/sample_apps/financial_research_app/data/sample_company_report.txt
@@ -1,0 +1,3 @@
+Example Corp reported 2025 revenue of 120 million dollars, up 20 percent year over year.
+Operating margin improved from 12 percent to 15 percent. Management identified customer
+concentration and foreign-exchange volatility as principal risks. This is synthetic demo data.

--- a/examples/sample_apps/financial_research_app/intelligence/__init__.py
+++ b/examples/sample_apps/financial_research_app/intelligence/__init__.py
@@ -1,0 +1,1 @@
+"""Financial research application components."""

--- a/examples/sample_apps/financial_research_app/intelligence/agentic/__init__.py
+++ b/examples/sample_apps/financial_research_app/intelligence/agentic/__init__.py
@@ -1,0 +1,1 @@
+"""Agentic component package."""

--- a/examples/sample_apps/financial_research_app/intelligence/agentic/tool/__init__.py
+++ b/examples/sample_apps/financial_research_app/intelligence/agentic/tool/__init__.py
@@ -1,0 +1,1 @@
+"""Tool configurations for the sample."""

--- a/examples/sample_apps/financial_research_app/intelligence/agentic/tool/financial_evidence_tool.yaml
+++ b/examples/sample_apps/financial_research_app/intelligence/agentic/tool/financial_evidence_tool.yaml
@@ -1,0 +1,11 @@
+name: financial_evidence_tool
+description: Tenant-isolated financial evidence ingestion and cited retrieval.
+database_path: financial-research.db
+max_citations: 5
+input_keys:
+  - mode
+  - tenant_id
+metadata:
+  type: TOOL
+  module: examples.sample_apps.financial_research_app.components
+  class: FinancialEvidenceTool

--- a/examples/sample_apps/financial_research_app/intelligence/test/test_workspace.py
+++ b/examples/sample_apps/financial_research_app/intelligence/test/test_workspace.py
@@ -1,0 +1,139 @@
+import json
+import sqlite3
+from pathlib import Path
+
+# ruff: noqa: S101
+import pytest
+
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.work_pattern.work_pattern import WorkPattern
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+from examples.sample_apps.financial_research_app.application import FinancialResearchApplication
+from examples.sample_apps.financial_research_app.components import FinancialEvidenceTool
+from examples.sample_apps.financial_research_app.workspace import FinancialResearchWorkspace
+
+
+def test_offline_ingest_retrieve_report_and_resume(tmp_path):
+    workspace = FinancialResearchWorkspace(tmp_path / "research.db")
+    first = workspace.ingest("tenant-a", "report", "Revenue grew 20 percent. Margin reached 15 percent.")
+    assert workspace.ingest("tenant-a", "report", "Revenue grew 20 percent. Margin reached 15 percent.") == first
+    job = workspace.create_job("tenant-a", "revenue margin")
+    report = workspace.run("tenant-a", job)
+    assert report["citations"] and report["citations"][0]["title"] == "report"
+    assert workspace.run("tenant-a", job) == report
+    assert workspace.job("tenant-a", job)["checkpoint"] == "reported"
+
+
+def test_tenant_isolation(tmp_path):
+    workspace = FinancialResearchWorkspace(tmp_path / "research.db")
+    workspace.ingest("a", "private-a", "revenue secret alpha")
+    workspace.ingest("b", "private-b", "revenue public beta")
+    assert [item.title for item in workspace.retrieve("a", "revenue")] == ["private-a"]
+    assert [item.title for item in workspace.retrieve("b", "revenue")] == ["private-b"]
+
+
+def test_bounds_and_cross_tenant_job_access(tmp_path):
+    workspace = FinancialResearchWorkspace(tmp_path / "research.db")
+    job = workspace.create_job("a", "q")
+    with pytest.raises(KeyError):
+        workspace.run("b", job)
+    with pytest.raises(ValueError, match="between 1 and 20"):
+        workspace.retrieve("a", "q", top_k=100)
+    with pytest.raises(ValueError, match="chunk_chars"):
+        workspace.ingest("a", "bad", "content", chunk_chars=5)
+
+
+def test_retrieval_checkpoint_resume_and_evaluation(tmp_path):
+    workspace = FinancialResearchWorkspace(tmp_path / "research.db")
+    source = workspace.ingest("tenant", "annual", "Revenue reached 120 million in FY2025.")
+    job = workspace.create_job("tenant", "FY2025 revenue")
+    citation = workspace.retrieve("tenant", "FY2025 revenue")[0].to_dict()
+    with workspace.connection:
+        workspace.connection.execute(
+            "UPDATE research_job SET state='running',checkpoint='retrieved',evidence=? "
+            "WHERE tenant_id=? AND job_id=?",
+            (json.dumps([citation]), "tenant", job),
+        )
+    report = workspace.run("tenant", job)
+    assert report["citations"] == [citation]
+    assert workspace.evaluate(report, [source]) == {
+        "citation_precision": 1.0,
+        "citation_recall": 1.0,
+        "matched_sources": [source],
+    }
+
+
+def test_existing_pre_checkpoint_database_is_upgraded(tmp_path):
+    database = tmp_path / "legacy.db"
+    connection = sqlite3.connect(database)
+    connection.execute("""
+        CREATE TABLE research_job (
+          tenant_id TEXT NOT NULL, job_id TEXT NOT NULL, question TEXT NOT NULL,
+          state TEXT NOT NULL, checkpoint TEXT NOT NULL, report TEXT,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, job_id))
+    """)
+    connection.close()
+    workspace = FinancialResearchWorkspace(database)
+    job = workspace.create_job("tenant", "question")
+    stored = workspace.job("tenant", job)
+    assert stored["evidence"] is None
+    assert stored["report"] is None
+
+
+class RecordingWorkPattern(WorkPattern):
+    name: str = "recording_pattern"
+
+    def invoke(self, input_object: InputObject, work_pattern_input: dict, **kwargs) -> dict:
+        return {
+            "question": input_object.get_data("question"),
+            "citation_count": len(input_object.get_data("citations")),
+            "retry_count": work_pattern_input["retry_count"],
+        }
+
+    async def async_invoke(self, input_object: InputObject,
+                           work_pattern_input: dict, **kwargs) -> dict:
+        return self.invoke(input_object, work_pattern_input, **kwargs)
+
+
+def test_native_processors_and_work_pattern_receive_cited_evidence(tmp_path):
+    workspace = FinancialResearchWorkspace(tmp_path / "research.db")
+    app = FinancialResearchApplication.with_native_defaults(
+        workspace, work_pattern=RecordingWorkPattern(),
+    )
+    app.ingest("tenant", "annual report", "FY2025 revenue reached 120 million and margin was 18 percent.")
+    report = app.research("tenant", "FY2025 revenue margin", retry_count=2)
+    pipeline = report["agentuniverse"]
+    assert pipeline["doc_processors"] == [
+        "FinancialIndicatorExtractor", "MMRProcessor",
+    ]
+    assert pipeline["analysis_documents"][0]["metadata"]["financial_metrics"]
+    assert pipeline["work_pattern_result"] == {
+        "question": "FY2025 revenue margin", "citation_count": 1, "retry_count": 2,
+    }
+
+
+def test_tool_adapter_and_yaml_component_configuration(tmp_path):
+    tool = FinancialEvidenceTool(database_path=str(tmp_path / "tool.db"))
+    ingested = json.loads(tool.execute(
+        "ingest", "tenant", title="report",
+        content="Revenue reached 50 million in FY2025.",
+    ))
+    assert ingested["source_id"]
+    report = json.loads(tool.execute(
+        "research", "tenant", question="FY2025 revenue",
+    ))
+    assert report["citations"][0]["source_id"] == ingested["source_id"]
+
+    # Locate the checked-out sample without depending on pytest's working directory.
+    path = Path(__file__).parents[1] / "agentic/tool/financial_evidence_tool.yaml"
+    configer = ToolConfiger().load_by_configer(Configer(path=str(path)).load())
+    configured = FinancialEvidenceTool().initialize_by_component_configer(configer)
+    assert configured.name == "financial_evidence_tool"
+    assert configured.max_citations == 5
+
+    app_root = Path(__file__).parents[2]
+    app_config = Configer(path=str(app_root / "config/config.toml")).load().value
+    log_path = app_root / "config" / app_config["SUB_CONFIG_PATH"]["log_config_path"]
+    assert log_path.resolve().is_file()

--- a/examples/sample_apps/financial_research_app/workspace.py
+++ b/examples/sample_apps/financial_research_app/workspace.py
@@ -1,0 +1,226 @@
+"""Resumable, tenant-isolated storage for the financial research sample."""
+# ruff: noqa: TRY003
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import uuid
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Citation:
+    citation_id: str
+    source_id: str
+    title: str
+    excerpt: str
+    score: float
+    ordinal: int
+    content_hash: str
+    metadata: dict
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class FinancialResearchWorkspace:
+    """Small operational store around agentUniverse research components."""
+
+    def __init__(self, database: str | Path = ":memory:") -> None:
+        self.connection = sqlite3.connect(str(database))
+        self.connection.row_factory = sqlite3.Row
+        self.connection.executescript("""
+        CREATE TABLE IF NOT EXISTS research_job (
+          tenant_id TEXT NOT NULL, job_id TEXT NOT NULL, question TEXT NOT NULL,
+          state TEXT NOT NULL, checkpoint TEXT NOT NULL, evidence TEXT, report TEXT,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, job_id));
+        CREATE TABLE IF NOT EXISTS research_source (
+          tenant_id TEXT NOT NULL, source_id TEXT NOT NULL, title TEXT NOT NULL,
+          content TEXT NOT NULL, content_hash TEXT NOT NULL, metadata TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, source_id));
+        CREATE TABLE IF NOT EXISTS research_chunk (
+          tenant_id TEXT NOT NULL, source_id TEXT NOT NULL, chunk_id TEXT NOT NULL,
+          ordinal INTEGER NOT NULL, content TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, chunk_id));
+        CREATE INDEX IF NOT EXISTS ix_research_chunk_tenant_source
+          ON research_chunk (tenant_id, source_id);
+        """)
+        self._upgrade_job_schema()
+
+    def _upgrade_job_schema(self) -> None:
+        columns = {
+            row["name"] for row in self.connection.execute(
+                "PRAGMA table_info(research_job)"
+            ).fetchall()
+        }
+        if "evidence" not in columns:
+            with self.connection:
+                self.connection.execute(
+                    "ALTER TABLE research_job ADD COLUMN evidence TEXT"
+                )
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def ingest(self, tenant_id: str, title: str, content: str, *,
+               metadata: dict | None = None, chunk_chars: int = 800) -> str:
+        if not tenant_id or not title or not content.strip():
+            raise ValueError("tenant_id, title and non-empty content are required")
+        if not 100 <= chunk_chars <= 10_000:
+            raise ValueError("chunk_chars must be between 100 and 10000")
+        digest = hashlib.sha256(content.encode()).hexdigest()
+        source_id = digest[:24]
+        with self.connection:
+            self.connection.execute(
+                "INSERT OR IGNORE INTO research_source "
+                "(tenant_id,source_id,title,content,content_hash,metadata) "
+                "VALUES (?,?,?,?,?,?)",
+                (tenant_id, source_id, title, content, digest,
+                 json.dumps(metadata or {}, sort_keys=True)),
+            )
+            for ordinal, start in enumerate(range(0, len(content), chunk_chars)):
+                chunk = content[start:start + chunk_chars]
+                chunk_id = hashlib.sha256(
+                    f"{source_id}:{ordinal}:{chunk}".encode()
+                ).hexdigest()[:24]
+                self.connection.execute(
+                    "INSERT OR IGNORE INTO research_chunk "
+                    "(tenant_id,source_id,chunk_id,ordinal,content) "
+                    "VALUES (?,?,?,?,?)",
+                    (tenant_id, source_id, chunk_id, ordinal, chunk),
+                )
+        return source_id
+
+    def create_job(self, tenant_id: str, question: str, *,
+                   job_id: str | None = None) -> str:
+        if not tenant_id or not question.strip():
+            raise ValueError("tenant_id and a non-empty question are required")
+        job_id = job_id or uuid.uuid4().hex
+        now = self._now()
+        with self.connection:
+            self.connection.execute(
+                "INSERT INTO research_job "
+                "(tenant_id,job_id,question,state,checkpoint,evidence,report,"
+                "created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                (tenant_id, job_id, question, "pending", "created", None,
+                 None, now, now),
+            )
+        return job_id
+
+    @staticmethod
+    def _tokens(text: str) -> set[str]:
+        return set(re.findall(r"[a-z0-9_]+", text.lower()))
+
+    def retrieve(self, tenant_id: str, query: str, *,
+                 top_k: int = 5) -> list[Citation]:
+        if top_k < 1 or top_k > 20:
+            raise ValueError("top_k must be between 1 and 20")
+        query_tokens = self._tokens(query)
+        rows = self.connection.execute("""
+          SELECT c.source_id,c.chunk_id,c.ordinal,c.content,
+                 s.title,s.content_hash,s.metadata
+          FROM research_chunk c
+          JOIN research_source s
+            ON s.tenant_id=c.tenant_id AND s.source_id=c.source_id
+          WHERE c.tenant_id=?""", (tenant_id,)).fetchall()
+        scored = []
+        for row in rows:
+            tokens = self._tokens(row["content"])
+            score = len(query_tokens & tokens) / max(len(query_tokens), 1)
+            if score:
+                scored.append(Citation(
+                    citation_id=row["chunk_id"], source_id=row["source_id"],
+                    title=row["title"], excerpt=row["content"][:500],
+                    score=score, ordinal=row["ordinal"],
+                    content_hash=row["content_hash"],
+                    metadata=json.loads(row["metadata"]),
+                ))
+        return sorted(
+            scored, key=lambda item: (-item.score, item.citation_id)
+        )[:top_k]
+
+    def run(self, tenant_id: str, job_id: str, *, top_k: int = 5) -> dict:
+        """Prepare an evidence package, resuming after the retrieval checkpoint."""
+        row = self.connection.execute(
+            "SELECT * FROM research_job WHERE tenant_id=? AND job_id=?",
+            (tenant_id, job_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(job_id)
+        if row["state"] == "completed":
+            return json.loads(row["report"])
+
+        if row["checkpoint"] == "retrieved" and row["evidence"]:
+            citations = json.loads(row["evidence"])
+        else:
+            citations = [
+                item.to_dict()
+                for item in self.retrieve(tenant_id, row["question"], top_k=top_k)
+            ]
+            with self.connection:
+                self.connection.execute(
+                    "UPDATE research_job SET state='running',checkpoint='retrieved',"
+                    "evidence=?,updated_at=? WHERE tenant_id=? AND job_id=?",
+                    (json.dumps(citations, sort_keys=True), self._now(),
+                     tenant_id, job_id),
+                )
+
+        report = {
+            "job_id": job_id,
+            "tenant_id": tenant_id,
+            "question": row["question"],
+            "summary": "Evidence package ready for agentUniverse analysis.",
+            "citations": citations,
+            "provenance": {
+                "retriever": "deterministic_token_overlap",
+                "citation_count": len(citations),
+                "source_hashes": sorted({
+                    item["content_hash"] for item in citations
+                }),
+            },
+        }
+        with self.connection:
+            self.connection.execute(
+                "UPDATE research_job SET state='completed',checkpoint='reported',"
+                "report=?,updated_at=? WHERE tenant_id=? AND job_id=?",
+                (json.dumps(report, sort_keys=True), self._now(),
+                 tenant_id, job_id),
+            )
+        return report
+
+    @staticmethod
+    def evaluate(report: dict, expected_source_ids: Iterable[str]) -> dict:
+        """Calculate deterministic citation precision/recall for demo datasets."""
+        expected = set(expected_source_ids)
+        cited = {item["source_id"] for item in report.get("citations", [])}
+        matched = cited & expected
+        return {
+            "citation_precision": len(matched) / len(cited) if cited else 0.0,
+            "citation_recall": len(matched) / len(expected) if expected else 1.0,
+            "matched_sources": sorted(matched),
+        }
+
+    def job(self, tenant_id: str, job_id: str) -> dict:
+        row = self.connection.execute(
+            "SELECT * FROM research_job WHERE tenant_id=? AND job_id=?",
+            (tenant_id, job_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(job_id)
+        return dict(row)
+
+    def close(self) -> None:
+        self.connection.close()
+
+    def __enter__(self) -> FinancialResearchWorkspace:
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()


### PR DESCRIPTION
## Summary

This PR contributes an offline-first, auditable financial research sample application for #254.

Unlike a standalone notebook, the sample uses agentUniverse native Tool, DocProcessor, Document, Query, manager, and optional WorkPattern contracts. It can run without credentials or network access and can also run through normal agentUniverse component registration.

## Application flow

    local reports
      -> tenant-isolated SQLite workspace
      -> bounded retrieval with stable citations/source hashes
      -> agentUniverse Document + Query
      -> FinancialIndicatorExtractor
      -> MMRProcessor
      -> optional registered WorkPattern/PEER

## What changed

- added tenant-isolated ingestion, source metadata, stable citation IDs, and content hashes;
- added resumable SQLite jobs with a persisted retrieval checkpoint;
- added deterministic citation precision/recall evaluation helpers;
- added FinancialResearchApplication using native financial indicator and MMR processors;
- added optional resolution of processors and work patterns through agentUniverse managers;
- added FinancialEvidenceTool and its YAML registration;
- added offline and registered-component CLI modes;
- added a self-contained application config, logging config, and synthetic report;
- added English/Chinese usage documentation and framework guide entry;
- added deterministic tests with no hosted LLM or market-data dependency.

The sample keeps citations separate from processed analysis documents so financial extraction or reranking cannot erase the original provenance.

Addresses #254.

## Checklist

- [x] I have read and understood the contributor guidelines.
- [x] I checked the existing sample apps and financial components before implementing this sample.
- [x] I accept maintainer suggestions to revise or close this PR.
- [x] Test files and reproducible results are provided.
- [x] Documentation is included.
- [x] A runnable application example and configuration are included.

## Validation

Focused local regression:

    financial research sample + MMR + financial indicator tests
    50 passed

Independent Ubuntu/Python 3.10.12 server:

    financial research sample + MMR + financial indicator + financial event tests
    72 passed

Registered-mode server experiment:

    CLI_RESULT {"citations": 1, "processors": ["financial_indicator_extractor", "mmr_processor"]}

The server also successfully started agentUniverse, registered FinancialEvidenceTool, and resolved both document processors from their managers.

Test file:

- examples/sample_apps/financial_research_app/intelligence/test/test_workspace.py

## Documentation

- examples/sample_apps/financial_research_app/README.md
- examples/sample_apps/financial_research_app/README_zh.md
- docs/guidebook/en/Examples/Financial_Research_Workspace.md
