### PR TITLE
fix(reader,tool): robustness for pdf/docx/xlsx/pptx/epub readers + excel use-after-close

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/docx_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/docx_reader.py
@@ -33,7 +33,13 @@ class DocxReader(Reader):
 
         if isinstance(file, str):
             file = Path(file)
-        text = docx2txt.process(file)
+        try:
+            text = docx2txt.process(file)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse DOCX file {file.name}: {exc}") from exc
+        if text is None:
+            text = ""
         metadata = {"file_name": file.name}
         if ext_info is not None:
             metadata.update(ext_info)

--- a/agentuniverse/agent/action/knowledge/reader/file/epub_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/epub_reader.py
@@ -45,27 +45,42 @@ class EpubReader(Reader):
             file = Path(file)
 
         # Load the EPUB book
-        book = epub.read_epub(str(file))
+        try:
+            book = epub.read_epub(str(file))
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse EPUB file {file.name}: {exc}") from exc
         document_list = []
+
+        def _safe_meta(key: str) -> str:
+            """Safely extract a metadata field, handling None values."""
+            raw = book.get_metadata('DC', key)
+            if raw and raw[0] and raw[0][0]:
+                return str(raw[0][0])
+            return "Unknown"
 
         # Extract book metadata
         book_metadata = {
             "file_name": file.name,
-            "title": book.get_metadata('DC', 'title')[0][0] if book.get_metadata('DC', 'title') else "Unknown",
-            "author": book.get_metadata('DC', 'creator')[0][0] if book.get_metadata('DC', 'creator') else "Unknown",
-            "language": book.get_metadata('DC', 'language')[0][0] if book.get_metadata('DC', 'language') else "Unknown",
-            "publisher": book.get_metadata('DC', 'publisher')[0][0] if book.get_metadata('DC', 'publisher') else "Unknown"
+            "title": _safe_meta('title'),
+            "author": _safe_meta('creator'),
+            "language": _safe_meta('language'),
+            "publisher": _safe_meta('publisher'),
         }
 
         chapter_count = 0
-        
+
         # Process each item in the book
         for item in book.get_items():
             if item.get_type() == ebooklib.ITEM_DOCUMENT:
                 chapter_count += 1
-                
-                # Extract text content from HTML
-                content = item.get_content().decode('utf-8', errors='ignore')
+
+                # Extract text content from HTML. get_content() can return
+                # None on corrupt/truncated epubs.
+                raw_content = item.get_content()
+                if raw_content is None:
+                    continue
+                content = raw_content.decode('utf-8', errors='ignore')
                 text_content = self._extract_text_from_html(content)
                 
                 if text_content.strip():  # Only add non-empty chapters

--- a/agentuniverse/agent/action/knowledge/reader/file/pdf_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/pdf_reader.py
@@ -39,9 +39,19 @@ class PdfReader(Reader):
             # Iterate over every page
             docs = []
             for page in range(num_pages):
-                # Extract the text from the page
-                page_text = pdf.pages[page].extract_text()
-                page_label = pdf.page_labels[page]
+                # Extract the text from the page. extract_text() can return
+                # None on scanned/encrypted pages; fall back to empty string.
+                try:
+                    page_text = pdf.pages[page].extract_text() or ""
+                except Exception:
+                    page_text = ""
+
+                # page_labels is not always available (depends on PDF type);
+                # fall back to the 1-based page number.
+                try:
+                    page_label = pdf.page_labels[page]
+                except (IndexError, KeyError, AttributeError):
+                    page_label = str(page + 1)
 
                 metadata = {"page_label": page_label, "file_name": file.name}
                 if ext_info is not None:

--- a/agentuniverse/agent/action/knowledge/reader/file/pptx_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/pptx_reader.py
@@ -29,14 +29,17 @@ class PptxReader(Reader):
             )
         if isinstance(file, str):
             file = Path(file)
-        presentation = Presentation(file)
+        try:
+            presentation = Presentation(file)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse PPTX file {file.name}: {exc}") from exc
         document_list = []
         for slide_number, slide in enumerate(presentation.slides, start=1):
             for shape in slide.shapes:
-                if hasattr(shape, "text"):
+                if hasattr(shape, "text") and shape.text and shape.text.strip():
                     metadata = {"slide_number": slide_number, "file_name": file.name}
                     if ext_info is not None:
                         metadata.update(ext_info)
