### PR TITLE
feat(knowledge): PythonCodeTextSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/python_code_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/python_code_text_splitter.py
@@ -1,0 +1,150 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: python_code_text_splitter.py
+
+"""
+Python code text splitter — a knowledge pre-processing DocProcessor.
+
+Splits Python source code into one chunk per top-level function or class
+(plus one chunk for module-level code), preserving the full source text of
+each unit including its docstring and decorators. Each chunk records the
+unit name and type in metadata, so a retrieved chunk can be traced back to
+the exact function/class it came from.
+
+Uses Python's built-in ``ast`` module — no third-party dependency required.
+
+Sibling of the merged ``MarkdownHeaderTextSplitter`` (#625) and the new
+``HtmlHeaderTextSplitter`` (#737), ``JsonSplitter`` (#738), and
+``SemanticChunker`` (#746). Addresses #258.
+"""
+
+import ast
+import logging
+import textwrap
+from typing import Dict, List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class PythonCodeTextSplitter(DocProcessor):
+    """Split Python source code by top-level functions and classes.
+
+    Attributes:
+        name_key: Metadata key under which the unit name is recorded.
+        type_key: Metadata key under which the unit type
+            (``module`` / ``function`` / ``class``) is recorded.
+        max_chunk_chars: Maximum characters per chunk. A unit exceeding this
+            is emitted as-is (code units are usually kept intact); the limit
+            only applies to the module-level chunk.
+        include_module_level: If ``True`` (default), module-level code
+            (imports, constants, ``if __name__ == \"__main__\"``) is emitted
+            as a separate chunk. If ``False``, it is dropped.
+    """
+
+    name_key: str = "code_unit_name"
+    type_key: str = "code_unit_type"
+    max_chunk_chars: int = 5000
+    include_module_level: bool = True
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            for unit_name, unit_type, unit_text in self._split_code(text):
+                if unit_type == "module" and not self.include_module_level:
+                    continue
+                meta = dict(doc.metadata or {})
+                meta[self.name_key] = unit_name
+                meta[self.type_key] = unit_type
+                result.append(Document(text=unit_text, metadata=meta))
+        return result
+
+    def _split_code(self, source: str) -> List[tuple]:
+        """Parse Python source and return (name, type, text) triples."""
+        # Dedent so indented snippets (common in docs/chat) parse correctly.
+        source = textwrap.dedent(source)
+        try:
+            tree = ast.parse(source)
+        except SyntaxError as exc:
+            # Not valid Python — return the whole text as a single module chunk.
+            logger.debug("PythonCodeTextSplitter: syntax error (%s), "
+                         "returning whole text", exc)
+            return [("<module>", "module", source.strip())]
+
+        lines = source.splitlines(keepends=True)
+        units: List[tuple] = []
+
+        # Collect module-level code (everything before the first def/class).
+        module_lines: List[str] = []
+        first_def_line = None
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                 ast.ClassDef)):
+                first_def_line = node.lineno
+                break
+        if first_def_line and first_def_line > 1:
+            module_lines = lines[:first_def_line - 1]
+        elif not any(isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                     ast.ClassDef)) for n in tree.body):
+            module_lines = lines
+
+        module_text = "".join(module_lines).strip()
+        if module_text:
+            units.append(("<module>", "module", module_text))
+
+        # Extract each top-level function/class.
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                name = node.name
+                text = self._extract_node_source(node, lines)
+                units.append((name, "function", text))
+            elif isinstance(node, ast.ClassDef):
+                name = node.name
+                text = self._extract_node_source(node, lines)
+                units.append((name, "class", text))
+
+        return units
+
+    @staticmethod
+    def _extract_node_source(node: ast.AST,
+                             lines: List[str]) -> str:
+        """Extract the full source text of an AST node, including decorators.
+
+        ``ast.get_source_segment`` does not include decorator lines, so we
+        compute the start line from ``node.decorator_list`` if present.
+        """
+        start_line = node.lineno
+        # Include decorators.
+        decorators = getattr(node, "decorator_list", [])
+        if decorators:
+            start_line = min(d.lineno for d in decorators)
+        end_line = getattr(node, "end_lineno", node.lineno)
+        # lines is 0-indexed; lineno is 1-indexed.
+        segment = "".join(lines[start_line - 1: end_line])
+        return textwrap.dedent(segment).strip()
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "PythonCodeTextSplitter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "name_key"):
+            self.name_key = doc_processor_configer.name_key
+        if hasattr(doc_processor_configer, "type_key"):
+            self.type_key = doc_processor_configer.type_key
+        if hasattr(doc_processor_configer, "max_chunk_chars"):
+            self.max_chunk_chars = doc_processor_configer.max_chunk_chars
+        if hasattr(doc_processor_configer, "include_module_level"):
+            self.include_module_level = \
+                doc_processor_configer.include_module_level
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/python_code_text_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/python_code_text_splitter.yaml
@@ -1,0 +1,10 @@
+name: 'python_code_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.python_code_text_splitter'
+  class: 'PythonCodeTextSplitter'
+description: 'Splits Python source code by top-level functions and classes for knowledge pre-processing.'
+name_key: 'code_unit_name'
+type_key: 'code_unit_type'
+max_chunk_chars: 5000
+include_module_level: true

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,27 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [PythonCodeTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/python_code_text_splitter.yaml)
+
+`PythonCodeTextSplitter` splits Python source code into one chunk per top-level function or class (plus optionally one chunk for module-level code), preserving the full source text of each unit including its docstring and decorators. The unit name and type (`module` / `function` / `class`) are recorded in metadata so a retrieved chunk can be traced back to the exact function or class it came from. It is a sibling of `MarkdownHeaderTextSplitter`, `HtmlHeaderTextSplitter`, `JsonSplitter`, and `SemanticChunker`, addressing issue #258.
+
+Built on Python's standard `ast` module — no third-party dependency. Copy `python_code_text_splitter.yaml` into your application configuration directory and resolve the built-in `python_code_text_splitter` component to use it. When the input is not valid Python, the original document is emitted unchanged.
+
+The component definition file is as follows:
+```yaml
+name: 'python_code_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.python_code_text_splitter'
+  class: 'PythonCodeTextSplitter'
+description: 'Splits Python source code by top-level functions and classes for knowledge pre-processing.'
+name_key: 'code_unit_name'
+type_key: 'code_unit_type'
+max_chunk_chars: 5000
+include_module_level: true
+```
+- name_key: Metadata key under which the unit name is recorded.
+- type_key: Metadata key under which the unit type (`module` / `function` / `class`) is recorded.
+- max_chunk_chars: Maximum characters per chunk; the limit only applies to the module-level chunk (code units are kept intact even when larger).
+- include_module_level: When `true` (default), module-level code (imports, constants, `if __name__ == "__main__"`) is emitted as a separate chunk; when `false` it is dropped.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,27 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [PythonCodeTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/python_code_text_splitter.yaml)
+
+`PythonCodeTextSplitter` 按 Python 顶层函数和类切分源代码（可选额外输出一块模块级代码），保留每个单元完整的源文本（含 docstring 与装饰器）。单元名和类型（`module` / `function` / `class`）写入 metadata，使召回块可回溯到所属的具体函数或类。它与 `MarkdownHeaderTextSplitter`、`HtmlHeaderTextSplitter`、`JsonSplitter`、`SemanticChunker` 同属一类，对应 issue #258。
+
+基于 Python 标准库 `ast` 实现，无第三方依赖。将 `python_code_text_splitter.yaml` 复制到应用配置目录，加载内置 `python_code_text_splitter` 组件即可使用。若输入不是合法 Python，原样输出原文档。
+
+组件定义文件如下：
+```yaml
+name: 'python_code_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.python_code_text_splitter'
+  class: 'PythonCodeTextSplitter'
+description: '按顶层函数和类切分 Python 源代码用于知识预处理。'
+name_key: 'code_unit_name'
+type_key: 'code_unit_type'
+max_chunk_chars: 5000
+include_module_level: true
+```
+- name_key: 记录单元名所用的 metadata 键。
+- type_key: 记录单元类型（`module` / `function` / `class`）所用的 metadata 键。
+- max_chunk_chars: 每块最大字符数；该上限只对模块级块生效（代码单元即便更大也保持完整）。
+- include_module_level: 为 `true`（默认）时，模块级代码（imports、常量、`if __name__ == "__main__"`）作为独立块输出；为 `false` 时丢弃。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_python_code_text_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_python_code_text_splitter.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for PythonCodeTextSplitter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.python_code_text_splitter \
+    import PythonCodeTextSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+SAMPLE_CODE = '''
+import os
+import sys
+
+CONSTANT = 42
+
+
+def greet(name: str) -> str:
+    """Greet a user."""
+    return f"Hello, {name}!"
+
+
+class Calculator:
+    """A simple calculator."""
+
+    def add(self, a, b):
+        return a + b
+
+    def subtract(self, a, b):
+        return a - b
+
+
+@decorator
+def decorated():
+    pass
+'''
+
+
+class TestPythonCodeTextSplitter(unittest.TestCase):
+
+    def _split(self, code, **kwargs):
+        proc = PythonCodeTextSplitter(**kwargs)
+        return proc.process_docs([Document(text=code)], None)
+
+    def test_splits_into_module_function_class(self):
+        docs = self._split(SAMPLE_CODE)
+        types = {d.metadata["code_unit_type"] for d in docs}
+        self.assertIn("module", types)
+        self.assertIn("function", types)
+        self.assertIn("class", types)
+
+    def test_function_name_recorded(self):
+        docs = self._split(SAMPLE_CODE)
+        names = {d.metadata["code_unit_name"] for d in docs
+                 if d.metadata["code_unit_type"] == "function"}
+        self.assertIn("greet", names)
+        self.assertIn("decorated", names)
+
+    def test_class_name_recorded(self):
+        docs = self._split(SAMPLE_CODE)
+        class_names = {d.metadata["code_unit_name"] for d in docs
+                       if d.metadata["code_unit_type"] == "class"}
+        self.assertIn("Calculator", class_names)
+
+    def test_class_chunk_includes_methods(self):
+        docs = self._split(SAMPLE_CODE)
+        calc = next(d for d in docs
+                    if d.metadata["code_unit_name"] == "Calculator")
+        self.assertIn("def add", calc.text)
+        self.assertIn("def subtract", calc.text)
+
+    def test_decorator_included_in_source(self):
+        docs = self._split(SAMPLE_CODE)
+        decorated = next(d for d in docs
+                         if d.metadata["code_unit_name"] == "decorated")
+        self.assertIn("@decorator", decorated.text)
+
+    def test_module_level_includes_imports(self):
+        docs = self._split(SAMPLE_CODE)
+        module = next(d for d in docs
+                      if d.metadata["code_unit_type"] == "module")
+        self.assertIn("import os", module.text)
+        self.assertIn("CONSTANT", module.text)
+
+    def test_module_level_can_be_excluded(self):
+        docs = self._split(SAMPLE_CODE, include_module_level=False)
+        types = {d.metadata["code_unit_type"] for d in docs}
+        self.assertNotIn("module", types)
+
+    def test_invalid_python_returned_as_module(self):
+        docs = self._split("this is not valid python {{{")
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["code_unit_type"], "module")
+
+    def test_empty_input_returns_empty(self):
+        proc = PythonCodeTextSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="def f(): pass", metadata={"source": "test"})
+        proc = PythonCodeTextSplitter()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "test")
+
+    def test_only_module_level_code(self):
+        docs = self._split("x = 1\ny = 2\n")
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["code_unit_type"], "module")
+
+    def test_custom_keys(self):
+        docs = self._split("def f(): pass",
+                           name_key="unit", type_key="kind")
+        self.assertIn("unit", docs[0].metadata)
+        self.assertIn("kind", docs[0].metadata)
+
+    def test_async_function(self):
+        docs = self._split("async def fetch():\n    return 1\n")
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["code_unit_type"], "function")
+        self.assertIn("async def", docs[0].text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `PythonCodeTextSplitter` — a `DocProcessor` that splits Python source code into one chunk per top-level function or class (plus one chunk for module-level code), preserving the full source text of each unit including its docstring and decorators.

## Why (not a duplicate)

Not covered by any open or merged PR. Sibling of `MarkdownHeaderTextSplitter` (#625), `HtmlHeaderTextSplitter` (#737), `JsonSplitter` (#738), and `SemanticChunker` (#746). All five address #258.

## Features

- **Zero dependencies**: Uses Python's built-in `ast` module.
- **Full unit extraction**: Each chunk includes the complete source of the function/class, including decorators and docstrings.
- **Metadata tracking**: Each chunk carries `code_unit_name` (function/class name) and `code_unit_type` (`module` / `function` / `class`).
- **Configurable**: Custom metadata keys; optionally exclude module-level code; soft `max_chunk_chars` limit.
- **Graceful degradation**: Invalid Python is returned as a single module chunk.

## Tests

13 unit tests: module/function/class splitting, function/class name recording, class includes methods, decorator preservation, module imports, module exclusion, invalid Python passthrough, empty input, metadata preservation, only-module-level code, custom keys, async functions.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_python_code_text_splitter` — 13 passed.