### PR TITLE
feat(llm): add MiniMax model integration

### DIFF
--- a/agentuniverse/llm/default/minimax_openai_style_llm.py
+++ b/agentuniverse/llm/default/minimax_openai_style_llm.py
@@ -1,0 +1,69 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/20 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: minimax_openai_style_llm.py
+
+from typing import Optional, Any, Union, Iterator, AsyncIterator
+
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+MINIMAX_MAX_CONTEXT_LENGTH = {
+    "MiniMax-Text-01": 1000192,
+    "MiniMax-VL-01": 1000192,
+    "abab6.5s-chat": 8000,
+    "abab6.5-chat": 8000,
+    "abab5.5s-chat": 8000,
+    "abab5.5-chat": 8000,
+}
+
+
+class MiniMaxOpenAIStyleLLM(OpenAIStyleLLM):
+    """The agentUniverse default MiniMax llm module.
+
+    LLM parameters, such as name/description/model_name/max_tokens,
+    are injected into this class by the minimax_openai_style_llm.yaml configuration.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_API_KEY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_ORGANIZATION"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_API_BASE"))
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_PROXY"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """ The call method of the LLM.
+
+        Users can customize how the model interacts by overriding call method of the LLM class.
+
+        Args:
+            messages (list): The messages to send to the LLM.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """ The async call method of the LLM.
+
+        Users can customize how the model interacts by overriding acall method of the LLM class.
+
+        Args:
+            messages (list): The messages to send to the LLM.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Max context length.
+
+          The total length of input tokens and generated tokens is limited by the MiniMax model's context length.
+          """
+        if super().max_context_length():
+            return super().max_context_length()
+        return MINIMAX_MAX_CONTEXT_LENGTH.get(self.model_name, 8000)

--- a/agentuniverse/llm/default/minimax_openai_style_llm.yaml
+++ b/agentuniverse/llm/default/minimax_openai_style_llm.yaml
@@ -1,0 +1,8 @@
+name: 'default_minimax_llm'
+description: 'default default_minimax_llm llm with spi'
+model_name: 'MiniMax-Text-01'
+max_tokens: 1000
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.minimax_openai_style_llm'
+  class: 'MiniMaxOpenAIStyleLLM'

--- a/agentuniverse/llm/llm_channel/minimax_official_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/minimax_official_llm_channel.py
@@ -1,0 +1,28 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/20 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: minimax_official_llm_channel.py
+from typing import Optional
+
+from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
+
+MINIMAX_MAX_CONTEXT_LENGTH = {
+    "MiniMax-Text-01": 1000192,
+    "MiniMax-VL-01": 1000192,
+    "abab6.5s-chat": 8000,
+    "abab6.5-chat": 8000,
+    "abab5.5s-chat": 8000,
+    "abab5.5-chat": 8000,
+}
+
+
+class MiniMaxOfficialLLMChannel(LLMChannel):
+    channel_api_base: Optional[str] = 'https://api.minimaxi.com/v1'
+
+    def max_context_length(self) -> int:
+        if super().max_context_length():
+            return super().max_context_length()
+        return MINIMAX_MAX_CONTEXT_LENGTH.get(self.channel_model_name, 8000)

--- a/agentuniverse_product/base/constant/llm_constant.py
+++ b/agentuniverse_product/base/constant/llm_constant.py
@@ -32,4 +32,8 @@ LLM_MODEL_NAME = {
     'baichuan_llm': ['Baichuan4', 'Baichuan3-Turbo', 'Baichuan3-Turbo-128k', 'Baichuan2-Turbo', 'Baichuan2-Turbo-192k'],
     'default_baichuan_llm': ['Baichuan4', 'Baichuan3-Turbo', 'Baichuan3-Turbo-128k', 'Baichuan2-Turbo',
                              'Baichuan2-Turbo-192k'],
+    'minimax_llm': ['MiniMax-Text-01', 'MiniMax-VL-01', 'abab6.5s-chat', 'abab6.5-chat',
+                    'abab5.5s-chat', 'abab5.5-chat'],
+    'default_minimax_llm': ['MiniMax-Text-01', 'MiniMax-VL-01', 'abab6.5s-chat', 'abab6.5-chat',
+                            'abab5.5s-chat', 'abab5.5-chat'],
 }

