### PR TITLE
fix(monitor,trace): pop mutation, bare except, token-count race

### DIFF
--- a/agentuniverse/base/tracing/au_trace_context.py
+++ b/agentuniverse/base/tracing/au_trace_context.py
@@ -145,14 +145,20 @@ class AuTraceContext:
     def add_current_token_usage_to_parent(self, token_usage=None, parent_span_id=None):
         if not token_usage:
             token_usage = self.get_current_token_usage()
+        # The shared _token_count_dict is mutated by concurrent LLM sub-calls
+        # reporting to the same parent (e.g. an agent span fanning out to
+        # parallel LLM calls in a thread pool). Protect both branches with
+        # the instance lock, matching add_current_token_usage's sync path.
         if parent_span_id and parent_span_id in self._token_count_dict:
-            self._token_count_dict[parent_span_id] += token_usage
+            with self._token_count_lock:
+                self._token_count_dict[parent_span_id] += token_usage
             return
 
         span = trace.get_current_span()
         parent_ctx = span.parent  # Only SpanContext, which may be None.
         if parent_ctx is not None and parent_ctx.span_id and parent_ctx.span_id in self._token_count_dict:
-            self._token_count_dict[parent_ctx.span_id] += token_usage
+            with self._token_count_lock:
+                self._token_count_dict[parent_ctx.span_id] += token_usage
 
     def get_current_token_usage(self, span_id=None):
         span_id = span_id or trace.get_current_span().get_span_context().span_id

--- a/agentuniverse/base/util/monitor/monitor.py
+++ b/agentuniverse/base/util/monitor/monitor.py
@@ -243,9 +243,12 @@ class Monitor(BaseModel):
                 for key, value in cur_token_usage.items():
                     try:
                         result_usage[key] = old_token_usage[key] + value if key in old_token_usage else value
-                    except:
-                        # not addable value
-                        pass
+                    except TypeError:
+                        # Non-addable value (e.g. mixed types from a custom
+                        # TokenUsage subclass); log so the field doesn't
+                        # silently disappear from totals.
+                        logger.debug(f"Token usage field {key!r} is not addable "
+                                     f"({type(value).__name__}); skipping.")
                 FrameworkContextManager().set_context(trace_id + '_token_usage', result_usage)
 
     @staticmethod
@@ -291,7 +294,10 @@ class Monitor(BaseModel):
 
             if llm_obj is None or llm_input is None:
                 return {}
-            messages = llm_input.get('kwargs', {}).pop('messages', None)
+            # NOTE: use .get, not .pop — .pop mutates the caller's input dict,
+            # silently removing `messages` so any later use (retry loops,
+            # logging of the full input) finds it missing.
+            messages = llm_input.get('kwargs', {}).get('messages', None)
 
             input_str = ''
             if messages is not None and isinstance(messages, list):