-                    # Extract the text from the shape
                     document_list.append(Document(text=shape.text, metadata=metadata))
         return document_list

--- a/agentuniverse/agent/action/knowledge/reader/file/xlsx_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/xlsx_reader.py
@@ -42,7 +42,11 @@ class XlsxReader(Reader):
             file = Path(file)
 
         # Load the workbook
-        workbook = openpyxl.load_workbook(file, data_only=True)
+        try:
+            workbook = openpyxl.load_workbook(file, data_only=True)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse XLSX file {file.name}: {exc}") from exc
         document_list = []
 
         # Process each worksheet
@@ -60,9 +64,12 @@ class XlsxReader(Reader):
                 for col in range(1, max_col + 1):
                     cell = worksheet.cell(row=row, column=col)
                     if cell.value is not None:
-                        # Convert cell value to string, handling different data types
-                        if isinstance(cell.value, (int, float)):
-                            row_data.append(str(cell.value))
+                        # Handle datetime specially; everything else str().
+                        import datetime as _dt
+                        if isinstance(cell.value, _dt.datetime):
+                            row_data.append(cell.value.isoformat())
+                        elif isinstance(cell.value, _dt.date):
+                            row_data.append(cell.value.isoformat())
                         else:
                             row_data.append(str(cell.value))
                     else:

--- a/agentuniverse/agent/action/tool/common_tool/excel_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/excel_tool.py
@@ -373,6 +373,10 @@ class ExcelTool(Tool):
                 row_counts[sheet_name] = row_count
                 col_counts[sheet_name] = col_count
 
+            # Cache sheet names before close(): openpyxl read_only workbooks
+            # are invalid after close(), and accessing .sheetnames afterwards
+            # raises or returns empty, producing wrong total_sheets.
+            sheet_names = list(workbook.sheetnames)
             workbook.close()
 
             file_size = os.path.getsize(file_path)
@@ -382,9 +386,9 @@ class ExcelTool(Tool):
                 "file_path": file_path,
                 "file_size": file_size,
                 "file_size_mb": round(file_size / (1024 * 1024), 2),
-                "total_sheets": len(workbook.sheetnames),
+                "total_sheets": len(sheet_names),
                 "sheets": sheets_info,
-                "sheet_names": workbook.sheetnames
+                "sheet_names": sheet_names
             }
 
         except Exception as e:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_reader_robustness.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_reader_robustness.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for reader robustness fixes (pdf, docx, xlsx, pptx, epub).
