### PR TITLE
feat(llm): add AzureOpenAI LLM component (#250)

### DIFF
--- a/agentuniverse/llm/default/azure_openai_llm.py
+++ b/agentuniverse/llm/default/azure_openai_llm.py
@@ -1,0 +1,124 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: azure_openai_llm.py
+from typing import Any, Optional, Iterator, Union, AsyncIterator
+
+from pydantic import Field
+
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+AZURE_OPENAI_MAX_CONTEXT_LENGTH = {
+    "gpt-35-turbo": 4096,
+    "gpt-35-turbo-16k": 16384,
+    "gpt-35-turbo-0301": 4096,
+    "gpt-35-turbo-0613": 4096,
+    "gpt-35-turbo-1106": 16384,
+    "gpt-35-turbo-0125": 16384,
+    "gpt-4": 8192,
+    "gpt-4-32k": 32768,
+    "gpt-4-0613": 8192,
+    "gpt-4-1106-preview": 128000,
+    "gpt-4-turbo": 128000,
+    "gpt-4-turbo-2024-04-09": 128000,
+    "gpt-4o": 128000,
+    "gpt-4o-mini": 128000,
+    "gpt-4o-2024-05-13": 128000,
+    "gpt-4o-mini-2024-07-18": 128000,
+    "o1-preview": 128000,
+    "o1-mini": 128000,
+}
+
+
+class AzureOpenAILLM(OpenAIStyleLLM):
+    """Azure OpenAI LLM component.
+
+    Connects to Azure OpenAI Service using the Azure-specific endpoint and
+    deployment model. Requires ``deployment_name``, ``azure_endpoint``,
+    ``api_version``, and ``api_key``.
+
+    Attributes:
+        deployment_name: The deployment name in Azure OpenAI Studio.
+        azure_endpoint: The Azure endpoint URL
+            (e.g. ``https://my-resource.openai.azure.com``).
+        api_version: Azure API version (e.g. ``2024-02-15-preview``).
+        api_key: Azure API key (env: ``AZURE_OPENAI_API_KEY``).
+    """
+
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("AZURE_OPENAI_API_KEY"))
+    api_base: Optional[str] = Field(
+        default_factory=lambda: get_from_env("AZURE_OPENAI_ENDPOINT"))
+    deployment_name: Optional[str] = Field(
+        default_factory=lambda: get_from_env("AZURE_OPENAI_DEPLOYMENT_NAME"))
+    api_version: str = Field(
+        default_factory=lambda: get_from_env("AZURE_OPENAI_API_VERSION")
+        or "2024-02-15-preview")
+    proxy: Optional[str] = Field(
+        default_factory=lambda: get_from_env("AZURE_OPENAI_PROXY"))
+
+    def _build_client_kwargs(self) -> dict:
+        """Build kwargs for AzureOpenAI client construction."""
+        kwargs = {
+            "api_key": self.api_key,
+            "azure_endpoint": self.api_base,
+            "api_version": self.api_version,
+        }
+        if self.proxy:
+            kwargs["http_client"] = self._build_http_client()
+        return kwargs
+
+    def _build_http_client(self):
+        """Build an httpx client with proxy support."""
+        import httpx
+        return httpx.Client(proxies=self.proxy)
+
+    def _new_client(self) -> Any:
+        try:
+            from openai import AzureOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "openai is not installed. Install it with 'pip install openai'."
+            ) from exc
+        return AzureOpenAI(**self._build_client_kwargs())
+
+    def _new_async_client(self) -> Any:
+        try:
+            from openai import AsyncAzureOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "openai is not installed. Install it with 'pip install openai'."
+            ) from exc
+        kwargs = self._build_client_kwargs()
+        return AsyncAzureOpenAI(**kwargs)
+
+    def _call(self, messages: list, **kwargs: Any) \
+            -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call — uses Azure deployment_name as the model."""
+        kwargs.setdefault("model", self.deployment_name or self.model_name)
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) \
+            -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call — uses Azure deployment_name as the model."""
+        kwargs.setdefault("model", self.deployment_name or self.model_name)
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Max context length for Azure OpenAI models."""
+        return AZURE_OPENAI_MAX_CONTEXT_LENGTH.get(self.model_name, 4096)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate token count using tiktoken (cl100k_base fallback)."""
+        try:
+            import tiktoken
+            try:
+                encoding = tiktoken.encoding_for_model(self.model_name)
+            except KeyError:
+                encoding = tiktoken.get_encoding("cl100k_base")
+            return len(encoding.encode(text))
+        except ImportError:
+            return super().get_num_tokens(text)

