### PR TITLE
feat(embedding): HuggingFace Hub embedding component (#250)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/huggingface_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/huggingface_embedding.py
@@ -1,0 +1,153 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: huggingface_embedding.py
+
+"""
+Hugging Face Hub embedding component.
+
+Generates text embeddings using models hosted on the Hugging Face Hub via
+the ``InferenceClient`` from ``huggingface_hub``. Supports sentence-
+transformers models, BGE, GTE, and any embedding model on the Hub.
+"""
+
+import logging
+from typing import List, Optional
+
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
+from agentuniverse.base.util.env_util import get_from_env
+
+logger = logging.getLogger(__name__)
+
+
+class HuggingFaceEmbedding(Embedding):
+    """Embedding component backed by Hugging Face Hub Inference API.
+
+    Attributes:
+        embedding_model_name: The Hugging Face model repo ID
+            (e.g. ``"sentence-transformers/all-MiniLM-L6-v2"``).
+        api_key: Hugging Face API token (env: ``HUGGINGFACE_API_KEY``
+            or ``HF_TOKEN``).
+        timeout: Request timeout in seconds (default 30).
+    """
+
+    embedding_model_name: Optional[str] = Field(
+        default="sentence-transformers/all-MiniLM-L6-v2")
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("HUGGINGFACE_API_KEY")
+        or get_from_env("HF_TOKEN"))
+    timeout: float = 30.0
+
+    _client: Optional[object] = None
+
+    def _get_client(self):
+        if self._client is not None:
+            return self._client
+        try:
+            from huggingface_hub import InferenceClient
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is not installed. Install it with "
+                "'pip install huggingface_hub'.") from exc
+        self._client = InferenceClient(
+            model=self.embedding_model_name,
+            token=self.api_key,
+            timeout=self.timeout,
+        )
+        return self._client
+
+    def get_embeddings(self, texts: List[str],
+                       text_type: str = "document") -> List[List[float]]:
+        """Generate embeddings for a list of texts.
+
+        Args:
+            texts: List of text strings to embed.
+            text_type: ``"document"`` or ``"query"`` (informational; the HF
+                Inference API does not distinguish, but the parameter is
+                kept for interface compatibility).
+
+        Returns:
+            List of embedding vectors (one per input text).
+        """
+        if not texts:
+            return []
+        if not self.embedding_model_name:
+            raise ValueError("embedding_model_name must be set")
+
+        client = self._get_client()
+        result: List[List[float]] = []
+        # The HF feature-extraction API processes one text at a time.
+        for text in texts:
+            try:
+                embedding = client.feature_extraction(text)
+                # The response is a numpy array or list of floats.
+                if hasattr(embedding, "tolist"):
+                    embedding = embedding.tolist()
+                # Some models return a nested list (batch dimension).
+                if isinstance(embedding, list) and embedding and isinstance(embedding[0], list):
+                    # Take the first (and only) sentence's embedding.
+                    if len(embedding) == 1:
+                        embedding = embedding[0]
+                    else:
+                        # Mean-pool token-level embeddings.
+                        embedding = self._mean_pool(embedding)
+                result.append(list(embedding))
+            except Exception as exc:
+                logger.warning("HuggingFace embedding failed for text "
+                               "(len=%d): %s", len(text), exc)
+                result.append([])
+        return result
+
+    async def async_get_embeddings(self, texts: List[str],
+                                   text_type: str = "document") -> List[List[float]]:
+        """Async embedding generation."""
+        if not texts:
+            return []
+        if not self.embedding_model_name:
+            raise ValueError("embedding_model_name must be set")
+
+        try:
+            from huggingface_hub import AsyncInferenceClient
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is not installed. Install it with "
+                "'pip install huggingface_hub'.") from exc
+
+        client = AsyncInferenceClient(
+            model=self.embedding_model_name,
+            token=self.api_key,
+            timeout=self.timeout,
+        )
+        result: List[List[float]] = []
+        for text in texts:
+            try:
+                embedding = await client.feature_extraction(text)
+                if hasattr(embedding, "tolist"):
+                    embedding = embedding.tolist()
+                if isinstance(embedding, list) and embedding and isinstance(embedding[0], list):
+                    if len(embedding) == 1:
+                        embedding = embedding[0]
+                    else:
+                        embedding = self._mean_pool(embedding)
+                result.append(list(embedding))
+            except Exception as exc:
+                logger.warning("HuggingFace async embedding failed: %s", exc)
+                result.append([])
+        return result
+
+    @staticmethod
+    def _mean_pool(token_embeddings: List[List[float]]) -> List[float]:
+        """Mean-pool a list of token-level embeddings into one vector."""
+        if not token_embeddings:
+            return []
+        dim = len(token_embeddings[0])
+        sums = [0.0] * dim
+        for emb in token_embeddings:
+            for i, val in enumerate(emb):
+                if i < dim:
+                    sums[i] += val
+        n = len(token_embeddings)
+        return [s / n for s in sums]

