### PR TITLE
fix(trace,retry,context): invocation chain double-pop, retry exception type, span API, context archive

### DIFF
--- a/agentuniverse/base/annotation/retry.py
+++ b/agentuniverse/base/annotation/retry.py
@@ -7,8 +7,11 @@
 # @FileName: retry.py
 
 import functools
+import logging
 import time
 from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
 
 
 def retry(max_retries: int = 3, delay: float = 1.0) -> Callable:
@@ -24,7 +27,13 @@ def retry(max_retries: int = 3, delay: float = 1.0) -> Callable:
                     last_exception = e
                     retries += 1
                     if retries < max_retries:
+                        logger.debug("retry %s attempt %d/%d failed: %s",
+                                     func.__name__, retries, max_retries, e)
                         time.sleep(delay)
-            raise Exception(f"Failed after {max_retries} retries. Last error: {str(last_exception)}")
+            # Preserve the original exception type and traceback instead of
+            # wrapping it in a bare Exception. Callers that catch specific
+            # types (HttpError, TimeoutError, ...) will now work, and the
+            # full stack trace is retained for diagnosis.
+            raise last_exception
         return wrapper
     return decorator

--- a/agentuniverse/base/annotation/trace.py
+++ b/agentuniverse/base/annotation/trace.py
@@ -209,7 +209,8 @@ async def _default_agent_wrapper_async(func, *args, **kwargs):
                                                          result,
                                                          start_info,
                                                          pair_id)
-        Monitor.pop_invocation_chain()
+        # InvocationChainContext.__exit__ already calls Monitor.pop_invocation_chain();
+        # the explicit pop here was a duplicate that over-popped the caller's node.
         return result
 
 

--- a/agentuniverse/base/context/context_archive_utils.py
+++ b/agentuniverse/base/context/context_archive_utils.py
@@ -29,7 +29,11 @@ def get_current_context_archive():
         'context_archive', None)
     if not context_archive:
         context_archive = {}
-        FrameworkContextManager().set_context('context_archive', {})
+        # Set the SAME dict object we return, so that subsequent
+        # update_context_archive mutations on the returned reference are
+        # visible to later get_current_context_archive calls. The previous
+        # code set a throwaway {} and returned a different local dict.
+        FrameworkContextManager().set_context('context_archive', context_archive)
 
     return context_archive
 

--- a/agentuniverse/base/tracing/au_trace_context.py
+++ b/agentuniverse/base/tracing/au_trace_context.py
@@ -122,7 +122,12 @@ class AuTraceContext:
         span = trace.get_current_span()
         if not span.is_recording():
             return None
-        return span.context.span_id
+        # OpenTelemetry Span exposes get_span_context(), not a .context
+        # attribute (SpanContext has .span_id). The previous code used
+        # span.context.span_id which raised AttributeError when the span
+        # was recording. Every other call site in this file already uses
+        # get_span_context().
+        return span.get_span_context().span_id
 
     def init_new_token_usage(self, span_id=None):
         span_id = span_id or trace.get_current_span().get_span_context().span_id