--- a/examples/sample_standard_app/config/custom_key.toml.sample
+++ b/examples/sample_standard_app/config/custom_key.toml.sample
@@ -61,6 +61,12 @@ GOOGLE_API_KEY=''
 GOOGLE_API_BASE='https://generativelanguage.googleapis.com/v1beta/openai/'
 GOOGLE_PROXY=''
 
+#minimax default name: default_minimax_llm
+MINIMAX_API_KEY=''
+MINIMAX_API_BASE='https://api.minimaxi.com/v1'
+MINIMAX_PROXY = ''
+MINIMAX_ORGANIZATION = ''
+
 #  ========================================================================
 #  The following section is used for key configuration of search tools.
 #  ========================================================================

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/abab6_5s_chat.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/abab6_5s_chat.yaml
@@ -1,0 +1,9 @@
+name: 'abab6.5s-chat'
+description: 'abab6.5s-chat'
+model_name: 'abab6.5s-chat'
+max_tokens: 2000
+temperature: 0.5
+streaming: True
+max_context_length: 8000
+channel: abab6.5s-chat-official
+meta_class: 'agentuniverse.llm.default.minimax_openai_style_llm.MiniMaxOpenAIStyleLLM'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/__init__.py
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/__init__.py
@@ -1,0 +1,7 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/20 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: __init__.py

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/abab6_5s_chat_official_channel.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/abab6_5s_chat_official_channel.yaml
@@ -1,0 +1,8 @@
+channel_name: 'abab6.5s-chat-official'
+channel_api_key: '${MINIMAX_API_KEY}'
+channel_api_base: 'https://api.minimaxi.com/v1'
+channel_model_name: 'abab6.5s-chat'
+model_support_stream: True
+model_support_max_context_length: 8000
+model_is_openai_protocol_compatible: True
+meta_class: 'agentuniverse.llm.llm_channel.minimax_official_llm_channel.MiniMaxOfficialLLMChannel'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_text_01_official_channel.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_text_01_official_channel.yaml
@@ -1,0 +1,8 @@
+channel_name: 'minimax-text-01-official'
+channel_api_key: '${MINIMAX_API_KEY}'
+channel_api_base: 'https://api.minimaxi.com/v1'
+channel_model_name: 'MiniMax-Text-01'
+model_support_stream: True
+model_support_max_context_length: 1000192
+model_is_openai_protocol_compatible: True
+meta_class: 'agentuniverse.llm.llm_channel.minimax_official_llm_channel.MiniMaxOfficialLLMChannel'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_vl_01_official_channel.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_vl_01_official_channel.yaml
@@ -1,0 +1,8 @@
+channel_name: 'minimax-vl-01-official'
+channel_api_key: '${MINIMAX_API_KEY}'
+channel_api_base: 'https://api.minimaxi.com/v1'
+channel_model_name: 'MiniMax-VL-01'
+model_support_stream: True
+model_support_max_context_length: 1000192
+model_is_openai_protocol_compatible: True
+meta_class: 'agentuniverse.llm.llm_channel.minimax_official_llm_channel.MiniMaxOfficialLLMChannel'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_text_01.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_text_01.yaml
@@ -1,0 +1,9 @@
+name: 'minimax-text-01'
+description: 'minimax-text-01'
+model_name: 'MiniMax-Text-01'
+max_tokens: 2000
+temperature: 0.5
+streaming: True
+max_context_length: 1000192
+channel: minimax-text-01-official
+meta_class: 'agentuniverse.llm.default.minimax_openai_style_llm.MiniMaxOpenAIStyleLLM'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_vl_01.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_vl_01.yaml
@@ -1,0 +1,9 @@
+name: 'minimax-vl-01'
+description: 'minimax-vl-01'
+model_name: 'MiniMax-VL-01'
+max_tokens: 2000
+temperature: 0.5
+streaming: True
+max_context_length: 1000192
+channel: minimax-vl-01-official
+meta_class: 'agentuniverse.llm.default.minimax_openai_style_llm.MiniMaxOpenAIStyleLLM'


