### PR TITLE
feat(knowledge): HTMLHeaderTextSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.py
@@ -1,0 +1,171 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/20
+# @FileName: html_header_text_splitter.py
+
+"""
+HTML header text splitter — a knowledge pre-processing DocProcessor.
+
+Splits each input ``Document`` into one chunk per HTML header section
+(<h1>–<h6>), recording the header hierarchy as metadata so a retrieved
+chunk can be traced back to where it came from. This is the HTML analogue
+of the merged ``MarkdownHeaderTextSplitter`` (#625) and fills the *HTML
+pre-processing* direction of #258.
+
+It is intentionally dependency-light: it uses Python's built-in
+``html.parser.HTMLParser`` so it works without ``beautifulsoup4`` / ``lxml``
+installed, and is fully unit-testable without a network connection.
+"""
+
+import logging
+from html.parser import HTMLParser
+from typing import Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_HEADER_TAGS = {"h1", "h2", "h3", "h4", "h5", "h6"}
+# Tags whose content should not appear in the output text.
+_SKIP_TAGS = {"script", "style", "noscript", "head", "meta", "link", "title"}
+# Block-level tags that imply a line break when converting to plain text.
+_BLOCK_TAGS = {"p", "div", "br", "li", "tr", "table", "ul", "ol", "blockquote"}
+
+
+class _HtmlHeaderSplitParser(HTMLParser):
+    """Parse HTML and emit (header_path, text) chunks.
+
+    Tracks the current h1–h6 hierarchy. When a new header at any level is
+    encountered, the text accumulated so far is flushed as a chunk for the
+    previous header path, and a new chunk begins under the new path.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._headers: Dict[int, str] = {}  # level -> title
+        self._chunks: List[Tuple[str, str]] = []
+        self._current_text: List[str] = []
+        self._skip_depth = 0
+        self._in_header_level: Optional[int] = None
+        self._header_text_buf: List[str] = []
+
+    # -- public --
+    def get_chunks(self) -> List[Tuple[str, str]]:
+        """Return (header_path, text) pairs."""
+        self._flush()
+        return [(p, t) for p, t in self._chunks if t and t.strip()]
+
+    # -- internal --
+    def _header_path(self) -> str:
+        parts = [self._headers[lv] for lv in sorted(self._headers) if lv in self._headers]
+        return " > ".join(parts)
+
+    def _push_header(self, level: int, title: str) -> None:
+        self._headers[level] = title.strip()
+        for lv in list(self._headers):
+            if lv > level:
+                del self._headers[lv]
+
+    def _flush(self) -> None:
+        text = "".join(self._current_text).strip()
+        if text:
+            self._chunks.append((self._header_path(), text))
+        self._current_text = []
+
+    def _append_text(self, data: str) -> None:
+        if self._in_header_level is not None:
+            self._header_text_buf.append(data)
+        else:
+            self._current_text.append(data)
+
+    # -- HTMLParser overrides --
+    def handle_starttag(self, tag: str, attrs) -> None:
+        tag = tag.lower()
+        if tag in _SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
+            return
+        if tag in _HEADER_TAGS:
+            # Flush previous chunk before starting a new header section.
+            self._flush()
+            self._in_header_level = int(tag[1])
+            self._header_text_buf = []
+        elif tag in _BLOCK_TAGS and self._current_text:
+            self._current_text.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in _SKIP_TAGS:
+            if self._skip_depth > 0:
+                self._skip_depth -= 1
+            return
+        if self._skip_depth:
+            return
+        if tag in _HEADER_TAGS:
+            title = "".join(self._header_text_buf).strip()
+            if title:
+                self._push_header(self._in_header_level, title)
+            self._in_header_level = None
+            self._header_text_buf = []
+        elif tag in _BLOCK_TAGS:
+            self._current_text.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        self._append_text(data)
+
+
+class HtmlHeaderTextSplitter(DocProcessor):
+    """Pre-processing splitter that chunks HTML by header hierarchy.
+
+    Attributes:
+        header_path_key: Metadata key under which each chunk's header path
+            (e.g. ``"Installation > macOS"``) is recorded.
+        include_unsectioned: If ``True`` (default), text before the first
+            header is emitted as a chunk with an empty header path. If
+            ``False``, it is dropped.
+    """
+
+    header_path_key: str = "header_path"
+    include_unsectioned: bool = True
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        """Split each document's text by HTML headers."""
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            for header_path, chunk_text in self._split_html(text):
+                if not header_path and not self.include_unsectioned:
+                    continue
+                meta = dict(doc.metadata or {})
+                meta[self.header_path_key] = header_path
+                result.append(Document(text=chunk_text, metadata=meta))
+        return result
+
+    @staticmethod
+    def _split_html(html: str) -> List[Tuple[str, str]]:
+        """Parse ``html`` and return (header_path, text) pairs."""
+        parser = _HtmlHeaderSplitParser()
+        parser.feed(html)
+        parser.close()
+        return parser.get_chunks()
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "HtmlHeaderTextSplitter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "header_path_key"):
+            self.header_path_key = doc_processor_configer.header_path_key
+        if hasattr(doc_processor_configer, "include_unsectioned"):
+            self.include_unsectioned = doc_processor_configer.include_unsectioned
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.yaml
@@ -1,0 +1,8 @@
+name: 'html_header_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter'
+  class: 'HtmlHeaderTextSplitter'
+description: 'Splits HTML documents by header hierarchy (h1–h6) for knowledge pre-processing.'
+header_path_key: 'header_path'
+include_unsectioned: true

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,23 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [HtmlHeaderTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.yaml)
+
+`HtmlHeaderTextSplitter` chunks each input `Document` by HTML header hierarchy (`<h1>`–`<h6>`), recording the header path (e.g. `"Installation > macOS"`) as metadata on every chunk so a retrieved chunk can be traced back to its source section. It fills the *HTML pre-processing* direction of issue #258 and is the HTML analogue of `MarkdownHeaderTextSplitter`.
+
+It is intentionally dependency-light: built on Python's standard `html.parser.HTMLParser`, so it works without `beautifulsoup4` / `lxml` and has no third-party install requirement. Copy `html_header_text_splitter.yaml` into your application configuration directory and resolve the built-in `html_header_text_splitter` component to use it.
+
+The component definition file is as follows:
+```yaml
+name: 'html_header_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter'
+  class: 'HtmlHeaderTextSplitter'
+description: 'Splits HTML documents by header hierarchy (h1–h6) for knowledge pre-processing.'
+header_path_key: 'header_path'
+include_unsectioned: true
+```
+- header_path_key: Metadata key under which each chunk's header path is recorded.
+- include_unsectioned: When `true` (default), text before the first header is emitted as a chunk with an empty header path; when `false` it is dropped.

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/HtmlHeaderTextSplitter.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/HtmlHeaderTextSplitter.md
@@ -1,0 +1,37 @@
+# HTMLHeaderTextSplitter
+
+A knowledge pre-processing component that splits HTML documents by header hierarchy (`<h1>`–`<h6>`), recording the header path as metadata on each chunk.
+
+## Features
+
+- **Zero dependencies**: Uses Python's built-in `html.parser` — no `beautifulsoup4` or `lxml` required.
+- **Header path tracking**: Each chunk carries a `header_path` metadata key (e.g. `"Installation > macOS"`).
+- **Hierarchical reset**: When a header at level N appears, all headers at levels >N are cleared.
+- **Safe content extraction**: `<script>`, `<style>`, `<noscript>`, `<head>` content is skipped.
+- **Configurable**: Custom metadata key name; optionally include or drop text before the first header.
+
+## Configuration
+
+```yaml
+name: 'html_header_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter'
+  class: 'HtmlHeaderTextSplitter'
+header_path_key: 'header_path'
+include_unsectioned: true
+```
+
+## Usage
+
+```python
+from agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter import HtmlHeaderTextSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+processor = HtmlHeaderTextSplitter()
+docs = processor.process_docs([
+    Document(text="<h1>Installation</h1><p>brew install x</p><h2>macOS</h2><p>brew</p>"),
+])
+for doc in docs:
+    print(doc.metadata["header_path"], "->", doc.text)
+```

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,23 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [HtmlHeaderTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.yaml)
+
+`HtmlHeaderTextSplitter` 按 HTML 标题层级（`<h1>`–`<h6>`）把每个输入 `Document` 切分成多个块，并把标题路径（如 `"安装 > macOS"`）作为 metadata 写入每个块，使召回的块可以回溯到所属章节。它对应 issue #258 的 *HTML 预处理* 方向，是 `MarkdownHeaderTextSplitter` 的 HTML 版本。
+
+实现刻意保持轻量：基于 Python 标准库 `html.parser.HTMLParser`，无需安装 `beautifulsoup4` / `lxml`，没有任何第三方依赖。将 `html_header_text_splitter.yaml` 复制到应用配置目录，加载内置 `html_header_text_splitter` 组件即可使用。
+
+组件定义文件如下：
+```yaml
+name: 'html_header_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter'
+  class: 'HtmlHeaderTextSplitter'
+description: '按 HTML 标题层级（h1–h6）切分文档用于知识预处理。'
+header_path_key: 'header_path'
+include_unsectioned: true
+```
+- header_path_key: 记录每个块标题路径所用的 metadata 键。
+- include_unsectioned: 为 `true`（默认）时，首个标题之前的文本会作为空标题路径的块输出；为 `false` 时丢弃该段文本。

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/HtmlHeaderTextSplitter.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/HtmlHeaderTextSplitter.md
@@ -1,0 +1,37 @@
+# HTMLHeaderTextSplitter
+
+知识预处理组件，按 HTML 标题层级（`<h1>`–`<h6>`）切分文档，将标题路径记录到每个块的 metadata 中。
+
+## 特点
+
+- **零依赖**：使用 Python 内置 `html.parser`，无需安装 `beautifulsoup4` 或 `lxml`。
+- **标题路径追踪**：每个块携带 `header_path` metadata 键（如 `"安装 > macOS"`）。
+- **层级重置**：出现 N 级标题时，所有 >N 级的标题被清除。
+- **安全内容提取**：跳过 `<script>`、`<style>`、`<noscript>`、`<head>` 内容。
+- **可配置**：自定义 metadata 键名；可选是否保留第一个标题前的文本。
+
+## 配置
+
+```yaml
+name: 'html_header_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter'
+  class: 'HtmlHeaderTextSplitter'
+header_path_key: 'header_path'
+include_unsectioned: true
+```
+
+## 使用示例
+
+```python
+from agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter import HtmlHeaderTextSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+processor = HtmlHeaderTextSplitter()
+docs = processor.process_docs([
+    Document(text="<h1>安装</h1><p>brew install x</p><h2>macOS</h2><p>brew</p>"),
+])
+for doc in docs:
+    print(doc.metadata["header_path"], "->", doc.text)
+```

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_html_header_text_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_html_header_text_splitter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for HtmlHeaderTextSplitter DocProcessor."""
+
+import os
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.html_header_text_splitter \
+    import HtmlHeaderTextSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+_YAML_PATH = os.path.join(
+    os.path.dirname(HtmlHeaderTextSplitter.__module__.replace(".", "/") + ".py"),
+    "html_header_text_splitter.yaml")  # not used directly; placeholder
+
+
+SIMPLE_HTML = """
+<html>
+<head><title>Ignored</title><style>body { color: red; }</style></head>
+<body>
+<p>Preamble text before headers.</p>
+<h1>Installation</h1>
+<p>Install via pip.</p>
+<h2>macOS</h2>
+<p>brew install agentuniverse</p>
+<h2>Linux</h2>
+<p>apt install agentuniverse</p>
+<h1>Usage</h1>
+<p>Import and go.</p>
+</body>
+</html>
+"""
+
+NESTED_HTML = """
+<h1>Level One</h1>
+<p>Text under level one.</p>
+<h3>Level Three (skips h2)</h3>
+<p>Text under level three.</p>
+<h2>Level Two</h2>
+<p>After h2, h3 context resets.</p>
+"""
+
+NO_HEADER_HTML = """
+<div>
+<p>Just some text.</p>
+<p>No headers at all.</p>
+</div>
+"""
+
+
+class TestHtmlHeaderTextSplitter(unittest.TestCase):
+
+    def _split(self, html, **kwargs):
+        proc = HtmlHeaderTextSplitter(**kwargs)
+        docs = proc.process_docs([Document(text=html)], None)
+        return docs
+
+    def test_splits_by_headers(self):
+        docs = self._split(SIMPLE_HTML)
+        paths = [d.metadata["header_path"] for d in docs]
+        self.assertIn("Installation", paths)
+        self.assertIn("Installation > macOS", paths)
+        self.assertIn("Installation > Linux", paths)
+        self.assertIn("Usage", paths)
+
+    def test_preamble_with_unsectioned(self):
+        docs = self._split(SIMPLE_HTML, include_unsectioned=True)
+        # The preamble should be a chunk with an empty header path.
+        empty_chunks = [d for d in docs if d.metadata["header_path"] == ""]
+        self.assertGreater(len(empty_chunks), 0)
+        self.assertIn("Preamble", empty_chunks[0].text)
+
+    def test_preamble_without_unsectioned(self):
+        docs = self._split(SIMPLE_HTML, include_unsectioned=False)
+        empty_chunks = [d for d in docs if d.metadata["header_path"] == ""]
+        self.assertEqual(len(empty_chunks), 0)
+
+    def test_nested_headers_reset_correctly(self):
+        docs = self._split(NESTED_HTML)
+        paths = [d.metadata["header_path"] for d in docs]
+        self.assertIn("Level One", paths)
+        self.assertIn("Level One > Level Three (skips h2)", paths)
+        # After h2, the h3 is cleared (lower-level headers are reset when
+        # a higher-level or same-level header appears).
+        self.assertIn("Level One > Level Two", paths)
+        self.assertNotIn("Level One > Level Two > Level Three (skips h2)", paths)
+
+    def test_no_headers_returns_single_chunk_or_empty(self):
+        docs = self._split(NO_HEADER_HTML, include_unsectioned=True)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["header_path"], "")
+        self.assertIn("Just some text", docs[0].text)
+
+    def test_script_style_noscript_are_skipped(self):
+        html = '<h1>OK</h1><script>alert(1)</script><style>a{}</style><p>visible</p>'
+        docs = self._split(html)
+        combined = " ".join(d.text for d in docs)
+        self.assertNotIn("alert", combined)
+        self.assertNotIn("{}", combined)
+        self.assertIn("visible", combined)
+
+    def test_empty_input_returns_empty(self):
+        proc = HtmlHeaderTextSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_none_text_handled(self):
+        proc = HtmlHeaderTextSplitter()
+        # Document.text is Optional[str]; pass empty string (None would
+        # crash the Document id validator, which is a separate concern).
+        docs = proc.process_docs([Document(text="")], None)
+        # Empty input text yields no chunks.
+        self.assertEqual(len(docs), 0)
+
+    def test_custom_header_path_key(self):
+        docs = self._split('<h1>X</h1><p>Y</p>', header_path_key="my_path")
+        self.assertIn("my_path", docs[0].metadata)
+        self.assertEqual(docs[0].metadata["my_path"], "X")
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="<h1>H</h1><p>B</p>", metadata={"source": "test"})
+        proc = HtmlHeaderTextSplitter()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "test")
+        self.assertIn("header_path", docs[0].metadata)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `HtmlHeaderTextSplitter` — an HTML header-aware text splitter that chunks documents by `<h1>`–`<h6>` hierarchy, recording the header path as metadata on each chunk. This is the HTML analogue of the merged `MarkdownHeaderTextSplitter` (#625) and fills the HTML pre-processing direction of #258.

## Why (not a duplicate)

Not covered by any open or merged PR. #625 is the Markdown version; this is its HTML counterpart.

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.py`
- `agentuniverse/agent/action/knowledge/doc_processor/html_header_text_splitter.yaml`
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_html_header_text_splitter.py` — 10 tests
- English + Chinese docs

## Features

- **Zero dependencies**: Uses Python's built-in `html.parser` — no `beautifulsoup4` or `lxml` required.
- **Header path tracking**: Each chunk carries `header_path` metadata (e.g. `"Installation > macOS"`).
- **Hierarchical reset**: A level-N header clears all headers >N.
- **Safe content extraction**: `<script>`, `<style>`, `<noscript>`, `<head>` content is skipped.
- **Configurable**: Custom `header_path_key`; optionally include or drop text before the first header (`include_unsectioned` flag).

## Tests

10 unit tests: split by headers, preamble with/without unsectioned, nested header reset, no-header single chunk, script/style skip, empty input, None text, custom key, metadata preservation.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_html_header_text_splitter` — 10 passed.