### PR TITLE
fix(reader): handle empty markdown loads

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/markdown_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/markdown_reader.py
@@ -38,6 +38,8 @@ class MarkdownReader(Reader):
         if isinstance(file, str):
             file = Path(file)
         data = UnstructuredMarkdownLoader(file).load()
+        if not data:
+            return []
         metadata = {"file_name": file.name}
         if ext_info is not None:
             metadata.update(ext_info)

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_markdown_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_markdown_reader.py
@@ -1,0 +1,33 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.file.markdown_reader import MarkdownReader
+
+
+class TestMarkdownReader(unittest.TestCase):
+
+    def test_load_data_returns_empty_list_for_empty_loader_result(self):
+        class EmptyMarkdownLoader:
+            def __init__(self, file):
+                self.file = file
+
+            def load(self):
+                return []
+
+        community_module = types.ModuleType("langchain_community")
+        loaders_module = types.ModuleType("langchain_community.document_loaders")
+        loaders_module.UnstructuredMarkdownLoader = EmptyMarkdownLoader
+
+        with patch.dict(sys.modules, {
+            "langchain_community": community_module,
+            "langchain_community.document_loaders": loaders_module,
+        }):
+            documents = MarkdownReader()._load_data("empty.md")
+
+        self.assertEqual(documents, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Make `MarkdownReader` return an empty list when the underlying markdown loader returns no documents.
- This avoids an `IndexError` from indexing `data[0]` on empty loader results.
- Add regression coverage with a mocked `UnstructuredMarkdownLoader` that returns an empty list.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_markdown_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/file/markdown_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_markdown_reader.py`: passed.
- `python -m unittest tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_markdown_reader.py`: not run to completion locally because this environment is missing project dependency `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.