### PR TITLE
feat(tool): add bounded FileSystemTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/filesystem_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/filesystem_tool.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Bounded file system operations tool.
+
+Provides mkdir, list, copy, move, delete, and tree operations, all confined
+to ``base_dir`` via ``resolve_safe_path``. Every operation is bounded by
+configurable limits (max files listed, max tree depth, max file count for
+copy/move batches).
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import logging
+import os
+import shutil
+from typing import Any, ClassVar
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import \
+    resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class FileSystemTool(Tool):
+    """Bounded file system operations confined to ``base_dir``.
+
+    Attributes:
+        base_dir: Root directory; all paths are resolved underneath it.
+        max_list_entries: Maximum entries returned by list/tree (default 500).
+        max_tree_depth: Maximum depth for tree (default 5).
+        max_batch_size: Maximum files per copy/move batch (default 100).
+    """
+
+    base_dir: str = "."
+    max_list_entries: int = 500
+    max_tree_depth: int = 5
+    max_batch_size: int = 100
+
+    def execute(self, mode: str, path: str = "", target: str = "",
+                **kwargs) -> dict:
+        try:
+            self._validate_config()
+            op = self._normalize_mode(mode)
+            safe_path = self._resolve(path) if path else self.base_dir
+            if op == "list":
+                return self._list(safe_path)
+            if op == "tree":
+                return self._tree(safe_path, kwargs.get("depth", self.max_tree_depth))
+            if op == "mkdir":
+                return self._mkdir(safe_path)
+            if op == "copy":
+                return self._copy(safe_path, self._resolve(target))
+            if op == "move":
+                return self._move(safe_path, self._resolve(target))
+            if op == "delete":
+                return self._delete(safe_path)
+            if op == "exists":
+                return self._exists(safe_path)
+            if op == "info":
+                return self._info(safe_path)
+            return self._error("validation_error", f"Unknown mode: {mode}")
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("operation_error", str(exc))
+
+    # ------------------------------------------------------------------ #
+    # Config
+    # ------------------------------------------------------------------ #
+    def _validate_config(self) -> None:
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+        for field in ("max_list_entries", "max_tree_depth", "max_batch_size"):
+            value = getattr(self, field)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{field} must be a positive integer")
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "FileSystemTool":
+        super()._initialize_by_component_configer(configer)
+        if hasattr(configer, "base_dir"):
+            self.base_dir = configer.base_dir
+        if hasattr(configer, "max_list_entries"):
+            self.max_list_entries = configer.max_list_entries
+        if hasattr(configer, "max_tree_depth"):
+            self.max_tree_depth = configer.max_tree_depth
+        if hasattr(configer, "max_batch_size"):
+            self.max_batch_size = configer.max_batch_size
+        return self
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        normalized = mode.strip().lower()
+        allowed = {"list", "tree", "mkdir", "copy", "move", "delete", "exists", "info"}
+        if normalized not in allowed:
+            raise ValueError(f"mode must be one of: {', '.join(sorted(allowed))}")
+        return normalized
+
+    def _resolve(self, path: str) -> str:
+        return resolve_safe_path(path, self.base_dir)
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}
+
+    @staticmethod
+    def _ok(**kwargs) -> dict:
+        return {"status": "success", **kwargs}
+
+    # ------------------------------------------------------------------ #
+    # Operations
+    # ------------------------------------------------------------------ #
+    def _list(self, path: str) -> dict:
+        if not os.path.isdir(path):
+            return self._error("validation_error", f"Not a directory: {path}")
+        entries = []
+        truncated = False
+        try:
+            for i, name in enumerate(sorted(os.listdir(path))):
+                if i >= self.max_list_entries:
+                    truncated = True
+                    break
+                full = os.path.join(path, name)
+                entries.append({
+                    "name": name,
+                    "type": "dir" if os.path.isdir(full) else "file",
+                    "size": os.path.getsize(full) if os.path.isfile(full) else 0,
+                })
+        except OSError as exc:
+            return self._error("operation_error", str(exc))
+        return self._ok(path=path, entries=entries, count=len(entries),
+                        truncated=truncated, max_entries=self.max_list_entries)
+
+    def _tree(self, path: str, max_depth: int) -> dict:
+        if not os.path.isdir(path):
+            return self._error("validation_error", f"Not a directory: {path}")
+        depth = min(max_depth, self.max_tree_depth)
+        result = []
+
+        def _walk(current: str, prefix: str, d: int):
+            if d > depth or len(result) >= self.max_list_entries:
+                return
+            try:
+                items = sorted(os.listdir(current))
+            except OSError:
+                return
+            for name in items:
+                if len(result) >= self.max_list_entries:
+                    return
+                full = os.path.join(current, name)
+                is_dir = os.path.isdir(full)
+                result.append({
+                    "name": f"{prefix}{name}",
+                    "type": "dir" if is_dir else "file",
+                })
+                if is_dir and d < depth:
+                    _walk(full, f"{prefix}{name}/", d + 1)
+
+        _walk(path, "", 0)
+        return self._ok(path=path, entries=result, count=len(result),
+                        truncated=len(result) >= self.max_list_entries)
+
+    def _mkdir(self, path: str) -> dict:
+        os.makedirs(path, exist_ok=True)
+        return self._ok(mode="mkdir", path=path)
+
+    def _copy(self, src: str, dst: str) -> dict:
+        if not os.path.exists(src):
+            return self._error("validation_error", f"Source does not exist: {src}")
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src, dst)
+        return self._ok(mode="copy", source=src, target=dst)
+
+    def _move(self, src: str, dst: str) -> dict:
+        if not os.path.exists(src):
+            return self._error("validation_error", f"Source does not exist: {src}")
+        shutil.move(src, dst)
+        return self._ok(mode="move", source=src, target=dst)
+
+    def _delete(self, path: str) -> dict:
+        if not os.path.exists(path):
+            return self._ok(mode="delete", path=path, deleted=False,
+                            message="Path does not exist; nothing deleted")
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+        return self._ok(mode="delete", path=path, deleted=True)
+
+    def _exists(self, path: str) -> dict:
+        exists = os.path.exists(path)
+        return self._ok(path=path, exists=exists,
+                        type=("dir" if os.path.isdir(path)
+                              else "file" if os.path.isfile(path) else "none"))
+
+    def _info(self, path: str) -> dict:
+        if not os.path.exists(path):
+            return self._error("validation_error", f"Path does not exist: {path}")
+        stat = os.stat(path)
+        return self._ok(
+            path=path,
+            type="dir" if os.path.isdir(path) else "file",
+            size=stat.st_size,
+            modified=stat.st_mtime,
+        )

