### PR TITLE
feat(embedding): Cohere embedding component (#250)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/cohere_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/cohere_embedding.py
@@ -1,0 +1,99 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: cohere_embedding.py
+
+"""
+Cohere embedding component.
+
+Generates text embeddings using the Cohere Embed v3 API. Supports
+multilingual models (embed-multilingual-v3.0) and English-optimised models
+(embed-english-v3.0).
+"""
+
+import logging
+from typing import List, Optional
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
+from agentuniverse.base.util.env_util import get_from_env
+
+logger = logging.getLogger(__name__)
+
+_COHERE_EMBED_URL = "https://api.cohere.com/v2/embed"
+
+
+class CohereEmbedding(Embedding):
+    """Embedding component backed by the Cohere Embed v3 API.
+
+    Attributes:
+        embedding_model_name: Cohere embed model
+            (default ``embed-multilingual-v3.0``).
+        api_key: Cohere API key (env: ``COHERE_API_KEY``).
+        input_type: ``"document"`` or ``"query"`` — Cohere recommends
+            specifying this for best retrieval quality.
+        request_timeout: Timeout in seconds (default 30).
+    """
+
+    embedding_model_name: str = "embed-multilingual-v3.0"
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("COHERE_API_KEY"))
+    input_type: str = "document"
+    request_timeout: int = 30
+
+    def get_embeddings(self, texts: List[str],
+                       text_type: str = "document") -> List[List[float]]:
+        if not texts:
+            return []
+        if not self.api_key:
+            raise ValueError(
+                "CohereEmbedding requires an api_key. Set it on the component "
+                "or via the COHERE_API_KEY environment variable.")
+
+        effective_type = text_type if text_type in ("document", "query") \
+            else self.input_type
+
+        try:
+            response = requests.post(
+                _COHERE_EMBED_URL,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self.embedding_model_name,
+                    "texts": texts,
+                    "input_type": effective_type,
+                    "embedding_types": ["float"],
+                },
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+        except requests.exceptions.Timeout:
+            logger.warning("Cohere embed request timed out.")
+            return [[] for _ in texts]
+        except requests.exceptions.HTTPError as exc:
+            raise RuntimeError(
+                f"Cohere embed API returned status "
+                f"{exc.response.status_code if exc.response is not None else '?'}"
+            ) from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Cohere embed API returned non-JSON: {exc}") from exc
+
+        embeddings_list = data.get("embeddings", {}).get("float", [])
+        if not embeddings_list:
+            logger.warning("Cohere embed returned empty embeddings list")
+            return [[] for _ in texts]
+        return [list(emb) for emb in embeddings_list]
+
+    async def async_get_embeddings(self, texts: List[str],
+                                   text_type: str = "document") -> List[List[float]]:
+        # Cohere v2 does not have a dedicated async endpoint; reuse sync.
+        return self.get_embeddings(texts, text_type)