--- a/tests/test_agentuniverse/unit/base/annotation/test_trace_retry_context_fixes.py
+++ b/tests/test_agentuniverse/unit/base/annotation/test_trace_retry_context_fixes.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for four independent bugs across trace, retry, and context layers.
+
+1. trace.py: _default_agent_wrapper_async popped invocation chain twice
+   (once explicitly, once via __exit__), corrupting the caller's chain node.
+2. retry.py: raised bare Exception(...) discarding the original exception
+   type and traceback.
+3. au_trace_context.py: _get_current_span_id used span.context.span_id
+   (wrong API) instead of span.get_span_context().span_id.
+4. context_archive_utils.py: set a throwaway {} into the context manager
+   but returned a different local dict, so mutations were lost.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestTraceAsyncWrapperNoDoublePop(unittest.TestCase):
+    """The async agent wrapper must not pop the invocation chain twice."""
+
+    def test_async_wrapper_does_not_explicitly_pop(self):
+        import inspect
+        from agentuniverse.base.annotation import trace as trace_module
+
+        src = inspect.getsource(trace_module._default_agent_wrapper_async)
+        # The bug: an explicit Monitor.pop_invocation_chain() INSIDE the
+        # `with InvocationChainContext(...)` block, which __exit__ also pops.
+        # The fix removes the explicit pop; the with-block's __exit__ is the
+        # sole pop. Check the source no longer has a bare pop before return.
+        lines = src.split("\n")
+        # Find lines that are inside the with-block and pop.
+        pops_in_with = [
+            l for l in lines
+            if "Monitor.pop_invocation_chain()" in l
+            and "return" not in l
+            and "#" not in l.split("pop")[0]  # not a comment
+        ]
+        self.assertEqual(pops_in_with, [],
+                         "async agent wrapper must not explicitly pop inside "
+                         "the with-block (InvocationChainContext.__exit__ pops)")
+
+
+class TestRetryPreservesOriginalException(unittest.TestCase):
+    """retry must re-raise the original exception, not wrap it."""
+
+    def test_original_exception_type_preserved(self):
+        from agentuniverse.base.annotation.retry import retry
+
+        class MyError(Exception):
+            pass
+
+        @retry(max_retries=2, delay=0)
+        def always_fail():
+            raise MyError("boom")
+
+        with self.assertRaises(MyError) as ctx:
+            always_fail()
+        self.assertIn("boom", str(ctx.exception))
+
+    def test_returns_value_on_success(self):
+        from agentuniverse.base.annotation.retry import retry
+
+        @retry(max_retries=3, delay=0)
+        def succeeds_on_third_try():
+            succeeds_on_third_try.calls += 1
+            if succeeds_on_third_try.calls < 3:
+                raise ValueError("not yet")
+            return "ok"
+
+        succeeds_on_third_try.calls = 0
+        result = succeeds_on_third_try()
+        self.assertEqual(result, "ok")
+        self.assertEqual(succeeds_on_third_try.calls, 3)
+
+    def test_source_does_not_raise_bare_exception(self):
+        import inspect
+        from agentuniverse.base.annotation.retry import retry
+
+        src = inspect.getsource(retry)
+        self.assertNotIn(
+            'raise Exception(f"Failed after', src,
+            "retry must re-raise the original exception, not a bare Exception")
+
+
+class TestAuTraceContextGetCurrentSpanId(unittest.TestCase):
+    """_get_current_span_id must use get_span_context(), not .context."""
+
+    def test_source_uses_get_span_context(self):
+        import inspect
+        from agentuniverse.base.tracing.au_trace_context import AuTraceContext
+
+        src = inspect.getsource(AuTraceContext._get_current_span_id)
+        self.assertIn("get_span_context().span_id", src)
+        # Check that no CODE line (non-comment) uses span.context.span_id.
+        code_lines = [l.strip() for l in src.split("\n")
+                      if l.strip() and not l.strip().startswith("#")]
+        for line in code_lines:
+            self.assertNotIn(
+                "span.context.span_id", line,
+                f"code line must not use span.context.span_id: {line!r}")
+
+
+class TestContextArchiveUtilsSetSameDict(unittest.TestCase):
+    """get_current_context_archive must set the SAME dict it returns."""
+
+    def test_source_sets_context_archive_not_throwaway(self):
+        import inspect
+        from agentuniverse.base.context import context_archive_utils
+
+        src = inspect.getsource(context_archive_utils.get_current_context_archive)
+        # The fix: set_context('context_archive', context_archive) — the same
+        # local dict — not set_context('context_archive', {}).
+        self.assertIn(
+            "set_context('context_archive', context_archive)", src,
+            "must set the same dict object that is returned, not a throwaway {}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Four independent bugs across the trace, retry, and context layers. Each is a 1–5 line fix.

## Changes

### 1. trace.py — invocation chain double-pop (async agent wrapper)
\`_default_agent_wrapper_async\` popped the invocation chain TWICE — once explicitly inside the \`with InvocationChainContext\` block, then again via \`__exit__\`. Every async agent run over-popped the caller's chain node, corrupting trace/memory source attribution. The sync wrapper never had this bug. Removed the explicit pop.

### 2. retry.py — original exception type discarded
\`raise Exception(f"Failed after {max_retries} retries...")\` discarded the original exception type and traceback. Callers catching specific types (\`HttpError\`, \`TimeoutError\`, ...) could never match. Now re-raises the original exception directly. Added debug logging of each retry attempt.

### 3. au_trace_context.py — wrong OpenTelemetry API
\`_get_current_span_id\` used \`span.context.span_id\` — Span exposes \`get_span_context()\`, not a \`.context\` attribute. This raised \`AttributeError\` whenever the span was recording. Now uses \`get_span_context().span_id\`, matching every other call site in the file.

### 4. context_archive_utils.py — set throwaway dict, returned different one
\`get_current_context_archive\` set a throwaway \`{}\` into \`FrameworkContextManager\` but returned a different local dict. Subsequent \`update_context_archive\` mutations on the returned reference were invisible to later calls. Now sets the same dict object.

## Tests

\`tests/test_agentuniverse/unit/base/annotation/test_trace_retry_context_fixes.py\` — 6 regressions:
- async wrapper source has no explicit pop inside the with-block
- retry preserves original exception type
- retry succeeds on Nth attempt
- retry source has no bare \`raise Exception\`
- \`_get_current_span_id\` uses \`get_span_context()\`
- context archive sets the same dict it returns

\`python -m unittest tests.test_agentuniverse.unit.base.annotation.test_trace_retry_context_fixes\` — 6 passed.