### PR TITLE
fix(tool,reader): langchain None.get, code_reader encoding, google_search API key, arxiv temp file

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/code_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/code_reader.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List, Union, Optional, Dict
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
+from agentuniverse.agent.action.knowledge.reader.utils import detect_file_encoding
 from agentuniverse.agent.action.knowledge.store.document import Document
 
 
@@ -51,7 +52,8 @@ class CodeReader(Reader):
         if isinstance(file, Path):
             if not file.exists():
                 raise FileNotFoundError(f"Code file not found: {file}")
-        file_content = file.read_text(encoding="utf-8")
+        file_content = file.read_text(encoding=detect_file_encoding(file),
+                                      errors="replace")
         file_name = file.name
         file_suffix = file.suffix.lower()
         language = CODE_FILE_EXTENSIONS.get(file_suffix, 'unknown')

--- a/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
@@ -30,9 +30,12 @@ class PaperSummary:
 
 
 class ArxivTool(Tool):
-    
+
     sch_engine: Optional[Any] = None
     MAX_QUERY_LENGTH: int = Field(default=300, description="查询字符串最大长度")
+    max_pdf_size_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        description="Maximum PDF size in bytes for retrieve_full_paper_text")
 
     def execute(self, input: str | ToolInput, mode: str = None):
         if isinstance(input, ToolInput):
@@ -106,19 +109,46 @@ class ArxivTool(Tool):
             raise ImportError("arxiv is required. Install with: pip install arxiv")
         search = arxiv.Search(id_list=[paper_id])
         paper = next(self.sch_engine.results(search))
-        paper.download_pdf(filename="downloaded-paper.pdf") 
-        
+
+        import tempfile
+        # Use a unique temp file per call instead of a fixed CWD filename,
+        # so concurrent calls do not overwrite each other and the temp file
+        # is cleaned up even when pypdf raises on a corrupt/encrypted PDF.
+        tmp_path = None
         try:
-            import pypdf
-        except ImportError:
-            raise ImportError(
-                "pypdf is required to read PDF files: `pip install pypdf`"
-            )
-        reader = pypdf.PdfReader('downloaded-paper.pdf')
-        text_content = [page.extract_text() for page in reader.pages]
-        if os.path.exists("downloaded-paper.pdf"):
-            os.remove("downloaded-paper.pdf")
-        return "\n\n".join(text_content)
+            with tempfile.NamedTemporaryFile(
+                suffix=".pdf", delete=False
+            ) as tmp:
+                tmp_path = tmp.name
+            paper.download_pdf(filename=tmp_path)
+
+            # Reject unreasonably large PDFs before loading them.
+            if os.path.getsize(tmp_path) > self.max_pdf_size_bytes:
+                raise ValueError(
+                    f"Downloaded PDF for {paper_id} is "
+                    f"{os.path.getsize(tmp_path)} bytes, exceeding "
+                    f"max_pdf_size_bytes ({self.max_pdf_size_bytes}).")
+
+            try:
+                import pypdf
+            except ImportError:
+                raise ImportError(
+                    "pypdf is required to read PDF files: `pip install pypdf`"
+                )
+            reader = pypdf.PdfReader(tmp_path)
+            text_content = []
+            for page in reader.pages:
+                try:
+                    text_content.append(page.extract_text() or "")
+                except Exception:
+                    text_content.append("")
+            return "\n\n".join(text_content)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
 
     def _format_paper_results(self, papers: List[PaperSummary]) -> str:
         if not papers:

--- a/agentuniverse/agent/action/tool/common_tool/google_search_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/google_search_tool.py
@@ -24,12 +24,21 @@ class GoogleSearchTool(Tool):
 
     serper_api_key: Optional[str] = Field(default_factory=lambda: get_from_env("SERPER_API_KEY"))
 
+    def _ensure_api_key(self):
+        if not self.serper_api_key:
+            raise ValueError(
+                "SERPER_API_KEY is not set. Configure it via the "
+                "SERPER_API_KEY environment variable or the serper_api_key "
+                "field on the GoogleSearchTool component.")
+
     def execute(self, input: str):
         # get top10 results from Google search.
+        self._ensure_api_key()
         search = GoogleSerperAPIWrapper(serper_api_key=self.serper_api_key, k=10, gl="us", hl="en", type="search")
         return search.run(query=input)
 
     async def async_execute(self, input: str):
         # get top10 results from Google search.
+        self._ensure_api_key()
         search = GoogleSerperAPIWrapper(serper_api_key=self.serper_api_key, k=10, gl="us", hl="en", type="search")
         return await search.arun(query=input)

--- a/agentuniverse/agent/action/tool/common_tool/langchain_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/langchain_tool.py
@@ -33,6 +33,10 @@ class LangChainTool(Tool):
 
     def init_langchain_tool(self, component_configer):
         langchain_info = component_configer.configer.value.get('langchain')
+        if not langchain_info or not isinstance(langchain_info, dict):
+            raise ValueError(
+                "A 'langchain' section (with module and class_name) is "
+                "required in the LangChainTool component configuration.")
         module = langchain_info.get("module")
         class_name = langchain_info.get("class_name")
         module = importlib.import_module(module)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_tool_reader_four_bugs.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_tool_reader_four_bugs.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for four tool/reader bug fixes.
