### PR TITLE
feat(knowledge): MarkdownTextSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_text_splitter.py
@@ -1,0 +1,226 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: markdown_text_splitter.py
+
+"""
+Markdown text splitter — a knowledge pre-processing DocProcessor.
+
+Splits Markdown documents into chunks along structural boundaries (code
+fences, list blocks, blockquotes, table blocks, and paragraph breaks),
+while respecting ``max_chunk_size``. Unlike ``MarkdownHeaderTextSplitter``
+(#625) which splits by header hierarchy, this splitter focuses on keeping
+structurally cohesive blocks together and only splitting when a chunk
+exceeds the size budget.
+
+Pure Python, zero third-party dependency. Addresses #258.
+"""
+
+import logging
+import re
+from typing import List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Block-level patterns that should not be split mid-block.
+_CODE_FENCE_START = re.compile(r"^(`{3,}|~{3,})", re.MULTILINE)
+_TABLE_ROW = re.compile(r"^\|.*\|$")
+_HR = re.compile(r"^(-{3,}|\*{3,}|_{3,})\s*$")
+_BLOCKQUOTE = re.compile(r"^>\s")
+_LIST_ITEM = re.compile(r"^(\s*)([-*+]|\d+\.)\s")
+_HEADING = re.compile(r"^#{1,6}\s")
+
+
+class MarkdownTextSplitter(DocProcessor):
+    """Split Markdown by structural blocks with size-bounded chunking.
+
+    Attributes:
+        max_chunk_size: Maximum characters per chunk (default 1500).
+        min_chunk_size: Minimum characters; smaller chunks are merged into
+            the next one (default 200).
+        chunk_overlap: Number of characters of overlap between adjacent
+            chunks when a hard split is needed (default 100).
+    """
+
+    max_chunk_size: int = 1500
+    min_chunk_size: int = 200
+    chunk_overlap: int = 100
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            for chunk_text in self._split(text):
+                meta = dict(doc.metadata or {})
+                meta["chunk_method"] = "markdown_text"
+                result.append(Document(text=chunk_text, metadata=meta))
+        return result
+
+    def _split(self, text: str) -> List[str]:
+        blocks = self._identify_blocks(text)
+        chunks = self._assemble_chunks(blocks)
+        return chunks
+
+    @staticmethod
+    def _identify_blocks(text: str) -> List[str]:
+        """Split text into structural blocks (code, table, list, paragraph)."""
+        lines = text.split("\n")
+        blocks: List[str] = []
+        current: List[str] = []
+        in_code_fence = False
+        fence_marker = None
+
+        def _flush():
+            if current:
+                blocks.append("\n".join(current).strip())
+                current.clear()
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Code fence handling.
+            fence_match = _CODE_FENCE_START.match(stripped)
+            if fence_match:
+                if not in_code_fence:
+                    _flush()
+                    in_code_fence = True
+                    fence_marker = fence_match.group(1)[0]
+                    current.append(line)
+                elif in_code_fence and stripped.startswith(fence_marker * 3):
+                    current.append(line)
+                    in_code_fence = False
+                    fence_marker = None
+                    _flush()
+                else:
+                    current.append(line)
+                continue
+
+            if in_code_fence:
+                current.append(line)
+                continue
+
+            # Structural boundaries that flush the current block.
+            is_heading = bool(_HEADING.match(stripped))
+            is_hr = bool(_HR.match(stripped))
+            is_table = bool(_TABLE_ROW.match(stripped))
+            is_blockquote = bool(_BLOCKQUOTE.match(stripped))
+            is_list = bool(_LIST_ITEM.match(stripped))
+            is_blank = stripped == ""
+
+            # Transition between block types — flush.
+            prev_stripped = current[-1].strip() if current else ""
+            prev_is_table = bool(_TABLE_ROW.match(prev_stripped))
+            prev_is_list = bool(_LIST_ITEM.match(prev_stripped))
+            prev_is_blockquote = bool(_BLOCKQUOTE.match(prev_stripped))
+
+            if (is_heading or is_hr) and current:
+                _flush()
+            elif is_table and current and not prev_is_table:
+                _flush()
+            elif is_list and current and not prev_is_list and not is_blank:
+                _flush()
+            elif is_blockquote and current and not prev_is_blockquote:
+                _flush()
+            elif is_blank and current and prev_stripped:
+                _flush()
+
+            current.append(line)
+
+        _flush()
+        return [b for b in blocks if b]
+
+    def _assemble_chunks(self, blocks: List[str]) -> List[str]:
+        """Group blocks into chunks respecting max/min chunk size."""
+        if not blocks:
+            return []
+
+        chunks: List[str] = []
+        current_parts: List[str] = []
+        current_size = 0
+
+        for block in blocks:
+            block_size = len(block)
+
+            if block_size > self.max_chunk_size:
+                # Flush current chunk first.
+                if current_parts:
+                    chunks.append("\n\n".join(current_parts))
+                    current_parts = []
+                    current_size = 0
+                # Hard-split the oversized block.
+                chunks.extend(self._hard_split_block(block))
+                continue
+
+            if current_size + block_size + 2 > self.max_chunk_size:
+                # Flush current, start new chunk.
+                if current_parts and current_size >= self.min_chunk_size:
+                    chunks.append("\n\n".join(current_parts))
+                    current_parts = []
+                    current_size = 0
+                elif current_parts:
+                    # Merge because current is below min_chunk_size.
+                    pass
+
+            current_parts.append(block)
+            current_size += block_size + 2  # +2 for "\n\n"
+
+        if current_parts:
+            chunks.append("\n\n".join(current_parts))
+
+        return [c.strip() for c in chunks if c.strip()]
+
+    def _hard_split_block(self, block: str) -> List[str]:
+        """Split a block that exceeds max_chunk_size at line boundaries."""
+        lines = block.split("\n")
+        parts: List[str] = []
+        current: List[str] = []
+        current_size = 0
+
+        for line in lines:
+            if current_size + len(line) + 1 > self.max_chunk_size and current:
+                parts.append("\n".join(current))
+                # Overlap: carry last few lines.
+                overlap_lines = self._overlap_lines(current)
+                current = overlap_lines + [line]
+                current_size = sum(len(l) + 1 for l in current)
+            else:
+                current.append(line)
+                current_size += len(line) + 1
+
+        if current:
+            parts.append("\n".join(current))
+
+        return [p.strip() for p in parts if p.strip()]
+
+    def _overlap_lines(self, lines: List[str]) -> List[str]:
+        """Return the trailing lines fitting within chunk_overlap."""
+        overlap: List[str] = []
+        size = 0
+        for line in reversed(lines):
+            size += len(line) + 1
+            if size > self.chunk_overlap:
+                break
+            overlap.insert(0, line)
+        return overlap
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "MarkdownTextSplitter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "max_chunk_size"):
+            self.max_chunk_size = doc_processor_configer.max_chunk_size
+        if hasattr(doc_processor_configer, "min_chunk_size"):
+            self.min_chunk_size = doc_processor_configer.min_chunk_size
+        if hasattr(doc_processor_configer, "chunk_overlap"):
+            self.chunk_overlap = doc_processor_configer.chunk_overlap
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_text_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_text_splitter.yaml
@@ -1,0 +1,9 @@
+name: 'markdown_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.markdown_text_splitter'
+  class: 'MarkdownTextSplitter'
+description: 'Splits Markdown by structural blocks (code, table, list, paragraph) with size-bounded chunking.'
+max_chunk_size: 1500
+min_chunk_size: 200
+chunk_overlap: 100

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,25 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [MarkdownTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/markdown_text_splitter.yaml)
+
+`MarkdownTextSplitter` splits Markdown documents along structural boundaries — code fences, list blocks, blockquotes, table blocks, and paragraph breaks — while respecting a configurable size budget. Unlike `MarkdownHeaderTextSplitter` (#625), which splits by header hierarchy, this splitter focuses on keeping structurally cohesive blocks together and only splitting when a chunk exceeds `max_chunk_size`. It addresses issue #258.
+
+Pure Python with zero third-party dependency. Copy `markdown_text_splitter.yaml` into your application configuration directory and resolve the built-in `markdown_text_splitter` component to use it. Each produced chunk carries `chunk_method: "markdown_text"` in its metadata.
+
+The component definition file is as follows:
+```yaml
+name: 'markdown_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.markdown_text_splitter'
+  class: 'MarkdownTextSplitter'
+description: 'Splits Markdown by structural blocks (code, table, list, paragraph) with size-bounded chunking.'
+max_chunk_size: 1500
+min_chunk_size: 200
+chunk_overlap: 100
+```
+- max_chunk_size: Maximum characters per chunk (default 1500).
+- min_chunk_size: Minimum characters; smaller chunks are merged into the next one (default 200).
+- chunk_overlap: Number of characters of overlap between adjacent chunks when a hard split is needed (default 100).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,25 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [MarkdownTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/markdown_text_splitter.yaml)
+
+`MarkdownTextSplitter` 沿结构边界切分 Markdown 文档——代码块、列表、引用块、表格块、段落换行——同时遵守可配置的大小预算。与按标题层级切分的 `MarkdownHeaderTextSplitter`（#625）不同，本切分器优先保持结构上聚合的块完整，只有当块超出 `max_chunk_size` 时才进一步切分。对应 issue #258。
+
+纯 Python 实现，零第三方依赖。将 `markdown_text_splitter.yaml` 复制到应用配置目录，加载内置 `markdown_text_splitter` 组件即可使用。每个生成的块在 metadata 中带 `chunk_method: "markdown_text"`。
+
+组件定义文件如下：
+```yaml
+name: 'markdown_text_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.markdown_text_splitter'
+  class: 'MarkdownTextSplitter'
+description: '按结构块（代码、表格、列表、段落）切分 Markdown，并以大小约束分块。'
+max_chunk_size: 1500
+min_chunk_size: 200
+chunk_overlap: 100
+```
+- max_chunk_size: 每块最大字符数（默认 1500）。
+- min_chunk_size: 最小字符数；过小的块会被合并到下一块（默认 200）。
+- chunk_overlap: 硬切分时相邻块之间的重叠字符数（默认 100）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_markdown_text_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_markdown_text_splitter.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for MarkdownTextSplitter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.markdown_text_splitter \
+    import MarkdownTextSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+SAMPLE_MD = """# Title
+
+First paragraph of text.
+
+Second paragraph here.
+
+```python
+def hello():
+    print("hello world")
+```
+
+| Col A | Col B |
+|-------|-------|
+| 1     | 2     |
+
+- Item one
+- Item two
+- Item three
+
+> A blockquote.
+
+Final paragraph.
+"""
+
+
+class TestMarkdownTextSplitter(unittest.TestCase):
+
+    def _split(self, md, **kwargs):
+        proc = MarkdownTextSplitter(**kwargs)
+        return proc.process_docs([Document(text=md)], None)
+
+    def test_code_fence_kept_intact(self):
+        docs = self._split(SAMPLE_MD, max_chunk_size=5000)
+        combined = " ".join(d.text for d in docs)
+        self.assertIn("```python", combined)
+        self.assertIn("def hello", combined)
+
+    def test_multiple_chunks_for_large_doc(self):
+        long = "Paragraph text here.\n\n" * 100
+        docs = self._split(long, max_chunk_size=200)
+        self.assertGreater(len(docs), 1)
+
+    def test_short_doc_single_chunk(self):
+        docs = self._split("Short text.\n")
+        self.assertEqual(len(docs), 1)
+
+    def test_empty_input(self):
+        proc = MarkdownTextSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_max_chunk_size_respected(self):
+        docs = self._split("Line.\n" * 200, max_chunk_size=100)
+        for d in docs:
+            self.assertLessEqual(len(d.text), 110)
+
+    def test_min_chunk_size_merges_small(self):
+        docs = self._split("A.\n\nB.\n\nC.\n\n", max_chunk_size=200, min_chunk_size=50)
+        # Small paragraphs merged, not one-per-chunk.
+        self.assertLess(len(docs), 4)
+
+    def test_code_fence_not_split_mid_block(self):
+        code = "```python\n" + "x = 1\n" * 50 + "```\n"
+        docs = self._split(code, max_chunk_size=100)
+        # The code block exceeds max_chunk_size, so it's hard-split.
+        self.assertGreater(len(docs), 1)
+
+    def test_table_block_kept_together(self):
+        md = "| A | B |\n|---|---|\n| 1 | 2 |\n"
+        docs = self._split(md, max_chunk_size=5000)
+        combined = " ".join(d.text for d in docs)
+        self.assertIn("| A | B |", combined)
+
+    def test_metadata_includes_chunk_method(self):
+        docs = self._split("Hello.")
+        self.assertEqual(docs[0].metadata["chunk_method"], "markdown_text")
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="Some text.", metadata={"source": "test"})
+        proc = MarkdownTextSplitter()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "test")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `MarkdownTextSplitter` — splits Markdown documents into chunks along structural boundaries (code fences, tables, lists, blockquotes, headings, paragraph breaks) while respecting configurable max/min chunk size.

## Why (not a duplicate)

Not covered by any open or merged PR. `MarkdownHeaderTextSplitter` (#625) splits by header hierarchy; this splitter focuses on keeping structurally cohesive blocks together (code blocks, tables) and only splitting when a chunk exceeds the size budget, with configurable overlap. Complementary, not overlapping.

## Capabilities

- **Pure Python**, zero third-party dependencies.
- **Block-aware splitting**: code fences, tables, lists, blockquotes, and headings are treated as atomic blocks when possible.
- **Size-bounded**: `max_chunk_size` (1500), `min_chunk_size` (200), `chunk_overlap` (100).
- **Hard-split**: oversized blocks (e.g. very long code) are split at line boundaries with overlap.
- **Merge**: blocks below `min_chunk_size` are merged into the next chunk.

## Tests

10 unit tests: code fence kept intact, multiple chunks for large docs, short doc single chunk, empty input, max_chunk_size respected, min_chunk_size merges, code fence hard-split, table block kept together, metadata, original metadata preserved.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_markdown_text_splitter` — 10 passed.
