### PR TITLE
fix(store): parse Qdrant vector flag strictly

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/qdrant_store.py
+++ b/agentuniverse/agent/action/knowledge/store/qdrant_store.py
@@ -54,6 +54,22 @@ class QdrantStore(Store):
 
     VECTOR_NAME: ClassVar[str] = "embedding"
 
+    @staticmethod
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off"}:
+                return False
+        raise ValueError(f"Invalid boolean value for with_vectors: {value!r}")
+
     def _metric_from_str(self) -> Distance:
         return {
             "COSINE": Distance.COSINE,
@@ -82,7 +98,7 @@ class QdrantStore(Store):
         if hasattr(qdrant_store_configer, "similarity_top_k"):
             self.similarity_top_k = qdrant_store_configer.similarity_top_k
         if hasattr(qdrant_store_configer, "with_vectors"):
-            self.with_vectors = bool(qdrant_store_configer.with_vectors)
+            self.with_vectors = self._coerce_bool(qdrant_store_configer.with_vectors)
         return self
 
     def _ensure_collection(self, dim: int):

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store.py
@@ -1,0 +1,20 @@
+import unittest
+
+from agentuniverse.agent.action.knowledge.store.qdrant_store import QdrantStore
+
+
+class TestQdrantStore(unittest.TestCase):
+
+    def test_coerce_bool_handles_boolean_strings(self):
+        self.assertFalse(QdrantStore._coerce_bool("false"))
+        self.assertFalse(QdrantStore._coerce_bool("0"))
+        self.assertTrue(QdrantStore._coerce_bool("true"))
+        self.assertTrue(QdrantStore._coerce_bool("1"))
+
+    def test_coerce_bool_rejects_unknown_string(self):
+        with self.assertRaisesRegex(ValueError, "Invalid boolean value"):
+            QdrantStore._coerce_bool("enabled")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Parse Qdrant `with_vectors` configuration with an explicit boolean coercion helper instead of using `bool(value)`.
- This prevents string values such as `"false"` or `"0"` from being treated as `True`.
- Keep common boolean spellings supported (`true/false`, `1/0`, `yes/no`, `on/off`) and reject unknown strings with a clear `ValueError`.
- Add regression coverage for boolean strings and invalid values.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/store/qdrant_store.py tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store.py`: passed.
- `python -m unittest tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_store.py`: not run to completion locally because this environment is missing project dependency `qdrant_client`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.