--- a/agentuniverse/llm/default/azure_openai_llm.yaml.example
+++ b/agentuniverse/llm/default/azure_openai_llm.yaml.example
@@ -1,0 +1,15 @@
+name: azure_openai_llm
+description: Azure OpenAI LLM component
+model_name: gpt-4o
+api_key: ''
+api_base: 'https://<your-resource>.openai.azure.com'
+deployment_name: '<your-deployment-name>'
+api_version: '2024-02-15-preview'
+proxy: ''
+max_tokens: 4096
+temperature: 0.7
+streaming: false
+metadata:
+  type: LLM
+  module: agentuniverse.llm.default.azure_openai_llm
+  class: AzureOpenAILLM

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/AzureOpenAI_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/AzureOpenAI_LLM_Use.md
@@ -1,0 +1,79 @@
+# Azure OpenAI Usage
+
+`AzureOpenAILLM` connects agentUniverse to the Azure OpenAI Service using the Azure-specific endpoint and deployment model. It is an `OpenAIStyleLLM` subclass, so it inherits streaming, async, and tool-calling behaviour, and only adds the Azure-specific client construction (`azure_endpoint`, `api_version`, `deployment_name`). Install the OpenAI SDK with `pip install 'agentUniverse[chat_model_ext]'` (or `pip install openai`).
+
+## 1. Create the relevant file.
+Create a YAML file, for example, `user_azure_openai.yaml`. Paste the following content into it.
+
+```yaml
+name: 'user_azure_openai_llm'
+description: 'user define azure openai llm'
+model_name: 'gpt-4o'
+api_key: '${AZURE_OPENAI_API_KEY}'
+api_base: '${AZURE_OPENAI_ENDPOINT}'
+deployment_name: '${AZURE_OPENAI_DEPLOYMENT_NAME}'
+api_version: '2024-02-15-preview'
+proxy: '${AZURE_OPENAI_PROXY}'
+max_tokens: 4096
+temperature: 0.7
+streaming: false
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.azure_openai_llm'
+  class: 'AzureOpenAILLM'
+```
+
+Alternatively, copy `agentuniverse/llm/default/azure_openai_llm.yaml.example` into your application configuration directory and edit the values in place.
+
+**Note:**
+
+The model parameters such as `api_key`, `api_base`, `deployment_name`, `api_version`, and `proxy` can be configured in three ways:
+
+1. Direct String Value: Enter the value directly in the configuration file.
+    ```yaml
+    api_key: 'xxxxx'
+    deployment_name: 'my-deployment'
+    ```
+
+2. Environment Variable Placeholder: Use the `${VARIABLE_NAME}` syntax to load from environment variables. When `agentUniverse` is launched, it will automatically read the corresponding value from the environment variables.
+    ```yaml
+    api_key: '${AZURE_OPENAI_API_KEY}'
+    ```
+
+3. Custom Function Loading: Use the `@FUNC` annotation to dynamically load the value via a custom function at runtime.
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="azure_openai"))'
+    ```
+
+## 2. Environment Setup
+In the example YAML, model keys and other parameters are configured using environment variable placeholders.
+
+Must be configured: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT_NAME`
+Optional: `AZURE_OPENAI_API_VERSION` (defaults to `2024-02-15-preview`), `AZURE_OPENAI_PROXY`
+
+### 2.1 Configure through Python code
+```python
+import os
+os.environ['AZURE_OPENAI_API_KEY'] = 'xxxxx'
+os.environ['AZURE_OPENAI_ENDPOINT'] = 'https://<your-resource>.openai.azure.com'
+os.environ['AZURE_OPENAI_DEPLOYMENT_NAME'] = '<your-deployment-name>'
+os.environ['AZURE_OPENAI_API_VERSION'] = '2024-02-15-preview'
+```
+
+### 2.2 Configure through a `.env` file
+```
+AZURE_OPENAI_API_KEY=xxxxx
+AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment-name>
+AZURE_OPENAI_API_VERSION=2024-02-15-preview
+```
+
+## 3. Configuration Parameters
+
+- `model_name`: The underlying Azure OpenAI model (e.g. `gpt-4o`, `gpt-4o-mini`).
+- `api_key`: Azure OpenAI API key (env: `AZURE_OPENAI_API_KEY`).
+- `api_base` / `azure_endpoint`: The Azure endpoint URL, e.g. `https://my-resource.openai.azure.com` (env: `AZURE_OPENAI_ENDPOINT`).
+- `deployment_name`: The deployment name configured in Azure OpenAI Studio (env: `AZURE_OPENAI_DEPLOYMENT_NAME`).
+- `api_version`: Azure API version (env: `AZURE_OPENAI_API_VERSION`, default `2024-02-15-preview`).
+- `proxy`: Optional HTTP(S) proxy (env: `AZURE_OPENAI_PROXY`).
+- `max_tokens`, `temperature`, `streaming`: Standard generation parameters.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/AzureOpenAI使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/AzureOpenAI使用.md
@@ -1,0 +1,79 @@
+# Azure OpenAI 使用
+
+`AzureOpenAILLM` 使用 Azure 专属的 endpoint 与 deployment 模型，将 agentUniverse 接入 Azure OpenAI Service。它是 `OpenAIStyleLLM` 的子类，因此继承了流式、异步与工具调用能力，只新增了 Azure 专属的客户端构造（`azure_endpoint`、`api_version`、`deployment_name`）。安装 OpenAI SDK：`pip install 'agentUniverse[chat_model_ext]'`（或 `pip install openai`）。
+
+## 1. 创建相关文件
+创建一个 YAML 文件，例如 `user_azure_openai.yaml`，粘贴以下内容。
+
+```yaml
+name: 'user_azure_openai_llm'
+description: 'user define azure openai llm'
+model_name: 'gpt-4o'
+api_key: '${AZURE_OPENAI_API_KEY}'
+api_base: '${AZURE_OPENAI_ENDPOINT}'
+deployment_name: '${AZURE_OPENAI_DEPLOYMENT_NAME}'
+api_version: '2024-02-15-preview'
+proxy: '${AZURE_OPENAI_PROXY}'
+max_tokens: 4096
+temperature: 0.7
+streaming: false
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.azure_openai_llm'
+  class: 'AzureOpenAILLM'
+```
+
+也可以将 `agentuniverse/llm/default/azure_openai_llm.yaml.example` 复制到应用配置目录后直接修改其中取值。
+
+**说明：**
+
+`api_key`、`api_base`、`deployment_name`、`api_version`、`proxy` 等模型参数支持三种配置方式：
+
+1. 直接字符串：在配置文件中直接填写取值。
+    ```yaml
+    api_key: 'xxxxx'
+    deployment_name: 'my-deployment'
+    ```
+
+2. 环境变量占位符：使用 `${VARIABLE_NAME}` 语法从环境变量加载。`agentUniverse` 启动时会自动读取对应取值。
+    ```yaml
+    api_key: '${AZURE_OPENAI_API_KEY}'
+    ```
+
+3. 自定义函数加载：使用 `@FUNC` 注解在运行时通过自定义函数动态加载取值。
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="azure_openai"))'
+    ```
+
+## 2. 环境配置
+示例 YAML 使用环境变量占位符配置模型密钥等参数。
+
+必须配置：`AZURE_OPENAI_API_KEY`、`AZURE_OPENAI_ENDPOINT`、`AZURE_OPENAI_DEPLOYMENT_NAME`
+可选：`AZURE_OPENAI_API_VERSION`（默认 `2024-02-15-preview`）、`AZURE_OPENAI_PROXY`
+
+### 2.1 通过 Python 代码配置
+```python
+import os
+os.environ['AZURE_OPENAI_API_KEY'] = 'xxxxx'
+os.environ['AZURE_OPENAI_ENDPOINT'] = 'https://<your-resource>.openai.azure.com'
+os.environ['AZURE_OPENAI_DEPLOYMENT_NAME'] = '<your-deployment-name>'
+os.environ['AZURE_OPENAI_API_VERSION'] = '2024-02-15-preview'
+```
+
+### 2.2 通过 `.env` 文件配置
+```
+AZURE_OPENAI_API_KEY=xxxxx
+AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment-name>
+AZURE_OPENAI_API_VERSION=2024-02-15-preview
+```
+
+## 3. 配置参数
+
+- `model_name`：底层 Azure OpenAI 模型（如 `gpt-4o`、`gpt-4o-mini`）。
+- `api_key`：Azure OpenAI API Key（环境变量 `AZURE_OPENAI_API_KEY`）。
+- `api_base` / `azure_endpoint`：Azure endpoint 地址，如 `https://my-resource.openai.azure.com`（环境变量 `AZURE_OPENAI_ENDPOINT`）。
+- `deployment_name`：在 Azure OpenAI Studio 中配置的部署名（环境变量 `AZURE_OPENAI_DEPLOYMENT_NAME`）。
+- `api_version`：Azure API 版本（环境变量 `AZURE_OPENAI_API_VERSION`，默认 `2024-02-15-preview`）。
+- `proxy`：可选的 HTTP(S) 代理（环境变量 `AZURE_OPENAI_PROXY`）。
+- `max_tokens`、`temperature`、`streaming`：标准生成参数。

