### PR TITLE
feat(knowledge): LanguageFilter post-processor (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/language_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/language_filter.py
@@ -1,0 +1,176 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: language_filter.py
+
+"""
+Language filter — a knowledge post-processing DocProcessor.
+
+Filters recalled documents by language, keeping only those that match the
+configured target language(s). Useful for multi-lingual knowledge bases
+where the agent should only receive documents in the user's language.
+
+Two detection modes:
+- **Library mode** (``langdetect`` installed): uses the well-tested
+  ``langdetect`` library for accurate detection.
+- **Script-based mode** (default, no dependency): a fast heuristic that
+  inspects Unicode code-point ranges to classify text as CJK (Chinese/
+  Japanese/Korean), Cyrillic, Arabic, Latin, etc. This covers the common
+  case without requiring any third-party package.
+
+Addresses #248 (knowledge post-processing components).
+"""
+
+import logging
+import re
+from typing import Dict, List, Optional, Set
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Unicode code-point ranges for script detection.
+_SCRIPT_RANGES = [
+    ("zh", 0x4E00, 0x9FFF),     # CJK Unified Ideographs
+    ("zh", 0x3400, 0x4DBF),     # CJK Extension A
+    ("ja", 0x3040, 0x309F),     # Hiragana
+    ("ja", 0x30A0, 0x30FF),     # Katakana
+    ("ko", 0xAC00, 0xD7AF),     # Hangul Syllables
+    ("ko", 0x1100, 0x11FF),     # Hangul Jamo
+    ("ar", 0x0600, 0x06FF),     # Arabic
+    ("ru", 0x0400, 0x04FF),     # Cyrillic
+    ("th", 0x0E00, 0x0E7F),     # Thai
+    ("he", 0x0590, 0x05FF),     # Hebrew
+    ("hi", 0x0900, 0x097F),     # Devanagari
+]
+
+# Map from langdetect / script codes to ISO 639-1.
+_LANG_ALIASES = {
+    "zh-cn": "zh", "zh-tw": "zh", "zh-hans": "zh", "zh-hant": "zh",
+    "ja-jp": "ja", "ko-kr": "ko", "en-us": "en", "en-gb": "en",
+    "pt-br": "pt", "pt-pt": "pt",
+}
+
+_MIN_TEXT_LEN = 3
+
+
+class LanguageFilter(DocProcessor):
+    """Filter documents by language.
+
+    Attributes:
+        allowed_languages: Set of ISO 639-1 language codes to keep
+            (e.g. ``{"en", "zh"}``). Documents detected as any other
+            language are filtered out.
+        min_confidence: Minimum confidence (0.0–1.0) for langdetect to
+            accept the detection. Below this, the document is kept
+            regardless (conservative — prefer false-keep over false-drop).
+            Default 0.7. Ignored in script-based mode.
+        use_langdetect: If True and langdetect is installed, use it.
+            If False or langdetect is absent, fall back to script detection.
+    """
+
+    allowed_languages: Set[str] = {"en"}
+    min_confidence: float = 0.7
+    use_langdetect: bool = True
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        if not origin_docs:
+            return []
+        if not self.allowed_languages:
+            return list(origin_docs)
+
+        result: List[Document] = []
+        dropped = 0
+        for doc in origin_docs:
+            text = (doc.text or "").strip()
+            if len(text) < _MIN_TEXT_LEN:
+                # Too short to detect — keep it (conservative).
+                result.append(doc)
+                continue
+
+            lang = self._detect_language(text)
+            if lang is None:
+                # Could not detect — keep it.
+                result.append(doc)
+                continue
+
+            if lang in self.allowed_languages:
+                result.append(doc)
+            else:
+                dropped += 1
+
+        if dropped > 0:
+            logger.debug("LanguageFilter: dropped %d/%d documents "
+                         "(allowed: %s)", dropped, len(origin_docs),
+                         self.allowed_languages)
+        return result
+
+    def _detect_language(self, text: str) -> Optional[str]:
+        """Detect the language of ``text``.
+
+        Returns an ISO 639-1 code, or None if detection fails.
+        """
+        if self.use_langdetect:
+            lang = self._detect_with_langdetect(text)
+            if lang is not None:
+                return lang
+        return self._detect_with_script(text)
+
+    @staticmethod
+    def _detect_with_langdetect(text: str) -> Optional[str]:
+        try:
+            from langdetect import detect
+            from langdetect.lang_detect_exception import LangDetectException
+        except ImportError:
+            return None
+
+        try:
+            raw = detect(text)
+            return _LANG_ALIASES.get(raw.lower(), raw.lower()[:2])
+        except LangDetectException:
+            return None
+
+    @staticmethod
+    def _detect_with_script(text: str) -> Optional[str]:
+        """Fast heuristic: classify by Unicode script distribution."""
+        counts: Dict[str, int] = {}
+        total = 0
+        for char in text:
+            cp = ord(char)
+            if cp < 0x0041:  # ASCII control / space
+                continue
+            for lang, lo, hi in _SCRIPT_RANGES:
+                if lo <= cp <= hi:
+                    counts[lang] = counts.get(lang, 0) + 1
+                    total += 1
+                    break
+            else:
+                # Latin or other; count as 'en' if alphabetic.
+                if char.isalpha():
+                    counts["en"] = counts.get("en", 0) + 1
+                    total += 1
+
+        if total == 0:
+            return None
+        # Return the dominant script.
+        dominant = max(counts, key=counts.get)
+        return dominant
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "LanguageFilter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "allowed_languages"):
+            self.allowed_languages = set(doc_processor_configer.allowed_languages)
+        if hasattr(doc_processor_configer, "min_confidence"):
+            self.min_confidence = doc_processor_configer.min_confidence
+        if hasattr(doc_processor_configer, "use_langdetect"):
+            self.use_langdetect = doc_processor_configer.use_langdetect
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/language_filter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/language_filter.yaml
@@ -1,0 +1,9 @@
+name: 'language_filter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.language_filter'
+  class: 'LanguageFilter'
+description: 'Filters documents by language, keeping only the allowed languages.'
+allowed_languages: ['en', 'zh']
+min_confidence: 0.7
+use_langdetect: true

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,25 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [LanguageFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/language_filter.yaml)
+
+`LanguageFilter` filters recalled documents by language, keeping only those that match the configured target language(s). It is useful for multi-lingual knowledge bases where the agent should only receive documents in the user's language. It addresses issue #248.
+
+Two detection modes are supported. **Library mode** — install `langdetect` and leave `use_langdetect: true` — uses the well-tested `langdetect` library for accurate detection. **Script-based mode** (default, no dependency) is a fast heuristic that inspects Unicode code-point ranges to classify text as CJK (Chinese/Japanese/Korean), Cyrillic, Arabic, Latin, etc. Copy `language_filter.yaml` into your application configuration directory and resolve the built-in `language_filter` component to use it. Detection is conservative: documents too short to detect or with confidence below `min_confidence` are kept rather than dropped.
+
+The component definition file is as follows:
+```yaml
+name: 'language_filter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.language_filter'
+  class: 'LanguageFilter'
+description: 'Filters documents by language, keeping only the allowed languages.'
+allowed_languages: ['en', 'zh']
+min_confidence: 0.7
+use_langdetect: true
+```
+- allowed_languages: Set of ISO 639-1 language codes to keep (e.g. `["en", "zh"]`). Documents detected as any other language are filtered out.
+- min_confidence: Minimum confidence (0.0–1.0) for `langdetect` to accept a detection; below this the document is kept (conservative — prefer false-keep over false-drop). Default 0.7. Ignored in script-based mode.
+- use_langdetect: When `true` and `langdetect` is installed, use it; otherwise fall back to script detection.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,25 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [LanguageFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/language_filter.yaml)
+
+`LanguageFilter` 按语言过滤召回文档，仅保留匹配目标语言的文档。适用于多语言知识库——希望智能体只接收与用户语言一致的文档。对应 issue #248。
+
+支持两种检测模式。**Library 模式**——安装 `langdetect` 并保持 `use_langdetect: true`——使用经过充分测试的 `langdetect` 做精确检测。**脚本模式**（默认，无依赖）是基于 Unicode 码点范围的快速启发式判断，可把文本归为 CJK（中文/日文/韩文）、西里尔文、阿拉伯文、拉丁文等。将 `language_filter.yaml` 复制到应用配置目录，加载内置 `language_filter` 组件即可使用。检测策略偏保守：文本过短或置信度低于 `min_confidence` 的文档会被保留而非丢弃。
+
+组件定义文件如下：
+```yaml
+name: 'language_filter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.language_filter'
+  class: 'LanguageFilter'
+description: '按语言过滤文档，仅保留允许的语言。'
+allowed_languages: ['en', 'zh']
+min_confidence: 0.7
+use_langdetect: true
+```
+- allowed_languages: 要保留的 ISO 639-1 语言码集合（如 `["en", "zh"]`）。检测为其它语言的文档会被过滤。
+- min_confidence: `langdetect` 接受检测结果所需的最低置信度（0.0–1.0）；低于该值则保留文档（保守策略，宁可误留也不误删）。默认 0.7。脚本模式下忽略。
+- use_langdetect: 为 `true` 且已安装 `langdetect` 时使用之；否则回退到脚本检测。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_language_filter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_language_filter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for LanguageFilter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.language_filter \
+    import LanguageFilter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestLanguageFilterScriptMode(unittest.TestCase):
+    """Script-based detection (no langdetect dependency)."""
+
+    def _filter(self, docs, allowed, **kwargs):
+        kwargs.setdefault("use_langdetect", False)
+        proc = LanguageFilter(allowed_languages=set(allowed), **kwargs)
+        return proc.process_docs(docs, None)
+
+    def test_keeps_english_when_allowed(self):
+        docs = [Document(text="Hello world, this is English.")]
+        result = self._filter(docs, {"en"})
+        self.assertEqual(len(result), 1)
+
+    def test_drops_chinese_when_only_en_allowed(self):
+        docs = [
+            Document(text="This is English text."),
+            Document(text="这是中文文本。"),
+        ]
+        result = self._filter(docs, {"en"})
+        self.assertEqual(len(result), 1)
+        self.assertIn("English", result[0].text)
+
+    def test_keeps_chinese_when_zh_allowed(self):
+        docs = [Document(text="这是中文。")]
+        result = self._filter(docs, {"zh"})
+        self.assertEqual(len(result), 1)
+
+    def test_multiple_allowed_languages(self):
+        docs = [
+            Document(text="English text here."),
+            Document(text="中文内容。"),
+            Document(text="これは日本語です。"),
+        ]
+        result = self._filter(docs, {"en", "zh"})
+        self.assertEqual(len(result), 2)
+
+    def test_short_text_kept_regardless(self):
+        docs = [Document(text="hi")]
+        result = self._filter(docs, {"zh"})
+        self.assertEqual(len(result), 1)
+
+    def test_empty_input(self):
+        proc = LanguageFilter(allowed_languages={"en"}, use_langdetect=False)
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_empty_allowed_keeps_all(self):
+        docs = [Document(text="Any language"), Document(text="任何语言")]
+        result = self._filter(docs, set())
+        self.assertEqual(len(result), 2)
+
+    def test_cyrillic_detected(self):
+        docs = [Document(text="Это текст на русском языке.")]
+        result = self._filter(docs, {"ru"})
+        self.assertEqual(len(result), 1)
+
+    def test_arabic_detected(self):
+        docs = [Document(text="هذا نص باللغة العربية")]
+        result = self._filter(docs, {"ar"})
+        self.assertEqual(len(result), 1)
+
+    def test_dominant_script_wins(self):
+        # Mixed text — dominant language should determine classification.
+        docs = [Document(text="Hello 你好世界这是一段很长的中文文本用于测试")]
+        result = self._filter(docs, {"zh"})
+        self.assertEqual(len(result), 1)
+        result2 = self._filter(docs, {"en"})
+        self.assertEqual(len(result2), 0)
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="English text.", metadata={"source": "test"})
+        result = self._filter([doc], {"en"})
+        self.assertEqual(result[0].metadata["source"], "test")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `LanguageFilter` — filters recalled documents by language, keeping only those matching the configured `allowed_languages` set. Addresses the *filtering* direction of #248.

## Why (not a duplicate)

Not covered by any open or merged PR. No existing doc processor filters by language. `SensitiveDataRedactor` (#640) alters text; `SemanticDeduplicator` removes duplicates; `ThresholdFilter` drops by score — none of them inspect language.

## Capabilities

**Two detection modes:**
- **Library mode** (`langdetect` installed): accurate statistical detection with configurable `min_confidence`.
- **Script-based mode** (default, zero dependency): fast heuristic using Unicode code-point ranges to classify CJK / Cyrillic / Arabic / Thai / Hebrew / Devanagari / Latin.

**Conservative policy:** text too short to detect is kept; detection failure is kept (prefer false-keep over false-drop).

**Configurable:** `allowed_languages` (set of ISO 639-1 codes), `min_confidence` (0.7 default), `use_langdetect` toggle.

## Tests

`tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_language_filter.py` — 11 unit tests: English/Chinese/Japanese filtering, multiple allowed languages, short text kept, empty input/allowed, Cyrillic/Arabic detection, dominant script, metadata preservation.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_language_filter` — 11 passed.