+
+1. LangChainTool.init_langchain_tool None.get crash on missing config.
+2. CodeReader hardcoded utf-8 encoding.
+3. GoogleSearchTool missing API key produces cryptic langchain error.
+4. ArxivTool temp file leak + no size cap + corrupt PDF crash.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestLangChainToolNoneGuard(unittest.TestCase):
+
+    def test_missing_langchain_config_raises_clear_error(self):
+        from agentuniverse.agent.action.tool.common_tool.langchain_tool \
+            import LangChainTool
+        tool = LangChainTool()
+        configer = MagicMock()
+        configer.configer.value = {}  # no 'langchain' key
+        with self.assertRaises(ValueError) as ctx:
+            tool.init_langchain_tool(configer)
+        self.assertIn("langchain", str(ctx.exception).lower())
+
+
+class TestCodeReaderEncoding(unittest.TestCase):
+
+    def test_source_uses_detect_file_encoding(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.code_reader \
+            import CodeReader
+        src = inspect.getsource(CodeReader._load_data)
+        self.assertIn("detect_file_encoding", src,
+                      "CodeReader must use detect_file_encoding, not hardcoded utf-8")
+        self.assertNotIn('encoding="utf-8"', src)
+
+
+class TestGoogleSearchToolAPIKeyGuard(unittest.TestCase):
+
+    def test_missing_api_key_raises_clear_error(self):
+        from agentuniverse.agent.action.tool.common_tool.google_search_tool \
+            import GoogleSearchTool
+        tool = GoogleSearchTool()
+        tool.serper_api_key = None
+        with self.assertRaises(ValueError) as ctx:
+            tool.execute("test query")
+        self.assertIn("SERPER_API_KEY", str(ctx.exception))
+
+    def test_present_api_key_proceeds_to_search(self):
+        from agentuniverse.agent.action.tool.common_tool.google_search_tool \
+            import GoogleSearchTool
+        tool = GoogleSearchTool()
+        tool.serper_api_key = "fake-key"
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "google_search_tool.GoogleSerperAPIWrapper") as wrapper_cls:
+            wrapper = MagicMock()
+            wrapper.run.return_value = "search results"
+            wrapper_cls.return_value = wrapper
+            result = tool.execute("test query")
+        self.assertEqual(result, "search results")
+
+
+class TestArxivToolTempFileAndSizeGuard(unittest.TestCase):
+
+    def test_source_uses_tempfile_not_fixed_filename(self):
+        import inspect
+        from agentuniverse.agent.action.tool.common_tool.arxiv_tool \
+            import ArxivTool
+        src = inspect.getsource(ArxivTool.retrieve_full_paper_text)
+        self.assertIn("tempfile", src,
+                      "ArxivTool must use tempfile, not a fixed CWD filename")
+        self.assertNotIn('"downloaded-paper.pdf"', src)
+
+    def test_source_has_finally_cleanup(self):
+        import inspect
+        from agentuniverse.agent.action.tool.common_tool.arxiv_tool \
+            import ArxivTool
+        src = inspect.getsource(ArxivTool.retrieve_full_paper_text)
+        self.assertIn("finally:", src,
+                      "ArxivTool must clean up the temp file in a finally block")
+
+    def test_source_checks_max_pdf_size(self):
+        import inspect
+        from agentuniverse.agent.action.tool.common_tool.arxiv_tool \
+            import ArxivTool
+        src = inspect.getsource(ArxivTool.retrieve_full_paper_text)
+        self.assertIn("max_pdf_size_bytes", src,
+                      "ArxivTool must check PDF size against max_pdf_size_bytes")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Four independent bugs across tools and file readers.

## Changes

### 1. LangChainTool — None.get crash on missing config

`init_langchain_tool` did `.get('langchain').get('module')` without checking if the key exists. Missing config crashed with `AttributeError`. Now raises `ValueError` naming the required config section.

### 2. CodeReader — hardcoded utf-8 encoding

Non-UTF-8 source files (GBK, latin-1) raised `UnicodeDecodeError`. Now uses `detect_file_encoding` (the same utility txt/csv/json readers already use) with `errors="replace"`.

### 3. GoogleSearchTool — missing API key produces cryptic error

Called `GoogleSerperAPIWrapper(serper_api_key=None)` when `SERPER_API_KEY` was not set, producing a langchain-internal `ValueError`. Now validates the key first and raises a clear `ValueError` naming the env var. Matches `BingSearchTool` and `GoogleSearchTool_v2`.

### 4. ArxivTool — temp file leak + no size cap + corrupt PDF crash

Wrote a fixed-name `downloaded-paper.pdf` to CWD (concurrent overwrite), cleaned up outside `finally` (corrupt PDF leaked temp file), and crashed on `extract_text()` for encrypted pages. Now uses `tempfile.NamedTemporaryFile`, checks PDF size against `max_pdf_size_bytes` (50 MB default), guards per-page extraction, and cleans up in `finally`.

## Tests

`tests/test_agentuniverse/unit/agent/action/tool/test_tool_reader_four_bugs.py` — 7 regressions: missing langchain config raises clear error, CodeReader source uses detect_file_encoding, missing API key raises clear error, present API key proceeds, ArxivTool source uses tempfile + finally + size check.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_tool_reader_four_bugs` — 7 passed.