--- a/agentuniverse/agent/action/knowledge/embedding/cohere_embedding.yaml.example
+++ b/agentuniverse/agent/action/knowledge/embedding/cohere_embedding.yaml.example
@@ -1,0 +1,10 @@
+name: 'cohere_embedding'
+description: 'Embedding component backed by the Cohere Embed API (embed-v3 family).'
+embedding_model_name: 'embed-multilingual-v3.0'
+api_key: ''
+input_type: 'document'
+request_timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.cohere_embedding'
+  class: 'CohereEmbedding'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
@@ -1,0 +1,26 @@
+# Embedding
+
+agentUniverse provides several built-in embedding components used by the Knowledge store and doc processors to vectorise text. Each component is registered with `metadata.type: EMBEDDING` and exposes `get_embeddings(texts, text_type=...)`.
+
+## CohereEmbedding
+
+`CohereEmbedding` generates text embeddings using the Cohere Embed v3 API. It supports the multilingual model (`embed-multilingual-v3.0`, default) and the English-optimised model (`embed-english-v3.0`). No extra install (`requests` is already a core dependency) — only a Cohere API key.
+
+Register a component pointing at `agentuniverse.agent.action.knowledge.embedding.cohere_embedding.CohereEmbedding`, then reference it by name from a store or processor (e.g. `embedding_model: cohere_embedding`). The API key is read from `COHERE_API_KEY`.
+
+```yaml
+name: 'cohere_embedding'
+description: 'embedding via Cohere Embed v3 API'
+embedding_model_name: 'embed-multilingual-v3.0'
+api_key: '${COHERE_API_KEY}'
+input_type: 'document'
+request_timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.cohere_embedding'
+  class: 'CohereEmbedding'
+```
+- embedding_model_name: Cohere embed model (default `embed-multilingual-v3.0`).
+- api_key: Cohere API key (env: `COHERE_API_KEY`).
+- input_type: `document` or `query` — Cohere recommends specifying this for best retrieval quality (default `document`).
+- request_timeout: Timeout in seconds (default 30).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
@@ -1,0 +1,26 @@
+# Embedding（向量化）
+
+agentUniverse 提供若干内置 embedding 组件，供知识库 store 与文档处理器对文本向量化。每个组件以 `metadata.type: EMBEDDING` 注册，并暴露 `get_embeddings(texts, text_type=...)` 方法。
+
+## CohereEmbedding
+
+`CohereEmbedding` 使用 Cohere Embed v3 API 生成文本向量。支持多语言模型（`embed-multilingual-v3.0`，默认）和英文优化模型（`embed-english-v3.0`）。无需额外安装（`requests` 已是核心依赖）——只需一个 Cohere API Key。
+
+注册一个指向 `agentuniverse.agent.action.knowledge.embedding.cohere_embedding.CohereEmbedding` 的组件，然后在 store 或处理器中按名引用（如 `embedding_model: cohere_embedding`）。API Key 从 `COHERE_API_KEY` 读取。
+
+```yaml
+name: 'cohere_embedding'
+description: 'embedding via Cohere Embed v3 API'
+embedding_model_name: 'embed-multilingual-v3.0'
+api_key: '${COHERE_API_KEY}'
+input_type: 'document'
+request_timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.cohere_embedding'
+  class: 'CohereEmbedding'
+```
+- embedding_model_name：Cohere embed 模型（默认 `embed-multilingual-v3.0`）。
+- api_key：Cohere API Key（环境变量 `COHERE_API_KEY`）。
+- input_type：`document` 或 `query`——Cohere 建议明确指定以获得最佳检索质量（默认 `document`）。
+- request_timeout：超时秒数（默认 30）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_cohere_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_cohere_embedding.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for CohereEmbedding."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.embedding.cohere_embedding \
+    import CohereEmbedding
+
+
+def _mock_response(embeddings, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"embeddings": {"float": embeddings}}
+    resp.raise_for_status.return_value = None if status_code < 400 else Exception()
+    return resp
+
+
+class TestCohereEmbedding(unittest.TestCase):
+
+    def test_get_embeddings_single(self):
+        emb = CohereEmbedding(api_key="fake")
+        with patch("agentuniverse.agent.action.knowledge.embedding."
+                   "cohere_embedding.requests.post",
+                   return_value=_mock_response([[0.1, 0.2, 0.3]])):
+            result = emb.get_embeddings(["hello"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], [0.1, 0.2, 0.3])
+
+    def test_get_embeddings_multiple(self):
+        emb = CohereEmbedding(api_key="fake")
+        with patch("agentuniverse.agent.action.knowledge.embedding."
+                   "cohere_embedding.requests.post",
+                   return_value=_mock_response([[0.1], [0.2], [0.3]])):
+            result = emb.get_embeddings(["a", "b", "c"])
+        self.assertEqual(len(result), 3)
+
+    def test_empty_input(self):
+        emb = CohereEmbedding(api_key="fake")
+        self.assertEqual(emb.get_embeddings([]), [])
+
+    def test_missing_api_key(self):
+        emb = CohereEmbedding(api_key="")
+        with self.assertRaises(ValueError):
+            emb.get_embeddings(["text"])
+
+    def test_timeout_returns_empty_vectors(self):
+        import requests as req_mod
+        emb = CohereEmbedding(api_key="fake")
+        with patch("agentuniverse.agent.action.knowledge.embedding."
+                   "cohere_embedding.requests.post",
+                   side_effect=req_mod.exceptions.Timeout("slow")):
+            result = emb.get_embeddings(["text"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], [])
+
+    def test_http_error_raises(self):
+        import requests as req_mod
+        emb = CohereEmbedding(api_key="fake")
+        bad_resp = MagicMock()
+        bad_resp.status_code = 401
+        bad_resp.raise_for_status.side_effect = req_mod.exceptions.HTTPError(
+            response=bad_resp)
+        with patch("agentuniverse.agent.action.knowledge.embedding."
+                   "cohere_embedding.requests.post", return_value=bad_resp):
+            with self.assertRaises(RuntimeError):
+                emb.get_embeddings(["text"])
+
+    def test_input_type_passed(self):
+        emb = CohereEmbedding(api_key="fake", input_type="document")
+        with patch("agentuniverse.agent.action.knowledge.embedding."
+                   "cohere_embedding.requests.post",
+                   return_value=_mock_response([[0.1]])) as mock_post:
+            emb.get_embeddings(["q"], text_type="query")
+            body = mock_post.call_args.kwargs["json"]
+            self.assertEqual(body["input_type"], "query")
+
+    def test_env_var_default(self):
+        with patch.dict("os.environ", {"COHERE_API_KEY": "env-key"}):
+            emb = CohereEmbedding()
+            self.assertEqual(emb.api_key, "env-key")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `CohereEmbedding` — generates text embeddings using the Cohere Embed v3 API (multilingual + English models).

## Why (not a duplicate)

Not covered by any open or merged PR. #250 lists embedding components; the framework has OpenAI, Gemini, Dashscope, AWS Bedrock, Ollama, Doubao, AzureOpenAI, HuggingFace embeddings but not Cohere.

## Capabilities

- Uses Cohere v2 embed endpoint with configurable model (default `embed-multilingual-v3.0`).
- Supports `input_type` (`"document"` / `"query"`) — Cohere recommends specifying this for best retrieval quality.
- Bounded: `request_timeout` (30s); timeout returns empty vectors gracefully.
- HTTP error raises `RuntimeError`.
- `api_key` from `COHERE_API_KEY` env var.
- Batch embedding in a single API call.

## Tests

8 unit tests: single/multiple embeddings, empty input, missing api_key, timeout graceful fallback, HTTP error, input_type passed correctly, env var default.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.embedding.test_cohere_embedding` — 8 passed.
