### PR TITLE
feat(knowledge): JsonSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/json_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/json_splitter.py
@@ -1,0 +1,135 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/20
+# @FileName: json_splitter.py
+
+"""
+JSON structure splitter — a knowledge pre-processing DocProcessor.
+
+Recursively traverses JSON objects/arrays and emits one chunk per leaf
+value (or per configurable depth), recording the JSON path as metadata.
+This is useful for indexing structured data sources (API docs, database
+schemas, configuration files) where each field/value pair should be a
+retrievable unit.
+
+Sibling of the merged ``MarkdownHeaderTextSplitter`` (#625) and the
+``HtmlHeaderTextSplitter`` (#737): all three address the *knowledge
+pre-processing* direction of #258.
+
+Pure Python with no third-party dependency.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class JsonSplitter(DocProcessor):
+    """Split JSON documents into one chunk per leaf value or per depth level.
+
+    Traverses the JSON tree and emits a ``Document`` for each scalar value
+    found at or below ``max_depth``. The JSON path (e.g. ``root > users > [0]
+    > name``) is recorded in metadata under ``path_key``.
+
+    Attributes:
+        path_key: Metadata key for the JSON path.
+        max_depth: Maximum traversal depth (``None`` = unlimited). At
+            ``max_depth``, a nested object/array is serialised as JSON text
+            rather than traversed further.
+        max_value_length: Maximum characters of a scalar value to include in
+            the chunk text; longer values are truncated with an ellipsis.
+        drop_empty: If ``True`` (default), empty strings / None / empty
+            lists are not emitted as chunks.
+    """
+
+    path_key: str = "json_path"
+    max_depth: Optional[int] = None
+    max_value_length: int = 10_000
+    drop_empty: bool = True
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            parsed = self._parse_json(text)
+            if parsed is None:
+                # Not valid JSON — emit the original document unchanged.
+                result.append(doc)
+                continue
+            for path, value_text in self._traverse(parsed, depth=0, prefix="root"):
+                if self.drop_empty and not value_text.strip():
+                    continue
+                meta = dict(doc.metadata or {})
+                meta[self.path_key] = path
+                result.append(Document(text=value_text, metadata=meta))
+        return result
+
+    def _parse_json(self, text: str) -> Any:
+        try:
+            return json.loads(text)
+        except (ValueError, TypeError):
+            return None
+
+    def _traverse(self, obj: Any, depth: int, prefix: str) -> List[Tuple[str, str]]:
+        """Recursively traverse ``obj`` and yield (path, text) pairs."""
+        results: List[Tuple[str, str]] = []
+
+        if self.max_depth is not None and depth >= self.max_depth:
+            # At max depth, serialise the remaining structure as a chunk.
+            serialised = json.dumps(obj, ensure_ascii=False, default=str)
+            results.append((prefix, self._truncate(serialised)))
+            return results
+
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                path = f"{prefix} > {key}"
+                results.extend(self._traverse(value, depth + 1, path))
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                path = f"{prefix} > [{i}]"
+                results.extend(self._traverse(item, depth + 1, path))
+        else:
+            # Leaf value.
+            text = self._leaf_to_text(obj)
+            results.append((prefix, text))
+
+        return results
+
+    def _leaf_to_text(self, value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        text = str(value)
+        return self._truncate(text)
+
+    def _truncate(self, text: str) -> str:
+        if len(text) <= self.max_value_length:
+            return text
+        return text[: max(0, self.max_value_length - 1)] + "…"
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "JsonSplitter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "path_key"):
+            self.path_key = doc_processor_configer.path_key
+        if hasattr(doc_processor_configer, "max_depth"):
+            self.max_depth = doc_processor_configer.max_depth
+        if hasattr(doc_processor_configer, "max_value_length"):
+            self.max_value_length = doc_processor_configer.max_value_length
+        if hasattr(doc_processor_configer, "drop_empty"):
+            self.drop_empty = doc_processor_configer.drop_empty
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/json_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/json_splitter.yaml
@@ -1,0 +1,10 @@
+name: 'json_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.json_splitter'
+  class: 'JsonSplitter'
+description: 'Splits JSON documents into one chunk per leaf value, recording the JSON path as metadata.'
+path_key: 'json_path'
+max_depth: null
+max_value_length: 10000
+drop_empty: true

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,27 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [JsonSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/json_splitter.yaml)
+
+`JsonSplitter` recursively traverses a JSON document and emits one chunk per leaf scalar value (or per configurable depth), recording the JSON path (e.g. `"root > users > [0] > name"`) as metadata on every chunk. It is the right splitter for structured data sources — API docs, database schemas, configuration files — where each field/value pair should be a separately retrievable unit. It is a sibling of `MarkdownHeaderTextSplitter` and `HtmlHeaderTextSplitter`, all addressing the *knowledge pre-processing* direction of issue #258.
+
+Pure Python with no third-party dependency; copy `json_splitter.yaml` into your application configuration directory and resolve the built-in `json_splitter` component to use it. When the input text is not valid JSON, the original document is emitted unchanged.
+
+The component definition file is as follows:
+```yaml
+name: 'json_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.json_splitter'
+  class: 'JsonSplitter'
+description: 'Splits JSON documents into one chunk per leaf value, recording the JSON path as metadata.'
+path_key: 'json_path'
+max_depth: null
+max_value_length: 10000
+drop_empty: true
+```
+- path_key: Metadata key under which each chunk's JSON path is recorded.
+- max_depth: Maximum traversal depth (`null` = unlimited). At `max_depth`, a nested object/array is serialised as JSON text rather than traversed further.
+- max_value_length: Maximum characters of a scalar value included in chunk text; longer values are truncated with an ellipsis.
+- drop_empty: When `true` (default), empty strings / `None` / empty containers are not emitted as chunks.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,27 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [JsonSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/json_splitter.yaml)
+
+`JsonSplitter` 递归遍历 JSON 文档，对每个叶子标量值（或指定深度的每一层）生成一个块，并把 JSON 路径（如 `"root > users > [0] > name"`）写入每个块的 metadata。它适用于结构化数据源——API 文档、数据库 schema、配置文件——这类场景下每个字段/取值都应是一个独立的检索单元。它与 `MarkdownHeaderTextSplitter`、`HtmlHeaderTextSplitter` 同属一类，对应 issue #258 的*知识预处理*方向。
+
+纯 Python 实现，无第三方依赖；将 `json_splitter.yaml` 复制到应用配置目录，加载内置 `json_splitter` 组件即可使用。若输入文本不是合法 JSON，则原样输出原文档。
+
+组件定义文件如下：
+```yaml
+name: 'json_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.json_splitter'
+  class: 'JsonSplitter'
+description: '将 JSON 文档切分为每个叶子取值一个块，并把 JSON 路径记录到 metadata。'
+path_key: 'json_path'
+max_depth: null
+max_value_length: 10000
+drop_empty: true
+```
+- path_key: 记录每个块 JSON 路径所用的 metadata 键。
+- max_depth: 最大遍历深度（`null` 表示不限）。到达 `max_depth` 时，嵌套对象/数组会被序列化为 JSON 文本，而不再继续下钻。
+- max_value_length: 写入块文本的标量值最大字符数，超出部分以省略号截断。
+- drop_empty: 为 `true`（默认）时，空字符串 / `None` / 空容器不会作为块输出。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_json_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_json_splitter.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for JsonSplitter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.json_splitter import \
+    JsonSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestJsonSplitter(unittest.TestCase):
+
+    def _split(self, json_text, **kwargs):
+        proc = JsonSplitter(**kwargs)
+        return proc.process_docs([Document(text=json_text)], None)
+
+    def test_flat_object(self):
+        docs = self._split('{"name": "Alice", "age": 30}')
+        paths = {d.metadata["json_path"] for d in docs}
+        self.assertIn("root > name", paths)
+        self.assertIn("root > age", paths)
+        texts = {d.text for d in docs}
+        self.assertIn("Alice", texts)
+        self.assertIn("30", texts)
+
+    def test_nested_object(self):
+        docs = self._split('{"user": {"name": "Bob", "city": "NYC"}}')
+        paths = {d.metadata["json_path"] for d in docs}
+        self.assertIn("root > user > name", paths)
+        self.assertIn("root > user > city", paths)
+
+    def test_array(self):
+        docs = self._split('{"items": ["a", "b", "c"]}')
+        paths = {d.metadata["json_path"] for d in docs}
+        self.assertIn("root > items > [0]", paths)
+        self.assertIn("root > items > [1]", paths)
+        self.assertIn("root > items > [2]", paths)
+
+    def test_max_depth_limits_traversal(self):
+        docs = self._split('{"a": {"b": {"c": "deep"}}}', max_depth=2)
+        # At depth 2, {"c": "deep"} is serialised as JSON text.
+        self.assertEqual(len(docs), 1)
+        self.assertIn("c", docs[0].text)
+        self.assertIn("deep", docs[0].text)
+
+    def test_null_value_dropped_by_default(self):
+        docs = self._split('{"x": null, "y": "present"}', drop_empty=True)
+        texts = [d.text for d in docs]
+        self.assertNotIn("", texts)
+        self.assertIn("present", texts)
+
+    def test_null_value_kept_when_drop_empty_false(self):
+        docs = self._split('{"x": null}', drop_empty=False)
+        self.assertTrue(any(d.text == "" for d in docs))
+
+    def test_boolean_value(self):
+        docs = self._split('{"flag": true}')
+        self.assertEqual(docs[0].text, "true")
+
+    def test_non_json_returned_unchanged(self):
+        docs = self._split("not json at all")
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].text, "not json at all")
+        self.assertNotIn("json_path", docs[0].metadata or {})
+
+    def test_empty_input_returns_empty(self):
+        proc = JsonSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_max_value_length_truncates(self):
+        long_val = "x" * 200
+        docs = self._split(f'{{"k": "{long_val}"}}', max_value_length=10)
+        self.assertLessEqual(len(docs[0].text), 10)
+
+    def test_custom_path_key(self):
+        docs = self._split('{"a": 1}', path_key="my_path")
+        self.assertIn("my_path", docs[0].metadata)
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text='{"a": 1}', metadata={"source": "api"})
+        proc = JsonSplitter()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "api")
+        self.assertIn("json_path", docs[0].metadata)
+
+    def test_mixed_array_of_objects(self):
+        json_text = '{"users": [{"name": "A"}, {"name": "B"}]}'
+        docs = self._split(json_text)
+        paths = {d.metadata["json_path"] for d in docs}
+        self.assertIn("root > users > [0] > name", paths)
+        self.assertIn("root > users > [1] > name", paths)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `JsonSplitter` — a `DocProcessor` that recursively traverses JSON objects/arrays and emits one chunk per leaf value, recording the JSON path (e.g. `root > users > [0] > name`) as metadata. Useful for indexing structured data sources (API docs, database schemas, configuration files) where each field/value pair should be a retrievable unit.

Sibling of the merged `MarkdownHeaderTextSplitter` (#625) and the new `HtmlHeaderTextSplitter` (#737): all three address the *knowledge pre-processing* direction of #258.

## Why (not a duplicate)

Not covered by any open or merged PR. #625 is Markdown, #737 is HTML; this is JSON.

## Features

- **Pure Python**, zero third-party dependencies.
- **Configurable `max_depth`**: limit traversal and serialise deeper structures as JSON text.
- **`max_value_length` truncation** for large scalar values.
- **`drop_empty` flag** to skip None / empty strings.
- **Non-JSON input returned unchanged** (graceful degradation).
- **Custom `path_key`** for the metadata field.

## Tests

13 unit tests: flat/nested objects, arrays, max_depth truncation, null drop/keep, boolean, non-JSON passthrough, empty input, value length truncation, custom key, metadata preservation, mixed array of objects.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_json_splitter` — 13 passed.