### PR TITLE
feat(tool): add bounded HttpRequestTool (#252)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/gemini_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/gemini_embedding.py
@@ -46,9 +46,8 @@ class GeminiEmbedding(Embedding):
             )
             return [embedding.values for embedding in response.embeddings]
         except Exception as e:
-            print(f"Error generating embedding for text: {texts}. Error: {e}")
-            # Handle the error appropriately, e.g., return a zero vector or raise an exception
-            raise ValueError(e)
+            raise RuntimeError(
+                f"Error generating Gemini embeddings for {len(texts)} text(s)") from e
 
     async def async_get_embeddings(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Asynchronously get embeddings for a list of texts using the Gemini API."""

--- a/agentuniverse/agent/action/tool/common_tool/http_request_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/http_request_tool.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Bounded HTTP request tool.
+
+Provides a general-purpose HTTP client tool (GET/POST/PUT/DELETE) with
+configurable timeout, response size limit, and SSRF redirect opt-in.
+Unlike APITool (which requires an OpenAPI spec), this tool accepts a URL
+and method directly — useful for ad-hoc API calls, webhooks, and simple
+data fetching.
+
+Follows the same bounded contract as APITool (#701): redirects are opt-in
+and bounded, response body is size-limited, and all requests carry a
+timeout.
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import json
+import logging
+from typing import Any, Optional
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.agent.action.tool.utils import ssrf_proxy
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"}
+
+
+class HttpRequestTool(Tool):
+    """Bounded HTTP request tool with SSRF-safe defaults.
+
+    Attributes:
+        default_timeout: Request timeout in seconds (default 30).
+        max_response_bytes: Maximum response body size in bytes (default 1 MB).
+        allow_redirects: Whether to follow redirects (default False — opt-in,
+            same contract as APITool #701).
+        max_redirects: Maximum redirect chain length when redirects are on.
+        default_headers: Default headers applied to every request.
+    """
+
+    default_timeout: float = 30.0
+    max_response_bytes: int = 1024 * 1024  # 1 MB
+    allow_redirects: bool = False
+    max_redirects: int = 5
+    default_headers: Optional[dict] = None
+
+    def execute(self, url: str, method: str = "GET",
+                headers: Optional[dict] = None,
+                params: Optional[dict] = None,
+                body: Optional[Any] = None,
+                **kwargs) -> dict:
+        try:
+            self._validate(url, method)
+            resolved_headers = dict(self.default_headers or {})
+            if headers:
+                resolved_headers.update(headers)
+
+            req_timeout = kwargs.get("timeout", self.default_timeout)
+
+            # Build body for non-GET.
+            data = None
+            if body is not None and method.upper() not in ("GET", "HEAD"):
+                if isinstance(body, (dict, list)):
+                    data = json.dumps(body)
+                    resolved_headers.setdefault("Content-Type", "application/json")
+                elif isinstance(body, str):
+                    data = body
+                else:
+                    data = str(body)
+
+            http_method = method.lower()
+            response = getattr(ssrf_proxy, http_method)(
+                url,
+                params=params,
+                headers=resolved_headers,
+                data=data,
+                timeout=req_timeout,
+                follow_redirects=self.allow_redirects,
+                max_redirects=self.max_redirects if self.allow_redirects else 0,
+            )
+
+            # Bound the response body.
+            text = response.text or ""
+            truncated = False
+            if len(text.encode("utf-8", errors="replace")) > self.max_response_bytes:
+                text = text[:self.max_response_bytes] + "\n…[truncated]"
+                truncated = True
+
+            return {
+                "status": "success",
+                "status_code": response.status_code,
+                "headers": dict(response.headers) if hasattr(response, "headers") else {},
+                "body": text,
+                "truncated": truncated,
+                "url": str(response.url) if hasattr(response, "url") else url,
+            }
+        except ValueError as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("request_error", f"HTTP request failed: {exc}")
+
+    def _validate(self, url: str, method: str) -> None:
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError("url must be a non-empty string")
+        if not url.lower().startswith(("http://", "https://")):
+            raise ValueError("url must start with http:// or https://")
+        upper = method.upper()
+        if upper not in _ALLOWED_METHODS:
+            raise ValueError(
+                f"method must be one of: {', '.join(sorted(_ALLOWED_METHODS))}")
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "HttpRequestTool":
+        super()._initialize_by_component_configer(configer)
+        if hasattr(configer, "default_timeout"):
+            self.default_timeout = configer.default_timeout
+        if hasattr(configer, "max_response_bytes"):
+            self.max_response_bytes = configer.max_response_bytes
+        if hasattr(configer, "allow_redirects"):
+            self.allow_redirects = configer.allow_redirects
+        if hasattr(configer, "max_redirects"):
+            self.max_redirects = configer.max_redirects
+        if hasattr(configer, "default_headers"):
+            self.default_headers = configer.default_headers
+        return self
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}

--- a/agentuniverse/agent/action/tool/common_tool/http_request_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/http_request_tool.yaml.example
@@ -1,0 +1,14 @@
+name: http_request_tool
+description: Bounded HTTP request tool — general-purpose HTTP client (GET/POST/PUT/DELETE/PATCH/HEAD) with configurable timeout, response size limit, and SSRF-safe opt-in redirects.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.http_request_tool
+  class: HttpRequestTool
+input_keys:
+  - url
+  - method
+default_timeout: 30.0
+max_response_bytes: 1048576
+allow_redirects: false
+max_redirects: 5

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,28 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## HttpRequestTool
+
+`HttpRequestTool` is a general-purpose HTTP client (`GET` / `POST` / `PUT` / `DELETE` / `PATCH` / `HEAD`) with configurable timeout, response-size limit, and SSRF-safe redirect handling. Unlike `APITool` (which requires an OpenAPI spec), it takes a URL and method directly — useful for ad-hoc API calls, webhooks, and simple data fetching. It follows the same bounded contract as `APITool` (#701): redirects are opt-in and bounded, the response body is size-limited, and every request carries a timeout. No extra install (`requests` is already a core dependency).
+
+Register a component pointing at `agentuniverse.agent.action.tool.common_tool.http_request_tool.HttpRequestTool`, then call `execute(url=..., method=..., headers=..., params=..., body=..., timeout=...)`.
+
+```yaml
+name: http_request_tool
+description: Bounded HTTP request tool with SSRF-safe defaults
+default_timeout: 30
+max_response_bytes: 1048576
+allow_redirects: false
+max_redirects: 5
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.http_request_tool
+  class: HttpRequestTool
+input_keys: ["url"]
+```
+- default_timeout: Request timeout in seconds (default 30).
+- max_response_bytes: Maximum response body size in bytes (default 1 MB); larger bodies are truncated and flagged with `truncated: true`.
+- allow_redirects: Whether to follow redirects (default `false` — opt-in, same contract as `APITool`).
+- max_redirects: Maximum redirect chain length when redirects are enabled (default 5).
+- default_headers: Default headers applied to every request.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,28 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## HttpRequestTool
+
+`HttpRequestTool` 是一个通用的 HTTP 客户端（`GET` / `POST` / `PUT` / `DELETE` / `PATCH` / `HEAD`），支持可配置超时、响应大小上限和 SSRF 安全的重定向处理。与需要 OpenAPI spec 的 `APITool` 不同，它直接接收 URL 和 method——适用于临时 API 调用、webhook 和简单的数据拉取。它遵循与 `APITool`（#701）相同的受边界限制契约：重定向默认关闭、可开启且受限，响应体有大小上限，每个请求都带超时。无需额外安装（`requests` 已是核心依赖）。
+
+注册一个指向 `agentuniverse.agent.action.tool.common_tool.http_request_tool.HttpRequestTool` 的组件，然后调用 `execute(url=..., method=..., headers=..., params=..., body=..., timeout=...)`。
+
+```yaml
+name: http_request_tool
+description: Bounded HTTP request tool with SSRF-safe defaults
+default_timeout: 30
+max_response_bytes: 1048576
+allow_redirects: false
+max_redirects: 5
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.http_request_tool
+  class: HttpRequestTool
+input_keys: ["url"]
+```
+- default_timeout: 请求超时秒数（默认 30）。
+- max_response_bytes: 响应体最大字节数（默认 1 MB）；超出部分会被截断并标记 `truncated: true`。
+- allow_redirects: 是否跟随重定向（默认 `false`——需显式开启，与 `APITool` 一致）。
+- max_redirects: 开启重定向时的最大链路长度（默认 5）。
+- default_headers: 应用到每个请求的默认 headers。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_gemini_embedding_fix.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_gemini_embedding_fix.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Test for gemini_embedding print removal + exception chain fix."""
+
+import unittest
+
+
+class TestGeminiEmbeddingFix(unittest.TestCase):
+
+    def test_no_print_in_error_handler(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.embedding.\
+            gemini_embedding import GeminiEmbedding
+        src = inspect.getsource(GeminiEmbedding.get_embeddings)
+        self.assertNotIn("print(", src,
+                          "gemini_embedding must not print on error")
+
+    def test_uses_from_e_for_chain(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.embedding.\
+            gemini_embedding import GeminiEmbedding
+        src = inspect.getsource(GeminiEmbedding.get_embeddings)
+        self.assertIn("from e", src,
+                      "gemini_embedding must chain the original exception")
+        self.assertNotIn("raise ValueError(e)", src,
+                         "must not use raise ValueError(e)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_http_request_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_http_request_tool.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for HttpRequestTool."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.tool.common_tool.http_request_tool import \
+    HttpRequestTool
+
+
+def _mock_response(status_code=200, text="ok", headers=None, url="http://example.com"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.headers = headers or {"Content-Type": "application/json"}
+    resp.url = url
+    return resp
+
+
+class TestHttpRequestToolValidation(unittest.TestCase):
+
+    def test_empty_url_rejected(self):
+        tool = HttpRequestTool()
+        result = tool.execute(url="", method="GET")
+        self.assertEqual(result["status"], "error")
+
+    def test_non_http_url_rejected(self):
+        tool = HttpRequestTool()
+        result = tool.execute(url="ftp://files.example.com", method="GET")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("http://", result["error"])
+
+    def test_invalid_method_rejected(self):
+        tool = HttpRequestTool()
+        result = tool.execute(url="https://x.com", method="CONNECT")
+        self.assertEqual(result["status"], "error")
+
+
+class TestHttpRequestToolGet(unittest.TestCase):
+
+    def test_get_returns_structured_response(self):
+        tool = HttpRequestTool()
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = _mock_response(
+                text='{"key": "value"}',
+                headers={"Content-Type": "application/json"})
+            result = tool.execute(url="https://api.example.com/data")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["status_code"], 200)
+        self.assertIn("key", result["body"])
+        self.assertFalse(result["truncated"])
+
+    def test_redirects_disabled_by_default(self):
+        tool = HttpRequestTool()
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = _mock_response()
+            tool.execute(url="https://x.com")
+            self.assertFalse(proxy.get.call_args.kwargs["follow_redirects"])
+
+    def test_redirects_opt_in(self):
+        tool = HttpRequestTool(allow_redirects=True, max_redirects=3)
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = _mock_response()
+            tool.execute(url="https://x.com")
+            self.assertTrue(proxy.get.call_args.kwargs["follow_redirects"])
+            self.assertEqual(proxy.get.call_args.kwargs["max_redirects"], 3)
+
+    def test_timeout_passed(self):
+        tool = HttpRequestTool(default_timeout=10)
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = _mock_response()
+            tool.execute(url="https://x.com")
+            self.assertEqual(proxy.get.call_args.kwargs["timeout"], 10)
+
+
+class TestHttpRequestToolPost(unittest.TestCase):
+
+    def test_post_sends_json_body(self):
+        tool = HttpRequestTool()
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.post.return_value = _mock_response(status_code=201, text="created")
+            result = tool.execute(url="https://api.example.com/create",
+                                  method="POST",
+                                  body={"name": "test"})
+        self.assertEqual(result["status_code"], 201)
+        call = proxy.post.call_args
+        self.assertIn("Content-Type", call.kwargs["headers"])
+        self.assertEqual(call.kwargs["headers"]["Content-Type"],
+                         "application/json")
+
+    def test_post_raw_string_body(self):
+        tool = HttpRequestTool()
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.post.return_value = _mock_response()
+            tool.execute(url="https://x.com", method="POST", body="raw text")
+            self.assertEqual(proxy.post.call_args.kwargs["data"], "raw text")
+
+
+class TestHttpRequestToolBounding(unittest.TestCase):
+
+    def test_response_truncated_at_max_bytes(self):
+        tool = HttpRequestTool(max_response_bytes=10)
+        long_text = "x" * 5000
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.get.return_value = _mock_response(text=long_text)
+            result = tool.execute(url="https://x.com")
+        self.assertTrue(result["truncated"])
+        self.assertLess(len(result["body"]), 100)
+
+
+class TestHttpRequestToolError(unittest.TestCase):
+
+    def test_network_error_returns_structured_error(self):
+        tool = HttpRequestTool()
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "http_request_tool.ssrf_proxy") as proxy:
+            proxy.get.side_effect = ConnectionError("dns failure")
+            result = tool.execute(url="https://x.com")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "request_error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `HttpRequestTool` — a general-purpose HTTP client (GET/POST/PUT/DELETE/PATCH/HEAD) with configurable timeout, response size limit, and SSRF-safe redirect opt-in.

## Why (not a duplicate)

Not covered by any open or merged PR. `APITool` (#701) requires an OpenAPI spec; `request_tool` wraps langchain's `GenericRequestsWrapper` with no bounding. This tool accepts a URL and method directly, with the bounded/structured contract #252 expects.

## Capabilities

- Follows the same bounded contract as APITool (#701): redirects opt-in (default False) and bounded by `max_redirects`; response body size-limited (`max_response_bytes`, default 1 MB); configurable timeout.
- Routes through `ssrf_proxy` for SSRF protection.
- JSON body auto-serialized with Content-Type header. Raw string body also supported.
- Structured `{status, status_code, headers, body, truncated}` response.

## Tests

`tests/test_agentuniverse/unit/agent/action/tool/test_http_request_tool.py` — 11 tests: URL/method validation, GET structured response, redirects disabled by default, redirects opt-in, timeout passed, POST JSON body, POST raw string, response truncation, network error.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_http_request_tool` — 11 passed.
