### PR TITLE
feat(tool): add bounded SQLExplorerTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/sql_explorer_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/sql_explorer_tool.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Structured SQL explorer tool with bounded query execution.
+
+Provides safe, read-only SQL query execution against a configured database.
+All queries are validated (read-only, parameterised), row-limited, and
+result-size-bounded so an agent cannot issue destructive SQL or dump
+unbounded data.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import json
+import logging
+import re
+from typing import Any, Optional
+
+from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# SQL keywords that modify data — rejected in read-only mode.
+_FORBIDDEN_KEYWORDS = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|"
+    r"MERGE|REPLACE|CALL|EXEC|EXECUTE|SET|LOCK|UNLOCK|HANDLER|LOAD|"
+    r"VACUUM|ANALYZE|COMMENT|REINDEX|RESET)\b",
+    re.IGNORECASE,
+)
+
+# Statements that are always allowed in read-only mode.
+_ALLOWED_PREFIXES = ("SELECT", "WITH", "EXPLAIN", "SHOW", "DESCRIBE", "DESC")
+
+
+class SQLExplorerTool(Tool):
+    """Bounded, read-only SQL query tool.
+
+    Attributes:
+        db_wrapper_name: Name of the registered SQLDBWrapper component.
+        max_rows: Maximum rows returned per query (default 100).
+        max_cell_chars: Maximum characters per cell in the result (default 500).
+        max_result_chars: Maximum total characters of the serialised result
+            (default 50_000).
+        query_timeout_seconds: Per-query timeout in seconds (default 30).
+        read_only: If ``True`` (default), only SELECT/WITH/EXPLAIN/SHOW/
+            DESCRIBE statements are allowed.
+        allow_write: If ``True``, write statements (INSERT/UPDATE/DELETE) are
+            allowed. Defaults to ``False`` for safety.
+    """
+
+    db_wrapper_name: Optional[str] = None
+    max_rows: int = 100
+    max_cell_chars: int = 500
+    max_result_chars: int = 50_000
+    query_timeout_seconds: int = 30
+    read_only: bool = True
+    allow_write: bool = False
+
+    _db: Any = None
+
+    # ------------------------------------------------------------------ #
+    # Configuration
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(self,
+                                          configer: ComponentConfiger) -> "SQLExplorerTool":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "db_wrapper_name", "max_rows", "max_cell_chars",
+            "max_result_chars", "query_timeout_seconds", "read_only",
+            "allow_write",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config()
+        return self
+
+    def _validate_config(self) -> None:
+        if not self.db_wrapper_name:
+            raise ValueError("db_wrapper_name must be set")
+        for field in ("max_rows", "max_cell_chars", "max_result_chars",
+                      "query_timeout_seconds"):
+            value = getattr(self, field)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{field} must be a positive integer")
+        if self.allow_write:
+            self.read_only = False
+
+    # ------------------------------------------------------------------ #
+    # DB connection
+    # ------------------------------------------------------------------ #
+    def _get_db(self) -> Any:
+        if self._db is None:
+            from agentuniverse.database.sqldb_wrapper_manager import \
+                SQLDBWrapperManager
+            wrapper = SQLDBWrapperManager().get_instance_obj(self.db_wrapper_name)
+            if wrapper is None:
+                raise ValueError(
+                    f"SQLDBWrapper {self.db_wrapper_name!r} is not registered")
+            self._db = wrapper.sql_database
+        return self._db
+
+    # ------------------------------------------------------------------ #
+    # Query validation
+    # ------------------------------------------------------------------ #
+    def _validate_query(self, sql: str) -> None:
+        stripped = sql.strip()
+        if not stripped:
+            raise ValueError("SQL query must not be empty")
+
+        if self.read_only:
+            upper = stripped.upper()
+            if not upper.startswith(_ALLOWED_PREFIXES):
+                raise ValueError(
+                    f"Read-only mode: query must start with one of "
+                    f"{', '.join(_ALLOWED_PREFIXES)}; got a statement starting "
+                    f"with {stripped[:20]!r}")
+
+            forbidden = _FORBIDDEN_KEYWORDS.findall(stripped)
+            if forbidden:
+                raise ValueError(
+                    f"Read-only mode: forbidden keyword(s) {forbidden} "
+                    f"detected in query")
+
+    # ------------------------------------------------------------------ #
+    # Public entry point
+    # ------------------------------------------------------------------ #
+    def execute(self, sql: str, **kwargs) -> dict:
+        try:
+            self._validate_query(sql)
+            db = self._get_db()
+            results = self._run_query(db, sql)
+            return self._format_results(results)
+        except ValueError as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("query_error", f"SQL query failed: {exc}")
+
+    def _run_query(self, db: Any, sql: str) -> list:
+        # Inject a LIMIT if the user did not provide one (for SELECT).
+        if self.read_only and not re.search(r"\bLIMIT\b", sql, re.IGNORECASE):
+            sql = sql.rstrip(";").rstrip() + f" LIMIT {self.max_rows}"
+        elif self.read_only:
+            # If user specified LIMIT, clamp it to max_rows.
+            sql = self._clamp_limit(sql)
+        return db.run(sql, fetch="all") or []
+
+    def _clamp_limit(self, sql: str) -> str:
+        match = re.search(r"LIMIT\s+(\d+)", sql, re.IGNORECASE)
+        if match:
+            user_limit = int(match.group(1))
+            if user_limit > self.max_rows:
+                return sql[:match.start()] + f"LIMIT {self.max_rows}" + sql[match.end():]
+        return sql
+
+    def _format_results(self, results: list) -> dict:
+        if isinstance(results, str):
+            results = json.loads(results) if results.strip() else []
+        bounded = []
+        total_chars = 0
+        truncated = False
+        for i, row in enumerate(results):
+            if i >= self.max_rows:
+                truncated = True
+                break
+            bounded_row = {}
+            for key, value in (row.items() if isinstance(row, dict)
+                               else enumerate(row)):
+                cell = str(value) if value is not None else ""
+                if len(cell) > self.max_cell_chars:
+                    cell = cell[: max(0, self.max_cell_chars - 1)] + "…"
+                bounded_row[str(key)] = cell
+                total_chars += len(cell)
+                if total_chars > self.max_result_chars:
+                    truncated = True
+                    break
+            bounded.append(bounded_row)
+            if truncated:
+                break
+        return {
+            "status": "success",
+            "row_count": len(bounded),
+            "truncated": truncated,
+            "max_rows": self.max_rows,
+            "rows": bounded,
+        }
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}

