### PR TITLE
feat(tool): HashCryptoTool — hash/HMAC/encode/decode (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/hash_crypto_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/hash_crypto_tool.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Hash and crypto utility tool.
+
+Provides hash (md5/sha1/sha256/sha512), HMAC, base64 encode/decode, and
+hex encode/decode operations. All using Python's standard library — zero
+third-party dependency.
+
+Addresses #252 (more tools).
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import base64
+import hashlib
+import hmac
+import logging
+from typing import Any
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_HASH_ALGOS = {"md5", "sha1", "sha256", "sha512"}
+_ENCODE_FORMATS = {"base64", "hex"}
+
+
+class HashCryptoTool(Tool):
+    """Hash, HMAC, and encoding/decoding utility tool.
+
+    All operations use Python's standard ``hashlib``, ``hmac``, and
+    ``base64`` modules — zero third-party dependency.
+    """
+
+    def execute(self, mode: str, text: str = "", algorithm: str = "sha256",
+                key: str = "", encoding: str = "base64",
+                **kwargs) -> dict:
+        try:
+            op = self._normalize_mode(mode)
+            if op == "hash":
+                return self._hash(text, algorithm)
+            if op == "hmac":
+                return self._hmac(text, key, algorithm)
+            if op == "encode":
+                return self._encode(text, encoding)
+            if op == "decode":
+                return self._decode(text, encoding)
+            return self._error("validation_error", f"Unknown mode: {mode}")
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("operation_error", str(exc))
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        normalized = mode.strip().lower()
+        allowed = {"hash", "hmac", "encode", "decode"}
+        if normalized not in allowed:
+            raise ValueError(f"mode must be one of: {', '.join(sorted(allowed))}")
+        return normalized
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}
+
+    @staticmethod
+    def _ok(**kwargs) -> dict:
+        return {"status": "success", **kwargs}
+
+    def _hash(self, text: str, algorithm: str) -> dict:
+        if not isinstance(text, str):
+            raise ValueError("text must be a string")
+        algorithm = (algorithm or "sha256").lower()
+        if algorithm not in _HASH_ALGOS:
+            raise ValueError(
+                f"algorithm must be one of: {', '.join(sorted(_HASH_ALGOS))}")
+        data = text.encode("utf-8")
+        digest = hashlib.new(algorithm, data).hexdigest()
+        return self._ok(mode="hash", algorithm=algorithm,
+                        input_length=len(text), digest=digest)
+
+    def _hmac(self, text: str, key: str, algorithm: str) -> dict:
+        if not isinstance(text, str) or not isinstance(key, str):
+            raise ValueError("text and key must be strings")
+        if not key:
+            raise ValueError("key is required for HMAC")
+        algorithm = (algorithm or "sha256").lower()
+        if algorithm not in _HASH_ALGOS:
+            raise ValueError(
+                f"algorithm must be one of: {', '.join(sorted(_HASH_ALGOS))}")
+        digest = hmac.new(
+            key.encode("utf-8"), text.encode("utf-8"), algorithm
+        ).hexdigest()
+        return self._ok(mode="hmac", algorithm=algorithm, digest=digest)
+
+    def _encode(self, text: str, encoding: str) -> dict:
+        if not isinstance(text, str):
+            raise ValueError("text must be a string")
+        encoding = (encoding or "base64").lower()
+        if encoding not in _ENCODE_FORMATS:
+            raise ValueError(
+                f"encoding must be one of: {', '.join(sorted(_ENCODE_FORMATS))}")
+        data = text.encode("utf-8")
+        if encoding == "base64":
+            encoded = base64.b64encode(data).decode("ascii")
+        else:
+            encoded = data.hex()
+        return self._ok(mode="encode", encoding=encoding, encoded=encoded)
+
+    def _decode(self, text: str, encoding: str) -> dict:
+        if not isinstance(text, str) or not text:
+            raise ValueError("text must be a non-empty string")
+        encoding = (encoding or "base64").lower()
+        if encoding not in _ENCODE_FORMATS:
+            raise ValueError(
+                f"encoding must be one of: {', '.join(sorted(_ENCODE_FORMATS))}")
+        try:
+            if encoding == "base64":
+                decoded = base64.b64decode(text).decode("utf-8")
+            else:
+                decoded = bytes.fromhex(text).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise ValueError(
+                f"Failed to decode {encoding!r} input: {exc}") from exc
+        return self._ok(mode="decode", encoding=encoding, decoded=decoded)
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) \
+            -> "HashCryptoTool":
+        super()._initialize_by_component_configer(configer)
+        return self

