### PR TITLE
feat(knowledge): CsvSplitter pre-processing component (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/csv_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/csv_splitter.py
@@ -1,0 +1,108 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: csv_splitter.py
+
+"""
+CSV/TSV splitter — a knowledge pre-processing DocProcessor.
+
+Splits CSV or TSV text into one chunk per row group, where each chunk
+contains a configurable number of rows plus the header. The header is
+preserved on every chunk so that each is self-contained and retrievable
+in context.
+
+Pure Python with the built-in ``csv`` module — no third-party dependency.
+Sibling of the merged ``MarkdownHeaderTextSplitter`` (#625) and the new
+``HtmlHeaderTextSplitter`` (#737), ``JsonSplitter`` (#738), etc.
+Addresses #258.
+"""
+
+import csv
+import io
+import logging
+from typing import List
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class CsvSplitter(DocProcessor):
+    """Split CSV/TSV text into row-grouped chunks with header preserved.
+
+    Attributes:
+        rows_per_chunk: Number of data rows per chunk (default 50). The
+            header row is prepended to every chunk.
+        delimiter: Column delimiter. ``","`` for CSV (default), ``"\\t"``
+            for TSV, or any other single character.
+        max_cell_chars: Maximum characters per cell in the output text;
+            longer cells are truncated (default 1000).
+    """
+
+    rows_per_chunk: int = 50
+    delimiter: str = ","
+    max_cell_chars: int = 1000
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        if not origin_docs:
+            return []
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            for chunk_text in self._split_csv(text):
+                meta = dict(doc.metadata or {})
+                meta["chunk_method"] = "csv"
+                result.append(Document(text=chunk_text, metadata=meta))
+        return result
+
+    def _split_csv(self, text: str) -> List[str]:
+        """Parse CSV text and return chunk strings."""
+        reader = csv.reader(io.StringIO(text), delimiter=self.delimiter)
+        rows = list(reader)
+        if not rows:
+            return []
+
+        header = rows[0]
+        data_rows = rows[1:]
+        if not data_rows:
+            return [self._format_csv([header])]
+
+        chunks: List[str] = []
+        for i in range(0, len(data_rows), self.rows_per_chunk):
+            batch = data_rows[i:i + self.rows_per_chunk]
+            chunk_rows = [header] + batch
+            chunks.append(self._format_csv(chunk_rows))
+        return chunks
+
+    def _format_csv(self, rows: List[List[str]]) -> str:
+        """Format rows back to CSV text, truncating oversized cells."""
+        output = io.StringIO()
+        writer = csv.writer(output, delimiter=self.delimiter)
+        for row in rows:
+            truncated_row = []
+            for cell in row:
+                if len(cell) > self.max_cell_chars:
+                    truncated_row.append(
+                        cell[:max(0, self.max_cell_chars - 1)] + "…")
+                else:
+                    truncated_row.append(cell)
+            writer.writerow(truncated_row)
+        return output.getvalue().strip()
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> "CsvSplitter":
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "rows_per_chunk"):
+            self.rows_per_chunk = doc_processor_configer.rows_per_chunk
+        if hasattr(doc_processor_configer, "delimiter"):
+            self.delimiter = doc_processor_configer.delimiter
+        if hasattr(doc_processor_configer, "max_cell_chars"):
+            self.max_cell_chars = doc_processor_configer.max_cell_chars
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/csv_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/csv_splitter.yaml
@@ -1,0 +1,9 @@
+name: 'csv_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.csv_splitter'
+  class: 'CsvSplitter'
+description: 'Splits CSV/TSV text into row-grouped chunks with header preserved on every chunk.'
+rows_per_chunk: 50
+delimiter: ','
+max_cell_chars: 1000

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,25 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [CsvSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/csv_splitter.yaml)
+
+`CsvSplitter` splits CSV or TSV text into one chunk per row group, where each chunk contains a configurable number of data rows plus the header. The header is prepended to every chunk so each chunk is self-contained and retrievable in context. It is a sibling of the other structure-aware splitters (`MarkdownHeaderTextSplitter`, `HtmlHeaderTextSplitter`, `JsonSplitter`, …) addressing issue #258.
+
+Pure Python with the built-in `csv` module — no third-party dependency. Copy `csv_splitter.yaml` into your application configuration directory and resolve the built-in `csv_splitter` component to use it. Each produced chunk carries `chunk_method: "csv"` in its metadata.
+
+The component definition file is as follows:
+```yaml
+name: 'csv_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.csv_splitter'
+  class: 'CsvSplitter'
+description: 'Splits CSV/TSV text into row-grouped chunks with header preserved on every chunk.'
+rows_per_chunk: 50
+delimiter: ','
+max_cell_chars: 1000
+```
+- rows_per_chunk: Number of data rows per chunk (default 50). The header row is prepended to every chunk.
+- delimiter: Column delimiter. `","` for CSV (default), `"\t"` for TSV, or any other single character.
+- max_cell_chars: Maximum characters per cell in the output text; longer cells are truncated (default 1000).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,25 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [CsvSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/csv_splitter.yaml)
+
+`CsvSplitter` 把 CSV/TSV 文本按行组切分，每组包含若干数据行加上表头。表头会被预置到每个块中，使每块都是自包含、可独立检索的。它与其它结构感知切分器（`MarkdownHeaderTextSplitter`、`HtmlHeaderTextSplitter`、`JsonSplitter` 等）同属一类，对应 issue #258。
+
+纯 Python 实现，基于标准库 `csv`，无第三方依赖。将 `csv_splitter.yaml` 复制到应用配置目录，加载内置 `csv_splitter` 组件即可使用。每个生成的块在 metadata 中带 `chunk_method: "csv"`。
+
+组件定义文件如下：
+```yaml
+name: 'csv_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.csv_splitter'
+  class: 'CsvSplitter'
+description: '将 CSV/TSV 文本按行组切分，并在每块保留表头。'
+rows_per_chunk: 50
+delimiter: ','
+max_cell_chars: 1000
+```
+- rows_per_chunk: 每块的数据行数（默认 50）。表头会被预置到每个块。
+- delimiter: 列分隔符。CSV 用 `","`（默认），TSV 用 `"\t"`，也可为任意单字符。
+- max_cell_chars: 输出文本中每个单元格的最大字符数；超出部分截断（默认 1000）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_csv_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_csv_splitter.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for CsvSplitter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.csv_splitter \
+    import CsvSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+CSV_10_ROWS = "name,age,city\n" + \
+    "\n".join(f"Person{i},{20+i},City{i}" for i in range(1, 11))
+
+TSV_5_ROWS = "name\tage\n" + \
+    "\n".join(f"P{i}\t{i}" for i in range(1, 6))
+
+
+class TestCsvSplitter(unittest.TestCase):
+
+    def _split(self, text, **kwargs):
+        proc = CsvSplitter(**kwargs)
+        return proc.process_docs([Document(text=text)], None)
+
+    def test_single_chunk_when_rows_fit(self):
+        docs = self._split(CSV_10_ROWS, rows_per_chunk=50)
+        self.assertEqual(len(docs), 1)
+
+    def test_multiple_chunks(self):
+        docs = self._split(CSV_10_ROWS, rows_per_chunk=3)
+        # 10 data rows / 3 per chunk = 4 chunks (3+3+3+1).
+        self.assertEqual(len(docs), 4)
+
+    def test_header_on_every_chunk(self):
+        docs = self._split(CSV_10_ROWS, rows_per_chunk=3)
+        for d in docs:
+            self.assertIn("name,age,city", d.text)
+
+    def test_tsv_delimiter(self):
+        docs = self._split(TSV_5_ROWS, delimiter="\t", rows_per_chunk=2)
+        self.assertGreater(len(docs), 1)
+        for d in docs:
+            self.assertIn("name\tage", d.text)
+
+    def test_empty_input(self):
+        proc = CsvSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_header_only(self):
+        docs = self._split("col1,col2\n")
+        self.assertEqual(len(docs), 1)
+        self.assertIn("col1", docs[0].text)
+
+    def test_empty_text(self):
+        docs = self._split("")
+        self.assertEqual(len(docs), 0)
+
+    def test_max_cell_chars_truncates(self):
+        long_val = "x" * 200
+        csv_text = f"data\n{long_val}\n"
+        docs = self._split(csv_text, max_cell_chars=10)
+        self.assertIn("…", docs[0].text)
+        # The truncated cell should be short.
+        lines = docs[0].text.split("\n")
+        self.assertLessEqual(len(lines[1]), 11)
+
+    def test_metadata_includes_chunk_method(self):
+        docs = self._split(CSV_10_ROWS)
+        self.assertEqual(docs[0].metadata["chunk_method"], "csv")
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="a,b\n1,2", metadata={"source": "file.csv"})
+        proc = CsvSplitter()
+        docs = proc.process_docs([doc], None)
+        self.assertEqual(docs[0].metadata["source"], "file.csv")
+
+    def test_quoted_fields_preserved(self):
+        csv_text = 'name,desc\n"John Doe","Hello, World"\n'
+        docs = self._split(csv_text)
+        self.assertIn("John Doe", docs[0].text)
+        self.assertIn("Hello, World", docs[0].text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `CsvSplitter` — splits CSV or TSV text into row-grouped chunks where each chunk includes the header row, making every chunk self-contained and retrievable in context.

## Why (not a duplicate)

Not covered by any open or merged PR. No existing doc processor handles CSV/TSV row-level splitting. `JsonSplitter` (#738) handles JSON structures; `CsvSplitter` handles tabular data — complementary.

## Capabilities

- **Pure Python** with the built-in `csv` module — zero third-party dependency.
- **Header preserved** on every chunk so each is self-contained.
- **Configurable**: `rows_per_chunk` (50), `delimiter` (`,` for CSV, `\t` for TSV, or any character), `max_cell_chars` (1000) for cell truncation.
- **Quoted fields** with embedded delimiters/newlines are handled correctly by `csv.reader`.

## Tests

11 unit tests: single chunk, multiple chunks, header on every chunk, TSV delimiter, empty input/text, header-only, cell truncation, metadata, original metadata preserved, quoted fields.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_csv_splitter` — 11 passed.