### PR DESCRIPTION
##https://github.com/agentuniverse-ai/agentUniverse/issues/250
 PR 类型 / Type

`feat` — 新增功能 (New feature)

## 标题 / Title

feat(llm): 新增 MiniMax（MiniMax）大模型连接方式

## 一、需求背景 / Background

agentUniverse 框架目前已经支持 OpenAI、Kimi、Qwen、DeepSeek、Gemini、Claude、Zhipu、Baichuan、Wenxin、Ollama 等国内外主流 LLM 提供商，但尚未集成 **MiniMax（MiniMax）** 开放平台的模型。

MiniMax 提供与 OpenAI 兼容的 Chat Completion 接口，主流模型包括：

| 模型名 | 上下文长度 | 备注 |
| --- | --- | --- |
| `MiniMax-Text-01` | 1,000,192 | 长文本主力模型 |
| `MiniMax-VL-01` | 1,000,192 | 视觉理解模型 |
| `abab6.5s-chat` | 8,192 | 通用对话模型 |
| `abab6.5-chat` | 8,192 | 通用对话模型 |
| `abab5.5s-chat` | 8,192 | 通用对话模型 |
| `abab5.5-chat` | 8,192 | 通用对话模型 |

OpenAI 兼容的 Base URL：`https://api.minimaxi.com/v1`

## 二、变更内容 / What Changed

本 PR 严格沿用框架中 Kimi / DeepSeek / Qwen / Gemini 等其它 OpenAI 兼容 LLM 的接入模式（`agentuniverse/llm/default/*_openai_style_llm.py` + `agentuniverse/llm/llm_channel/*_official_llm_channel.py` + `buildin/<provider>/` 下的 yaml 资源），对框架既有逻辑零侵入。

### 1. 新增 LLM 类与通道类（核心代码）

- **`agentuniverse/llm/default/minimax_openai_style_llm.py`** 新增 `MiniMaxOpenAIStyleLLM`，继承自 `OpenAIStyleLLM`：
  - `api_key` → `MINIMAX_API_KEY`
  - `api_base` → `MINIMAX_API_BASE`
  - `proxy` → `MINIMAX_PROXY`
  - `organization` → `MINIMAX_ORGANIZATION`
  - 重写 `max_context_length()`，按模型名返回对应上下文长度。

- **`agentuniverse/llm/default/minimax_openai_style_llm.yaml`** 注册默认 LLM `default_minimax_llm`，默认模型 `MiniMax-Text-01`。

- **`agentuniverse/llm/llm_channel/minimax_official_llm_channel.py`** 新增 `MiniMaxOfficialLLMChannel`，设置 `channel_api_base` 为 `https://api.minimaxi.com/v1`，并提供 `max_context_length()`。

### 2. 注册模型名

- **`agentuniverse_product/base/constant/llm_constant.py`** 在 `LLM_MODEL_NAME` 字典中新增 `minimax_llm` 与 `default_minimax_llm` 两条注册项，列出全部 6 个 MiniMax 模型。

### 3. Key 配置模板

- **`examples/sample_standard_app/config/custom_key.toml.sample`** 在 `[KEY_LIST]` 的 models 段，按其它 LLM 的位置顺序追加： ```toml #minimax default name: default_minimax_llm MINIMAX_API_KEY='' MINIMAX_API_BASE='https://api.minimaxi.com/v1' MINIMAX_PROXY = '' MINIMAX_ORGANIZATION = '' ``` 用户复制 `custom_key.toml.sample` 为 `custom_key.toml` 后填入自己的 `MINIMAX_API_KEY` 即可使用。

### 4. Buildin 示例通道配置（参考 Kimi / DeepSeek 的 `buildin/<provider>` 结构）

在 `examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/` 下新增：