--- a/tests/test_agentuniverse/unit/base/util/test_monitor_and_trace_fixes.py
+++ b/tests/test_agentuniverse/unit/base/util/test_monitor_and_trace_fixes.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for Monitor and AuTraceContext fixes.
+
+1. Monitor.get_llm_token_usage previously did ``.pop('messages')`` on the
+   caller's input dict, silently removing messages so later use (retry,
+   logging) found it missing. Now uses .get.
+2. Monitor.add_token_usage had a bare ``except:`` that swallowed every
+   exception (including KeyboardInterrupt) when a token field was not
+   addable. Now narrowed to TypeError with a debug log.
+3. AuTraceContext.add_current_token_usage_to_parent mutated the shared
+   _token_count_dict without the instance lock, losing updates under
+   concurrent LLM sub-calls. Now both branches hold the lock.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestMonitorGetLLMTokenUsageNoMutation(unittest.TestCase):
+    """get_llm_token_usage must not mutate the caller's llm_input."""
+
+    def test_get_llm_token_usage_does_not_pop_messages(self):
+        from agentuniverse.base.util.monitor.monitor import Monitor
+
+        # Build an llm_input whose kwargs contain messages; the LLM output
+        # has no usage so the code walks the messages path.
+        messages = [{"role": "user", "content": "hello world"}]
+        llm_input = {"kwargs": {"messages": messages}}
+        llm_obj = MagicMock()
+        llm_obj.get_num_tokens.return_value = 2
+        output = MagicMock()
+        output.usage = None
+        output.text = "response"
+
+        Monitor.get_llm_token_usage(output, llm_obj, llm_input)
+
+        # messages must still be present in the caller's dict (the bug: .pop
+        # removed it).
+        self.assertIn("messages", llm_input["kwargs"],
+                      "get_llm_token_usage must not pop messages from the "
+                      "caller's input dict")
+        self.assertEqual(llm_input["kwargs"]["messages"], messages)
+
+
+class TestMonitorAddTokenUsageBareExcept(unittest.TestCase):
+    """add_token_usage must not swallow non-addable fields silently."""
+
+    def test_non_addable_field_is_skipped_not_crashing(self):
+        from agentuniverse.base.util.monitor.monitor import Monitor
+
+        with patch("agentuniverse.base.util.monitor.monitor.AuTraceManager") \
+                as trace_mgr, \
+             patch("agentuniverse.base.util.monitor.monitor."
+                   "FrameworkContextManager") as ctx_mgr:
+            trace_mgr.return_value.get_trace_id.return_value = "trace1"
+            ctx_mgr.return_value.get_context.return_value = {
+                "prompt_tokens": 10,
+                "weird_field": "not_a_number",
+            }
+            # cur_token_usage has a weird_field that can't be added to a str.
+            cur = {"prompt_tokens": 5, "weird_field": 5}
+            # Must not raise (the bare except caught everything; the narrowed
+            # TypeError should still skip the field gracefully).
+            Monitor.add_token_usage(cur)
+            # The set_context call carries the merged result.
+            set_call = ctx_mgr.return_value.set_context.call_args
+            result = set_call.args[1]
+            self.assertEqual(result["prompt_tokens"], 15)
+
+    def test_add_token_usage_source_does_not_bare_except(self):
+        import inspect
+        from agentuniverse.base.util.monitor.monitor import Monitor
+
+        src = inspect.getsource(Monitor.add_token_usage)
+        # The bare ``except:`` must be gone.
+        self.assertNotIn("except:", src,
+                         "add_token_usage must not use a bare except; narrow "
+                         "to TypeError")
+        self.assertIn("except TypeError", src)
+
+
+class TestAuTraceContextTokenLock(unittest.TestCase):
+    """add_current_token_usage_to_parent must hold the instance lock."""
+
+    def test_source_uses_lock_in_parent_branch(self):
+        import inspect
+        from agentuniverse.base.tracing.au_trace_context import AuTraceContext
+
+        src = inspect.getsource(AuTraceContext.add_current_token_usage_to_parent)
+        # Both += branches must be inside `with self._token_count_lock:`.
+        # Count the lock acquisitions vs the += operations.
+        self.assertGreaterEqual(src.count("with self._token_count_lock"), 2,
+                                "both parent-id and parent-span branches must "
+                                "hold the lock when mutating the shared dict")
+
+    def test_parent_token_usage_accumulates_under_lock(self):
+        from agentuniverse.base.tracing.au_trace_context import AuTraceContext
+        from agentuniverse.llm.llm_output import TokenUsage
+
+        ctx = AuTraceContext()
+        ctx._token_count_dict = {"parent_span": TokenUsage()}
+        # Simulate two concurrent reports to the same parent. TokenUsage
+        # stores text_in / text_out; prompt_tokens is a derived property.
+        t1 = TokenUsage(text_in=10, text_out=5)
+        t2 = TokenUsage(text_in=20, text_out=8)
+        ctx.add_current_token_usage_to_parent(t1, parent_span_id="parent_span")
+        ctx.add_current_token_usage_to_parent(t2, parent_span_id="parent_span")
+        total = ctx._token_count_dict["parent_span"]
+        self.assertEqual(total.prompt_tokens, 30)
+        self.assertEqual(total.completion_tokens, 13)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Three bugs in monitor and tracing: destructive `.pop`, a bare `except:`, and a token-count race.

## Why (not a duplicate)

Not covered by any open or merged PR. #712 fixed silent-exception patterns in ContextManager and Memory but did not touch monitor.py or au_trace_context.py.

## Changes

### 1. Monitor.get_llm_token_usage — destructive `.pop('messages')`
\`llm_input.get('kwargs', {}).pop('messages')\` mutated the caller's input dict, silently removing \`messages\` so any later use (retry loops, logging of the full input) found it missing. Now uses \`.get\` (non-destructive).

### 2. Monitor.add_token_usage — bare `except:`
A bare \`except:\` swallowed every exception (including \`KeyboardInterrupt\` / \`SystemExit\`) when a token field was not addable, silently dropping the field from totals. Narrowed to \`except TypeError\` with a debug log naming the field.

### 3. AuTraceContext.add_current_token_usage_to_parent — token-count race
Mutated the shared \`_token_count_dict\` without the instance lock (the sibling \`add_current_token_usage\` DOES lock its sync path). Under concurrent LLM sub-calls reporting to the same parent span (agent fan-out in a thread pool), the \`+=\` lost updates and parent token counts were under-counted. Both branches now hold \`self._token_count_lock\`.

## Tests

\`tests/test_agentuniverse/unit/base/util/test_monitor_and_trace_fixes.py\` — 5 regressions:
- \`get_llm_token_usage\` does not pop \`messages\` from the caller's dict
- non-addable field skipped without crashing (narrowed except)
- source contract: \`add_token_usage\` has no bare \`except:\`
- source contract: both branches of \`add_current_token_usage_to_parent\` acquire the lock
- parent token usage accumulates correctly across two reports

\`python -m unittest tests.test_agentuniverse.unit.base.util.test_monitor_and_trace_fixes\` — 5 passed.

## Behaviour change

- \`llm_input['kwargs']['messages']\` is no longer destroyed by token accounting.
- Parent-span token counts are now accurate under concurrent LLM sub-calls.