### PR TITLE
feat(knowledge): CohereReranker post-processor (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/cohere_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/cohere_reranker.py
@@ -1,0 +1,131 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: cohere_reranker.py
+
+"""
+Cohere reranker — a knowledge post-processing DocProcessor.
+
+Re-ranks recalled documents using the Cohere Rerank API. Sibling of the
+merged ``JinaReranker`` (#646) and ``DashscopeReranker``; addresses the
+*Rerank* direction of #248.
+"""
+
+import logging
+from typing import List, Optional
+
+import requests
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.util.env_util import get_from_env
+
+logger = logging.getLogger(__name__)
+
+_COHERE_RERANK_URL = "https://api.cohere.com/v2/rerank"
+
+
+class CohereReranker(DocProcessor):
+    """Cohere Rerank API post-processor.
+
+    Attributes:
+        api_key: Cohere API key. Falls back to the ``COHERE_API_KEY`` env var.
+        model_name: Cohere rerank model (default ``rerank-multilingual-v3.0``).
+        top_n: Maximum number of documents returned after reranking.
+        request_timeout: Timeout in seconds for the rerank HTTP call.
+        score_key: Optional metadata key under which each document's relevance
+            score is stamped.
+    """
+
+    api_key: Optional[str] = None
+    model_name: str = "rerank-multilingual-v3.0"
+    top_n: int = 10
+    request_timeout: int = 30
+    score_key: Optional[str] = "rerank_score"
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        if not origin_docs:
+            return []
+        if query is None or not query.query_str:
+            logger.warning("CohereReranker needs a query string; returning docs unchanged.")
+            return origin_docs
+        if not self.api_key:
+            raise ValueError(
+                "CohereReranker requires an api_key. Set it on the component "
+                "or via the COHERE_API_KEY environment variable.")
+
+        effective_top_n = min(self.top_n, len(origin_docs))
+        texts = [doc.text or "" for doc in origin_docs]
+
+        try:
+            response = requests.post(
+                _COHERE_RERANK_URL,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self.model_name,
+                    "query": query.query_str,
+                    "documents": texts,
+                    "top_n": effective_top_n,
+                },
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+        except requests.exceptions.Timeout:
+            logger.warning("Cohere rerank request timed out; returning docs unchanged.")
+            return origin_docs
+        except requests.exceptions.HTTPError as exc:
+            raise RuntimeError(
+                f"Cohere rerank API returned status "
+                f"{exc.response.status_code if exc.response is not None else '?'}: "
+                f"{exc}") from exc
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Cohere rerank API returned a non-JSON body: {exc}") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Cohere rerank API returned non-JSON response: {exc}") from exc
+
+        results = data.get("results", [])
+        reranked: List[Document] = []
+        for item in results:
+            idx = item.get("index")
+            score = item.get("relevance_score")
+            if idx is None or idx < 0 or idx >= len(origin_docs):
+                continue
+            doc = origin_docs[idx]
+            if self.score_key and score is not None:
+                meta = dict(doc.metadata or {})
+                meta[self.score_key] = float(score)
+                doc = Document(text=doc.text, metadata=meta, embedding=doc.embedding)
+            reranked.append(doc)
+        return reranked if reranked else origin_docs
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "CohereReranker":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "api_key"):
+            self.api_key = doc_processor_configer.api_key
+        if hasattr(doc_processor_configer, "model_name"):
+            self.model_name = doc_processor_configer.model_name
+        if hasattr(doc_processor_configer, "top_n"):
+            self.top_n = doc_processor_configer.top_n
+        if hasattr(doc_processor_configer, "request_timeout"):
+            self.request_timeout = doc_processor_configer.request_timeout
+        if hasattr(doc_processor_configer, "score_key"):
+            self.score_key = doc_processor_configer.score_key
+        if not self.api_key:
+            self.api_key = get_from_env("COHERE_API_KEY")
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/cohere_reranker.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/cohere_reranker.yaml
@@ -1,0 +1,11 @@
+name: 'cohere_reranker'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.cohere_reranker'
+  class: 'CohereReranker'
+description: 'Cohere Rerank API post-processor for knowledge retrieval.'
+api_key: ''
+model_name: 'rerank-multilingual-v3.0'
+top_n: 10
+request_timeout: 30
+score_key: 'rerank_score'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,29 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [CohereReranker](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/cohere_reranker.yaml)
+
+`CohereReranker` re-ranks the documents recalled by the Store using the Cohere Rerank API, ordering them by relevance to the `Query`. It is a sibling of `JinaReranker` (#646) and `DashscopeReranker`, addressing the *Rerank* direction of issue #248.
+
+It needs no extra install (`requests` is already a core dependency) — only a Cohere API key. Copy `cohere_reranker.yaml` into your application configuration directory, set `api_key` (or expose `COHERE_API_KEY`), and resolve the built-in `cohere_reranker` component. A query string is required: without one the documents are returned unchanged.
+
+The component definition file is as follows:
+```yaml
+name: 'cohere_reranker'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.cohere_reranker'
+  class: 'CohereReranker'
+description: 'Cohere Rerank API post-processor for knowledge retrieval.'
+api_key: ''
+model_name: 'rerank-multilingual-v3.0'
+top_n: 10
+request_timeout: 30
+score_key: 'rerank_score'
+```
+- api_key: Cohere API key. Falls back to the `COHERE_API_KEY` environment variable when left empty.
+- model_name: Cohere rerank model (default `rerank-multilingual-v3.0`).
+- top_n: Maximum number of documents returned after reranking.
+- request_timeout: Timeout in seconds for the rerank HTTP call.
+- score_key: Metadata key under which each document's relevance score is stamped; empty stamps nothing.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,29 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [CohereReranker](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/cohere_reranker.yaml)
+
+`CohereReranker` 使用 Cohere Rerank API 对 store 召回的文档重排，按与 `Query` 的相关性重新排序。它是 `JinaReranker`（#646）、`DashscopeReranker` 的同类组件，对应 issue #248 的*Rerank*方向。
+
+无需额外安装（`requests` 已是核心依赖）——只需一个 Cohere API Key。将 `cohere_reranker.yaml` 复制到应用配置目录，设置 `api_key`（或配置 `COHERE_API_KEY` 环境变量），加载内置 `cohere_reranker` 组件即可使用。调用时必须提供查询字符串，否则原样返回文档。
+
+组件定义文件如下：
+```yaml
+name: 'cohere_reranker'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.cohere_reranker'
+  class: 'CohereReranker'
+description: 'Cohere Rerank API 知识检索后处理组件。'
+api_key: ''
+model_name: 'rerank-multilingual-v3.0'
+top_n: 10
+request_timeout: 30
+score_key: 'rerank_score'
+```
+- api_key: Cohere API Key。留空时回退读取 `COHERE_API_KEY` 环境变量。
+- model_name: Cohere rerank 模型（默认 `rerank-multilingual-v3.0`）。
+- top_n: 重排后返回的最大文档数。
+- request_timeout: rerank HTTP 调用的超时秒数。
+- score_key: 写入每个文档相关性得分的 metadata 键；为空则不写入。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_cohere_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_cohere_reranker.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for CohereReranker DocProcessor."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.doc_processor.cohere_reranker \
+    import CohereReranker
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+
+
+def _mock_response(json_body, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status.return_value = None if status_code < 400 else Exception("HTTP error")
+    return resp
+
+
+class TestCohereReranker(unittest.TestCase):
+
+    def _docs(self):
+        return [
+            Document(id="d1", text="Python is great"),
+            Document(id="d2", text="Java is also good"),
+            Document(id="d3", text="Rust is fast"),
+        ]
+
+    def test_rerank_reorders_by_relevance(self):
+        proc = CohereReranker(api_key="fake", top_n=2)
+        cohere_resp = _mock_response({
+            "results": [
+                {"index": 2, "relevance_score": 0.95},
+                {"index": 0, "relevance_score": 0.80},
+            ]
+        })
+        with patch("agentuniverse.agent.action.knowledge.doc_processor."
+                   "cohere_reranker.requests.post", return_value=cohere_resp):
+            result = proc.process_docs(self._docs(), Query(query_str="fast language"))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].text, "Rust is fast")
+        self.assertEqual(result[1].text, "Python is great")
+        self.assertAlmostEqual(result[0].metadata["rerank_score"], 0.95)
+
+    def test_missing_api_key_raises(self):
+        proc = CohereReranker(api_key="")
+        with self.assertRaises(ValueError):
+            proc.process_docs(self._docs(), Query(query_str="q"))
+
+    def test_missing_query_returns_unchanged(self):
+        proc = CohereReranker(api_key="fake")
+        result = proc.process_docs(self._docs(), Query(query_str=""))
+        self.assertEqual(len(result), 3)
+
+    def test_empty_docs_returns_empty(self):
+        proc = CohereReranker(api_key="fake")
+        self.assertEqual(proc.process_docs([], Query(query_str="q")), [])
+
+    def test_timeout_returns_unchanged(self):
+        import requests as req_mod
+        proc = CohereReranker(api_key="fake")
+        with patch("agentuniverse.agent.action.knowledge.doc_processor."
+                   "cohere_reranker.requests.post",
+                   side_effect=req_mod.exceptions.Timeout("timed out")):
+            result = proc.process_docs(self._docs(), Query(query_str="q"))
+        self.assertEqual(len(result), 3)
+
+    def test_http_error_raises_runtime_error(self):
+        import requests as req_mod
+        proc = CohereReranker(api_key="fake")
+        bad_resp = MagicMock()
+        bad_resp.status_code = 429
+        bad_resp.raise_for_status.side_effect = req_mod.exceptions.HTTPError(
+            response=bad_resp)
+        with patch("agentuniverse.agent.action.knowledge.doc_processor."
+                   "cohere_reranker.requests.post", return_value=bad_resp):
+            with self.assertRaises(RuntimeError):
+                proc.process_docs(self._docs(), Query(query_str="q"))
+
+    def test_score_key_none_leaves_metadata_clean(self):
+        proc = CohereReranker(api_key="fake", top_n=1, score_key=None)
+        cohere_resp = _mock_response({
+            "results": [{"index": 0, "relevance_score": 0.99}]
+        })
+        with patch("agentuniverse.agent.action.knowledge.doc_processor."
+                   "cohere_reranker.requests.post", return_value=cohere_resp):
+            result = proc.process_docs(self._docs(), Query(query_str="q"))
+        self.assertNotIn("rerank_score", result[0].metadata or {})
+
+    def test_top_n_capped_at_input_length(self):
+        proc = CohereReranker(api_key="fake", top_n=100)
+        cohere_resp = _mock_response({
+            "results": [{"index": 0, "relevance_score": 0.9}]
+        })
+        with patch("agentuniverse.agent.action.knowledge.doc_processor."
+                   "cohere_reranker.requests.post", return_value=cohere_resp):
+            result = proc.process_docs(self._docs(), Query(query_str="q"))
+        # top_n is capped at len(docs)=3; API returns 1, so result is 1.
+        self.assertEqual(len(result), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `CohereReranker` — re-ranks recalled documents using the Cohere Rerank API (v2). Sibling of the merged `JinaReranker` (#646) and `DashscopeReranker`; addresses the *Rerank* direction of #248.

## Why (not a duplicate)

Not covered by any open or merged PR. Cohere Rerank is a top-2 rerank service in the RAG ecosystem; the framework already supports Jina and Dashscope rerankers but not Cohere.

## Capabilities

- Uses Cohere v2 rerank endpoint with configurable model (default `rerank-multilingual-v3.0`).
- Bounded: `request_timeout` (30s), `top_n` capped at input length.
- Timeout returns docs unchanged (graceful degradation, same as `JinaReranker`).
- HTTP error raises `RuntimeError` with status code.
- Non-JSON response raises `RuntimeError`.
- Optional `score_key` stamps relevance score into metadata.
- `api_key` from `COHERE_API_KEY` env var.

## Tests

`tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_cohere_reranker.py` — 8 unit tests: rerank reordering, missing api_key, missing query, empty docs, timeout graceful fallback, HTTP error, score_key=None, top_n capped.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_cohere_reranker` — 8 passed.
