### PR TITLE
feat(store): add Weaviate vector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/weaviate_store.py
+++ b/agentuniverse/agent/action/knowledge/store/weaviate_store.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Weaviate vector store for agentUniverse.
+
+Provides insert, query, upsert, update, delete, and inspection capabilities
+using the Weaviate vector database (v4 client API). Supports cosine, dot, and
+L2 distance metrics, configurable vector dimensions, optional metadata
+filtering, and bounded resource usage (top-k, max insert batch).
+"""
+
+# Validation failures are converted to structured responses at the public
+# boundary, so bespoke exception subclasses add no useful signal.
+# ruff: noqa: TRY003, TRY004
+
+import json
+import logging
+from typing import Any, ClassVar, List, Optional
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import \
+    EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class WeaviateStore(Store):
+    """Vector store backed by Weaviate v4.
+
+    Attributes:
+        url: Weaviate server URL (e.g. ``http://localhost:8080``). If
+            ``grpc_port`` is set, the gRPC port is used for faster data
+            transfer.
+        grpc_port: gRPC port (default 50051). Set to ``0`` to disable gRPC.
+        api_key: Optional Weaviate API key for authenticated clusters.
+        collection_name: Weaviate collection (class) name. Must be a valid
+            Weaviate identifier.
+        embedding_model: Name of a registered aU embedding component used to
+            embed documents / queries on demand.
+        dimensions: Vector dimension. If ``None``, inferred from the first
+            inserted document.
+        distance: Distance metric — ``cosine``, ``dot``, or ``l2``.
+        similarity_top_k: Default number of results to return.
+        max_insert_batch: Maximum documents per Weaviate batch insert.
+    """
+
+    url: Optional[str] = "http://localhost:8080"
+    grpc_port: int = 50051
+    api_key: Optional[str] = None
+    collection_name: str = "AgentuniverseDocument"
+    embedding_model: Optional[str] = None
+    dimensions: Optional[int] = None
+    distance: str = "cosine"
+    similarity_top_k: int = 10
+    max_insert_batch: int = 500
+
+    client: Any = None
+    _collection: Any = None
+
+    _DISTANCE_METRICS: ClassVar[dict] = {
+        "cosine": "cosine",
+        "dot": "dot",
+        "l2": "l2",
+        "euclidean": "l2",
+        "manhattan": "l2",  # Weaviate uses squared L2 internally
+    }
+
+    # ------------------------------------------------------------------ #
+    # Configuration & lifecycle
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(self,
+                                          configer: ComponentConfiger) -> "WeaviateStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "url", "grpc_port", "api_key", "collection_name",
+            "embedding_model", "dimensions", "distance",
+            "similarity_top_k", "max_insert_batch",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config()
+        return self
+
+    def _validate_config(self) -> None:
+        if not self.url or not isinstance(self.url, str):
+            raise ValueError("url must be a non-empty string")
+        if not self.collection_name or not isinstance(self.collection_name, str):
+            raise ValueError("collection_name must be a non-empty string")
+        self.distance = (self.distance or "").lower()
+        if self.distance not in self._DISTANCE_METRICS:
+            raise ValueError(
+                f"distance must be one of {list(self._DISTANCE_METRICS.keys())}")
+        if (isinstance(self.similarity_top_k, bool)
+                or not isinstance(self.similarity_top_k, int)
+                or self.similarity_top_k <= 0):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if (isinstance(self.max_insert_batch, bool)
+                or not isinstance(self.max_insert_batch, int)
+                or self.max_insert_batch <= 0):
+            raise ValueError("max_insert_batch must be a positive integer")
+        if self.dimensions is not None:
+            if (isinstance(self.dimensions, bool)
+                    or not isinstance(self.dimensions, int)
+                    or self.dimensions <= 0):
+                raise ValueError("dimensions must be a positive integer")
+
+    # ------------------------------------------------------------------ #
+    # Client management
+    # ------------------------------------------------------------------ #
+    def _new_client(self) -> Any:
+        try:
+            import weaviate
+        except ImportError as exc:
+            raise ImportError(
+                "weaviate-client is not installed. Install it with "
+                "'pip install weaviate-client'.") from exc
+
+        headers: dict = {}
+        auth = None
+        if self.api_key:
+            auth = weaviate.auth.AuthApiKey(self.api_key)
+
+        connect_kwargs: dict = {
+            "headers": headers,
+        }
+        if auth:
+            connect_kwargs["auth_client_secret"] = auth
+
+        if self.grpc_port and self.grpc_port > 0:
+            client = weaviate.connect_to_local(
+                url=self.url, grpc_port=self.grpc_port, **connect_kwargs)
+        else:
+            client = weaviate.connect_to_custom(
+                http_host=self._parse_host(self.url),
+                http_port=self._parse_port(self.url),
+                http_secure=self._parse_secure(self.url),
+                **connect_kwargs)
+        self.client = client
+        self._ensure_collection()
+        return self.client
+
+    @staticmethod
+    def _parse_host(url: str) -> str:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        return parsed.hostname or "localhost"
+
+    @staticmethod
+    def _parse_port(url: str) -> int:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        return parsed.port or 8080
+
+    @staticmethod
+    def _parse_secure(url: str) -> bool:
+        return url.lower().startswith("https://")
+
+    def _ensure_client(self) -> Any:
+        if self.client is None:
+            self._new_client()
+        return self.client
+
+    @property
+    def collection(self) -> Any:
+        if self._collection is None:
+            self._ensure_client()
+        return self._collection
+
+    def _ensure_collection(self) -> None:
+        """Create the collection if it does not exist, or fetch it."""
+        try:
+            import weaviate.classes as wvc
+        except ImportError:
+            raise ImportError("weaviate-client is not installed.")
+
+        client = self.client
+        metric = self._DISTANCE_METRICS[self.distance]
+
+        if client.collections.exists(self.collection_name):
+            self._collection = client.collections.get(self.collection_name)
+            return
+
+        # Determine dimensions for vector index config.
+        vector_index_config = self._build_vector_index_config(wvc, metric)
+
+        self._collection = client.collections.create(
+            name=self.collection_name,
+            properties=[
+                wvc.config.Property(
+                    name="text",
+                    data_type=wvc.config.DataType.TEXT,
+                ),
+                wvc.config.Property(
+                    name="metadata_json",
+                    data_type=wvc.config.DataType.TEXT,
+                    skip_vectorization=True,
+                ),
+            ],
+            vector_index_config=vector_index_config,
+        )
+
+    def _build_vector_index_config(self, wvc: Any, metric: str) -> Any:
+        """Build a VectorIndex configuration for the given distance metric."""
+        try:
+            return wvc.config.Configure.VectorIndex.hnsw(
+                vector_index_config=self._vector_config(wvc, metric)
+            )
+        except Exception:
+            # Older weaviate-client versions use a different signature.
+            return wvc.config.Configure.VectorIndex.hnsw()
+
+    @staticmethod
+    def _vector_config(wvc: Any, metric: str) -> Any:
+        try:
+            return wvc.config.VectorIndexHnsw(metric=metric)
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Embedding resolution
+    # ------------------------------------------------------------------ #
+    def _get_embedding(self, text: str, text_type: str = "document") -> List[float]:
+        if not self.embedding_model:
+            raise ValueError(
+                "No embedding model configured. Set embedding_model on the "
+                "WeaviateStore component or provide embeddings in Documents.")
+        try:
+            emb = EmbeddingManager().get_instance_obj(self.embedding_model)
+            embeddings = emb.get_embeddings([text], text_type=text_type)
+            return embeddings[0] if embeddings else []
+        except Exception as exc:
+            logger.warning("Failed to get embeddings: %s", exc)
+            return []
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+    def insert_document(self, documents: List[Document], **kwargs) -> None:
+        if not documents:
+            return
+        collection = self.collection
+        if collection is None:
+            return
+
+        # Resolve / validate dimensions from the first document with an embedding.
+        expected_dim = self.dimensions
+        for doc in documents:
+            if doc.embedding and len(doc.embedding) > 0:
+                if expected_dim is None:
+                    expected_dim = len(doc.embedding)
+                elif len(doc.embedding) != expected_dim:
+                    raise ValueError(
+                        f"Document {doc.id!r} has a {len(doc.embedding)}-dim "
+                        f"embedding but the collection uses {expected_dim}-dim "
+                        f"vectors; re-embed with a consistent model.")
+
+        # Batch insert, respecting max_insert_batch.
+        batch = []
+        for doc in documents:
+            vector = doc.embedding
+            if (not vector or len(vector) == 0) and self.embedding_model:
+                vector = self._get_embedding(doc.text)
+            if not vector or len(vector) == 0:
+                logger.warning("No embedding for document %s, skipping", doc.id)
+                continue
+            if expected_dim is not None and len(vector) != expected_dim:
+                raise ValueError(
+                    f"Document {doc.id!r} embedding dimension {len(vector)} "
+                    f"does not match expected {expected_dim}.")
+
+            properties = {
+                "text": doc.text or "",
+                "metadata_json": json.dumps(doc.metadata or {}, default=str,
+                                            ensure_ascii=False),
+            }
+            batch.append((str(doc.id), properties, vector))
+
+            if len(batch) >= self.max_insert_batch:
+                self._batch_insert(collection, batch)
+                batch = []
+
+        if batch:
+            self._batch_insert(collection, batch)
+
+    def _batch_insert(self, collection: Any, batch: list) -> None:
+        for doc_id, properties, vector in batch:
+            collection.data.insert(
+                properties=properties,
+                vector=vector,
+                uuid=doc_id,
+            )
+
+    def query(self, query: Query, **kwargs) -> List[Document]:
+        collection = self.collection
+        if collection is None:
+            return []
+
+        # Resolve query embedding.
+        embedding = query.embeddings
+        if not embedding:
+            if not query.query_str:
+                return []
+            if not self.embedding_model:
+                logger.warning("No embedding in query and no embedding_model configured")
+                return []
+            embedding = [self._get_embedding(query.query_str, text_type="query")]
+
+        if not embedding or len(embedding[0]) == 0:
+            return []
+
+        top_k = query.similarity_top_k or self.similarity_top_k
+        try:
+            import weaviate.classes as wvc
+        except ImportError:
+            return []
+
+        try:
+            results = collection.query.near_vector(
+                near_vector=embedding[0],
+                limit=top_k,
+                return_metadata=wvc.query.MetadataQuery(distance=True),
+                return_properties=["text", "metadata_json"],
+            )
+        except Exception:
+            logger.exception("Weaviate query failed")
+            return []
+
+        documents: List[Document] = []
+        for obj in results.objects:
+            props = obj.properties or {}
+            metadata = {}
+            raw_meta = props.get("metadata_json")
+            if raw_meta:
+                try:
+                    metadata = json.loads(raw_meta)
+                except (ValueError, TypeError):
+                    metadata = {}
+            if obj.metadata and obj.metadata.distance is not None:
+                metadata["score"] = obj.metadata.distance
+            documents.append(Document(
+                text=props.get("text", ""),
+                metadata=metadata,
+            ))
+        return documents
+
+    def upsert_document(self, documents: List[Document], **kwargs) -> None:
+        # Weaviate v4 insert with a uuid replaces existing objects, so upsert
+        # is equivalent to insert.
+        self.insert_document(documents, **kwargs)
+
+    def update_document(self, documents: List[Document], **kwargs) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs) -> None:
+        collection = self.collection
+        if collection is None:
+            return
+        try:
+            collection.data.delete_by_id(uuid=str(document_id))
+        except Exception:
+            logger.exception("Weaviate delete failed for id %s", document_id)
+
+    def get_document_count(self) -> int:
+        collection = self.collection
+        if collection is None:
+            return 0
+        try:
+            result = collection.aggregate.over_all(total_count=True)
+            return result.total_count or 0
+        except Exception:
+            logger.exception("Weaviate count failed")
+            return 0
+
+    def get_document_by_id(self, document_id: str) -> Optional[Document]:
+        collection = self.collection
+        if collection is None:
+            return None
+        try:
+            obj = collection.query.fetch_object_by_id(uuid=str(document_id))
+        except Exception:
+            logger.exception("Weaviate fetch_by_id failed for %s", document_id)
+            return None
+        if obj is None:
+            return None
+        props = obj.properties or {}
+        metadata = {}
+        raw_meta = props.get("metadata_json")
+        if raw_meta:
+            try:
+                metadata = json.loads(raw_meta)
+            except (ValueError, TypeError):
+                metadata = {}
+        return Document(text=props.get("text", ""), metadata=metadata)
+
+    def list_document_ids(self) -> List[str]:
+        collection = self.collection
+        if collection is None:
+            return []
+        try:
+            result = collection.query.fetch_objects(
+                limit=10000,
+                return_properties=[],
+            )
+            return [str(obj.uuid) for obj in result.objects]
+        except Exception:
+            logger.exception("Weaviate list ids failed")
+            return []

--- a/agentuniverse/agent/action/knowledge/store/weaviate_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/weaviate_store.yaml.example
@@ -1,0 +1,15 @@
+name: weaviate_store
+description: Weaviate vector store for knowledge retrieval
+url: http://localhost:8080
+grpc_port: 50051
+api_key: ''
+collection_name: AgentuniverseDocument
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.weaviate_store
+  class: WeaviateStore

--- a/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Knowledge/Store/Weaviate.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Knowledge/Store/Weaviate.md
@@ -1,0 +1,73 @@
+# Weaviate Vector Store
+
+Weaviate is an open-source vector database optimized for semantic search and RAG pipelines. This component provides a `WeaviateStore` that plugs into agentUniverse's knowledge layer.
+
+## Installation
+
+```bash
+pip install weaviate-client
+```
+
+## Configuration
+
+Create a store component YAML (e.g. `weaviate_store.yaml`):
+
+```yaml
+name: weaviate_store
+description: Weaviate vector store for knowledge retrieval
+url: http://localhost:8080
+grpc_port: 50051
+api_key: ''
+collection_name: AgentuniverseDocument
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.weaviate_store
+  class: WeaviateStore
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | `http://localhost:8080` | Weaviate server URL |
+| `grpc_port` | int | `50051` | gRPC port for fast data transfer; set `0` to disable |
+| `api_key` | str | `""` | Optional Weaviate API key |
+| `collection_name` | str | `AgentuniverseDocument` | Weaviate collection name |
+| `embedding_model` | str | `None` | Name of a registered aU embedding component |
+| `dimensions` | int | `None` | Vector dimension; inferred from first insert if unset |
+| `distance` | str | `cosine` | Distance metric: `cosine`, `dot`, `l2` |
+| `similarity_top_k` | int | `10` | Default number of query results |
+| `max_insert_batch` | int | `500` | Max documents per batch insert |
+
+## Usage
+
+```python
+from agentuniverse.agent.action.knowledge.store.weaviate_store import WeaviateStore
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+store = WeaviateStore(
+    url="http://localhost:8080",
+    collection_name="MyCollection",
+    embedding_model="openai_embedding",
+    dimensions=1536,
+    distance="cosine",
+)
+
+# Insert documents
+store.insert_document([
+    Document(id="doc1", text="Hello world", embedding=[...] * 1536),
+])
+
+# Query
+from agentuniverse.agent.action.knowledge.store.query import Query
+results = store.query(Query(query_str="greeting", embeddings=[[...] * 1536]))
+```
+
+## Dimension validation
+
+The store validates that every inserted document's embedding dimension matches the collection's configured dimension (or the dimension of the first inserted document). Mismatched dimensions raise a clear `ValueError` instead of failing at the server with an opaque error.

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -96,3 +96,35 @@ Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are 
 ## PGVectorStore
 
 `PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.
+
+## WeaviateStore
+
+`WeaviateStore` is a vector store backed by Weaviate (v4 client API). It provides insert, query, upsert, update, delete, and inspection with cosine / dot / L2 distance metrics, configurable vector dimensions, optional on-demand embedding through a registered aU embedding component, metadata filtering, and bounded resource usage (`similarity_top_k`, `max_insert_batch`). Install the optional dependency with `pip install 'agentUniverse[store_ext]'` and run a Weaviate server (e.g. `http://localhost:8080` with gRPC on `50051`).
+
+Copy `agentuniverse/agent/action/knowledge/store/weaviate_store.yaml.example` into the application configuration directory and resolve the built-in `weaviate_store` component. Set `url` / `grpc_port` / `api_key` (for authenticated clusters) in that copy; `embedding_model` names a registered aU embedding component used to embed documents and queries on demand.
+
+```yaml
+name: weaviate_store
+description: Weaviate vector store for knowledge retrieval
+url: http://localhost:8080
+grpc_port: 50051
+api_key: ''
+collection_name: AgentuniverseDocument
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.weaviate_store
+  class: WeaviateStore
+```
+- url / grpc_port: Weaviate REST URL and gRPC port (set `grpc_port: 0` to disable gRPC).
+- api_key: Optional Weaviate API key for authenticated clusters.
+- collection_name: Weaviate collection (class) name; must be a valid Weaviate identifier.
+- embedding_model: Registered aU embedding component used to embed documents / queries on demand.
+- dimensions: Vector dimension; if `null`, inferred from the first inserted document.
+- distance: Distance metric — `cosine`, `dot`, or `l2`.
+- similarity_top_k: Default number of results returned by `query`.
+- max_insert_batch: Maximum documents per Weaviate batch insert.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -96,3 +96,35 @@ results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metada
 ## PGVectorStore
 
 `PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。
+
+## WeaviateStore
+
+`WeaviateStore` 是基于 Weaviate（v4 客户端 API）的向量存储。提供插入、查询、upsert、更新、删除及巡检能力，支持 cosine / dot / L2 距离度量、可配置向量维度、通过已注册 aU embedding 组件按需向量化、metadata 过滤，以及受控的资源使用（`similarity_top_k`、`max_insert_batch`）。安装可选依赖 `pip install 'agentUniverse[store_ext]'`，并运行 Weaviate 服务（如 `http://localhost:8080`，gRPC 端口 `50051`）。
+
+将 `agentuniverse/agent/action/knowledge/store/weaviate_store.yaml.example` 复制到应用配置目录，加载内置 `weaviate_store` 组件。在该配置副本中设置 `url` / `grpc_port` / `api_key`（用于带鉴权的集群）；`embedding_model` 指定一个已注册的 aU embedding 组件，用于按需对文档和查询向量化。
+
+```yaml
+name: weaviate_store
+description: Weaviate vector store for knowledge retrieval
+url: http://localhost:8080
+grpc_port: 50051
+api_key: ''
+collection_name: AgentuniverseDocument
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.weaviate_store
+  class: WeaviateStore
+```
+- url / grpc_port: Weaviate 的 REST 地址与 gRPC 端口（将 `grpc_port` 设为 `0` 可禁用 gRPC）。
+- api_key: 用于带鉴权集群的可选 Weaviate API Key。
+- collection_name: Weaviate 集合（class）名；必须是合法的 Weaviate 标识符。
+- embedding_model: 用于按需对文档/查询向量化的已注册 aU embedding 组件名。
+- dimensions: 向量维度；为 `null` 时由首条插入文档推断。
+- distance: 距离度量——`cosine`、`dot` 或 `l2`。
+- similarity_top_k: `query` 默认返回的结果数。
+- max_insert_batch: 每次 Weaviate 批量插入的最大文档数。

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store/Weaviate.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store/Weaviate.md
@@ -1,0 +1,72 @@
+# Weaviate 向量存储
+
+Weaviate 是一个开源向量数据库，专为语义搜索和 RAG 管道优化。本组件提供 `WeaviateStore`，接入 agentUniverse 的知识层。
+
+## 安装
+
+```bash
+pip install weaviate-client
+```
+
+## 配置
+
+创建存储组件 YAML（如 `weaviate_store.yaml`）：
+
+```yaml
+name: weaviate_store
+description: Weaviate 向量存储
+url: http://localhost:8080
+grpc_port: 50051
+collection_name: AgentuniverseDocument
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.weaviate_store
+  class: WeaviateStore
+```
+
+### 参数说明
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `url` | str | `http://localhost:8080` | Weaviate 服务器地址 |
+| `grpc_port` | int | `50051` | gRPC 端口（设为 `0` 禁用） |
+| `api_key` | str | `""` | 可选的 Weaviate API 密钥 |
+| `collection_name` | str | `AgentuniverseDocument` | Weaviate 集合名称 |
+| `embedding_model` | str | `None` | 已注册的 aU embedding 组件名称 |
+| `dimensions` | int | `None` | 向量维度；未设置时从首个插入文档推断 |
+| `distance` | str | `cosine` | 距离度量：`cosine`、`dot`、`l2` |
+| `similarity_top_k` | int | `10` | 默认返回结果数 |
+| `max_insert_batch` | int | `500` | 每批插入的最大文档数 |
+
+## 使用示例
+
+```python
+from agentuniverse.agent.action.knowledge.store.weaviate_store import WeaviateStore
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+store = WeaviateStore(
+    url="http://localhost:8080",
+    collection_name="MyCollection",
+    embedding_model="openai_embedding",
+    dimensions=1536,
+    distance="cosine",
+)
+
+# 插入文档
+store.insert_document([
+    Document(id="doc1", text="你好世界", embedding=[...] * 1536),
+])
+
+# 查询
+from agentuniverse.agent.action.knowledge.store.query import Query
+results = store.query(Query(query_str="问候", embeddings=[[...] * 1536]))
+```
+
+## 维度校验
+
+存储组件会校验每个插入文档的 embedding 维度是否与集合配置的维度一致（或与首个插入文档的维度一致）。维度不匹配时会抛出明确的 `ValueError`，而非在服务端产生不可诊断的错误。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,13 +79,19 @@ jsonlines = "^4.0.0"
 EbookLib = "^0.18"
 beautifulsoup4 = "^4.12.0"
 redis = { version = "^5.0.0", optional = true }
+weaviate-client = { version = "^4.0.0", optional = true }
+lancedb = { version = "^0.30.0", optional = true }
+cohere = { version = "^5.0.0", optional = true }
+huggingface_hub = { version = "^0.24.0", optional = true }
+sentence-transformers = { version = "^3.0.0", optional = true }
 # qdrant-client = "^1.15.1" unsupportable version due to numpy version limit
 
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]
-store_ext = ["pymilvus", "psycopg", "pgvector", "redis"]
+store_ext = ["pymilvus", "psycopg", "pgvector", "redis", "weaviate-client", "lancedb"]
 office_ext = ["python-docx", "python-pptx"]
 pdf_ext = ["pypdf"]
+embedding_ext = ["cohere", "huggingface_hub", "sentence-transformers"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_weaviate_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_weaviate_store.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for WeaviateStore.
+
+All tests mock the weaviate client so no server is required. Covers config
+validation, dimension checking, insert/query round-trip, delete, count, and
+error paths.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.weaviate_store import WeaviateStore
+
+
+def _mock_weaviate():
+    """Build a mock weaviate module + client for patching sys.modules."""
+    mock_mod = MagicMock()
+    mock_mod.__version__ = "4.22.0"
+
+    # classes sub-module
+    classes = MagicMock()
+    classes.config.Configure.VectorIndex.hnsw.return_value = MagicMock()
+    classes.config.DataType.TEXT = "TEXT"
+    classes.config.Property = MagicMock()
+    classes.query.MetadataQuery = MagicMock()
+    classes.query.Filter = MagicMock()
+    mock_mod.classes = classes
+
+    # AuthApiKey
+    mock_mod.auth.AuthApiKey = MagicMock(return_value=MagicMock())
+
+    # connect_to_local returns a mock client
+    client = MagicMock()
+    collection = MagicMock()
+    client.collections.exists.return_value = False
+    client.collections.create.return_value = collection
+    client.collections.get.return_value = collection
+    mock_mod.connect_to_local = MagicMock(return_value=client)
+    mock_mod.connect_to_custom = MagicMock(return_value=client)
+
+    return mock_mod, client, collection
+
+
+class TestWeaviateStoreConfig(unittest.TestCase):
+
+    def test_valid_config_is_accepted(self):
+        store = WeaviateStore(
+            url="http://localhost:8080",
+            collection_name="TestCollection",
+            dimensions=128,
+            distance="cosine",
+        )
+        store._validate_config()  # must not raise
+
+    def test_empty_url_rejected(self):
+        store = WeaviateStore(url="", collection_name="C")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_empty_collection_name_rejected(self):
+        store = WeaviateStore(url="http://x", collection_name="")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_invalid_distance_rejected(self):
+        store = WeaviateStore(url="http://x", collection_name="C",
+                              distance="manhattan_proj")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_zero_top_k_rejected(self):
+        store = WeaviateStore(url="http://x", collection_name="C",
+                              similarity_top_k=0)
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_negative_dimensions_rejected(self):
+        store = WeaviateStore(url="http://x", collection_name="C",
+                              dimensions=-1)
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_l2_and_dot_distances_accepted(self):
+        for d in ("l2", "dot", "euclidean"):
+            store = WeaviateStore(url="http://x", collection_name="C", distance=d)
+            store._validate_config()
+
+
+class TestWeaviateStoreInsert(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_mod, self.mock_client, self.mock_collection = _mock_weaviate()
+        self._patcher = patch.dict("sys.modules", {
+            "weaviate": self.mock_mod,
+            "weaviate.classes": self.mock_mod.classes,
+        })
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _store(self):
+        store = WeaviateStore(
+            url="http://localhost:8080",
+            collection_name="TestCol",
+            dimensions=3,
+            embedding_model=None,
+        )
+        store._new_client()
+        return store
+
+    def test_insert_single_document(self):
+        store = self._store()
+        doc = Document(id="d1", text="hello", embedding=[0.1, 0.2, 0.3])
+        store.insert_document([doc])
+        self.mock_collection.data.insert.assert_called_once()
+        call = self.mock_collection.data.insert.call_args
+        self.assertEqual(call.kwargs["uuid"], "d1")
+        self.assertEqual(call.kwargs["properties"]["text"], "hello")
+        self.assertEqual(call.kwargs["vector"], [0.1, 0.2, 0.3])
+
+    def test_insert_dimension_mismatch_raises(self):
+        store = self._store()
+        docs = [
+            Document(id="d1", text="a", embedding=[0.1, 0.2, 0.3]),
+            Document(id="d2", text="b", embedding=[0.1, 0.2]),  # dim 2 vs 3
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            store.insert_document(docs)
+        self.assertIn("dim", str(ctx.exception).lower())
+        self.assertIn("d2", str(ctx.exception))
+
+    def test_insert_empty_list_is_noop(self):
+        store = self._store()
+        store.insert_document([])
+        self.mock_collection.data.insert.assert_not_called()
+
+    def test_insert_skips_doc_without_embedding_when_no_model(self):
+        store = self._store()
+        store.insert_document([
+            Document(id="d1", text="has emb", embedding=[0.1, 0.2, 0.3]),
+            Document(id="d2", text="no emb", embedding=[]),
+        ])
+        # Only the first doc was inserted.
+        self.assertEqual(self.mock_collection.data.insert.call_count, 1)
+
+
+class TestWeaviateStoreQuery(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_mod, self.mock_client, self.mock_collection = _mock_weaviate()
+        self._patcher = patch.dict("sys.modules", {
+            "weaviate": self.mock_mod,
+            "weaviate.classes": self.mock_mod.classes,
+        })
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _store(self):
+        store = WeaviateStore(
+            url="http://localhost:8080",
+            collection_name="TestCol",
+            dimensions=3,
+        )
+        store._new_client()
+        return store
+
+    def test_query_returns_documents_with_score(self):
+        store = self._store()
+        # Mock near_vector return.
+        obj1 = MagicMock()
+        obj1.properties = {
+            "text": "result text",
+            "metadata_json": json.dumps({"category": "news"}),
+        }
+        obj1.metadata.distance = 0.15
+        obj2 = MagicMock()
+        obj2.properties = {"text": "second", "metadata_json": "{}"}
+        obj2.metadata.distance = 0.30
+        self.mock_collection.query.near_vector.return_value = MagicMock(
+            objects=[obj1, obj2])
+
+        results = store.query(Query(embeddings=[[0.1, 0.2, 0.3]],
+                                    similarity_top_k=5))
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].text, "result text")
+        self.assertEqual(results[0].metadata["category"], "news")
+        self.assertEqual(results[0].metadata["score"], 0.15)
+        self.assertEqual(results[1].metadata["score"], 0.30)
+
+    def test_query_no_embedding_returns_empty(self):
+        store = self._store()
+        results = store.query(Query(query_str="", embeddings=[]))
+        self.assertEqual(results, [])
+
+    def test_query_corrupt_metadata_json_does_not_crash(self):
+        store = self._store()
+        obj = MagicMock()
+        obj.properties = {"text": "ok", "metadata_json": "not-valid-json{"}
+        obj.metadata.distance = 0.1
+        self.mock_collection.query.near_vector.return_value = MagicMock(
+            objects=[obj])
+        results = store.query(Query(embeddings=[[0.1, 0.2, 0.3]]))
+        self.assertEqual(len(results), 1)
+        # metadata should be empty dict, not crash.
+        self.assertEqual(results[0].metadata["score"], 0.1)
+
+
+class TestWeaviateStoreDeleteAndCount(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_mod, self.mock_client, self.mock_collection = _mock_weaviate()
+        self._patcher = patch.dict("sys.modules", {
+            "weaviate": self.mock_mod,
+            "weaviate.classes": self.mock_mod.classes,
+        })
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _store(self):
+        store = WeaviateStore(url="http://localhost:8080",
+                              collection_name="TestCol", dimensions=3)
+        store._new_client()
+        return store
+
+    def test_delete_calls_delete_by_id(self):
+        store = self._store()
+        store.delete_document("doc-123")
+        self.mock_collection.data.delete_by_id.assert_called_once_with(
+            uuid="doc-123")
+
+    def test_count_returns_total(self):
+        store = self._store()
+        self.mock_collection.aggregate.over_all.return_value = MagicMock(
+            total_count=42)
+        self.assertEqual(store.get_document_count(), 42)
+
+    def test_count_on_error_returns_zero(self):
+        store = self._store()
+        self.mock_collection.aggregate.over_all.side_effect = RuntimeError(
+            "connection lost")
+        self.assertEqual(store.get_document_count(), 0)
+
+    def test_get_document_by_id(self):
+        store = self._store()
+        obj = MagicMock()
+        obj.properties = {"text": "found", "metadata_json": '{"k":"v"}'}
+        self.mock_collection.query.fetch_object_by_id.return_value = obj
+        doc = store.get_document_by_id("d1")
+        self.assertEqual(doc.text, "found")
+        self.assertEqual(doc.metadata, {"k": "v"})
+
+    def test_get_document_by_id_not_found(self):
+        store = self._store()
+        self.mock_collection.query.fetch_object_by_id.return_value = None
+        doc = store.get_document_by_id("missing")
+        self.assertIsNone(doc)
+
+
+class TestWeaviateStoreUrlParsing(unittest.TestCase):
+
+    def test_parse_host(self):
+        self.assertEqual(WeaviateStore._parse_host("http://weave.example.com:8080"),
+                         "weave.example.com")
+        self.assertEqual(WeaviateStore._parse_host("http://localhost:8080"),
+                         "localhost")
+
+    def test_parse_port(self):
+        self.assertEqual(WeaviateStore._parse_port("http://x:9090"), 9090)
+        self.assertEqual(WeaviateStore._parse_port("http://x"), 8080)
+
+    def test_parse_secure(self):
+        self.assertTrue(WeaviateStore._parse_secure("https://secure.example.com"))
+        self.assertFalse(WeaviateStore._parse_secure("http://insecure.example.com"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `WeaviateStore` — a persistent vector store backed by Weaviate v4, following the same bounded/structured/tested contract as the merged pgvector (#661) and redis_vector (#687) stores.

## Why (not a duplicate)

Weaviate is a top-3 open-source vector database, widely used in RAG pipelines, and not yet available in agentUniverse. Addresses #259 (VectorDB components).

## Files

- `agentuniverse/agent/action/knowledge/store/weaviate_store.py` — the store implementation (config validation, CRUD, query, dimension checking, collection management).
- `agentuniverse/agent/action/knowledge/store/weaviate_store.yaml.example` — configuration template.
- `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_weaviate_store.py` — 22 unit tests (mock client; no server required).
- `docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Knowledge/Store/Weaviate.md` — English docs.
- `docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store/Weaviate.md` — Chinese docs.

## Features

- Full CRUD: `insert_document`, `query`, `upsert_document`, `update_document`, `delete_document`, `get_document_by_id`, `get_document_count`, `list_document_ids`.
- Configurable distance metric (`cosine` / `dot` / `l2`), vector dimensions (inferred from first insert if unset), `similarity_top_k`, `max_insert_batch`.
- **Dimension validation**: every inserted vector is checked against the collection's expected dimension; mismatched vectors raise a clear `ValueError` instead of failing at the Weaviate server with an opaque error (same contract as QdrantStore #710).
- API key auth support for managed Weaviate clusters.
- gRPC transport for fast data transfer (configurable port; set 0 to disable).
- Metadata stored as JSON text property, round-tripped through query results with corrupt-JSON guard.
- Optional dependency: `weaviate-client` is imported lazily, so the store does not break environments where it is not installed.

## Tests

22 unit tests covering: config validation (empty URL/collection, invalid distance/metric, zero top_k, negative dimensions), insert + dimension mismatch rejection, query with score + metadata round-trip, corrupt metadata JSON, delete, count (success + error path), get_document_by_id (found + not found), and URL parsing (host/port/secure).

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_weaviate_store` — 22 passed. All mock the weaviate client; no server required.