### PR TITLE
feat(tool): DateTimeTool — timezone conversion, parse, format, diff (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/datetime_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/datetime_tool.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Bounded datetime/timezone tool for agent workflows.
+
+Provides ``now``, ``convert``, ``format``, ``parse``, and ``diff``
+operations. All timezone conversions use the IANA timezone database via
+``zoneinfo`` (Python 3.9+, zero third-party dependency). Bounded:
+``parse`` rejects ambiguous formats, ``diff`` caps at a reasonable range.
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Common datetime formats, tried in order by parse().
+_PARSE_FORMATS = [
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%dT%H:%M",
+    "%Y-%m-%d",
+    "%Y/%m/%d %H:%M:%S",
+    "%Y/%m/%d",
+    "%d/%m/%Y %H:%M:%S",
+    "%d/%m/%Y",
+    "%m/%d/%Y %H:%M:%S",
+    "%m/%d/%Y",
+    "%d-%m-%Y %H:%M:%S",
+    "%d-%m-%Y",
+    "%B %d, %Y",
+    "%b %d, %Y",
+    "%d %B %Y",
+    "%d %b %Y",
+]
+
+_DEFAULT_FORMAT = "%Y-%m-%d %H:%M:%S %Z"
+
+
+class DateTimeTool(Tool):
+    """Datetime and timezone operations tool.
+
+    Attributes:
+        default_timezone: IANA timezone name for ``now`` when no timezone
+            is specified (default ``"UTC"``).
+        max_diff_days: Maximum absolute difference in days for ``diff``
+            to prevent overflow (default 100000).
+    """
+
+    default_timezone: str = "UTC"
+    max_diff_days: int = 100_000
+
+    def execute(self, mode: str, datetime_str: str = "",
+                timezone_str: str = "", target_timezone: str = "",
+                fmt: str = "", unit: str = "days",
+                **kwargs) -> dict:
+        try:
+            op = self._normalize_mode(mode)
+            if op == "now":
+                return self._now(timezone_str or self.default_timezone)
+            if op == "convert":
+                return self._convert(datetime_str, timezone_str, target_timezone, fmt)
+            if op == "format":
+                return self._format_dt(datetime_str, timezone_str, fmt)
+            if op == "parse":
+                return self._parse(datetime_str)
+            if op == "diff":
+                return self._diff(datetime_str, kwargs.get("end_datetime", ""),
+                                  timezone_str, unit)
+            return self._error("validation_error", f"Unknown mode: {mode}")
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("operation_error", str(exc))
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        normalized = mode.strip().lower()
+        allowed = {"now", "convert", "format", "parse", "diff"}
+        if normalized not in allowed:
+            raise ValueError(f"mode must be one of: {', '.join(sorted(allowed))}")
+        return normalized
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}
+
+    @staticmethod
+    def _ok(**kwargs) -> dict:
+        return {"status": "success", **kwargs}
+
+    def _get_tz(self, tz_name: str):
+        if not tz_name or tz_name.upper() == "UTC":
+            return timezone.utc
+        try:
+            return ZoneInfo(tz_name)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(
+                f"Unknown timezone: {tz_name!r}. Use an IANA timezone name "
+                f"like 'America/New_York', 'Asia/Shanghai', 'Europe/London'."
+            ) from exc
+
+    def _now(self, tz_name: str) -> dict:
+        tz = self._get_tz(tz_name)
+        now = datetime.now(tz)
+        return self._ok(
+            mode="now",
+            datetime=now.strftime(_DEFAULT_FORMAT),
+            iso=now.isoformat(),
+            timestamp=now.timestamp(),
+            timezone=str(tz),
+        )
+
+    def _convert(self, dt_str: str, from_tz: str, to_tz: str,
+                 fmt: str) -> dict:
+        dt = self._parse_datetime(dt_str, from_tz)
+        target = self._get_tz(to_tz or "UTC")
+        converted = dt.astimezone(target)
+        output_format = fmt or _DEFAULT_FORMAT
+        return self._ok(
+            mode="convert",
+            original=dt.strftime(output_format),
+            converted=converted.strftime(output_format),
+            original_iso=dt.isoformat(),
+            converted_iso=converted.isoformat(),
+            from_timezone=str(dt.tzinfo),
+            to_timezone=str(target),
+        )
+
+    def _format_dt(self, dt_str: str, tz_name: str, fmt: str) -> dict:
+        dt = self._parse_datetime(dt_str, tz_name)
+        output_format = fmt or _DEFAULT_FORMAT
+        return self._ok(
+            mode="format",
+            formatted=dt.strftime(output_format),
+            iso=dt.isoformat(),
+        )
+
+    def _parse(self, dt_str: str) -> dict:
+        if not dt_str:
+            return self._error("validation_error", "datetime_str is required")
+        parsed = self._try_parse_formats(dt_str)
+        if parsed is None:
+            return self._error(
+                "validation_error",
+                f"Could not parse {dt_str!r}. Supported formats include: "
+                f"YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, ISO 8601, etc.")
+        return self._ok(
+            mode="parse",
+            datetime=parsed.strftime(_DEFAULT_FORMAT),
+            iso=parsed.isoformat(),
+        )
+
+    def _diff(self, start_str: str, end_str: str, tz_name: str,
+              unit: str) -> dict:
+        if not start_str:
+            return self._error("validation_error", "datetime_str (start) is required")
+        tz = self._get_tz(tz_name or "UTC")
+        start = self._parse_datetime(start_str, tz_name)
+        if end_str:
+            end = self._parse_datetime(end_str, tz_name)
+        else:
+            end = datetime.now(tz)
+
+        delta = end - start
+        unit = (unit or "days").lower()
+
+        if unit in ("days", "day", "d"):
+            value = delta.total_seconds() / 86400
+        elif unit in ("hours", "hour", "h"):
+            value = delta.total_seconds() / 3600
+        elif unit in ("minutes", "minute", "min", "m"):
+            value = delta.total_seconds() / 60
+        elif unit in ("seconds", "second", "sec", "s"):
+            value = delta.total_seconds()
+        else:
+            raise ValueError(f"Unknown unit: {unit!r}. Use days, hours, minutes, or seconds.")
+
+        if abs(value) > self.max_diff_days and unit in ("days", "d"):
+            raise ValueError(
+                f"Difference exceeds max_diff_days ({self.max_diff_days})")
+
+        return self._ok(
+            mode="diff",
+            start=start.isoformat(),
+            end=end.isoformat(),
+            unit=unit,
+            value=round(value, 6),
+        )
+
+    def _parse_datetime(self, dt_str: str, tz_name: str) -> datetime:
+        parsed = self._try_parse_formats(dt_str)
+        if parsed is None:
+            raise ValueError(
+                f"Could not parse {dt_str!r}. Supported formats: "
+                f"YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, ISO 8601, etc.")
+        tz = self._get_tz(tz_name or self.default_timezone)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=tz)
+        return parsed
+
+    @staticmethod
+    def _try_parse_formats(dt_str: str) -> Optional[datetime]:
+        dt_str = dt_str.strip()
+        for fmt in _PARSE_FORMATS:
+            try:
+                return datetime.strptime(dt_str, fmt)
+            except ValueError:
+                continue
+        # Try ISO 8601.
+        try:
+            return datetime.fromisoformat(
+                dt_str.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "DateTimeTool":
+        super()._initialize_by_component_configer(configer)
+        if hasattr(configer, "default_timezone"):
+            self.default_timezone = configer.default_timezone
+        if hasattr(configer, "max_diff_days"):
+            self.max_diff_days = configer.max_diff_days
+        return self

--- a/agentuniverse/agent/action/tool/common_tool/datetime_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/datetime_tool.yaml.example
@@ -1,0 +1,11 @@
+name: datetime_tool
+description: Bounded datetime tool — get the current time (now), parse/format datetimes, compute differences, and add/subtract durations across timezones.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.datetime_tool
+  class: DateTimeTool
+input_keys:
+  - mode
+default_timezone: UTC
+max_diff_days: 100000

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,23 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## DateTimeTool
+
+`DateTimeTool` gives an agent bounded datetime and timezone operations: `now`, `convert` (between IANA timezones), `format`, `parse`, and `diff`. All timezone conversions use the IANA timezone database through Python's built-in `zoneinfo` (Python 3.9+), so there is zero third-party dependency. `parse` tries a fixed list of common formats and rejects ambiguous inputs; `diff` is capped at `max_diff_days` to prevent overflow.
+
+Register a component pointing at `agentuniverse.agent.action.tool.common_tool.datetime_tool.DateTimeTool`, then call `execute(mode=..., datetime_str=..., timezone_str=..., target_timezone=..., fmt=..., unit=..., end_datetime=...)`.
+
+```yaml
+name: datetime_tool
+description: Bounded datetime and timezone operations
+default_timezone: UTC
+max_diff_days: 100000
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.datetime_tool
+  class: DateTimeTool
+input_keys: ["mode"]
+```
+- default_timezone: IANA timezone name used by `now` when no timezone is specified (default `UTC`).
+- max_diff_days: Maximum absolute difference in days for `diff` to prevent overflow (default 100000).

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,23 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## DateTimeTool
+
+`DateTimeTool` 为智能体提供受边界限制的日期时间与时区操作：`now`、`convert`（在 IANA 时区之间转换）、`format`、`parse`、`diff`。所有时区转换都通过 Python 内置的 `zoneinfo`（Python 3.9+）使用 IANA 时区数据库，因此零第三方依赖。`parse` 会依次尝试一组常见格式并拒绝歧义输入；`diff` 受 `max_diff_days` 上限约束以防止溢出。
+
+注册一个指向 `agentuniverse.agent.action.tool.common_tool.datetime_tool.DateTimeTool` 的组件，然后调用 `execute(mode=..., datetime_str=..., timezone_str=..., target_timezone=..., fmt=..., unit=..., end_datetime=...)`。
+
+```yaml
+name: datetime_tool
+description: Bounded datetime and timezone operations
+default_timezone: UTC
+max_diff_days: 100000
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.datetime_tool
+  class: DateTimeTool
+input_keys: ["mode"]
+```
+- default_timezone: 未指定时区时 `now` 使用的 IANA 时区名（默认 `UTC`）。
+- max_diff_days: `diff` 允许的最大绝对天数差，以防止溢出（默认 100000）。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_datetime_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_datetime_tool.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for DateTimeTool."""
+
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool.datetime_tool import \
+    DateTimeTool
+
+
+class TestDateTimeToolNow(unittest.TestCase):
+
+    def test_now_utc(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="now", timezone_str="UTC")
+        self.assertEqual(result["status"], "success")
+        self.assertIn("UTC", result["datetime"])
+
+    def test_now_with_timezone(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="now", timezone_str="Asia/Shanghai")
+        self.assertEqual(result["status"], "success")
+        self.assertIn("Asia/Shanghai", result["timezone"])
+
+    def test_invalid_timezone(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="now", timezone_str="Mars/Olympus")
+        self.assertEqual(result["status"], "error")
+
+
+class TestDateTimeToolConvert(unittest.TestCase):
+
+    def test_convert_utc_to_shanghai(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="convert",
+            datetime_str="2026-01-15 10:00:00",
+            timezone_str="UTC",
+            target_timezone="Asia/Shanghai")
+        self.assertEqual(result["status"], "success")
+        self.assertIn("18:00:00", result["converted"])
+
+    def test_convert_with_custom_format(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="convert",
+            datetime_str="2026-01-15 10:00:00",
+            timezone_str="UTC",
+            target_timezone="UTC",
+            fmt="%Y/%m/%d")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["converted"], "2026/01/15")
+
+
+class TestDateTimeToolParse(unittest.TestCase):
+
+    def test_parse_iso(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="parse", datetime_str="2026-01-15T10:30:00")
+        self.assertEqual(result["status"], "success")
+
+    def test_parse_slash_format(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="parse", datetime_str="2026/01/15")
+        self.assertEqual(result["status"], "success")
+
+    def test_parse_invalid_returns_error(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="parse", datetime_str="not-a-date")
+        self.assertEqual(result["status"], "error")
+
+    def test_parse_empty_string(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="parse", datetime_str="")
+        self.assertEqual(result["status"], "error")
+
+
+class TestDateTimeToolDiff(unittest.TestCase):
+
+    def test_diff_days(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="diff",
+            datetime_str="2026-01-01 00:00:00",
+            end_datetime="2026-01-11 00:00:00",
+            timezone_str="UTC",
+            unit="days")
+        self.assertEqual(result["status"], "success")
+        self.assertAlmostEqual(result["value"], 10.0)
+
+    def test_diff_hours(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="diff",
+            datetime_str="2026-01-01 00:00:00",
+            end_datetime="2026-01-01 12:00:00",
+            timezone_str="UTC",
+            unit="hours")
+        self.assertAlmostEqual(result["value"], 12.0)
+
+    def test_diff_no_end_uses_now(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="diff",
+            datetime_str="2020-01-01 00:00:00",
+            timezone_str="UTC",
+            unit="days")
+        self.assertEqual(result["status"], "success")
+        self.assertGreater(result["value"], 0)
+
+    def test_diff_invalid_unit(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="diff",
+            datetime_str="2026-01-01",
+            end_datetime="2026-01-02",
+            unit="centuries")
+        self.assertEqual(result["status"], "error")
+
+
+class TestDateTimeToolFormat(unittest.TestCase):
+
+    def test_format_with_custom(self):
+        tool = DateTimeTool()
+        result = tool.execute(
+            mode="format",
+            datetime_str="2026-03-15 14:30:00",
+            timezone_str="UTC",
+            fmt="%d %B %Y")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["formatted"], "15 March 2026")
+
+
+class TestDateTimeToolValidation(unittest.TestCase):
+
+    def test_unknown_mode(self):
+        tool = DateTimeTool()
+        result = tool.execute(mode="invalid")
+        self.assertEqual(result["status"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `DateTimeTool` — provides `now`, `convert` (timezone conversion), `format`, `parse`, and `diff` operations. Uses `zoneinfo` (Python 3.9+, zero third-party dependency) with the IANA timezone database.

## Why (not a duplicate)

Not covered by any open or merged PR. No existing tool handles datetime/timezone operations; agents that need time reasoning currently have no structured way to do so.

## Capabilities

- **now**: current time in any IANA timezone (UTC, Asia/Shanghai, America/New_York, etc.).
- **convert**: convert a datetime between timezones.
- **format**: format a datetime with a custom `strftime` pattern.
- **parse**: parse 18 common datetime formats + ISO 8601.
- **diff**: calculate the difference between two datetimes in days / hours / minutes / seconds.

**Bounded**: invalid timezone raises a clear error; unknown parse format returns a structured error naming the supported formats; `diff` has a `max_diff_days` cap.

## Tests

15 unit tests: now (UTC + named timezone + invalid), convert (UTC→Shanghai + custom format), parse (ISO + slash format + invalid + empty), diff (days + hours + now fallback + invalid unit), format (custom pattern), validation (unknown mode).

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_datetime_tool` — 15 passed.