```
minimax/
├── __init__.py
├── channel/
│   ├── __init__.py
│   ├── minimax_text_01_official_channel.yaml
│   ├── minimax_vl_01_official_channel.yaml
│   └── abab6_5s_chat_official_channel.yaml
├── minimax_text_01.yaml
├── minimax_vl_01.yaml
└── abab6_5s_chat.yaml
```

- 3 个 `*_official_channel.yaml`：定义 `channel_name`、`channel_api_key`（引用 `${MINIMAX_API_KEY}`）、`channel_api_base`、`channel_model_name`、`meta_class`。
- 3 个上层 llm yaml：通过 `channel: <channel_name>` 引用对应通道，`meta_class` 指向 `MiniMaxOpenAIStyleLLM`。

## 三、变更文件清单 / Files Changed

仅修改/新增以下 12 个文件，无对框架原有逻辑的修改：

```
examples/sample_standard_app/config/custom_key.toml.sample
agentuniverse/llm/default/minimax_openai_style_llm.py
agentuniverse/llm/default/minimax_openai_style_llm.yaml
agentuniverse/llm/llm_channel/minimax_official_llm_channel.py
agentuniverse_product/base/constant/llm_constant.py
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/__init__.py
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_text_01_official_channel.yaml
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_vl_01_official_channel.yaml
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/abab6_5s_chat_official_channel.yaml
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_text_01.yaml
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_vl_01.yaml
examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/abab6_5s_chat.yaml
```

## 四、使用方法 / How to Use

1. 复制配置模板： ```bash cp examples/sample_standard_app/config/custom_key.toml.sample \ examples/sample_standard_app/config/custom_key.toml ```
2. 在 `custom_key.toml` 中填入： ```toml MINIMAX_API_KEY='<your-minimax-api-key>' ```
3. 在 Agent 的 yaml 中将 LLM 切到 MiniMax： ```yaml profile: llm_model:
       name: 'minimax-text-01'   # 或 'minimax-vl-01' / 'abab6.5s-chat'
   ```
4. 直接运行示例：
   ```bash
   python examples/sample_standard_app/intelligence/test/run_demo_agent.py
   ```

## 五、测试结果 / Test Result

在 `examples/sample_standard_app/intelligence/test/run_demo_agent.py` 中以 `demo_agent` 为例进行端到端验证：

- ✅ 框架启动 banner 正常
- ✅ `minimax-text-01` LLM 成功注册
- ✅ 通道 `minimax-text-01-official` 成功加载
- ✅ Memory（`demo_memory`）、Tool（`mock_search_tool`）、Toolkit（`search_toolkit`）正常初始化
- ✅ 第一轮中文问题「分析下巴菲特减持比亚迪的原因」得到完整、结构化的回答
- ✅ 第二轮问题「我刚才问了什么问题」memory 正常工作，正确回忆上轮内容

> 注：本环境为 Python 3.13，需对 `numpy/core/getlimits.py` 的 longdouble 计算做兼容补丁；该补丁在 `.venv` 内，不在本次 PR 范围内。

## 六、兼容性 / Compatibility

- **不修改**任何已有 LLM 类的代码、配置或常量。
- **不引入**新的第三方依赖（复用 `openai` SDK）。
- `custom_key.toml.sample` 中其它 LLM 的 key 配置项保持不变。
- 对未启用 MiniMax 的项目无任何影响。

## 七、检查项 / Checklist

- [x] 已阅读并理解 [贡献者指南](CONTRIBUTING_zh.md)
- [x] 已检查未与已有功能重复
- [x] 已运行 demo agent 完成端到端测试
- [x] 命名、注释遵循 PEP8 / Google Python Style
- [x] 沿用项目已有 OpenAI 兼容 LLM 的集成模式（Kimi / DeepSeek / Qwen / Gemini）

## 八、关联信息 / Related

- 参考实现：`agentuniverse/llm/default/kimi_openai_style_llm.py`、`deep_seek_openai_style_llm.py`、`gemini_openai_style_llm.py`
- 参考通道：`agentuniverse/llm/llm_channel/kimi_official_llm_channel.py`、`deepseek_official_llm_channel.py`
- 默认 Base URL：`https://api.minimaxi.com/v1`（OpenAI 兼容）

**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

