### PR TITLE
fix(reader): NotionReader database pagination + row_id guard + print cleanup

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
@@ -3,7 +3,7 @@
 
 # @Time    : 2025/9/29
 # @FileName: notion_reader.py
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, ClassVar
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
@@ -18,8 +18,11 @@ class NotionReader(Reader):
         NOTION_TOKEN must be provided (or pass via ext_info)
     """
 
+    # Upper bound on the number of database pages fetched per load, so a
+    # misconfigured or hostile database cannot exhaust memory / API quota.
+    MAX_DATABASE_PAGES: ClassVar[int] = 500
+
     def _load_data(self, page_or_db_id: str, ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: NotionReader start load id={page_or_db_id}")
         if not page_or_db_id:
             raise ValueError("NotionReader requires a Notion page or database id")
 
@@ -43,24 +46,54 @@ class NotionReader(Reader):
 
         # Try as page
         try:
-            page = client.pages.retrieve(page_id=page_or_db_id)
+            client.pages.retrieve(page_id=page_or_db_id)
             metadata["type"] = "page"
             text_blocks.extend(self._export_page(client, page_or_db_id))
         except Exception as e_page:
-            print(f"debugging: NotionReader page retrieve failed: {e_page}")
             # Try as database
             try:
                 metadata["type"] = "database"
-                for row in client.databases.query(database_id=page_or_db_id).get("results", []):
-                    row_id = row.get("id")
-                    text_blocks.extend(self._export_page(client, row_id))
+                text_blocks.extend(self._export_database(client, page_or_db_id))
             except Exception as e_db:
-                raise RuntimeError(f"Failed to read Notion id={page_or_db_id}: {e_db}")
+                raise RuntimeError(
+                    f"Failed to read Notion id={page_or_db_id}: "
+                    f"page_error={e_page}, database_error={e_db}") from e_db
 
         text = "\n\n".join([b for b in text_blocks if b and b.strip()])
         if ext_info:
             metadata.update(self._public_metadata(ext_info))
         return [Document(text=text, metadata=metadata)]
+
+    def _export_database(self, client, database_id: str) -> List[str]:
+        """Export every row of a Notion database, following pagination.
+
+        The Notion ``databases.query`` API returns at most 100 rows per call;
+        the previous code only consumed the first page, silently dropping
+        every row beyond that. We now loop on ``has_more`` / ``next_cursor``
+        up to MAX_DATABASE_PAGES so the full database is read, with a cap to
+        bound runtime against a misconfigured/hostile source.
+        """
+        blocks: List[str] = []
+        cursor = None
+        pages_fetched = 0
+        while True:
+            response = client.databases.query(
+                database_id=database_id, start_cursor=cursor)
+            for row in response.get("results", []):
+                row_id = row.get("id")
+                # A row without an id cannot be exported; skip it rather than
+                # passing None to _export_page (which would 400 and abort the
+                # whole database read).
+                if not row_id:
+                    continue
+                blocks.extend(self._export_page(client, row_id))
+            pages_fetched += 1
+            if not response.get("has_more"):
+                break
+            cursor = response.get("next_cursor")
+            if pages_fetched >= self.MAX_DATABASE_PAGES:
+                break
+        return blocks
 
     @staticmethod
     def _public_metadata(ext_info: Dict) -> Dict:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader_pagination.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader_pagination.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for NotionReader database pagination and row_id guard.
+
+1. The previous code consumed only the first page of
+   ``client.databases.query`` (≤100 rows), silently dropping every row
+   beyond that. Now follows ``has_more`` / ``next_cursor``.
+2. A database row without an ``id`` used to pass ``None`` into
+   ``_export_page`` → Notion API 400 → the entire database read aborted.
+   Now skips the row.
+3. The pagination loop is bounded by MAX_DATABASE_PAGES so a hostile
+   database cannot exhaust memory / quota.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _query_page(results, has_more=False, next_cursor=None):
+    return {"results": results, "has_more": has_more, "next_cursor": next_cursor}
+
+
+def _row(row_id):
+    return {"id": row_id}
+
+
+class TestNotionReaderPagination(unittest.TestCase):
+
+    def _reader(self):
+        from agentuniverse.agent.action.knowledge.reader.cloud.notion_reader \
+            import NotionReader
+        return NotionReader()
+
+    def test_database_read_follows_pagination(self):
+        reader = self._reader()
+        client = MagicMock()
+        # Two pages of results: page 1 has rows [r1, r2] with has_more=True,
+        # page 2 has [r3] with has_more=False.
+        client.databases.query.side_effect = [
+            _query_page([_row("r1"), _row("r2")], has_more=True, next_cursor="c1"),
+            _query_page([_row("r3")], has_more=False),
+        ]
+        # _export_page returns one text block per page id.
+        with patch.object(reader, "_export_page", side_effect=lambda c, pid: [f"text-{pid}"]):
+            blocks = reader._export_database(client, "db1")
+        # All three rows exported; previously only r1, r2 were (first page).
+        self.assertEqual(blocks, ["text-r1", "text-r2", "text-r3"])
+        self.assertEqual(client.databases.query.call_count, 2)
+        # Second call used the next_cursor from the first.
+        second_call = client.databases.query.call_args_list[1]
+        self.assertEqual(second_call.kwargs.get("start_cursor"), "c1")
+
+    def test_database_read_single_page_when_no_more(self):
+        reader = self._reader()
+        client = MagicMock()
+        client.databases.query.return_value = _query_page(
+            [_row("r1")], has_more=False)
+        with patch.object(reader, "_export_page", side_effect=lambda c, pid: [f"t-{pid}"]):
+            blocks = reader._export_database(client, "db1")
+        self.assertEqual(blocks, ["t-r1"])
+        self.assertEqual(client.databases.query.call_count, 1)
+
+    def test_database_read_skips_row_without_id(self):
+        reader = self._reader()
+        client = MagicMock()
+        client.databases.query.return_value = _query_page(
+            [_row("r1"), {"no_id_field": True}, _row("r3")], has_more=False)
+        exported = []
+        with patch.object(reader, "_export_page",
+                          side_effect=lambda c, pid: exported.append(pid) or [pid]):
+            reader._export_database(client, "db1")
+        # The id-less row was skipped, not passed to _export_page.
+        self.assertEqual(exported, ["r1", "r3"])
+
+    def test_database_read_caps_at_max_pages(self):
+        from agentuniverse.agent.action.knowledge.reader.cloud.notion_reader \
+            import NotionReader
+        reader = self._reader()
+        client = MagicMock()
+        # Every page says has_more=True with a cursor; the loop must stop at
+        # MAX_DATABASE_PAGES rather than following forever.
+        client.databases.query.return_value = _query_page(
+            [_row("r")], has_more=True, next_cursor="c")
+        with patch.object(NotionReader, "MAX_DATABASE_PAGES", 3):
+            with patch.object(reader, "_export_page", return_value=["t"]):
+                reader._export_database(client, "db1")
+        self.assertEqual(client.databases.query.call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

NotionReader's database read silently truncated to the first 100 rows, aborted on a row without an id, and leaked debug prints.

## Why (not a duplicate)

Not covered by any open or merged PR. #683 (Loyal-Young) added the credential filter to NotionReader metadata; it did not touch pagination.

## Changes

### 1. Database pagination
\`_load_data\` consumed only the first page of \`client.databases.query\` (≤100 rows); every row beyond that was silently dropped. Added \`_export_database\` which loops on \`has_more\` / \`next_cursor\` so the full database is read, capped at \`MAX_DATABASE_PAGES\` (500) to bound runtime against a misconfigured or hostile source.

### 2. row_id guard
A database row without an \`id\` was passed as \`row_id=None\` into \`_export_page\` → \`client.blocks.children.list(block_id=None)\` → 400 → the entire database read aborted. Rows without an id are now skipped.

### 3. print cleanup
Removed stray \`print("debugging: ...")\` statements (one printed the page-retrieve exception text, which can carry credentials/tokens).

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_notion_reader_pagination.py\` — 4 regressions:
- pagination across two pages (all rows exported; second call uses next_cursor)
- single-page short-circuit when \`has_more=False\`
- id-less row is skipped, not passed to \`_export_page\`
- \`MAX_DATABASE_PAGES\` cap stops the loop

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.cloud.test_notion_reader_pagination\` — 4 passed (mock client; no network).

## Behaviour change

- Notion databases larger than 100 rows are now fully read (previously truncated).
- A row lacking an id no longer aborts the whole database read.