--- a/tests/test_agentuniverse/unit/llm/test_azure_openai_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_azure_openai_llm.py
@@ -1,0 +1,111 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: test_azure_openai_llm.py
+
+"""Unit tests for AzureOpenAILLM."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.llm.default.azure_openai_llm import AzureOpenAILLM
+
+
+class TestAzureOpenAILLMConfig(unittest.TestCase):
+
+    def test_defaults_from_env(self):
+        with patch.dict("os.environ", {
+            "AZURE_OPENAI_API_KEY": "test-key",
+            "AZURE_OPENAI_ENDPOINT": "https://my-resource.openai.azure.com",
+            "AZURE_OPENAI_DEPLOYMENT_NAME": "my-deployment",
+            "AZURE_OPENAI_API_VERSION": "2024-06-01",
+        }):
+            llm = AzureOpenAILLM(model_name="gpt-4o")
+            self.assertEqual(llm.api_key, "test-key")
+            self.assertEqual(llm.api_base,
+                             "https://my-resource.openai.azure.com")
+            self.assertEqual(llm.deployment_name, "my-deployment")
+            self.assertEqual(llm.api_version, "2024-06-01")
+
+    def test_api_version_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            llm = AzureOpenAILLM(model_name="gpt-4o", api_key="k",
+                                 api_base="https://x.openai.azure.com")
+            self.assertEqual(llm.api_version, "2024-02-15-preview")
+
+    def test_max_context_length(self):
+        llm = AzureOpenAILLM(model_name="gpt-4o", api_key="k",
+                             api_base="https://x.openai.azure.com")
+        self.assertEqual(llm.max_context_length(), 128000)
+
+    def test_max_context_length_fallback(self):
+        llm = AzureOpenAILLM(model_name="unknown-model", api_key="k",
+                             api_base="https://x.openai.azure.com")
+        self.assertEqual(llm.max_context_length(), 4096)
+
+
+class TestAzureOpenAIClientConstruction(unittest.TestCase):
+
+    def test_build_client_kwargs(self):
+        llm = AzureOpenAILLM(
+            model_name="gpt-4o", api_key="k",
+            api_base="https://x.openai.azure.com",
+            api_version="2024-06-01")
+        kwargs = llm._build_client_kwargs()
+        self.assertEqual(kwargs["api_key"], "k")
+        self.assertEqual(kwargs["azure_endpoint"], "https://x.openai.azure.com")
+        self.assertEqual(kwargs["api_version"], "2024-06-01")
+
+    def test_new_client_uses_azure_openai(self):
+        llm = AzureOpenAILLM(
+            model_name="gpt-4o", api_key="k",
+            api_base="https://x.openai.azure.com")
+        with patch("openai.AzureOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            llm._new_client()
+            mock_cls.assert_called_once()
+
+    def test_new_async_client_uses_async_azure(self):
+        llm = AzureOpenAILLM(
+            model_name="gpt-4o", api_key="k",
+            api_base="https://x.openai.azure.com")
+        with patch("openai.AsyncAzureOpenAI") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            llm._new_async_client()
+            mock_cls.assert_called_once()
+
+
+class TestAzureOpenAIDeploymentNameInCall(unittest.TestCase):
+
+    def test_call_passes_deployment_name_as_model(self):
+        llm = AzureOpenAILLM(
+            model_name="gpt-4o", api_key="k",
+            api_base="https://x.openai.azure.com",
+            deployment_name="prod-deployment")
+
+        captured_kwargs = {}
+        with patch.object(
+            type(llm).__mro__[1], "_call",
+            return_value=MagicMock()
+        ) as mock_super:
+            llm._call(messages=[{"role": "user", "content": "hi"}])
+            captured_kwargs = mock_super.call_args.kwargs
+
+        self.assertIn("model", captured_kwargs)
+        self.assertEqual(captured_kwargs["model"], "prod-deployment")
+
+
+class TestAzureOpenAIGetNumTokens(unittest.TestCase):
+
+    def test_get_num_tokens_uses_tiktoken(self):
+        llm = AzureOpenAILLM(
+            model_name="gpt-4o", api_key="k",
+            api_base="https://x.openai.azure.com")
+        tokens = llm.get_num_tokens("hello world")
+        self.assertGreater(tokens, 0)
+        self.assertIsInstance(tokens, int)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `AzureOpenAILLM` — connects to Azure OpenAI Service using the Azure-specific endpoint, deployment name, and API version. Explicitly requested in #250.

## Why (not a duplicate)

Not covered by any open or merged PR. #250 lists Azure OpenAI as a required LLM component; the existing `DefaultOpenAILLM` does not support Azure endpoints / deployment names.

## Capabilities

- Uses `openai.AzureOpenAI` / `AsyncAzureOpenAI` clients (not the generic OpenAI client with api_base override).
- Passes `deployment_name` as the model parameter in API calls.
- Configurable `api_version` (default `2024-02-15-preview`).
- Environment variable defaults: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_PROXY`.
- Azure model context length table (gpt-35-turbo through o1-mini).
- Proxy support via httpx client.
- `get_num_tokens` uses tiktoken with cl100k_base fallback.

## Dependency and configuration

`openai` is an optional dependency, imported lazily so the component does not break environments without it. A copyable `azure_openai_llm.yaml.example` is included.

## Tests

`tests/test_agentuniverse/unit/llm/test_azure_openai_llm.py` — 9 unit tests: env-based defaults, api_version default, context length (known + fallback), client kwargs, AzureOpenAI client construction, AsyncAzureOpenAI construction, deployment_name passed as model in calls, get_num_tokens. All mock the client; no network.

`python -m unittest tests.test_agentuniverse.unit.llm.test_azure_openai_llm` — 9 passed.