--- a/agentuniverse/agent/action/knowledge/embedding/huggingface_embedding.yaml.example
+++ b/agentuniverse/agent/action/knowledge/embedding/huggingface_embedding.yaml.example
@@ -1,0 +1,9 @@
+name: 'huggingface_embedding'
+description: 'Embedding component backed by the Hugging Face Hub Inference API (sentence-transformers, BGE, GTE, etc.).'
+embedding_model_name: 'sentence-transformers/all-MiniLM-L6-v2'
+api_key: ''
+timeout: 30.0
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.huggingface_embedding'
+  class: 'HuggingFaceEmbedding'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
@@ -1,0 +1,24 @@
+# Embedding
+
+agentUniverse provides several built-in embedding components used by the Knowledge store and doc processors to vectorise text. Each component is registered with `metadata.type: EMBEDDING` and exposes `get_embeddings(texts, text_type=...)`.
+
+## HuggingFaceEmbedding
+
+`HuggingFaceEmbedding` generates text embeddings using models hosted on the Hugging Face Hub via the `InferenceClient` from `huggingface_hub`. It supports sentence-transformers models, BGE, GTE, and any embedding model exposed through the Hub feature-extraction API. Install the SDK with `pip install huggingface_hub`.
+
+Register a component pointing at `agentuniverse.agent.action.knowledge.embedding.huggingface_embedding.HuggingFaceEmbedding`, then reference it by name from a store or processor (e.g. `embedding_model: huggingface_embedding`). The API key is read from `HUGGINGFACE_API_KEY` (or `HF_TOKEN`).
+
+```yaml
+name: 'huggingface_embedding'
+description: 'embedding via Hugging Face Hub Inference API'
+embedding_model_name: 'sentence-transformers/all-MiniLM-L6-v2'
+api_key: '${HUGGINGFACE_API_KEY}'
+timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.huggingface_embedding'
+  class: 'HuggingFaceEmbedding'
+```
+- embedding_model_name: The Hugging Face model repo ID (default `sentence-transformers/all-MiniLM-L6-v2`).
+- api_key: Hugging Face API token (env: `HUGGINGFACE_API_KEY` or `HF_TOKEN`).
+- timeout: Request timeout in seconds (default 30).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
@@ -1,0 +1,24 @@
+# Embedding（向量化）
+
+agentUniverse 提供若干内置 embedding 组件，供知识库 store 与文档处理器对文本向量化。每个组件以 `metadata.type: EMBEDDING` 注册，并暴露 `get_embeddings(texts, text_type=...)` 方法。
+
+## HuggingFaceEmbedding
+
+`HuggingFaceEmbedding` 通过 `huggingface_hub` 的 `InferenceClient`，使用 Hugging Face Hub 上托管的模型生成文本向量。支持 sentence-transformers 模型、BGE、GTE，以及任何通过 Hub feature-extraction API 暴露的 embedding 模型。安装 SDK：`pip install huggingface_hub`。
+
+注册一个指向 `agentuniverse.agent.action.knowledge.embedding.huggingface_embedding.HuggingFaceEmbedding` 的组件，然后在 store 或处理器中按名引用（如 `embedding_model: huggingface_embedding`）。API Key 从 `HUGGINGFACE_API_KEY`（或 `HF_TOKEN`）读取。
+
+```yaml
+name: 'huggingface_embedding'
+description: 'embedding via Hugging Face Hub Inference API'
+embedding_model_name: 'sentence-transformers/all-MiniLM-L6-v2'
+api_key: '${HUGGINGFACE_API_KEY}'
+timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.huggingface_embedding'
+  class: 'HuggingFaceEmbedding'
+```
+- embedding_model_name：Hugging Face 模型 repo ID（默认 `sentence-transformers/all-MiniLM-L6-v2`）。
+- api_key：Hugging Face API token（环境变量 `HUGGINGFACE_API_KEY` 或 `HF_TOKEN`）。
+- timeout：请求超时秒数（默认 30）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_huggingface_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_huggingface_embedding.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for HuggingFaceEmbedding."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.embedding.huggingface_embedding \
+    import HuggingFaceEmbedding
+
+
+class TestHuggingFaceEmbedding(unittest.TestCase):
+
+    def test_get_embeddings_single_text(self):
+        emb = HuggingFaceEmbedding(
+            embedding_model_name="sentence-transformers/all-MiniLM-L6-v2",
+            api_key="fake-key")
+        mock_client = MagicMock()
+        mock_client.feature_extraction.return_value = [0.1, 0.2, 0.3]
+        emb._client = mock_client
+
+        result = emb.get_embeddings(["hello world"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], [0.1, 0.2, 0.3])
+
+    def test_get_embeddings_multiple_texts(self):
+        emb = HuggingFaceEmbedding(api_key="k")
+        mock_client = MagicMock()
+        mock_client.feature_extraction.side_effect = [
+            [0.1, 0.2], [0.3, 0.4],
+        ]
+        emb._client = mock_client
+
+        result = emb.get_embeddings(["text1", "text2"])
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], [0.1, 0.2])
+        self.assertEqual(result[1], [0.3, 0.4])
+
+    def test_get_embeddings_handles_nested_list(self):
+        emb = HuggingFaceEmbedding(api_key="k")
+        mock_client = MagicMock()
+        # Model returns [[token1_emb]] — single sentence, token-level.
+        mock_client.feature_extraction.return_value = [[0.1, 0.2], [0.3, 0.4]]
+        emb._client = mock_client
+
+        result = emb.get_embeddings(["test"])
+        # Mean-pool: [(0.1+0.3)/2, (0.2+0.4)/2] = [0.2, 0.3]
+        self.assertAlmostEqual(result[0][0], 0.2, places=5)
+        self.assertAlmostEqual(result[0][1], 0.3, places=5)
+
+    def test_empty_input_returns_empty(self):
+        emb = HuggingFaceEmbedding(api_key="k")
+        result = emb.get_embeddings([])
+        self.assertEqual(result, [])
+
+    def test_missing_model_name_raises(self):
+        emb = HuggingFaceEmbedding(api_key="k")
+        emb.embedding_model_name = None
+        with self.assertRaises(ValueError):
+            emb.get_embeddings(["text"])
+
+    def test_api_error_returns_empty_vector(self):
+        emb = HuggingFaceEmbedding(api_key="k")
+        mock_client = MagicMock()
+        mock_client.feature_extraction.side_effect = RuntimeError("API down")
+        emb._client = mock_client
+
+        result = emb.get_embeddings(["text"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], [])
+
+    def test_env_var_defaults(self):
+        with patch.dict("os.environ", {"HUGGINGFACE_API_KEY": "env-key"}):
+            emb = HuggingFaceEmbedding()
+            self.assertEqual(emb.api_key, "env-key")
+
+    def test_hf_token_fallback(self):
+        with patch.dict("os.environ", {"HF_TOKEN": "token-val"}, clear=True):
+            emb = HuggingFaceEmbedding()
+            self.assertEqual(emb.api_key, "token-val")
+
+    def test_mean_pool(self):
+        result = HuggingFaceEmbedding._mean_pool([[1.0, 2.0], [3.0, 4.0]])
+        self.assertEqual(result, [2.0, 3.0])
+
+    def test_mean_pool_empty(self):
+        self.assertEqual(HuggingFaceEmbedding._mean_pool([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `HuggingFaceEmbedding` — generates text embeddings using models hosted on the Hugging Face Hub via `InferenceClient`. Explicitly requested in #250.

## Why (not a duplicate)

Not covered by any open or merged PR. #250 lists HuggingFace Hub as a required component; the framework has `OpenAIEmbedding`, `GeminiEmbedding`, `DashscopeEmbedding` etc. but no HuggingFace option.

## Capabilities

- Sync and async embedding generation.
- Token-level mean-pooling when model returns per-token embeddings.
- API error graceful degradation (returns empty vector for failed text, logs warning).
- Environment variable defaults: `HUGGINGFACE_API_KEY` / `HF_TOKEN`.
- Configurable timeout (default 30s).
- Lazy import (`huggingface_hub` optional; not required at framework startup).

## Tests

`tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_huggingface_embedding.py` — 10 unit tests: single/multiple text embeddings, nested list handling, empty input, missing model_name, API error graceful fallback, env var defaults, HF_TOKEN fallback, mean-pool, empty pool.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.embedding.test_huggingface_embedding` — 10 passed.
