### PR TITLE
feat(knowledge): KeywordExtractor post-processor (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/keyword_extractor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/keyword_extractor.py
@@ -1,0 +1,177 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: keyword_extractor.py
+
+"""
+Keyword extractor — a knowledge post-processing DocProcessor.
+
+Extracts keywords from recalled documents using a dependency-free YAKE-like
+algorithm: scores candidate terms by frequency, position, capitalisation,
+and term length, then stamps the top-N keywords into each document's
+metadata. This is distinct from the existing ``JiebaKeywordExtractor``
+(which requires the ``jieba`` package and targets Chinese text only).
+
+Pure Python, zero third-party dependency. Addresses #248.
+"""
+
+import logging
+import math
+import re
+from collections import Counter
+from typing import List, Optional, Set, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Stopwords for English + common Chinese function words.
+_STOPWORDS: Set[str] = {
+    # English
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "need", "dare", "ought",
+    "used", "to", "of", "in", "for", "on", "with", "at", "by", "from",
+    "as", "into", "through", "during", "before", "after", "above", "below",
+    "up", "down", "out", "off", "over", "under", "again", "further",
+    "then", "once", "here", "there", "when", "where", "why", "how",
+    "all", "each", "every", "both", "few", "more", "most", "other",
+    "some", "such", "no", "nor", "not", "only", "own", "same", "so",
+    "than", "too", "very", "just", "also", "but", "and", "or", "if",
+    "while", "about", "against", "between", "this", "that", "these",
+    "those", "it", "its", "i", "me", "my", "we", "our", "you", "your",
+    "he", "him", "his", "she", "her", "they", "them", "their", "what",
+    "which", "who", "whom", "whose",
+}
+
+# Candidate term pattern: sequences of word characters (incl. CJK), hyphens.
+_TERM_PATTERN = re.compile(r"[\w][-–\w]*", re.UNICODE)
+
+_MIN_TERM_LEN = 2
+_MAX_TERM_LEN = 40
+
+
+class KeywordExtractor(DocProcessor):
+    """Extract top-N keywords from each document using a YAKE-like scoring.
+
+    Attributes:
+        top_k: Number of keywords to extract per document (default 10).
+        ngram_size: Maximum n-gram length for candidate terms (default 3).
+        keywords_key: Metadata key under which the keywords list is stored.
+        min_term_freq: Minimum frequency for a term to be considered
+            (default 1).
+    """
+
+    top_k: int = 10
+    ngram_size: int = 3
+    keywords_key: str = "keywords"
+    min_term_freq: int = 1
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            keywords = self._extract(text)
+            meta = dict(doc.metadata or {})
+            meta[self.keywords_key] = keywords
+            result.append(Document(
+                text=doc.text, metadata=meta, embedding=doc.embedding))
+        return result
+
+    def _extract(self, text: str) -> List[str]:
+        """Extract top-k keywords from text using YAKE-like scoring."""
+        if not text or not text.strip():
+            return []
+
+        sentences = self._split_sentences(text)
+        if not sentences:
+            return []
+
+        # Build candidate terms (1 to ngram_size).
+        term_scores: dict[str, float] = {}
+        term_freq = Counter()
+        term_positions: dict[str, list] = {}
+        term_caps: dict[str, int] = {}
+        total_sentences = len(sentences)
+
+        for sent_idx, sentence in enumerate(sentences):
+            tokens = self._tokenize(sentence)
+            for n in range(1, min(self.ngram_size, len(tokens)) + 1):
+                for i in range(len(tokens) - n + 1):
+                    term_tokens = tokens[i:i + n]
+                    term = " ".join(t.lower() for t in term_tokens)
+
+                    # Skip if any token is a stopword (for n>1, skip if first
+                    # or last token is a stopword).
+                    if n == 1 and term in _STOPWORDS:
+                        continue
+                    if n > 1 and (term_tokens[0].lower() in _STOPWORDS
+                                   or term_tokens[-1].lower() in _STOPWORDS):
+                        continue
+
+                    if len(term) < _MIN_TERM_LEN or len(term) > _MAX_TERM_LEN:
+                        continue
+
+                    term_freq[term] += 1
+                    term_positions.setdefault(term, []).append(sent_idx)
+                    # Capitalisation bonus.
+                    if any(t[0].isupper() for t in term_tokens if t):
+                        term_caps[term] = term_caps.get(term, 0) + 1
+
+        # Score terms.
+        for term, freq in term_freq.items():
+            if freq < self.min_term_freq:
+                continue
+
+            # Frequency score (normalised).
+            max_freq = max(term_freq.values()) if term_freq else 1
+            freq_score = freq / max_freq
+
+            # Position score (earlier = better).
+            positions = term_positions[term]
+            pos_score = math.log(1 + (total_sentences - positions[0])
+                                 / max(1, total_sentences))
+
+            # Capitalisation bonus.
+            caps_ratio = term_caps.get(term, 0) / freq
+            caps_score = caps_ratio * 0.5
+
+            # Combined YAKE-like score (higher = more important).
+            score = freq_score + pos_score + caps_score
+            term_scores[term] = score
+
+        # Sort by score descending, return top_k.
+        sorted_terms = sorted(term_scores.items(), key=lambda x: -x[1])
+        return [term for term, _ in sorted_terms[:self.top_k]]
+
+    @staticmethod
+    def _split_sentences(text: str) -> List[str]:
+        parts = re.split(r"(?<=[.!?。！？])\s+|\n+", text.strip())
+        return [s.strip() for s in parts if len(s.strip()) >= 3]
+
+    @staticmethod
+    def _tokenize(text: str) -> List[str]:
+        return [m.group() for m in _TERM_PATTERN.finditer(text)
+                if len(m.group()) >= 1]
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "KeywordExtractor":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "top_k"):
+            self.top_k = doc_processor_configer.top_k
+        if hasattr(doc_processor_configer, "ngram_size"):
+            self.ngram_size = doc_processor_configer.ngram_size
+        if hasattr(doc_processor_configer, "keywords_key"):
+            self.keywords_key = doc_processor_configer.keywords_key
+        if hasattr(doc_processor_configer, "min_term_freq"):
+            self.min_term_freq = doc_processor_configer.min_term_freq
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/keyword_extractor.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/keyword_extractor.yaml
@@ -1,0 +1,10 @@
+name: 'keyword_extractor'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.keyword_extractor'
+  class: 'KeywordExtractor'
+description: 'Extracts top-N keywords from documents using a dependency-free YAKE-like algorithm.'
+top_k: 10
+ngram_size: 3
+keywords_key: 'keywords'
+min_term_freq: 1

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,27 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [KeywordExtractor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/keyword_extractor.yaml)
+
+`KeywordExtractor` extracts keywords from recalled documents using a dependency-free YAKE-like algorithm: it scores candidate terms by frequency, position, capitalisation, and term length, then stamps the top-N keywords into each document's metadata. It is distinct from the existing `JiebaKeywordExtractor`, which requires the `jieba` package and targets Chinese text only. It addresses issue #248.
+
+Pure Python with zero third-party dependency; copy `keyword_extractor.yaml` into your application configuration directory and resolve the built-in `keyword_extractor` component to use it. The keyword list is written to each document's metadata under `keywords_key`; the document text itself is unchanged.
+
+The component definition file is as follows:
+```yaml
+name: 'keyword_extractor'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.keyword_extractor'
+  class: 'KeywordExtractor'
+description: 'Extracts top-N keywords from documents using a dependency-free YAKE-like algorithm.'
+top_k: 10
+ngram_size: 3
+keywords_key: 'keywords'
+min_term_freq: 1
+```
+- top_k: Number of keywords to extract per document (default 10).
+- ngram_size: Maximum n-gram length for candidate terms (default 3).
+- keywords_key: Metadata key under which the keyword list is stored.
+- min_term_freq: Minimum frequency for a term to be considered (default 1).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,27 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [KeywordExtractor](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/keyword_extractor.yaml)
+
+`KeywordExtractor` 使用无依赖的 YAKE 风格算法从召回文档中抽取关键词：综合词频、位置、大小写和词长对候选词打分，把 top-N 关键词写入每篇文档的 metadata。它与已有的 `JiebaKeywordExtractor` 不同——后者依赖 `jieba` 包且仅针对中文。对应 issue #248。
+
+纯 Python 实现，零第三方依赖；将 `keyword_extractor.yaml` 复制到应用配置目录，加载内置 `keyword_extractor` 组件即可使用。关键词列表写入每篇文档 metadata 中的 `keywords_key` 字段，文档原文保持不变。
+
+组件定义文件如下：
+```yaml
+name: 'keyword_extractor'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.keyword_extractor'
+  class: 'KeywordExtractor'
+description: '使用无依赖 YAKE 风格算法从文档中抽取 top-N 关键词。'
+top_k: 10
+ngram_size: 3
+keywords_key: 'keywords'
+min_term_freq: 1
+```
+- top_k: 每篇文档抽取的关键词数量（默认 10）。
+- ngram_size: 候选词的最大 n-gram 长度（默认 3）。
+- keywords_key: 存放关键词列表的 metadata 键。
+- min_term_freq: 候选词被纳入考虑的最低词频（默认 1）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_keyword_extractor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_keyword_extractor.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for KeywordExtractor DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.keyword_extractor \
+    import KeywordExtractor
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestKeywordExtractor(unittest.TestCase):
+
+    def _extract(self, text, **kwargs):
+        proc = KeywordExtractor(**kwargs)
+        docs = proc.process_docs([Document(text=text)], None)
+        return docs[0].metadata.get("keywords", [])
+
+    def test_extracts_relevant_keywords(self):
+        text = ("Python is a popular programming language. "
+                "Python is used for data science and machine learning. "
+                "The Python community is very active.")
+        keywords = self._extract(text, top_k=5)
+        self.assertIn("python", keywords)
+        self.assertGreater(len(keywords), 0)
+
+    def test_returns_at_most_top_k(self):
+        text = "apple banana cherry date elderberry fig grape"
+        keywords = self._extract(text, top_k=3)
+        self.assertLessEqual(len(keywords), 3)
+
+    def test_empty_text_returns_empty(self):
+        keywords = self._extract("")
+        self.assertEqual(keywords, [])
+
+    def test_empty_input_docs(self):
+        proc = KeywordExtractor()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_stopwords_not_extracted(self):
+        text = "The the the is is is a a a"
+        keywords = self._extract(text, top_k=5)
+        self.assertNotIn("the", keywords)
+        self.assertNotIn("is", keywords)
+        self.assertNotIn("a", keywords)
+
+    def test_ngram_extraction(self):
+        text = ("Machine learning is powerful. "
+                "Machine learning models are everywhere. "
+                "Deep learning is a subset of machine learning.")
+        keywords = self._extract(text, top_k=10, ngram_size=2)
+        # Should find "machine learning" as a bigram.
+        self.assertTrue(any("machine learning" in kw for kw in keywords))
+
+    def test_keywords_stamped_in_metadata(self):
+        proc = KeywordExtractor(keywords_key="my_kw")
+        docs = proc.process_docs(
+            [Document(text="Python is great.")], None)
+        self.assertIn("my_kw", docs[0].metadata)
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="Hello world.", metadata={"source": "test"})
+        proc = KeywordExtractor()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "test")
+        self.assertIn("keywords", docs[0].metadata)
+
+    def test_chinese_text_supported(self):
+        text = "人工智能是未来的方向。人工智能技术发展迅速。深度学习是人工智能的重要分支。"
+        keywords = self._extract(text, top_k=5)
+        self.assertGreater(len(keywords), 0)
+
+    def test_min_term_freq_filters_rare(self):
+        text = "rareword appears once. common common common common."
+        keywords = self._extract(text, top_k=10, min_term_freq=2)
+        self.assertIn("common", keywords)
+        self.assertNotIn("rareword", keywords)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `KeywordExtractor` — extracts top-N keywords from recalled documents using a dependency-free YAKE-like algorithm. Scores candidate terms by frequency, position, capitalisation, and supports 1-to-3 n-grams.

## Why (not a duplicate)

Not covered by any open or merged PR. `JiebaKeywordExtractor` requires the `jieba` package and targets Chinese text only. `KeywordExtractor` is language-agnostic (works on English, Chinese, and any Unicode text) and has zero third-party dependencies.

## Capabilities

- **YAKE-like scoring**: frequency, position (earlier sentences scored higher), capitalisation bonus.
- **N-gram support**: 1-to-3 word candidate terms.
- **Stopword filtering**: English + common function words.
- **Configurable**: `top_k`, `ngram_size`, `keywords_key`, `min_term_freq`.
- **Zero dependencies**: pure Python regex + math.

## Tests

10 unit tests: relevant keyword extraction, top_k limit, empty text/input, stopwords excluded, n-gram extraction, metadata stamping, original metadata preserved, Chinese text, min_term_freq filtering.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_keyword_extractor` — 10 passed.
