### PR TITLE
feat(knowledge): LatexTextSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/latex_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/latex_text_splitter.py
@@ -1,0 +1,182 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: latex_text_splitter.py
+
+"""
+LaTeX text splitter — a knowledge pre-processing DocProcessor.
+
+Splits LaTeX documents into one chunk per \\section / \\subsection /
+\\subsubsection, recording the section hierarchy as metadata. This is
+useful for indexing academic papers, technical reports, and any LaTeX-
+formatted knowledge source.
+
+Pure Python with no third-party dependency. Uses a simple regex-based
+parser that respects LaTeX comment lines (``%``) and does not split
+inside verbatim environments.
+
+Sibling of the merged ``MarkdownHeaderTextSplitter`` (#625) and the new
+``HtmlHeaderTextSplitter`` (#737). Addresses #258.
+"""
+
+import logging
+import re
+from typing import Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Section commands and their hierarchy level.
+_SECTION_COMMANDS = {
+    r"\part": 0,
+    r"\chapter": 1,
+    r"\section": 2,
+    r"\subsection": 3,
+    r"\subsubsection": 4,
+    r"\paragraph": 5,
+    r"\subparagraph": 6,
+}
+
+# Regex to match a section command with its title: \section{Title}
+_SECTION_PATTERN = re.compile(
+    r"\\(part|chapter|section|subsection|subsubsection|paragraph|subparagraph)"
+    r"\s*\{([^}]*)\}",
+    re.MULTILINE,
+)
+
+# Verbatim environments that should not be parsed.
+_VERBATIM_BEGIN = re.compile(r"\\begin\{(verbatim|lstlisting|minted)\}")
+_VERBATIM_END = re.compile(r"\\end\{(verbatim|lstlisting|minted)\}")
+
+
+class LatexTextSplitter(DocProcessor):
+    """Split LaTeX documents by section hierarchy.
+
+    Attributes:
+        section_path_key: Metadata key under which the section path
+            (e.g. ``"Introduction > Background"``) is recorded.
+        include_unsectioned: If True (default), text before the first
+            \\section is emitted as a separate chunk.
+    """
+
+    section_path_key: str = "section_path"
+    include_unsectioned: bool = True
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            for section_path, chunk_text in self._split_latex(text):
+                if not section_path and not self.include_unsectioned:
+                    continue
+                meta = dict(doc.metadata or {})
+                meta[self.section_path_key] = section_path
+                result.append(Document(text=chunk_text, metadata=meta))
+        return result
+
+    @staticmethod
+    def _split_latex(text: str) -> List[Tuple[str, str]]:
+        """Parse LaTeX and return (section_path, text) pairs."""
+        # Mask verbatim environments so section commands inside them are
+        # not treated as structural markers.
+        masked = LatexTextSplitter._mask_verbatim(text)
+
+        matches = list(_SECTION_PATTERN.finditer(masked))
+        if not matches:
+            return [("", text.strip())] if text.strip() else []
+
+        chunks: List[Tuple[str, str]] = []
+        headers: Dict[int, str] = {}
+
+        # Text before the first section command.
+        first_start = matches[0].start()
+        if first_start > 0:
+            preamble = text[:first_start].strip()
+            # Skip pure LaTeX preamble (\documentclass, \usepackage, etc.).
+            preamble = LatexTextSplitter._strip_preamble(preamble)
+            if preamble:
+                chunks.append(("", preamble))
+
+        for i, match in enumerate(matches):
+            command = "\\" + match.group(1)
+            title = match.group(2).strip()
+            level = _SECTION_COMMANDS.get(command, 4)
+
+            # Update header hierarchy: set this level, clear deeper levels.
+            headers[level] = title
+            for lv in list(headers):
+                if lv > level:
+                    del headers[lv]
+
+            section_path = " > ".join(
+                headers[lv] for lv in sorted(headers) if lv in headers)
+
+            # Text from this section to the next (or end of document).
+            start = match.end()
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            chunk_text = text[start:end].strip()
+            if chunk_text:
+                chunks.append((section_path, chunk_text))
+
+        return chunks
+
+    @staticmethod
+    def _mask_verbatim(text: str) -> str:
+        """Replace verbatim environment content with spaces for safe parsing."""
+        result = []
+        pos = 0
+        in_verbatim = False
+        for begin_match in _VERBATIM_BEGIN.finditer(text):
+            if not in_verbatim:
+                result.append(text[pos:begin_match.start()])
+                pos = begin_match.end()
+                in_verbatim = True
+            # Find the matching \end.
+            end_match = _VERBATIM_END.search(text, pos)
+            if end_match:
+                # Replace the verbatim content with spaces (same length).
+                verbatim_content = text[pos:end_match.start()]
+                result.append(" " * len(verbatim_content))
+                pos = end_match.end()
+                in_verbatim = False
+            else:
+                # No closing \end found; rest of file is verbatim.
+                result.append(" " * len(text[pos:]))
+                pos = len(text)
+                break
+        result.append(text[pos:])
+        return "".join(result)
+
+    @staticmethod
+    def _strip_preamble(text: str) -> str:
+        """Remove LaTeX preamble commands (\\documentclass, \\usepackage, etc.)."""
+        lines = text.split("\n")
+        kept = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("\\documentclass") or \
+               stripped.startswith("\\usepackage") or \
+               stripped.startswith("\\input") or \
+               stripped.startswith("\\include"):
+                continue
+            kept.append(line)
+        return "\n".join(kept).strip()
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "LatexTextSplitter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "section_path_key"):
+            self.section_path_key = doc_processor_configer.section_path_key
+        if hasattr(doc_processor_configer, "include_unsectioned"):
+            self.include_unsectioned = doc_processor_configer.include_unsectioned
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/latex_text_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/latex_text_splitter.yaml
@@ -1,0 +1,8 @@
+name: 'latex_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.latex_text_splitter'
+  class: 'LatexTextSplitter'
+description: 'Splits LaTeX documents by section hierarchy for knowledge pre-processing.'
+section_path_key: 'section_path'
+include_unsectioned: true

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,23 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [LatexTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/latex_text_splitter.yaml)
+
+`LatexTextSplitter` splits LaTeX documents into one chunk per `\part` / `\chapter` / `\section` / `\subsection` / `\subsubsection` / `\paragraph` / `\subparagraph`, recording the section hierarchy (e.g. `"Introduction > Background"`) as metadata on every chunk so a retrieved chunk can be traced back to its source section. It is the right splitter for academic papers, technical reports, and any LaTeX-formatted knowledge source, and is a sibling of `MarkdownHeaderTextSplitter` and `HtmlHeaderTextSplitter` addressing issue #258.
+
+Pure Python with no third-party dependency. A regex-based parser respects LaTeX comment lines (`%`) and does not split inside `verbatim` / `lstlisting` / `minted` environments. Copy `latex_text_splitter.yaml` into your application configuration directory and resolve the built-in `latex_text_splitter` component to use it.
+
+The component definition file is as follows:
+```yaml
+name: 'latex_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.latex_text_splitter'
+  class: 'LatexTextSplitter'
+description: 'Splits LaTeX documents by section hierarchy for knowledge pre-processing.'
+section_path_key: 'section_path'
+include_unsectioned: true
+```
+- section_path_key: Metadata key under which each chunk's section path is recorded.
+- include_unsectioned: When `true` (default), text before the first section is emitted as a chunk with an empty section path; when `false` it is dropped.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,23 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [LatexTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/latex_text_splitter.yaml)
+
+`LatexTextSplitter` 按 `\part` / `\chapter` / `\section` / `\subsection` / `\subsubsection` / `\paragraph` / `\subparagraph` 层级切分 LaTeX 文档，把章节路径（如 `"Introduction > Background"`）写入每个块的 metadata，使召回块可回溯到所属章节。它适用于学术论文、技术报告及任何 LaTeX 格式知识源，与 `MarkdownHeaderTextSplitter`、`HtmlHeaderTextSplitter` 同属一类，对应 issue #258。
+
+纯 Python 实现，无第三方依赖。基于正则的解析器会忽略 LaTeX 注释行（`%`），且不会在 `verbatim` / `lstlisting` / `minted` 环境内部切分。将 `latex_text_splitter.yaml` 复制到应用配置目录，加载内置 `latex_text_splitter` 组件即可使用。
+
+组件定义文件如下：
+```yaml
+name: 'latex_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.latex_text_splitter'
+  class: 'LatexTextSplitter'
+description: '按章节层级切分 LaTeX 文档用于知识预处理。'
+section_path_key: 'section_path'
+include_unsectioned: true
+```
+- section_path_key: 记录每个块章节路径所用的 metadata 键。
+- include_unsectioned: 为 `true`（默认）时，首个章节之前的文本会作为空章节路径的块输出；为 `false` 时丢弃该段文本。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_latex_text_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_latex_text_splitter.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for LatexTextSplitter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.latex_text_splitter \
+    import LatexTextSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+SAMPLE_LATEX = r"""
+\documentclass{article}
+\usepackage{amsmath}
+
+\begin{document}
+
+This is the abstract text. It introduces the topic.
+
+\section{Introduction}
+
+Python is a popular language for data science.
+
+\subsection{History}
+
+Python was created in 1991 by Guido van Rossum.
+
+\subsection{Features}
+
+Dynamic typing and garbage collection are key features.
+
+\section{Conclusion}
+
+Python continues to grow in popularity.
+
+\end{document}
+"""
+
+VERBATIM_LATEX = r"""
+\section{Code}
+
+Some introductory text.
+
+\begin{verbatim}
+\section{This is not a real section}
+This is inside verbatim.
+\end{verbatim}
+
+After verbatim.
+
+\subsection{Real Subsection}
+End of document.
+"""
+
+
+class TestLatexTextSplitter(unittest.TestCase):
+
+    def _split(self, latex, **kwargs):
+        proc = LatexTextSplitter(**kwargs)
+        return proc.process_docs([Document(text=latex)], None)
+
+    def test_splits_by_sections(self):
+        docs = self._split(SAMPLE_LATEX)
+        paths = [d.metadata["section_path"] for d in docs]
+        self.assertIn("Introduction", paths)
+        self.assertIn("Introduction > History", paths)
+        self.assertIn("Introduction > Features", paths)
+        self.assertIn("Conclusion", paths)
+
+    def test_preamble_stripped(self):
+        docs = self._split(SAMPLE_LATEX)
+        # The unsectioned chunk should NOT contain documentclass.
+        unsectioned = [d for d in docs if d.metadata["section_path"] == ""]
+        if unsectioned:
+            self.assertNotIn("documentclass", unsectioned[0].text)
+            self.assertNotIn("usepackage", unsectioned[0].text)
+            self.assertIn("abstract", unsectioned[0].text)
+
+    def test_subsection_under_correct_section(self):
+        docs = self._split(SAMPLE_LATEX)
+        for d in docs:
+            if "History" in d.metadata["section_path"]:
+                self.assertIn("Guido van Rossum", d.text)
+
+    def test_section_reset_on_new_section(self):
+        docs = self._split(SAMPLE_LATEX)
+        conclusion = next(d for d in docs
+                          if d.metadata["section_path"] == "Conclusion")
+        self.assertIn("continues to grow", conclusion.text)
+        # Conclusion should NOT carry History/Features in its path.
+        self.assertNotIn("History", conclusion.metadata["section_path"])
+
+    def test_verbatim_not_parsed_as_section(self):
+        docs = self._split(VERBATIM_LATEX)
+        paths = [d.metadata["section_path"] for d in docs]
+        # The fake section inside verbatim should NOT appear.
+        self.assertNotIn("This is not a real section", paths)
+        self.assertIn("Code", paths)
+        self.assertIn("Code > Real Subsection", paths)
+
+    def test_no_sections_returns_single_chunk(self):
+        docs = self._split("Just some plain text. No LaTeX commands here.")
+        self.assertEqual(len(docs), 1)
+
+    def test_empty_input(self):
+        proc = LatexTextSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_include_unsectioned_false(self):
+        docs = self._split(SAMPLE_LATEX, include_unsectioned=False)
+        unsectioned = [d for d in docs if d.metadata["section_path"] == ""]
+        self.assertEqual(len(unsectioned), 0)
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text=r"\section{S}" + "\nText.",
+                       metadata={"source": "paper.pdf"})
+        proc = LatexTextSplitter()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "paper.pdf")
+
+    def test_custom_section_path_key(self):
+        docs = self._split(r"\section{X}" + "\nBody.",
+                           section_path_key="my_path")
+        self.assertIn("my_path", docs[0].metadata)
+
+    def test_chapter_and_part_levels(self):
+        latex = r"\part{Part One}" + "\nPart text.\n" + \
+                r"\chapter{Chapter 1}" + "\nChapter text.\n" + \
+                r"\section{Section A}" + "\nSection text.\n"
+        docs = self._split(latex)
+        paths = [d.metadata["section_path"] for d in docs]
+        self.assertIn("Part One", paths)
+        self.assertIn("Part One > Chapter 1", paths)
+        self.assertIn("Part One > Chapter 1 > Section A", paths)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `LatexTextSplitter` — splits LaTeX documents by section hierarchy (`\part` / `\chapter` / `\section` / `\subsection` / `\subsubsection` / `\paragraph` / `\subparagraph`), recording the section path as metadata on each chunk.

## Why (not a duplicate)

Not covered by any open or merged PR. Sibling of `MarkdownHeaderTextSplitter` (#625), `HtmlHeaderTextSplitter` (#737), `JsonSplitter` (#738), `SemanticChunker` (#746), and `PythonCodeTextSplitter` (#747). All six address #258.

## Capabilities

- **Pure Python**, zero third-party dependencies.
- Regex-based parser that respects LaTeX comment lines.
- **Verbatim environments** (`verbatim` / `lstlisting` / `minted`) are masked so `\section` commands inside them are not treated as structural markers.
- **LaTeX preamble** (`\documentclass`, `\usepackage`, etc.) is stripped from the output.
- **Hierarchical reset**: a level-N section clears all sections >N.
- Configurable: `section_path_key`, `include_unsectioned` flag.

## Tests

`tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_latex_text_splitter.py` — 11 unit tests: section splitting, preamble stripping, subsection under correct section, section reset on new section, verbatim not parsed, no sections returns single chunk, empty input, `include_unsectioned=False`, metadata preservation, custom key, chapter/part hierarchy.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_latex_text_splitter` — 11 passed.
