### PR TITLE
fix(reader): avoid rendered web debug prints

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/web/rendered_web_page_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/web/rendered_web_page_reader.py
@@ -18,12 +18,10 @@ class RenderedWebPageReader(Reader):
     """
 
     def _load_data(self, url: str, ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: RenderedWebPageReader start load url={url}")
         if not isinstance(url, str) or not url:
             raise ValueError("RenderedWebPageReader._load_data requires a non-empty url string")
 
         html = self._render_and_get_html(url)
-        print(f"debugging: RenderedWebPageReader rendered html length={len(html)}")
 
         # Reuse extraction logic from WebPageReader by importing on demand
         from .web_page_reader import WebPageReader
@@ -45,7 +43,6 @@ class RenderedWebPageReader(Reader):
                 "Install with `pip install playwright` and run `playwright install`"
             )
 
-        print("debugging: RenderedWebPageReader using playwright")
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True)
             try:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_rendered_web_page_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_rendered_web_page_reader.py
@@ -1,0 +1,32 @@
+import contextlib
+import io
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.web.rendered_web_page_reader import (
+    RenderedWebPageReader,
+)
+
+
+class TestRenderedWebPageReader(unittest.TestCase):
+
+    def test_load_data_does_not_print_debug_output(self):
+        reader = RenderedWebPageReader()
+        stdout = io.StringIO()
+
+        with patch.object(reader, "_render_and_get_html", return_value="<html></html>"), \
+                patch(
+                    "agentuniverse.agent.action.knowledge.reader.web.web_page_reader"
+                    ".WebPageReader._extract_main_text",
+                    return_value=("content", {"extractor": "mock"}),
+                ), \
+                contextlib.redirect_stdout(stdout):
+            documents = reader._load_data("https://example.com")
+
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(documents[0].text, "content")
+        self.assertTrue(documents[0].metadata["rendered"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Remove unconditional `print` debug output from `RenderedWebPageReader`.
- This keeps rendered web ingestion from writing URLs, rendered HTML lengths, and implementation details to stdout during normal use.
- Add regression coverage to assert `_load_data()` stays quiet during a mocked rendered page load.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_rendered_web_page_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/web/rendered_web_page_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_rendered_web_page_reader.py`: passed.
- `python -m unittest tests/test_agentuniverse/unit/agent/action/knowledge/reader/web/test_rendered_web_page_reader.py`: not run to completion locally because this environment is missing project dependency `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.