### PR TITLE
feat(llm): add HuggingFace Hub LLM component (#250)

### DIFF
--- a/agentuniverse/llm/default/huggingface_hub_llm.py
+++ b/agentuniverse/llm/default/huggingface_hub_llm.py
@@ -1,0 +1,145 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: huggingface_hub_llm.py
+import logging
+from typing import Any, Optional, Iterator, Union, AsyncIterator
+
+from pydantic import Field
+
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm import LLM
+from agentuniverse.llm.llm_output import LLMOutput
+
+logger = logging.getLogger(__name__)
+
+
+class HuggingFaceHubLLM(LLM):
+    """LLM component backed by Hugging Face Inference API.
+
+    Supports 100k+ models hosted on the Hugging Face Hub via the
+    ``InferenceClient`` from ``huggingface_hub``.
+
+    Attributes:
+        model_name: The Hugging Face model repo ID
+            (e.g. ``"meta-llama/Meta-Llama-3-8B-Instruct"``).
+        api_key: Hugging Face API token (env: ``HUGGINGFACE_API_KEY``
+            or ``HF_TOKEN``).
+        inference_endpoint: Optional custom inference endpoint URL for
+            dedicated endpoints (TEI / TGI).
+        timeout: Request timeout in seconds (default 30).
+    """
+
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("HUGGINGFACE_API_KEY")
+        or get_from_env("HF_TOKEN"))
+    inference_endpoint: Optional[str] = Field(
+        default_factory=lambda: get_from_env("HUGGINGFACE_INFERENCE_ENDPOINT"))
+    timeout: float = 30.0
+    client: Any = None
+    async_client: Any = None
+
+    def _new_client(self) -> Any:
+        try:
+            from huggingface_hub import InferenceClient
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is not installed. Install it with "
+                "'pip install huggingface_hub'.") from exc
+        self.client = InferenceClient(
+            model=self.inference_endpoint or self.model_name,
+            token=self.api_key,
+            timeout=self.timeout,
+        )
+        return self.client
+
+    def _new_async_client(self) -> Any:
+        try:
+            from huggingface_hub import AsyncInferenceClient
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is not installed. Install it with "
+                "'pip install huggingface_hub'.") from exc
+        self.async_client = AsyncInferenceClient(
+            model=self.inference_endpoint or self.model_name,
+            token=self.api_key,
+            timeout=self.timeout,
+        )
+        return self.async_client
+
+    def _ensure_client(self) -> Any:
+        if self.client is None:
+            self._new_client()
+        return self.client
+
+    def _ensure_async_client(self) -> Any:
+        if self.async_client is None:
+            self._new_async_client()
+        return self.async_client
+
+    def _call(self, messages: list, **kwargs: Any) \
+            -> Union[LLMOutput, Iterator[LLMOutput]]:
+        streaming = kwargs.pop("streaming", self.streaming)
+        client = self._ensure_client()
+
+        if streaming:
+            def _stream() -> Iterator[LLMOutput]:
+                for chunk in client.chat_completion(
+                    messages=messages,
+                    max_tokens=kwargs.get("max_tokens", self.max_tokens),
+                    temperature=kwargs.get("temperature", self.temperature),
+                    stream=True,
+                ):
+                    delta = chunk.choices[0].delta.content or ""
+                    if delta:
+                        yield LLMOutput(text=delta, raw=str(chunk))
+            return _stream()
+        else:
+            response = client.chat_completion(
+                messages=messages,
+                max_tokens=kwargs.get("max_tokens", self.max_tokens),
+                temperature=kwargs.get("temperature", self.temperature),
+                stream=False,
+            )
+            text = response.choices[0].message.content or ""
+            return LLMOutput(text=text, raw=str(response))
+
+    async def _acall(self, messages: list, **kwargs: Any) \
+            -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        streaming = kwargs.pop("streaming", self.streaming)
+        client = self._ensure_async_client()
+
+        if streaming:
+            async def _astream() -> AsyncIterator[LLMOutput]:
+                async for chunk in await client.chat_completion(
+                    messages=messages,
+                    max_tokens=kwargs.get("max_tokens", self.max_tokens),
+                    temperature=kwargs.get("temperature", self.temperature),
+                    stream=True,
+                ):
+                    delta = chunk.choices[0].delta.content or ""
+                    if delta:
+                        yield LLMOutput(text=delta, raw=str(chunk))
+            return _astream()
+        else:
+            response = await client.chat_completion(
+                messages=messages,
+                max_tokens=kwargs.get("max_tokens", self.max_tokens),
+                temperature=kwargs.get("temperature", self.temperature),
+                stream=False,
+            )
+            text = response.choices[0].message.content or ""
+            return LLMOutput(text=text, raw=str(response))
+
+    def max_context_length(self) -> int:
+        # HF models vary widely; 4096 is a safe default.
+        return 4096
+
+    def get_num_tokens(self, text: str) -> int:
+        try:
+            import tiktoken
+            encoding = tiktoken.get_encoding("cl100k_base")
+            return len(encoding.encode(text))
+        except ImportError:
+            return len(text) // 4