--- a/agentuniverse/agent/action/tool/common_tool/hash_crypto_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/hash_crypto_tool.yaml.example
@@ -1,0 +1,10 @@
+name: hash_crypto_tool
+description: Bounded hash and HMAC tool — compute message digests (sha256, sha512, md5, blake2, etc.) and keyed HMAC over text inputs.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.hash_crypto_tool
+  class: HashCryptoTool
+input_keys:
+  - mode
+  - text

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,24 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## HashCryptoTool
+
+`HashCryptoTool` exposes hash, HMAC, and encoding/decoding utilities for agent workflows: `hash` (md5 / sha1 / sha256 / sha512), `hmac` (keyed hash with the same algorithms), and `encode` / `decode` for `base64` and `hex`. Everything is implemented with Python's standard `hashlib`, `hmac`, and `base64` modules — zero third-party dependency. It addresses issue #252.
+
+Register a component pointing at `agentuniverse.agent.action.tool.common_tool.hash_crypto_tool.HashCryptoTool`, then call `execute(mode=..., text=..., algorithm=..., key=..., encoding=...)`.
+
+```yaml
+name: hash_crypto_tool
+description: Hash, HMAC, and encoding/decoding utility tool
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.hash_crypto_tool
+  class: HashCryptoTool
+input_keys: ["mode", "text"]
+```
+- mode: One of `hash`, `hmac`, `encode`, `decode`.
+- text: Input string for the operation.
+- algorithm: Hash algorithm for `hash` / `hmac` — `md5`, `sha1`, `sha256` (default), or `sha512`.
+- key: Secret key required by `hmac`.
+- encoding: Encoding format for `encode` / `decode` — `base64` (default) or `hex`.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,24 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## HashCryptoTool
+
+`HashCryptoTool` 为智能体工作流提供哈希、HMAC 和编解码工具：`hash`（md5 / sha1 / sha256 / sha512）、`hmac`（用同样算法做带密钥哈希）、以及 `base64` 和 `hex` 的 `encode` / `decode`。全部基于 Python 标准库 `hashlib`、`hmac`、`base64` 实现，零第三方依赖。对应 issue #252。
+
+注册一个指向 `agentuniverse.agent.action.tool.common_tool.hash_crypto_tool.HashCryptoTool` 的组件，然后调用 `execute(mode=..., text=..., algorithm=..., key=..., encoding=...)`。
+
+```yaml
+name: hash_crypto_tool
+description: Hash, HMAC, and encoding/decoding utility tool
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.hash_crypto_tool
+  class: HashCryptoTool
+input_keys: ["mode", "text"]
+```
+- mode: 取值 `hash`、`hmac`、`encode`、`decode`。
+- text: 操作的输入字符串。
+- algorithm: `hash` / `hmac` 使用的哈希算法——`md5`、`sha1`、`sha256`（默认）、`sha512`。
+- key: `hmac` 所需的密钥。
+- encoding: `encode` / `decode` 的编码格式——`base64`（默认）或 `hex`。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_hash_crypto_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_hash_crypto_tool.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for HashCryptoTool."""
+
+import hashlib
+import hmac
+import base64
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool.hash_crypto_tool \
+    import HashCryptoTool
+
+
+class TestHash(unittest.TestCase):
+
+    def test_sha256(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="hash", text="hello", algorithm="sha256")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["digest"],
+                         hashlib.sha256(b"hello").hexdigest())
+
+    def test_md5(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="hash", text="hello", algorithm="md5")
+        self.assertEqual(result["digest"],
+                         hashlib.md5(b"hello").hexdigest())
+
+    def test_invalid_algorithm(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="hash", text="x", algorithm="crc32")
+        self.assertEqual(result["status"], "error")
+
+    def test_default_algorithm_is_sha256(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="hash", text="test")
+        self.assertEqual(result["algorithm"], "sha256")
+
+
+class TestHMAC(unittest.TestCase):
+
+    def test_hmac_sha256(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="hmac", text="data", key="secret",
+                              algorithm="sha256")
+        expected = hmac.new(b"secret", b"data", "sha256").hexdigest()
+        self.assertEqual(result["digest"], expected)
+
+    def test_hmac_missing_key(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="hmac", text="data", key="")
+        self.assertEqual(result["status"], "error")
+
+
+class TestEncodeDecode(unittest.TestCase):
+
+    def test_base64_encode(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="encode", text="hello", encoding="base64")
+        self.assertEqual(result["encoded"], base64.b64encode(b"hello").decode())
+
+    def test_base64_decode(self):
+        tool = HashCryptoTool()
+        encoded = base64.b64encode(b"hello").decode()
+        result = tool.execute(mode="decode", text=encoded, encoding="base64")
+        self.assertEqual(result["decoded"], "hello")
+
+    def test_hex_encode(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="encode", text="AB", encoding="hex")
+        self.assertEqual(result["encoded"], "4142")
+
+    def test_hex_decode(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="decode", text="4142", encoding="hex")
+        self.assertEqual(result["decoded"], "AB")
+
+    def test_decode_invalid_input(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="decode", text="!!!notb64!!!", encoding="base64")
+        self.assertEqual(result["status"], "error")
+
+    def test_round_trip_base64(self):
+        tool = HashCryptoTool()
+        text = "Hello, World! 你好"
+        encoded = tool.execute(mode="encode", text=text, encoding="base64")["encoded"]
+        decoded = tool.execute(mode="decode", text=encoded, encoding="base64")["decoded"]
+        self.assertEqual(decoded, text)
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_unknown_mode(self):
+        tool = HashCryptoTool()
+        result = tool.execute(mode="encrypt")
+        self.assertEqual(result["status"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `HashCryptoTool` — provides hash (md5/sha1/sha256/sha512), HMAC, base64 encode/decode, and hex encode/decode operations. All using Python's standard library — zero third-party dependency.

## Why (not a duplicate)

Not covered by any open or merged PR. No existing tool provides hash/encoding operations; agents that need data integrity or encoding currently have no structured way to do so.

## Capabilities

- **Hash**: md5, sha1, sha256, sha512 — configurable algorithm (default sha256).
- **HMAC**: HMAC with any hash algorithm; requires a key.
- **Encode**: base64 or hex.
- **Decode**: base64 or hex, with clear error on invalid input.
- Structured `{status, mode, algorithm, digest}` / `{status, encoded}` / `{status, decoded}` response.
- Zero third-party dependencies.

## Tests

13 unit tests: sha256/md5/invalid algorithm/default, HMAC sha256/missing key, base64 encode/decode, hex encode/decode, invalid decode, round-trip (including Unicode), unknown mode.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_hash_crypto_tool` — 13 passed.