+
+All tests use source-contract checks (inspect.getsource) to verify the
+fixes are in place, since the actual library dependencies are optional
+and constructing real corrupt files is heavy.
+"""
+
+import unittest
+
+
+class TestPdfReaderRobustness(unittest.TestCase):
+
+    def test_extract_text_guards_none(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.pdf_reader \
+            import PdfReader
+        src = inspect.getsource(PdfReader._load_data)
+        # Must guard extract_text returning None.
+        self.assertIn('or ""', src,
+                      "extract_text() return must be guarded against None")
+
+    def test_page_labels_has_fallback(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.pdf_reader \
+            import PdfReader
+        src = inspect.getsource(PdfReader._load_data)
+        self.assertIn("except", src)
+        self.assertIn("page + 1", src,
+                      "page_labels access must have a fallback to page number")
+
+
+class TestDocxReaderRobustness(unittest.TestCase):
+
+    def test_parse_has_try_except(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.docx_reader \
+            import DocxReader
+        src = inspect.getsource(DocxReader._load_data)
+        self.assertIn("try:", src)
+        self.assertIn("Failed to parse DOCX", src,
+                      "docx parse failure must raise ValueError with context")
+
+    def test_text_none_guard(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.docx_reader \
+            import DocxReader
+        src = inspect.getsource(DocxReader._load_data)
+        self.assertIn("is None", src,
+                      "docx2txt.process result must be guarded against None")
+
+
+class TestXlsxReaderRobustness(unittest.TestCase):
+
+    def test_load_workbook_has_try_except(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.xlsx_reader \
+            import XlsxReader
+        src = inspect.getsource(XlsxReader._load_data)
+        self.assertIn("Failed to parse XLSX", src,
+                      "openpyxl load_workbook must be wrapped in try/except")
+
+    def test_no_identical_if_else_branches(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.xlsx_reader \
+            import XlsxReader
+        src = inspect.getsource(XlsxReader._load_data)
+        # The old dead code had identical if/else bodies. The fix handles
+        # datetime/date specially.
+        self.assertIn("datetime", src,
+                      "cell value handling should special-case datetime")
+        self.assertIn("isoformat", src,
+                      "datetime cells should use isoformat()")
+
+    def test_no_duplicate_str_append(self):
+        """Verify the identical if/else dead code is gone."""
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.xlsx_reader \
+            import XlsxReader
+        src = inspect.getsource(XlsxReader._load_data)
+        # The old code had:
+        #   if isinstance(cell.value, (int, float)):
+        #       row_data.append(str(cell.value))
+        #   else:
+        #       row_data.append(str(cell.value))
+        # Both branches identical. Verify it's gone.
+        self.assertNotIn(
+            "if isinstance(cell.value, (int, float)):\n"
+            "                            row_data.append(str(cell.value))\n"
+            "                        else:\n"
+            "                            row_data.append(str(cell.value))",
+            src,
+            "the identical if/else dead code must be removed")
+
+
+class TestPptxReaderRobustness(unittest.TestCase):
+
+    def test_empty_shapes_skipped(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.pptx_reader \
+            import PptxReader
+        src = inspect.getsource(PptxReader._load_data)
+        # Must check that shape.text is non-empty before appending.
+        self.assertIn(".strip()", src,
+                      "empty shape text must be skipped")
+
+    def test_parse_has_try_except(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.pptx_reader \
+            import PptxReader
+        src = inspect.getsource(PptxReader._load_data)
+        self.assertIn("Failed to parse PPTX", src,
+                      "Presentation() must be wrapped in try/except")
+
+
+class TestEpubReaderRobustness(unittest.TestCase):
+
+    def test_metadata_uses_safe_helper(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.epub_reader \
+            import EpubReader
+        src = inspect.getsource(EpubReader._load_data)
+        self.assertIn("_safe_meta", src,
+                      "metadata extraction must use a None-safe helper")
+        # Old code used [0][0] directly.
+        self.assertNotIn(
+            "book.get_metadata('DC', 'title')[0][0]",
+            src,
+            "raw [0][0] indexing on metadata must be replaced with safe access")
+
+    def test_get_content_none_guard(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.epub_reader \
+            import EpubReader
+        src = inspect.getsource(EpubReader._load_data)
+        self.assertIn("is None", src,
+                      "item.get_content() must be guarded against None")
+
+    def test_parse_has_try_except(self):
+        import inspect
+        from agentuniverse.agent.action.knowledge.reader.file.epub_reader \
+            import EpubReader
+        src = inspect.getsource(EpubReader._load_data)
+        self.assertIn("Failed to parse EPUB", src,
+                      "epub.read_epub must be wrapped in try/except")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Seven reader robustness fixes across pdf, docx, xlsx, pptx, epub readers and excel_tool.

## Changes

### 1. pdf_reader — `extract_text()` None + `page_labels` IndexError
`extract_text()` can return `None` on scanned/encrypted pages; now falls back to `""`. `page_labels` can raise `IndexError` / `AttributeError` on some PDFs; now falls back to 1-based page number.

### 2. docx_reader — None result + corrupt file
`docx2txt.process()` can return `None` or raise on corrupt files; now wrapped in `try/except` with clear `ValueError`, and `None` is coerced to `""`.

### 3. xlsx_reader — corrupt file + dead code
`openpyxl.load_workbook()` can raise on corrupt files; now wrapped in `try/except`. The identical `if/else` dead code (both branches `str(cell.value)`) is replaced with `datetime`/`date` special handling (`isoformat()`) + generic `str()` fallback.

### 4. pptx_reader — empty shapes + corrupt file
Empty shapes (placeholder objects with no text) were generating empty `Document` objects; now only non-empty shapes are emitted. `Presentation()` is wrapped in `try/except`.

### 5. epub_reader — None metadata + None content + corrupt file
`get_metadata()[0][0]` could return `None`; replaced with `_safe_meta` helper. `get_content()` can return `None` on truncated epubs; now guarded. `read_epub()` is wrapped in `try/except`.

### 6. excel_tool — use-after-close
`workbook.sheetnames` was accessed AFTER `workbook.close()`, which on openpyxl read_only workbooks is invalid. Now cached before `close()`.

## Tests

12 regressions (source-contract tests verifying each fix is in place).

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.test_reader_robustness` — 12 passed.