--- a/agentuniverse/llm/default/huggingface_hub_llm.yaml.example
+++ b/agentuniverse/llm/default/huggingface_hub_llm.yaml.example
@@ -1,0 +1,13 @@
+name: huggingface_hub_llm
+description: Hugging Face Hub LLM via Inference API
+model_name: 'meta-llama/Meta-Llama-3-8B-Instruct'
+api_key: ''
+inference_endpoint: ''
+timeout: 30
+max_tokens: 1024
+temperature: 0.7
+streaming: false
+metadata:
+  type: LLM
+  module: agentuniverse.llm.default.huggingface_hub_llm
+  class: HuggingFaceHubLLM

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/HuggingFaceHub_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/HuggingFaceHub_LLM_Use.md
@@ -1,0 +1,66 @@
+# Hugging Face Hub LLM Usage
+
+`HuggingFaceHubLLM` is an LLM component backed by the Hugging Face Inference API. Through the `InferenceClient` from `huggingface_hub`, it supports 100k+ models hosted on the Hugging Face Hub, as well as dedicated Inference Endpoints (TEI / TGI). Install the SDK with `pip install huggingface_hub`.
+
+## 1. Create the relevant file.
+Create a YAML file, for example, `user_huggingface_hub_llm.yaml`. Paste the following content into it.
+
+```yaml
+name: 'user_huggingface_hub_llm'
+description: 'Hugging Face Hub LLM via Inference API'
+model_name: 'meta-llama/Meta-Llama-3-8B-Instruct'
+api_key: '${HUGGINGFACE_API_KEY}'
+inference_endpoint: ''
+timeout: 30
+max_tokens: 1024
+temperature: 0.7
+streaming: false
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.huggingface_hub_llm'
+  class: 'HuggingFaceHubLLM'
+```
+
+Alternatively, copy `agentuniverse/llm/default/huggingface_hub_llm.yaml.example` into your application configuration directory and edit the values in place.
+
+**Note:**
+
+The model parameters such as `api_key` and `inference_endpoint` can be configured in three ways:
+
+1. Direct String Value: Enter the value directly in the configuration file.
+    ```yaml
+    api_key: 'hf_xxxxx'
+    ```
+
+2. Environment Variable Placeholder: Use the `${VARIABLE_NAME}` syntax to load from environment variables.
+    ```yaml
+    api_key: '${HUGGINGFACE_API_KEY}'
+    ```
+
+3. Custom Function Loading: Use the `@FUNC` annotation to dynamically load the value via a custom function at runtime.
+
+## 2. Environment Setup
+Must be configured: `HUGGINGFACE_API_KEY` (or `HF_TOKEN`)
+Optional: `HUGGINGFACE_INFERENCE_ENDPOINT` (for dedicated TEI / TGI endpoints)
+
+### 2.1 Configure through Python code
+```python
+import os
+os.environ['HUGGINGFACE_API_KEY'] = 'hf_xxxxx'
+# Optional: dedicated inference endpoint
+os.environ['HUGGINGFACE_INFERENCE_ENDPOINT'] = 'https://<your-endpoint>.endpoints.huggingface.cloud'
+```
+
+### 2.2 Configure through a `.env` file
+```
+HUGGINGFACE_API_KEY=hf_xxxxx
+HUGGINGFACE_INFERENCE_ENDPOINT=https://<your-endpoint>.endpoints.huggingface.cloud
+```
+
+## 3. Configuration Parameters
+
+- `model_name`: The Hugging Face model repo ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`).
+- `api_key`: Hugging Face API token (env: `HUGGINGFACE_API_KEY` or `HF_TOKEN`).
+- `inference_endpoint`: Optional custom inference endpoint URL for dedicated endpoints (TEI / TGI); env: `HUGGINGFACE_INFERENCE_ENDPOINT`. When set, it takes precedence over `model_name`.
+- `timeout`: Request timeout in seconds (default 30).
+- `max_tokens`, `temperature`, `streaming`: Standard generation parameters.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/HuggingFaceHub使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/HuggingFaceHub使用.md
@@ -1,0 +1,66 @@
+# Hugging Face Hub LLM 使用
+
+`HuggingFaceHubLLM` 是基于 Hugging Face Inference API 的 LLM 组件。通过 `huggingface_hub` 的 `InferenceClient`，它支持 Hugging Face Hub 上托管的 10 万+ 模型，以及专用的 Inference Endpoints（TEI / TGI）。安装 SDK：`pip install huggingface_hub`。
+
+## 1. 创建相关文件
+创建一个 YAML 文件，例如 `user_huggingface_hub_llm.yaml`，粘贴以下内容。
+
+```yaml
+name: 'user_huggingface_hub_llm'
+description: 'Hugging Face Hub LLM via Inference API'
+model_name: 'meta-llama/Meta-Llama-3-8B-Instruct'
+api_key: '${HUGGINGFACE_API_KEY}'
+inference_endpoint: ''
+timeout: 30
+max_tokens: 1024
+temperature: 0.7
+streaming: false
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.huggingface_hub_llm'
+  class: 'HuggingFaceHubLLM'
+```
+
+也可以将 `agentuniverse/llm/default/huggingface_hub_llm.yaml.example` 复制到应用配置目录后直接修改其中取值。
+
+**说明：**
+
+`api_key`、`inference_endpoint` 等模型参数支持三种配置方式：
+
+1. 直接字符串：在配置文件中直接填写取值。
+    ```yaml
+    api_key: 'hf_xxxxx'
+    ```
+
+2. 环境变量占位符：使用 `${VARIABLE_NAME}` 语法从环境变量加载。
+    ```yaml
+    api_key: '${HUGGINGFACE_API_KEY}'
+    ```
+
+3. 自定义函数加载：使用 `@FUNC` 注解在运行时通过自定义函数动态加载取值。
+
+## 2. 环境配置
+必须配置：`HUGGINGFACE_API_KEY`（或 `HF_TOKEN`）
+可选：`HUGGINGFACE_INFERENCE_ENDPOINT`（用于专用 TEI / TGI endpoint）
+
+### 2.1 通过 Python 代码配置
+```python
+import os
+os.environ['HUGGINGFACE_API_KEY'] = 'hf_xxxxx'
+# 可选：专用推理 endpoint
+os.environ['HUGGINGFACE_INFERENCE_ENDPOINT'] = 'https://<your-endpoint>.endpoints.huggingface.cloud'
+```
+
+### 2.2 通过 `.env` 文件配置
+```
+HUGGINGFACE_API_KEY=hf_xxxxx
+HUGGINGFACE_INFERENCE_ENDPOINT=https://<your-endpoint>.endpoints.huggingface.cloud
+```
+
+## 3. 配置参数
+
+- `model_name`：Hugging Face 模型 repo ID（如 `meta-llama/Meta-Llama-3-8B-Instruct`）。
+- `api_key`：Hugging Face API token（环境变量 `HUGGINGFACE_API_KEY` 或 `HF_TOKEN`）。
+- `inference_endpoint`：可选的自定义推理 endpoint URL，用于专用 endpoint（TEI / TGI）；环境变量 `HUGGINGFACE_INFERENCE_ENDPOINT`。设置后优先于 `model_name`。
+- `timeout`：请求超时秒数（默认 30）。
+- `max_tokens`、`temperature`、`streaming`：标准生成参数。

--- a/tests/test_agentuniverse/unit/llm/test_huggingface_hub_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_huggingface_hub_llm.py
@@ -1,0 +1,117 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for HuggingFaceHubLLM."""
+
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from agentuniverse.llm.default.huggingface_hub_llm import HuggingFaceHubLLM
+
+
+class TestHuggingFaceHubLLMConfig(unittest.TestCase):
+
+    def test_defaults_from_env(self):
+        with patch.dict("os.environ", {
+            "HUGGINGFACE_API_KEY": "hf-test-key",
+            "HUGGINGFACE_INFERENCE_ENDPOINT": "https://my-endpoint.endpoint.huggingface.cloud",
+        }):
+            llm = HuggingFaceHubLLM(model_name="meta-llama/Meta-Llama-3-8B-Instruct")
+            self.assertEqual(llm.api_key, "hf-test-key")
+            self.assertEqual(llm.inference_endpoint,
+                             "https://my-endpoint.endpoint.huggingface.cloud")
+
+    def test_fallback_to_hf_token_env(self):
+        with patch.dict("os.environ", {
+            "HF_TOKEN": "hf-token-fallback",
+        }, clear=True):
+            llm = HuggingFaceHubLLM(model_name="m")
+            self.assertEqual(llm.api_key, "hf-token-fallback")
+
+    def test_timeout_default(self):
+        llm = HuggingFaceHubLLM(model_name="m", api_key="k")
+        self.assertEqual(llm.timeout, 30.0)
+
+    def test_max_context_length_default(self):
+        llm = HuggingFaceHubLLM(model_name="m", api_key="k")
+        self.assertEqual(llm.max_context_length(), 4096)
+
+
+class TestHuggingFaceHubLLMClient(unittest.TestCase):
+
+    def test_new_client_uses_inference_client(self):
+        llm = HuggingFaceHubLLM(
+            model_name="meta-llama/Meta-Llama-3-8B-Instruct", api_key="k")
+        with patch("huggingface_hub.InferenceClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            llm._new_client()
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args.kwargs
+            self.assertEqual(call_kwargs["token"], "k")
+            self.assertEqual(call_kwargs["model"],
+                             "meta-llama/Meta-Llama-3-8B-Instruct")
+
+    def test_new_client_prefers_inference_endpoint(self):
+        llm = HuggingFaceHubLLM(
+            model_name="some-model", api_key="k",
+            inference_endpoint="https://my.endpoint.huggingface.cloud")
+        with patch("huggingface_hub.InferenceClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            llm._new_client()
+            call_kwargs = mock_cls.call_args.kwargs
+            self.assertEqual(call_kwargs["model"],
+                             "https://my.endpoint.huggingface.cloud")
+
+    def test_new_async_client(self):
+        llm = HuggingFaceHubLLM(model_name="m", api_key="k")
+        with patch("huggingface_hub.AsyncInferenceClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            llm._new_async_client()
+            mock_cls.assert_called_once()
+
+
+class TestHuggingFaceHubLLMCall(unittest.TestCase):
+
+    def test_call_non_streaming(self):
+        llm = HuggingFaceHubLLM(
+            model_name="m", api_key="k", streaming=False)
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content="hello from HF"))
+        ]
+        mock_client.chat_completion.return_value = mock_response
+        llm.client = mock_client
+
+        result = llm._call(messages=[{"role": "user", "content": "hi"}])
+        self.assertEqual(result.text, "hello from HF")
+
+    def test_call_streaming(self):
+        llm = HuggingFaceHubLLM(
+            model_name="m", api_key="k", streaming=True)
+        mock_client = MagicMock()
+
+        def _fake_stream(**kwargs):
+            for text in ["chunk1", "chunk2"]:
+                yield MagicMock(choices=[
+                    MagicMock(delta=MagicMock(content=text))
+                ])
+        mock_client.chat_completion.side_effect = lambda **kw: _fake_stream(**kw)
+        llm.client = mock_client
+
+        gen = llm._call(messages=[{"role": "user", "content": "hi"}])
+        chunks = [chunk.text for chunk in gen]
+        self.assertEqual(chunks, ["chunk1", "chunk2"])
+
+
+class TestHuggingFaceHubLLMGetNumTokens(unittest.TestCase):
+
+    def test_get_num_tokens(self):
+        llm = HuggingFaceHubLLM(model_name="m", api_key="k")
+        tokens = llm.get_num_tokens("hello world")
+        self.assertGreater(tokens, 0)
+        self.assertIsInstance(tokens, int)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `HuggingFaceHubLLM` — connects to Hugging Face Inference API via `InferenceClient` / `AsyncInferenceClient` from `huggingface_hub`. Supports 100k+ models hosted on the HF Hub. Explicitly requested in #250.

## Why (not a duplicate)

Not covered by any open or merged PR. #250 lists HuggingFace Hub as a required LLM component.

## Capabilities

- Uses `huggingface_hub.InferenceClient` / `AsyncInferenceClient`.
- Supports both standard Hub models and dedicated inference endpoints (TEI / TGI).
- Sync and async streaming via `chat_completion`.
- Environment variable defaults: `HUGGINGFACE_API_KEY` / `HF_TOKEN`, `HUGGINGFACE_INFERENCE_ENDPOINT`.
- Configurable timeout (default 30s).
- `get_num_tokens` uses tiktoken with cl100k_base fallback.

## Dependency and configuration

`huggingface_hub` is an optional dependency, imported lazily. A copyable `huggingface_hub_llm.yaml.example` is included.

## Tests

`tests/test_agentuniverse/unit/llm/test_huggingface_hub_llm.py` — 10 unit tests: env-based defaults, HF_TOKEN fallback, timeout, context length, InferenceClient construction, endpoint preference, AsyncInferenceClient, non-streaming call, streaming call, get_num_tokens. All mock the client; no network.

`python -m unittest tests.test_agentuniverse.unit.llm.test_huggingface_hub_llm` — 10 passed.