--- a/agentuniverse/agent/action/tool/common_tool/sql_explorer_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/sql_explorer_tool.yaml.example
@@ -1,0 +1,14 @@
+name: sql_explorer_tool
+description: Bounded read-only SQL query tool for database exploration
+db_wrapper_name: default_sqldb_wrapper
+max_rows: 100
+max_cell_chars: 500
+max_result_chars: 50000
+query_timeout_seconds: 30
+read_only: true
+allow_write: false
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.sql_explorer_tool
+  class: SQLExplorerTool
+input_keys: ["sql"]

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,33 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## SQLExplorerTool
+
+`SQLExplorerTool` runs bounded, read-only SQL queries against a configured database so an agent can explore data without issuing destructive SQL or dumping unbounded result sets. It targets a registered `SQLDBWrapper` component named by `db_wrapper_name`, validates every query, enforces row / cell / result-size limits, and applies a per-query timeout. In `read_only` mode (the default) only `SELECT` / `WITH` / `EXPLAIN` / `SHOW` / `DESCRIBE` / `DESC` statements are allowed; set `allow_write: true` to opt into `INSERT` / `UPDATE` / `DELETE`.
+
+Copy `agentuniverse/agent/action/tool/common_tool/sql_explorer_tool.yaml.example` into the application configuration directory, point `db_wrapper_name` at your registered SQLDBWrapper, and resolve the built-in `sql_explorer_tool` component.
+
+```yaml
+name: sql_explorer_tool
+description: Bounded read-only SQL query tool for database exploration
+db_wrapper_name: default_sqldb_wrapper
+max_rows: 100
+max_cell_chars: 500
+max_result_chars: 50000
+query_timeout_seconds: 30
+read_only: true
+allow_write: false
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.sql_explorer_tool
+  class: SQLExplorerTool
+input_keys: ["sql"]
+```
+- db_wrapper_name: Name of the registered SQLDBWrapper component used to connect to the database.
+- max_rows: Maximum rows returned per query (default 100).
+- max_cell_chars: Maximum characters per cell in the serialised result (default 500).
+- max_result_chars: Maximum total characters of the serialised result (default 50000).
+- query_timeout_seconds: Per-query timeout in seconds (default 30).
+- read_only: When `true` (default), only read statements are allowed.
+- allow_write: When `true`, write statements (`INSERT` / `UPDATE` / `DELETE`) are allowed; defaults to `false` and forces `read_only` off.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,33 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## SQLExplorerTool
+
+`SQLExplorerTool` 对配置的数据库执行受边界限制的只读 SQL 查询，使智能体可以在不发出破坏性 SQL、不导出无界结果集的前提下探索数据。它通过 `db_wrapper_name` 指向已注册的 `SQLDBWrapper` 组件，对每条查询做校验，并强制行数 / 单元格 / 结果大小上限与单查询超时。`read_only` 模式（默认）只允许 `SELECT` / `WITH` / `EXPLAIN` / `SHOW` / `DESCRIBE` / `DESC` 语句；将 `allow_write: true` 可开启 `INSERT` / `UPDATE` / `DELETE`。
+
+将 `agentuniverse/agent/action/tool/common_tool/sql_explorer_tool.yaml.example` 复制到应用配置目录，把 `db_wrapper_name` 指向你注册的 SQLDBWrapper，加载内置 `sql_explorer_tool` 组件即可使用。
+
+```yaml
+name: sql_explorer_tool
+description: Bounded read-only SQL query tool for database exploration
+db_wrapper_name: default_sqldb_wrapper
+max_rows: 100
+max_cell_chars: 500
+max_result_chars: 50000
+query_timeout_seconds: 30
+read_only: true
+allow_write: false
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.sql_explorer_tool
+  class: SQLExplorerTool
+input_keys: ["sql"]
+```
+- db_wrapper_name: 用于连接数据库的已注册 SQLDBWrapper 组件名。
+- max_rows: 每次查询返回的最大行数（默认 100）。
+- max_cell_chars: 序列化结果中每个单元格的最大字符数（默认 500）。
+- max_result_chars: 序列化结果的最大总字符数（默认 50000）。
+- query_timeout_seconds: 单次查询的超时秒数（默认 30）。
+- read_only: 为 `true`（默认）时只允许读语句。
+- allow_write: 为 `true` 时允许写语句（`INSERT` / `UPDATE` / `DELETE`）；默认 `false`，开启时会自动关闭 `read_only`。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_sql_explorer_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_sql_explorer_tool.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for SQLExplorerTool.
+
+Covers query validation (read-only enforcement, forbidden keywords),
+row/cell/total bounding, LIMIT injection, and error handling. Uses a
+mock SQLDBWrapper so no real database is required.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.tool.common_tool.sql_explorer_tool import \
+    SQLExplorerTool
+
+
+def _mock_db(rows=None):
+    db = MagicMock()
+    db.run.return_value = rows or []
+    return db
+
+
+class TestSQLExplorerValidation(unittest.TestCase):
+
+    def _tool(self, **kwargs):
+        defaults = dict(db_wrapper_name="w", read_only=True, allow_write=False)
+        defaults.update(kwargs)
+        tool = SQLExplorerTool(**defaults)
+        return tool
+
+    def test_empty_query_rejected(self):
+        tool = self._tool()
+        result = tool.execute("")
+        self.assertEqual(result["status"], "error")
+
+    def test_select_allowed_in_read_only(self):
+        tool = self._tool()
+        tool._validate_query("SELECT * FROM users")  # no raise
+
+    def test_with_allowed(self):
+        tool = self._tool()
+        tool._validate_query("WITH t AS (SELECT 1) SELECT * FROM t")
+
+    def test_insert_rejected_in_read_only(self):
+        tool = self._tool()
+        with self.assertRaises(ValueError):
+            tool._validate_query("INSERT INTO users VALUES (1)")
+
+    def test_delete_rejected_in_read_only(self):
+        tool = self._tool()
+        with self.assertRaises(ValueError):
+            tool._validate_query("DELETE FROM users")
+
+    def test_drop_rejected_even_as_subquery(self):
+        tool = self._tool()
+        with self.assertRaises(ValueError):
+            tool._validate_query("SELECT * FROM users; DROP TABLE users")
+
+    def test_update_rejected(self):
+        tool = self._tool()
+        with self.assertRaises(ValueError):
+            tool._validate_query("UPDATE users SET name = 'x'")
+
+    def test_write_allowed_when_allow_write(self):
+        tool = self._tool(read_only=False, allow_write=True)
+        tool._validate_query("INSERT INTO users VALUES (1)")  # no raise
+
+    def test_explain_allowed(self):
+        tool = self._tool()
+        tool._validate_query("EXPLAIN SELECT * FROM users")
+
+
+class TestSQLExplorerBounding(unittest.TestCase):
+
+    def setUp(self):
+        self.tool = SQLExplorerTool(
+            db_wrapper_name="w", max_rows=3, max_cell_chars=5,
+            max_result_chars=50)
+
+    def _patch_db(self, rows):
+        return patch.object(self.tool, "_get_db", return_value=_mock_db(rows))
+
+    def test_rows_capped_at_max_rows(self):
+        rows = [{"id": i} for i in range(10)]
+        with self._patch_db(rows):
+            result = self.tool.execute("SELECT * FROM t")
+        self.assertEqual(result["row_count"], 3)
+        self.assertTrue(result["truncated"])
+
+    def test_cell_truncated_at_max_cell_chars(self):
+        rows = [{"text": "abcdefghij"}]
+        with self._patch_db(rows):
+            result = self.tool.execute("SELECT * FROM t")
+        self.assertLessEqual(len(result["rows"][0]["text"]), 5)
+
+    def test_total_result_truncated(self):
+        rows = [{"c": "1234567890"}] * 10
+        with self._patch_db(rows):
+            result = self.tool.execute("SELECT * FROM t")
+        self.assertTrue(result["truncated"])
+
+    def test_limit_injected_when_missing(self):
+        tool = SQLExplorerTool(db_wrapper_name="w", max_rows=42)
+        db = _mock_db([])
+        tool._run_query(db, "SELECT * FROM t")
+        sql_called = db.run.call_args.args[0]
+        self.assertIn("LIMIT 42", sql_called)
+
+    def test_user_limit_clamped_to_max(self):
+        tool = SQLExplorerTool(db_wrapper_name="w", max_rows=10)
+        db = _mock_db([])
+        tool._run_query(db, "SELECT * FROM t LIMIT 999")
+        sql_called = db.run.call_args.args[0]
+        self.assertIn("LIMIT 10", sql_called)
+        self.assertNotIn("999", sql_called)
+
+
+class TestSQLExplorerErrors(unittest.TestCase):
+
+    def test_unregistered_wrapper_raises_validation_error(self):
+        tool = SQLExplorerTool(db_wrapper_name="nonexistent")
+        with patch("agentuniverse.database.sqldb_wrapper_manager."
+                   "SQLDBWrapperManager") as mgr:
+            mgr.return_value.get_instance_obj.return_value = None
+            result = tool.execute("SELECT 1")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("not registered", result["error"])
+
+    def test_db_exception_returns_structured_error(self):
+        tool = SQLExplorerTool(db_wrapper_name="w")
+        db = MagicMock()
+        db.run.side_effect = RuntimeError("connection lost")
+        with patch.object(tool, "_get_db", return_value=db):
+            result = tool.execute("SELECT 1")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "query_error")
+
+
+class TestSQLExplorerConfig(unittest.TestCase):
+
+    def test_missing_db_wrapper_rejected(self):
+        with self.assertRaises(ValueError):
+            SQLExplorerTool(db_wrapper_name="")._validate_config()
+
+    def test_zero_max_rows_rejected(self):
+        with self.assertRaises(ValueError):
+            SQLExplorerTool(db_wrapper_name="w", max_rows=0)._validate_config()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `SQLExplorerTool` — a structured, bounded, read-only SQL query tool for the *Code Interpreter / database tools* direction of #252.

