### PR TITLE
fix(reader): image OCR None guard, print cleanup, raise-from-e

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py
@@ -3,11 +3,14 @@
 
 # @Time    : 2025/9/29
 # @FileName: image_ocr_reader.py
+import logging
 from typing import List, Optional, Dict, Union
 from pathlib import Path
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
+
+logger = logging.getLogger(__name__)
 
 
 class ImageOCRReader(Reader):
@@ -21,14 +24,13 @@ class ImageOCRReader(Reader):
     """
 
     def _load_data(self, file: Union[str, Path], ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: ImageOCRReader start load file={file}")
         if isinstance(file, str):
             file = Path(file)
         if not isinstance(file, Path) or not file.exists():
             raise FileNotFoundError(f"ImageOCRReader file not found: {file}")
 
         text, engine = self._ocr(file)
-        print(f"debugging: ImageOCRReader extracted by {engine}, length={len(text)}")
+        logger.debug("ImageOCRReader extracted by %s, length=%d", engine, len(text))
 
         metadata: Dict = {"source": "image", "file_name": file.name, "engine": engine}
         if ext_info:
@@ -36,44 +38,56 @@ class ImageOCRReader(Reader):
         return [Document(text=text, metadata=metadata)]
 
     def _ocr(self, file: Path) -> (str, str):
+        last_exc = None
         # Try PaddleOCR
         try:
             from paddleocr import PaddleOCR  # type: ignore
-            print("debugging: ImageOCRReader using PaddleOCR")
             ocr = PaddleOCR(use_angle_cls=True, lang='ch')
             result = ocr.ocr(str(file), cls=True)
             lines: List[str] = []
-            for page in result:
+            # PaddleOCR returns [[None]] or [[(box, (None, conf))]] for
+            # low-confidence pages; the previous loop did `for line in page`
+            # and `line[1][0]` unconditionally and raised TypeError, which
+            # the outer except caught and silently downgraded to the next
+            # engine without surfacing the cause.
+            for page in result or []:
+                if page is None:
+                    continue
                 for line in page:
+                    if line is None or len(line) < 2 or line[1] is None:
+                        continue
                     txt = line[1][0]
                     if txt:
                         lines.append(txt)
             return "\n".join(lines), "paddleocr"
         except Exception as e_paddle:
-            print(f"debugging: ImageOCRReader PaddleOCR failed: {e_paddle}")
+            last_exc = e_paddle
+            logger.debug("ImageOCRReader PaddleOCR failed: %s", e_paddle,
+                         exc_info=True)
 
         # Fallback to pytesseract
         try:
             from PIL import Image  # type: ignore
             import pytesseract  # type: ignore
-            print("debugging: ImageOCRReader using pytesseract")
             img = Image.open(file)
             text = pytesseract.image_to_string(img, lang='chi_sim+eng')
             return text, "pytesseract"
         except Exception as e_tess:
-            print(f"debugging: ImageOCRReader pytesseract failed: {e_tess}")
+            last_exc = e_tess
+            logger.debug("ImageOCRReader pytesseract failed: %s", e_tess,
+                         exc_info=True)
 
         # Fallback to easyocr
         try:
             import easyocr  # type: ignore
-            print("debugging: ImageOCRReader using easyocr")
             reader = easyocr.Reader(['ch_sim', 'en'])
             result = reader.readtext(str(file), detail=0)
             return "\n".join(result), "easyocr"
         except Exception as e_easy:
+            last_exc = e_easy
             raise ImportError(
                 "No OCR engine available. Install one of: "
                 "`pip install paddleocr paddlepaddle` or "
                 "`pip install pytesseract pillow` or "
                 "`pip install easyocr`"
-            )
+            ) from last_exc

--- a/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
@@ -148,4 +148,4 @@ class ImageReader(Reader):
             })
             return [Document(text=image_text, metadata=metadata)]
         except Exception as e:
-            raise Exception(f"Error processing image {file}: {str(e)}")
+            raise RuntimeError(f"Error processing image {file}: {e}") from e

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_none_guard.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_none_guard.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for image OCR None-guard, print cleanup, and raise-from-e.
+
+1. PaddleOCR returns [[None]] / [[(box, (None, conf))]] for low-confidence
+   pages; the previous loop did `for line in page` / `line[1][0]`
+   unconditionally and raised TypeError, which the outer except caught and
+   silently downgraded to pytesseract without surfacing the cause.
+2. Stray `print("debugging: ...")` statements removed.
+3. image_reader `raise Exception(...)` lost the original traceback; now
+   `raise RuntimeError(...) from e`.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestImageOCRReaderPaddleNoneGuard(unittest.TestCase):
+    """PaddleOCR None page/line must be skipped, not crash into fallback."""
+
+    def _reader(self):
+        from agentuniverse.agent.action.knowledge.reader.image.\
+            image_ocr_reader import ImageOCRReader
+        return ImageOCRReader()
+
+    def test_none_page_is_skipped_not_crashing(self):
+        reader = self._reader()
+        fake_paddle = MagicMock()
+        # PaddleOCR.ocr returns [[None, [(box, ('text', 0.9))]]] — first page
+        # is None, second has a real line.
+        fake_paddle.PaddleOCR.return_value.ocr.return_value = [
+            None,
+            [[((0, 0), (1, 0), (1, 1), (0, 1)), ("hello", 0.95)]],
+        ]
+        with patch.dict("sys.modules", {"paddleocr": fake_paddle}):
+            text, engine = reader._ocr(__file__)
+        self.assertEqual(engine, "paddleocr")
+        self.assertIn("hello", text)
+
+    def test_none_line_is_skipped(self):
+        reader = self._reader()
+        fake_paddle = MagicMock()
+        fake_paddle.PaddleOCR.return_value.ocr.return_value = [
+            [[((0, 0), (1, 0), (1, 1), (0, 1)), None],
+             [((0, 0), (1, 0), (1, 1), (0, 1)), ("world", 0.9)]],
+        ]
+        with patch.dict("sys.modules", {"paddleocr": fake_paddle}):
+            text, engine = reader._ocr(__file__)
+        self.assertIn("world", text)
+        self.assertNotIn("None", text)
+
+
+class TestImageOCRReaderPrintCleanup(unittest.TestCase):
+    """No stray print('debugging: ...') statements."""
+
+    def test_source_has_no_debug_prints(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.image.\
+            image_ocr_reader import ImageOCRReader
+
+        src = inspect.getsource(ImageOCRReader)
+        self.assertNotIn('print("debugging:', src,
+                         "ImageOCRReader must not ship debug print statements")
+        self.assertNotIn("print(f\"debugging:", src)
+
+
+class TestImageReaderRaiseFromE(unittest.TestCase):
+    """image_reader must chain the original exception."""
+
+    def test_source_uses_from_e(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.image.\
+            image_reader import ImageReader
+
+        # The raise is in _load_data; check the source has `from e`.
+        src = inspect.getsource(ImageReader)
+        # Find the error-handling raise.
+        self.assertIn("raise RuntimeError", src,
+                      "image_reader should raise RuntimeError, not bare Exception")
+        self.assertIn("from e", src,
+                      "image_reader must chain the original exception with `from e`")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

ImageOCRReader crashed on PaddleOCR None output, shipped debug prints, and image_reader lost tracebacks.

## Why (not a duplicate)

Not covered by any open or merged PR. #648 cleaned WebPageReader prints; #712 added TxtReader size guard. These image reader files were untouched.

## Changes

### 1. ImageOCRReader — PaddleOCR None page/line guard
The PaddleOCR loop did \`for line in page\` / \`line[1][0]\` unconditionally. PaddleOCR returns \`[[None]\` or \`[[(box, (None, conf))]]\` for low-confidence pages; the loop raised \`TypeError\`, which the outer except caught and silently downgraded to pytesseract/easyocr without surfacing the cause. Now guards \`page\` and \`line[1]\` for None before indexing; the fallback \`ImportError\` chains the last real exception via \`from last_exc\`.

### 2. Debug print cleanup
Removed stray \`print("debugging: ...")\` statements from ImageOCRReader (one printed the OCR engine failure text, which can carry credentials). Replaced with a module \`logger.debug\`.

### 3. image_reader — raise-from-e
\`raise Exception(f"Error processing image {file}: {str(e)}")\` lost the original traceback. Now \`raise RuntimeError(...) from e\`.

## Tests

\`tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_none_guard.py\` — 4 regressions:
- None page is skipped (does not crash into fallback)
- None line is skipped
- source has no \`print("debugging:\` statements
- image_reader raises \`RuntimeError\` with \`from e\`

\`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.image.test_image_ocr_none_guard\` — 4 passed.

## Behaviour change

- PaddleOCR low-confidence output no longer silently downgrades to a different engine.
- No debug prints in production stdout.
- Image processing errors preserve the original traceback.