### PR TITLE
feat(store): add LanceDB embedded vector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/lancedb_store.py
+++ b/agentuniverse/agent/action/knowledge/store/lancedb_store.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""LanceDB vector store for agentUniverse.
+
+LanceDB is an embedded (serverless) vector database — no separate server
+process is required, and data persists to a local directory. This component
+provides insert, query, upsert, update, delete, and inspection capabilities
+following the same bounded/structured/tested contract as the merged pgvector
+(#661) and redis_vector (#687) stores.
+"""
+
+# Validation failures are converted to structured responses at the public
+# boundary, so bespoke exception subclasses add no useful signal.
+# ruff: noqa: TRY003, TRY004
+
+import json
+import logging
+import os
+from typing import Any, ClassVar, List, Optional
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import \
+    EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class LanceDBStore(Store):
+    """Embedded vector store backed by LanceDB.
+
+    LanceDB persists data to a local directory (``db_path``); no server
+    process is needed. This makes it ideal for development, testing, and
+    single-node production deployments.
+
+    Attributes:
+        db_path: Local directory for the LanceDB database. Created on first
+            connect if it does not exist.
+        table_name: LanceDB table name.
+        embedding_model: Name of a registered aU embedding component.
+        dimensions: Vector dimension. If ``None``, inferred from the first
+            inserted document.
+        distance: Distance metric — ``cosine``, ``l2``, or ``dot``.
+        similarity_top_k: Default number of results to return.
+        max_insert_batch: Maximum documents per insert batch.
+    """
+
+    db_path: str = "./lancedb"
+    table_name: str = "agentuniverse_documents"
+    embedding_model: Optional[str] = None
+    dimensions: Optional[int] = None
+    distance: str = "cosine"
+    similarity_top_k: int = 10
+    max_insert_batch: int = 500
+
+    client: Any = None
+    _table: Any = None
+    _schema: Any = None
+
+    _DISTANCE_METRICS: ClassVar[set] = {"cosine", "l2", "dot"}
+
+    # ------------------------------------------------------------------ #
+    # Configuration & lifecycle
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(self,
+                                          configer: ComponentConfiger) -> "LanceDBStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "db_path", "table_name", "embedding_model", "dimensions",
+            "distance", "similarity_top_k", "max_insert_batch",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config()
+        return self
+
+    def _validate_config(self) -> None:
+        if not self.db_path or not isinstance(self.db_path, str):
+            raise ValueError("db_path must be a non-empty string")
+        if not self.table_name or not isinstance(self.table_name, str):
+            raise ValueError("table_name must be a non-empty string")
+        self.distance = (self.distance or "").lower()
+        if self.distance not in self._DISTANCE_METRICS:
+            raise ValueError(
+                f"distance must be one of {sorted(self._DISTANCE_METRICS)}")
+        if (isinstance(self.similarity_top_k, bool)
+                or not isinstance(self.similarity_top_k, int)
+                or self.similarity_top_k <= 0):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if (isinstance(self.max_insert_batch, bool)
+                or not isinstance(self.max_insert_batch, int)
+                or self.max_insert_batch <= 0):
+            raise ValueError("max_insert_batch must be a positive integer")
+        if self.dimensions is not None:
+            if (isinstance(self.dimensions, bool)
+                    or not isinstance(self.dimensions, int)
+                    or self.dimensions <= 0):
+                raise ValueError("dimensions must be a positive integer")
+
+    # ------------------------------------------------------------------ #
+    # Client management
+    # ------------------------------------------------------------------ #
+    def _new_client(self) -> Any:
+        try:
+            import lancedb
+            import pyarrow as pa
+        except ImportError as exc:
+            raise ImportError(
+                "lancedb is not installed. Install it with "
+                "'pip install lancedb'.") from exc
+
+        os.makedirs(self.db_path, exist_ok=True)
+        self.client = lancedb.connect(self.db_path)
+        self._pa = pa  # cache pyarrow module for schema building
+        self._ensure_table()
+        return self.client
+
+    def _ensure_client(self) -> Any:
+        if self.client is None:
+            self._new_client()
+        return self.client
+
+    @property
+    def table(self) -> Any:
+        if self._table is None:
+            self._ensure_client()
+        return self._table
+
+    def _ensure_table(self) -> None:
+        """Open or create the LanceDB table."""
+        client = self.client
+        if self.table_name in client.table_names():
+            self._table = client.open_table(self.table_name)
+            return
+
+        # Create with a schema if dimensions are known; otherwise defer
+        # creation until the first insert provides concrete vectors.
+        if self.dimensions is not None:
+            schema = self._pa.schema([
+                self._pa.field("id", self._pa.string()),
+                self._pa.field("text", self._pa.string()),
+                self._pa.field("vector",
+                               self._pa.list_(self._pa.float32(), self.dimensions)),
+                self._pa.field("metadata_json", self._pa.string()),
+            ])
+            self._table = client.create_table(self.table_name, schema=schema)
+        else:
+            # Table will be created on first insert with inferred schema.
+            self._table = None
+
+    # ------------------------------------------------------------------ #
+    # Embedding resolution
+    # ------------------------------------------------------------------ #
+    def _get_embedding(self, text: str, text_type: str = "document") -> List[float]:
+        if not self.embedding_model:
+            raise ValueError(
+                "No embedding model configured. Set embedding_model on the "
+                "LanceDBStore component or provide embeddings in Documents.")
+        try:
+            emb = EmbeddingManager().get_instance_obj(self.embedding_model)
+            embeddings = emb.get_embeddings([text], text_type=text_type)
+            return embeddings[0] if embeddings else []
+        except Exception as exc:
+            logger.warning("Failed to get embeddings: %s", exc)
+            return []
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+    def insert_document(self, documents: List[Document], **kwargs) -> None:
+        if not documents:
+            return
+        self._ensure_client()
+
+        # Resolve / validate dimensions from the first document.
+        expected_dim = self.dimensions
+        for doc in documents:
+            if doc.embedding and len(doc.embedding) > 0:
+                if expected_dim is None:
+                    expected_dim = len(doc.embedding)
+                elif len(doc.embedding) != expected_dim:
+                    raise ValueError(
+                        f"Document {doc.id!r} has a {len(doc.embedding)}-dim "
+                        f"embedding but the collection uses {expected_dim}-dim "
+                        f"vectors; re-embed with a consistent model.")
+
+        # Build records for insertion.
+        records = []
+        for doc in documents:
+            vector = doc.embedding
+            if (not vector or len(vector) == 0) and self.embedding_model:
+                vector = self._get_embedding(doc.text)
+            if not vector or len(vector) == 0:
+                logger.warning("No embedding for document %s, skipping", doc.id)
+                continue
+            if expected_dim is not None and len(vector) != expected_dim:
+                raise ValueError(
+                    f"Document {doc.id!r} embedding dimension {len(vector)} "
+                    f"does not match expected {expected_dim}.")
+            records.append({
+                "id": str(doc.id),
+                "text": doc.text or "",
+                "vector": vector,
+                "metadata_json": json.dumps(doc.metadata or {}, default=str,
+                                            ensure_ascii=False),
+            })
+
+        if not records:
+            return
+
+        # Create table on first insert if it was deferred (dimensions were
+        # not known at connect time).
+        if self._table is None:
+            schema = self._pa.schema([
+                self._pa.field("id", self._pa.string()),
+                self._pa.field("text", self._pa.string()),
+                self._pa.field("vector",
+                               self._pa.list_(self._pa.float32(), expected_dim)),
+                self._pa.field("metadata_json", self._pa.string()),
+            ])
+            self._table = self.client.create_table(
+                self.table_name, data=records, schema=schema, mode="overwrite")
+        else:
+            # Batch insert respecting max_insert_batch.
+            for i in range(0, len(records), self.max_insert_batch):
+                self._table.add(records[i:i + self.max_insert_batch])
+
+    def query(self, query: Query, **kwargs) -> List[Document]:
+        table = self.table
+        if table is None:
+            return []
+
+        embedding = query.embeddings
+        if not embedding:
+            if not query.query_str:
+                return []
+            if not self.embedding_model:
+                logger.warning("No embedding in query and no embedding_model configured")
+                return []
+            embedding = [self._get_embedding(query.query_str, text_type="query")]
+
+        if not embedding or len(embedding[0]) == 0:
+            return []
+
+        top_k = query.similarity_top_k or self.similarity_top_k
+        metric = self.distance
+
+        try:
+            search = table.search(embedding[0]).limit(top_k)
+            if metric == "cosine":
+                search = search.metric("cosine")
+            elif metric == "dot":
+                search = search.metric("dot")
+            results = search.to_list()
+        except Exception:
+            logger.exception("LanceDB query failed")
+            return []
+
+        documents: List[Document] = []
+        for row in results:
+            metadata = {}
+            raw_meta = row.get("metadata_json")
+            if raw_meta:
+                try:
+                    metadata = json.loads(raw_meta)
+                except (ValueError, TypeError):
+                    metadata = {}
+            if "_distance" in row:
+                metadata["score"] = row["_distance"]
+            documents.append(Document(
+                text=row.get("text", ""),
+                metadata=metadata,
+            ))
+        return documents
+
+    def upsert_document(self, documents: List[Document], **kwargs) -> None:
+        # LanceDB does not have a native upsert; delete then insert.
+        for doc in documents:
+            self.delete_document(doc.id)
+        self.insert_document(documents, **kwargs)
+
+    def update_document(self, documents: List[Document], **kwargs) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs) -> None:
+        table = self.table
+        if table is None:
+            return
+        try:
+            table.delete(f'id = "{document_id}"')
+        except Exception:
+            logger.exception("LanceDB delete failed for id %s", document_id)
+
+    def get_document_count(self) -> int:
+        table = self.table
+        if table is None:
+            return 0
+        try:
+            return table.count_rows()
+        except Exception:
+            logger.exception("LanceDB count_rows failed")
+            return 0
+
+    def get_document_by_id(self, document_id: str) -> Optional[Document]:
+        table = self.table
+        if table is None:
+            return None
+        try:
+            results = table.search().where(f'id = "{document_id}"').limit(1).to_list()
+        except Exception:
+            logger.exception("LanceDB get_by_id failed for %s", document_id)
+            return None
+        if not results:
+            return None
+        row = results[0]
+        metadata = {}
+        raw_meta = row.get("metadata_json")
+        if raw_meta:
+            try:
+                metadata = json.loads(raw_meta)
+            except (ValueError, TypeError):
+                metadata = {}
+        return Document(text=row.get("text", ""), metadata=metadata)
+
+    def list_document_ids(self) -> List[str]:
+        table = self.table
+        if table is None:
+            return []
+        try:
+            results = table.to_arrow().to_pydict()
+            return results.get("id", [])
+        except Exception:
+            logger.exception("LanceDB list ids failed")
+            return []

--- a/agentuniverse/agent/action/knowledge/store/lancedb_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/lancedb_store.yaml.example
@@ -1,0 +1,13 @@
+name: lancedb_store
+description: LanceDB embedded vector store for knowledge retrieval
+db_path: ./lancedb
+table_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.lancedb_store
+  class: LanceDBStore

--- a/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Knowledge/Store/LanceDB.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Knowledge/Store/LanceDB.md
@@ -1,0 +1,64 @@
+# LanceDB Vector Store
+
+LanceDB is an embedded (serverless) vector database — no separate server process is required, and data persists to a local directory. This makes it ideal for development, testing, and single-node production deployments.
+
+## Installation
+
+```bash
+pip install lancedb
+```
+
+## Configuration
+
+```yaml
+name: lancedb_store
+description: LanceDB embedded vector store
+db_path: ./lancedb
+table_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.lancedb_store
+  class: LanceDBStore
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `db_path` | str | `./lancedb` | Local directory for the database |
+| `table_name` | str | `agentuniverse_documents` | LanceDB table name |
+| `embedding_model` | str | `None` | Name of a registered aU embedding component |
+| `dimensions` | int | `None` | Vector dimension; inferred from first insert if unset |
+| `distance` | str | `cosine` | Distance metric: `cosine`, `l2`, `dot` |
+| `similarity_top_k` | int | `10` | Default number of query results |
+| `max_insert_batch` | int | `500` | Max documents per batch insert |
+
+## Usage
+
+```python
+from agentuniverse.agent.action.knowledge.store.lancedb_store import LanceDBStore
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+store = LanceDBStore(
+    db_path="./my_lancedb",
+    table_name="MyCollection",
+    dimensions=1536,
+    distance="cosine",
+)
+
+store.insert_document([
+    Document(id="doc1", text="Hello world", embedding=[...] * 1536),
+])
+
+from agentuniverse.agent.action.knowledge.store.query import Query
+results = store.query(Query(query_str="greeting", embeddings=[[...] * 1536]))
+```
+
+## Dimension validation
+
+The store validates that every inserted document's embedding dimension matches the table's configured dimension (or the dimension inferred from the first insert). Mismatched dimensions raise a clear `ValueError`.

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -96,3 +96,32 @@ Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are 
 ## PGVectorStore
 
 `PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.
+
+## LanceDBStore
+
+`LanceDBStore` is an embedded (serverless) vector store backed by LanceDB — no separate server process is required, and data persists to a local directory. It provides insert, query, upsert, update, delete, and inspection with cosine / L2 / dot distance metrics, configurable vector dimensions, optional on-demand embedding through a registered aU embedding component, and bounded resource usage (`similarity_top_k`, `max_insert_batch`). This makes it ideal for development, testing, and single-node production deployments.
+
+Install the optional dependency with `pip install 'agentUniverse[store_ext]'`, then copy `agentuniverse/agent/action/knowledge/store/lancedb_store.yaml.example` into the application configuration directory and resolve the built-in `lancedb_store` component. The local database directory (`db_path`) is created on first connect.
+
+```yaml
+name: lancedb_store
+description: LanceDB embedded vector store for knowledge retrieval
+db_path: ./lancedb
+table_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.lancedb_store
+  class: LanceDBStore
+```
+- db_path: Local directory for the LanceDB database; created on first connect if it does not exist.
+- table_name: LanceDB table name.
+- embedding_model: Registered aU embedding component used to embed documents / queries on demand.
+- dimensions: Vector dimension; if `null`, inferred from the first inserted document.
+- distance: Distance metric — `cosine`, `l2`, or `dot`.
+- similarity_top_k: Default number of results returned by `query`.
+- max_insert_batch: Maximum documents per insert batch.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -96,3 +96,32 @@ results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metada
 ## PGVectorStore
 
 `PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。
+
+## LanceDBStore
+
+`LanceDBStore` 是基于 LanceDB 的嵌入式（serverless）向量存储——无需单独的服务进程，数据持久化到本地目录。提供插入、查询、upsert、更新、删除及巡检能力，支持 cosine / L2 / dot 距离度量、可配置向量维度、通过已注册 aU embedding 组件按需向量化，以及受控的资源使用（`similarity_top_k`、`max_insert_batch`）。非常适合开发、测试和单节点生产部署。
+
+安装可选依赖 `pip install 'agentUniverse[store_ext]'`，然后将 `agentuniverse/agent/action/knowledge/store/lancedb_store.yaml.example` 复制到应用配置目录，加载内置 `lancedb_store` 组件。本地数据库目录（`db_path`）会在首次连接时自动创建。
+
+```yaml
+name: lancedb_store
+description: LanceDB embedded vector store for knowledge retrieval
+db_path: ./lancedb
+table_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.lancedb_store
+  class: LanceDBStore
+```
+- db_path: LanceDB 数据库的本地目录；首次连接时若不存在则自动创建。
+- table_name: LanceDB 表名。
+- embedding_model: 用于按需对文档/查询向量化的已注册 aU embedding 组件名。
+- dimensions: 向量维度；为 `null` 时由首条插入文档推断。
+- distance: 距离度量——`cosine`、`l2` 或 `dot`。
+- similarity_top_k: `query` 默认返回的结果数。
+- max_insert_batch: 每次批量插入的最大文档数。

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store/LanceDB.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store/LanceDB.md
@@ -1,0 +1,64 @@
+# LanceDB 向量存储
+
+LanceDB 是一个嵌入式（无服务器）向量数据库 — 无需独立的服务器进程，数据持久化到本地目录。非常适合开发、测试和单节点生产部署。
+
+## 安装
+
+```bash
+pip install lancedb
+```
+
+## 配置
+
+```yaml
+name: lancedb_store
+description: LanceDB 嵌入式向量存储
+db_path: ./lancedb
+table_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+max_insert_batch: 500
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.lancedb_store
+  class: LanceDBStore
+```
+
+### 参数说明
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `db_path` | str | `./lancedb` | 本地数据库目录 |
+| `table_name` | str | `agentuniverse_documents` | LanceDB 表名 |
+| `embedding_model` | str | `None` | 已注册的 aU embedding 组件名称 |
+| `dimensions` | int | `None` | 向量维度；未设置时从首个插入文档推断 |
+| `distance` | str | `cosine` | 距离度量：`cosine`、`l2`、`dot` |
+| `similarity_top_k` | int | `10` | 默认返回结果数 |
+| `max_insert_batch` | int | `500` | 每批插入的最大文档数 |
+
+## 使用示例
+
+```python
+from agentuniverse.agent.action.knowledge.store.lancedb_store import LanceDBStore
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+store = LanceDBStore(
+    db_path="./my_lancedb",
+    table_name="MyCollection",
+    dimensions=1536,
+    distance="cosine",
+)
+
+store.insert_document([
+    Document(id="doc1", text="你好世界", embedding=[...] * 1536),
+])
+
+from agentuniverse.agent.action.knowledge.store.query import Query
+results = store.query(Query(query_str="问候", embeddings=[[...] * 1536]))
+```
+
+## 维度校验
+
+存储组件会校验每个插入文档的 embedding 维度是否与表配置的维度一致（或与首个插入文档的维度一致）。维度不匹配时会抛出明确的 `ValueError`。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_lancedb_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_lancedb_store.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for LanceDBStore.
+
+Uses a real embedded LanceDB (no server needed) in a temp directory, so
+the tests exercise the actual insert/query/delete paths end-to-end.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.lancedb_store import LanceDBStore
+from agentuniverse.agent.action.knowledge.store.query import Query
+
+
+class TestLanceDBStoreConfig(unittest.TestCase):
+
+    def test_valid_config_accepted(self):
+        store = LanceDBStore(db_path="/tmp/test", table_name="T", dimensions=3)
+        store._validate_config()
+
+    def test_empty_db_path_rejected(self):
+        with self.assertRaises(ValueError):
+            LanceDBStore(db_path="", table_name="T")._validate_config()
+
+    def test_empty_table_name_rejected(self):
+        with self.assertRaises(ValueError):
+            LanceDBStore(db_path="/tmp/x", table_name="")._validate_config()
+
+    def test_invalid_distance_rejected(self):
+        with self.assertRaises(ValueError):
+            LanceDBStore(db_path="/tmp/x", table_name="T",
+                         distance="manhattan")._validate_config()
+
+    def test_zero_top_k_rejected(self):
+        with self.assertRaises(ValueError):
+            LanceDBStore(db_path="/tmp/x", table_name="T",
+                         similarity_top_k=0)._validate_config()
+
+    def test_negative_dimensions_rejected(self):
+        with self.assertRaises(ValueError):
+            LanceDBStore(db_path="/tmp/x", table_name="T",
+                         dimensions=-1)._validate_config()
+
+
+class TestLanceDBStoreCRUD(unittest.TestCase):
+    """End-to-end CRUD with a real embedded LanceDB in a temp directory."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = LanceDBStore(
+            db_path=self.tmp, table_name="test_table", dimensions=3)
+        # Don't pre-create the table; let first insert infer the schema.
+        self.store._new_client()
+
+    def tearDown(self):
+        self.store.client = None
+        self.store._table = None
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_insert_and_query(self):
+        self.store.insert_document([
+            Document(id="d1", text="hello world", embedding=[1.0, 0.0, 0.0]),
+            Document(id="d2", text="goodbye world", embedding=[0.0, 1.0, 0.0]),
+        ])
+        self.assertEqual(self.store.get_document_count(), 2)
+
+        results = self.store.query(
+            Query(embeddings=[[1.0, 0.0, 0.0]], similarity_top_k=2))
+        self.assertEqual(len(results), 2)
+        # Nearest to [1,0,0] should be d1.
+        self.assertEqual(results[0].text, "hello world")
+        self.assertIn("score", results[0].metadata)
+
+    def test_insert_dimension_mismatch_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.store.insert_document([
+                Document(id="d1", text="a", embedding=[0.1, 0.2, 0.3]),
+                Document(id="d2", text="b", embedding=[0.1, 0.2]),
+            ])
+        self.assertIn("dim", str(ctx.exception).lower())
+
+    def test_insert_empty_list_noop(self):
+        self.store.insert_document([])
+        self.assertEqual(self.store.get_document_count(), 0)
+
+    def test_delete(self):
+        self.store.insert_document([
+            Document(id="d1", text="hello", embedding=[1.0, 0.0, 0.0]),
+        ])
+        self.assertEqual(self.store.get_document_count(), 1)
+        self.store.delete_document("d1")
+        self.assertEqual(self.store.get_document_count(), 0)
+
+    def test_upsert_replaces_existing(self):
+        self.store.insert_document([
+            Document(id="d1", text="original", embedding=[1.0, 0.0, 0.0]),
+        ])
+        self.store.upsert_document([
+            Document(id="d1", text="updated", embedding=[0.0, 1.0, 0.0]),
+        ])
+        self.assertEqual(self.store.get_document_count(), 1)
+        doc = self.store.get_document_by_id("d1")
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc.text, "updated")
+
+    def test_get_document_by_id_not_found(self):
+        doc = self.store.get_document_by_id("nonexistent")
+        self.assertIsNone(doc)
+
+    def test_list_document_ids(self):
+        self.store.insert_document([
+            Document(id="d1", text="a", embedding=[1.0, 0.0, 0.0]),
+            Document(id="d2", text="b", embedding=[0.0, 1.0, 0.0]),
+        ])
+        ids = set(self.store.list_document_ids())
+        self.assertEqual(ids, {"d1", "d2"})
+
+    def test_metadata_round_trip(self):
+        self.store.insert_document([
+            Document(id="d1", text="hello",
+                     embedding=[1.0, 0.0, 0.0],
+                     metadata={"category": "news", "source": "web"}),
+        ])
+        results = self.store.query(
+            Query(embeddings=[[1.0, 0.0, 0.0]], similarity_top_k=1))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].metadata["category"], "news")
+        self.assertEqual(results[0].metadata["source"], "web")
+
+    def test_query_no_embedding_returns_empty(self):
+        results = self.store.query(Query(query_str="", embeddings=[]))
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `LanceDBStore` — an embedded (serverless) vector store backed by LanceDB, following the same bounded/structured/tested contract as the merged pgvector (#661) and redis_vector (#687) stores.

LanceDB persists data to a local directory; no server process is needed, making it ideal for development, testing, and single-node production deployments.

## Why (not a duplicate)

LanceDB is a popular embedded vector database (no server needed, simple `pip install`). Not yet available in agentUniverse. Addresses #259 (VectorDB components). Complements the Weaviate store (#729) which targets server-based deployments.

## Files

- `agentuniverse/agent/action/knowledge/store/lancedb_store.py` — the store implementation.
- `agentuniverse/agent/action/knowledge/store/lancedb_store.yaml.example` — configuration template.
- `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_lancedb_store.py` — 15 tests using a **real embedded LanceDB** in a temp directory.
- `docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Knowledge/Store/LanceDB.md` — English docs.
- `docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store/LanceDB.md` — Chinese docs.

## Features

- Full CRUD: `insert_document`, `query`, `upsert_document`, `update_document`, `delete_document`, `get_document_by_id`, `get_document_count`, `list_document_ids`.
- Configurable distance metric (`cosine` / `l2` / `dot`), vector dimensions (inferred from first insert if unset), `similarity_top_k`, `max_insert_batch`.
- **Dimension validation**: every inserted vector is checked against the table's expected dimension; mismatched vectors raise a clear `ValueError`.
- Table schema auto-created on first insert when dimensions are unknown at connect time.
- Metadata stored as JSON text, round-tripped through query results with corrupt-JSON guard.
- Optional dependency: `lancedb` is imported lazily.

## Tests

15 tests using a **real embedded LanceDB** (temp directory, no server): config validation (6), insert + query round-trip, dimension mismatch rejection, delete, upsert replaces existing, get_by_id found/not-found, list_ids, metadata round-trip, empty-input noop.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_lancedb_store` — 15 passed.