### PR TITLE
fix(reader): skip empty PPTX shapes

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/pptx_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/pptx_reader.py
@@ -33,7 +33,7 @@ class PptxReader(Reader):
         document_list = []
         for slide_number, slide in enumerate(presentation.slides, start=1):
             for shape in slide.shapes:
-                if hasattr(shape, "text"):
+                if hasattr(shape, "text") and shape.text.strip():
                     metadata = {"slide_number": slide_number, "file_name": file.name}
                     if ext_info is not None:
                         metadata.update(ext_info)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_pptx_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_pptx_reader.py
@@ -1,0 +1,33 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.reader.file.pptx_reader import PptxReader
+
+
+class TestPptxReader(unittest.TestCase):
+
+    def test_load_data_skips_empty_shapes(self):
+        slide = MagicMock()
+        slide.shapes = [
+            MagicMock(text="Title"),
+            MagicMock(text="   "),
+            MagicMock(text=""),
+        ]
+        presentation = MagicMock()
+        presentation.slides = [slide]
+
+        pptx_module = types.ModuleType("pptx")
+        pptx_module.Presentation = MagicMock(return_value=presentation)
+
+        with patch.dict(sys.modules, {"pptx": pptx_module}):
+            documents = PptxReader()._load_data("deck.pptx")
+
+        self.assertEqual(len(documents), 1)
+        self.assertEqual(documents[0].text, "Title")
+        self.assertEqual(documents[0].metadata["slide_number"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Skip PPTX shapes whose `text` is empty or only whitespace.
- This avoids creating empty `Document` objects for blank placeholders or decorative text boxes.
- Add mocked regression coverage for a slide that contains one real text shape and empty text shapes.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_pptx_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/pptx_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_pptx_reader.py`: passed.
- `python -m unittest tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_pptx_reader.py`: not run to completion locally because this environment is missing project dependency `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.