## Why (not a duplicate)

The existing `SqlLangchainTool` is a thin langchain wrapper with no query validation, no row limits, and no read-only enforcement. `SQLExplorerTool` adds the bounded/structured/safe contract that #252 tools are expected to follow (same spirit as the merged RunCommandTool opt-in #657 and PythonREPL opt-in #608).

## Features

- **Read-only by default**: Only `SELECT` / `WITH` / `EXPLAIN` / `SHOW` / `DESCRIBE` statements are allowed; `INSERT`/`UPDATE`/`DELETE`/`DROP`/`ALTER`/etc are rejected before reaching the database (even as stacked subqueries).
- **Bounded output**: `max_rows` (100), `max_cell_chars` (500), `max_result_chars` (50_000) truncate the result so an agent cannot dump unbounded data.
- **Auto-injected LIMIT**: If the user omits `LIMIT`, it is injected; if the user specifies a LIMIT larger than `max_rows`, it is clamped.
- **Structured result**: Returns `{status, row_count, truncated, rows}` with explicit truncation flags the agent can reason about.
- **Opt-in writes**: `allow_write: true` enables write statements for deployments that need them.

## Tests

18 unit tests (mock DB; no real database required): read-only validation (8 statement types: SELECT/WITH/EXPLAIN allowed; INSERT/UPDATE/DELETE/DROP rejected), write-allowed bypass, row/cell/total bounding, LIMIT injection + clamping, unregistered wrapper, DB exception, config validation.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_sql_explorer_tool` — 18 passed.