--- a/agentuniverse/agent/action/tool/common_tool/filesystem_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/filesystem_tool.yaml.example
@@ -1,0 +1,14 @@
+name: filesystem_tool
+description: Bounded file system operations tool — mkdir, list, copy, move, delete, and tree, all confined to base_dir via resolve_safe_path.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.filesystem_tool
+  class: FileSystemTool
+input_keys:
+  - mode
+  - path
+base_dir: .
+max_list_entries: 500
+max_tree_depth: 5
+max_batch_size: 100

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,27 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## FileSystemTool
+
+`FileSystemTool` performs bounded file-system operations — `list`, `tree`, `mkdir`, `copy`, `move`, `delete`, `exists`, `info` — all confined to `base_dir` via path-resolution/sandboxing. Every operation is bounded by configurable limits (`max_list_entries`, `max_tree_depth`, `max_batch_size`) so an agent cannot enumerate or move unbounded amounts of data. Pure Python, no third-party dependency.
+
+Register a component pointing at `agentuniverse.agent.action.tool.common_tool.filesystem_tool.FileSystemTool`, then call `execute(mode=..., path=..., target=..., depth=...)`. Paths outside `base_dir` (including resolved symlinks and traversal segments) are rejected.
+
+```yaml
+name: filesystem_tool
+description: Bounded file system operations confined to base_dir
+base_dir: /srv/agent-files
+max_list_entries: 500
+max_tree_depth: 5
+max_batch_size: 100
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.filesystem_tool
+  class: FileSystemTool
+input_keys: ["mode", "path"]
+```
+- base_dir: Root directory; all paths are resolved underneath it.
+- max_list_entries: Maximum entries returned by `list` / `tree` (default 500).
+- max_tree_depth: Maximum depth for `tree` (default 5).
+- max_batch_size: Maximum files per `copy` / `move` batch (default 100).

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,27 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## FileSystemTool
+
+`FileSystemTool` 执行受边界限制的文件系统操作——`list`、`tree`、`mkdir`、`copy`、`move`、`delete`、`exists`、`info`——所有路径都通过路径解析/沙箱限制在 `base_dir` 之内。每个操作都受可配置上限约束（`max_list_entries`、`max_tree_depth`、`max_batch_size`），使智能体无法枚举或移动无界的数据量。纯 Python 实现，无第三方依赖。
+
+注册一个指向 `agentuniverse.agent.action.tool.common_tool.filesystem_tool.FileSystemTool` 的组件，然后调用 `execute(mode=..., path=..., target=..., depth=...)`。超出 `base_dir` 的路径（包括解析后的符号链接和穿越片段）会被拒绝。
+
+```yaml
+name: filesystem_tool
+description: Bounded file system operations confined to base_dir
+base_dir: /srv/agent-files
+max_list_entries: 500
+max_tree_depth: 5
+max_batch_size: 100
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.filesystem_tool
+  class: FileSystemTool
+input_keys: ["mode", "path"]
+```
+- base_dir: 根目录；所有路径都在其下解析。
+- max_list_entries: `list` / `tree` 返回的最大条目数（默认 500）。
+- max_tree_depth: `tree` 的最大深度（默认 5）。
+- max_batch_size: 每次 `copy` / `move` 批量的最大文件数（默认 100）。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_filesystem_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_filesystem_tool.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for FileSystemTool."""
+
+import os
+import tempfile
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool.filesystem_tool import \
+    FileSystemTool
+
+
+class TestFileSystemTool(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.tool = FileSystemTool(base_dir=self.tmp)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_mkdir_and_list(self):
+        result = self.tool.execute(mode="mkdir", path="subdir")
+        self.assertEqual(result["status"], "success")
+        result = self.tool.execute(mode="list", path=".")
+        self.assertEqual(result["status"], "success")
+        names = [e["name"] for e in result["entries"]]
+        self.assertIn("subdir", names)
+
+    def test_copy_file(self):
+        # Create a source file.
+        src = os.path.join(self.tmp, "src.txt")
+        with open(src, "w") as f:
+            f.write("hello")
+        result = self.tool.execute(mode="copy", path="src.txt", target="dst.txt")
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "dst.txt")))
+
+    def test_move_file(self):
+        src = os.path.join(self.tmp, "a.txt")
+        with open(src, "w") as f:
+            f.write("data")
+        result = self.tool.execute(mode="move", path="a.txt", target="b.txt")
+        self.assertEqual(result["status"], "success")
+        self.assertFalse(os.path.exists(src))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "b.txt")))
+
+    def test_delete_file(self):
+        f = os.path.join(self.tmp, "del.txt")
+        with open(f, "w") as fh:
+            fh.write("x")
+        result = self.tool.execute(mode="delete", path="del.txt")
+        self.assertTrue(result["deleted"])
+        self.assertFalse(os.path.exists(f))
+
+    def test_delete_nonexistent(self):
+        result = self.tool.execute(mode="delete", path="nope.txt")
+        self.assertEqual(result["status"], "success")
+        self.assertFalse(result["deleted"])
+
+    def test_exists(self):
+        result = self.tool.execute(mode="exists", path=".")
+        self.assertTrue(result["exists"])
+        result = self.tool.execute(mode="exists", path="nonexistent")
+        self.assertFalse(result["exists"])
+
+    def test_info(self):
+        f = os.path.join(self.tmp, "info.txt")
+        with open(f, "w") as fh:
+            fh.write("content")
+        result = self.tool.execute(mode="info", path="info.txt")
+        self.assertEqual(result["type"], "file")
+        self.assertEqual(result["size"], 7)
+
+    def test_tree(self):
+        os.makedirs(os.path.join(self.tmp, "a", "b", "c"))
+        result = self.tool.execute(mode="tree", path=".")
+        self.assertEqual(result["status"], "success")
+        names = [e["name"] for e in result["entries"]]
+        self.assertTrue(any("a" in n for n in names))
+
+    def test_path_escape_rejected(self):
+        result = self.tool.execute(mode="exists", path="../../../etc")
+        self.assertEqual(result["status"], "error")
+
+    def test_unknown_mode(self):
+        result = self.tool.execute(mode="invalid", path=".")
+        self.assertEqual(result["status"], "error")
+
+    def test_list_truncates_at_max_entries(self):
+        self.tool.max_list_entries = 3
+        for i in range(10):
+            open(os.path.join(self.tmp, f"f{i}.txt"), "w").close()
+        result = self.tool.execute(mode="list", path=".")
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["count"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `FileSystemTool` — provides mkdir, list, copy, move, delete, tree, exists, and info operations, all confined to `base_dir` via `resolve_safe_path`.

## Why (not a duplicate)

Not covered by any open or merged PR. The existing `ViewFileTool` / `WriteFileTool` only read/write single files; `FileSystemTool` adds directory management and batch operations with bounded limits.

## Capabilities

- All paths resolved via `resolve_safe_path` (path escape rejected).
- Bounded: `max_list_entries` (500), `max_tree_depth` (5), `max_batch_size` (100).
- Structured results: `{status, entries, count, truncated}` for list/tree; `{status, mode, path, deleted}` for destructive ops.
- Truncation flags so the agent knows when output was bounded.
- copy/move/delete handle both files and directories.

## Tests

`tests/test_agentuniverse/unit/agent/action/tool/test_filesystem_tool.py` — 11 tests: mkdir+list, copy, move, delete, delete nonexistent, exists, info, tree, path escape rejected, unknown mode, list truncation.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_filesystem_tool` — 11 passed.
