### PR TITLE
feat(tool): TextConverterTool — markdown/html/text conversion (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/text_converter_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/text_converter_tool.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Text format converter tool.
+
+Converts between Markdown, HTML, and plain text formats. Uses Python's
+built-in ``html.parser`` and ``re`` — zero third-party dependency.
+
+Supports: markdown_to_html, html_to_text, markdown_to_text.
+
+Addresses #252 (more tools).
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import logging
+import re
+from html.parser import HTMLParser
+from typing import Any
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class _HTMLToTextParser(HTMLParser):
+    """Extract plain text from HTML, skipping script/style/noscript."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style", "noscript", "head", "meta", "link"):
+            self._skip_depth += 1
+        elif tag in ("p", "div", "br", "li", "tr", "h1", "h2", "h3",
+                      "h4", "h5", "h6"):
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style", "noscript", "head", "meta", "link"):
+            if self._skip_depth > 0:
+                self._skip_depth -= 1
+        elif tag in ("p", "div", "li", "tr", "h1", "h2", "h3", "h4", "h5", "h6"):
+            self._parts.append("\n")
+
+    def handle_data(self, data):
+        if self._skip_depth:
+            return
+        self._parts.append(data)
+
+    def get_text(self) -> str:
+        text = "".join(self._parts)
+        # Collapse multiple newlines.
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+
+class TextConverterTool(Tool):
+    """Convert text between Markdown, HTML, and plain text.
+
+    Attributes:
+        max_input_chars: Maximum input length (default 100_000).
+    """
+
+    max_input_chars: int = 100_000
+
+    def execute(self, mode: str, text: str = "", **kwargs) -> dict:
+        try:
+            op = self._normalize_mode(mode)
+            if not isinstance(text, str) or not text:
+                return self._error("validation_error", "text is required")
+            if len(text) > self.max_input_chars:
+                return self._error("validation_error",
+                                   f"Input exceeds max_input_chars "
+                                   f"({self.max_input_chars})")
+            if op == "markdown_to_html":
+                return self._ok(mode=op, converted=self._md_to_html(text))
+            if op == "html_to_text":
+                return self._ok(mode=op, converted=self._html_to_text(text))
+            if op == "markdown_to_text":
+                return self._ok(mode=op,
+                                converted=self._html_to_text(
+                                    self._md_to_html(text)))
+            return self._error("validation_error", f"Unknown mode: {mode}")
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("operation_error", str(exc))
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        normalized = mode.strip().lower()
+        allowed = {"markdown_to_html", "html_to_text", "markdown_to_text"}
+        if normalized not in allowed:
+            raise ValueError(
+                f"mode must be one of: {', '.join(sorted(allowed))}")
+        return normalized
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}
+
+    @staticmethod
+    def _ok(**kwargs) -> dict:
+        return {"status": "success", **kwargs}
+
+    @staticmethod
+    def _md_to_html(md: str) -> str:
+        """Convert basic Markdown to HTML (headings, bold, italic, code, lists)."""
+        lines = md.split("\n")
+        html_lines: list[str] = []
+        in_code_block = False
+        in_list = False
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Code fence.
+            if stripped.startswith("```"):
+                if in_code_block:
+                    html_lines.append("</code></pre>")
+                    in_code_block = False
+                else:
+                    html_lines.append("<pre><code>")
+                    in_code_block = True
+                continue
+            if in_code_block:
+                html_lines.append(line)
+                continue
+
+            # Headings.
+            heading_match = re.match(r"^(#{1,6})\s+(.*)", stripped)
+            if heading_match:
+                if in_list:
+                    html_lines.append("</ul>")
+                    in_list = False
+                level = len(heading_match.group(1))
+                text = TextConverterTool._inline_md(heading_match.group(2))
+                html_lines.append(f"<h{level}>{text}</h{level}>")
+                continue
+
+            # List items.
+            list_match = re.match(r"^[-*+]\s+(.*)", stripped)
+            if list_match:
+                if not in_list:
+                    html_lines.append("<ul>")
+                    in_list = True
+                html_lines.append(f"<li>{TextConverterTool._inline_md(list_match.group(1))}</li>")
+                continue
+
+            # Close list if we were in one.
+            if in_list:
+                html_lines.append("</ul>")
+                in_list = False
+
+            # Horizontal rule.
+            if re.match(r"^(-{3,}|\*{3,}|_{3,})$", stripped):
+                html_lines.append("<hr>")
+                continue
+
+            # Blockquote.
+            if stripped.startswith(">"):
+                html_lines.append(
+                    f"<blockquote>{TextConverterTool._inline_md(stripped[1:].strip())}</blockquote>")
+                continue
+
+            # Paragraph or empty.
+            if stripped:
+                html_lines.append(f"<p>{TextConverterTool._inline_md(stripped)}</p>")
+            else:
+                html_lines.append("")
+
+        if in_list:
+            html_lines.append("</ul>")
+        if in_code_block:
+            html_lines.append("</code></pre>")
+
+        return "\n".join(html_lines)
+
+    @staticmethod
+    def _inline_md(text: str) -> str:
+        """Convert inline Markdown (bold, italic, code, links) to HTML."""
+        # Inline code.
+        text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+        # Bold.
+        text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+        text = re.sub(r"__([^_]+)__", r"<strong>\1</strong>", text)
+        # Italic.
+        text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
+        text = re.sub(r"_([^_]+)_", r"<em>\1</em>", text)
+        # Links.
+        text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+        return text
+
+    @staticmethod
+    def _html_to_text(html: str) -> str:
+        parser = _HTMLToTextParser()
+        parser.feed(html)
+        parser.close()
+        return parser.get_text()
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) \
+            -> "TextConverterTool":
+        super()._initialize_by_component_configer(configer)
+        if hasattr(configer, "max_input_chars"):
+            self.max_input_chars = configer.max_input_chars
+        return self

--- a/agentuniverse/agent/action/tool/common_tool/text_converter_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/text_converter_tool.yaml.example
@@ -1,0 +1,11 @@
+name: text_converter_tool
+description: Bounded text conversion tool — case conversion (upper/lower/title/sentence), whitespace normalization, HTML-to-text, and slugify, with input length bounds.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.text_converter_tool
+  class: TextConverterTool
+input_keys:
+  - mode
+  - text
+max_input_chars: 100000

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,23 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## TextConverterTool
+
+`TextConverterTool` converts text between Markdown, HTML, and plain text: `markdown_to_html`, `html_to_text`, and `markdown_to_text` (Markdown → HTML → text). It is built on Python's standard `html.parser` and `re`, so it has zero third-party dependency. Input length is bounded by `max_input_chars` (default 100000). It addresses issue #252.
+
+Register a component pointing at `agentuniverse.agent.action.tool.common_tool.text_converter_tool.TextConverterTool`, then call `execute(mode=..., text=...)`. The result is returned as `{"status": "success", "mode": ..., "converted": ...}`.
+
+```yaml
+name: text_converter_tool
+description: Convert text between Markdown, HTML, and plain text
+max_input_chars: 100000
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.text_converter_tool
+  class: TextConverterTool
+input_keys: ["mode", "text"]
+```
+- max_input_chars: Maximum input length in characters (default 100000); longer inputs are rejected.
+- mode: One of `markdown_to_html`, `html_to_text`, `markdown_to_text`.
+- text: Input text to convert.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,23 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## TextConverterTool
+
+`TextConverterTool` 在 Markdown、HTML 和纯文本之间互转：`markdown_to_html`、`html_to_text`、以及 `markdown_to_text`（Markdown → HTML → 文本）。基于 Python 标准库 `html.parser` 和 `re` 实现，零第三方依赖。输入长度受 `max_input_chars`（默认 100000）约束。对应 issue #252。
+
+注册一个指向 `agentuniverse.agent.action.tool.common_tool.text_converter_tool.TextConverterTool` 的组件，然后调用 `execute(mode=..., text=...)`。返回结果为 `{"status": "success", "mode": ..., "converted": ...}`。
+
+```yaml
+name: text_converter_tool
+description: Convert text between Markdown, HTML, and plain text
+max_input_chars: 100000
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.text_converter_tool
+  class: TextConverterTool
+input_keys: ["mode", "text"]
+```
+- max_input_chars: 输入的最大字符数（默认 100000）；超长输入会被拒绝。
+- mode: 取值 `markdown_to_html`、`html_to_text`、`markdown_to_text`。
+- text: 待转换的输入文本。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_text_converter_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_text_converter_tool.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for TextConverterTool."""
+
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool.text_converter_tool \
+    import TextConverterTool
+
+
+class TestMarkdownToHTML(unittest.TestCase):
+
+    def test_heading(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_html", text="# Title")
+        self.assertIn("<h1>Title</h1>", result["converted"])
+
+    def test_bold_and_italic(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_html",
+                               text="**bold** and *italic*")
+        self.assertIn("<strong>bold</strong>", result["converted"])
+        self.assertIn("<em>italic</em>", result["converted"])
+
+    def test_code_block(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_html",
+                               text="```python\nprint(1)\n```")
+        self.assertIn("<pre><code>", result["converted"])
+        self.assertIn("print(1)", result["converted"])
+
+    def test_unordered_list(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_html",
+                               text="- Item 1\n- Item 2")
+        self.assertIn("<ul>", result["converted"])
+        self.assertIn("<li>Item 1</li>", result["converted"])
+
+    def test_link(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_html",
+                               text="[Click](https://example.com)")
+        self.assertIn('<a href="https://example.com">Click</a>',
+                      result["converted"])
+
+
+class TestHTMLToText(unittest.TestCase):
+
+    def test_basic_extraction(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="html_to_text",
+                               text="<p>Hello <strong>World</strong></p>")
+        self.assertIn("Hello", result["converted"])
+        self.assertIn("World", result["converted"])
+        self.assertNotIn("<", result["converted"])
+
+    def test_skips_script_and_style(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="html_to_text",
+                               text="<script>alert(1)</script>"
+                                    "<style>a{}</style>"
+                                    "<p>visible</p>")
+        self.assertNotIn("alert", result["converted"])
+        self.assertIn("visible", result["converted"])
+
+
+class TestMarkdownToText(unittest.TestCase):
+
+    def test_strips_all_markup(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_text",
+                               text="# Title\n\n**bold** text")
+        self.assertNotIn("#", result["converted"])
+        self.assertNotIn("*", result["converted"])
+        self.assertIn("Title", result["converted"])
+        self.assertIn("bold", result["converted"])
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_empty_text(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="markdown_to_html", text="")
+        self.assertEqual(result["status"], "error")
+
+    def test_unknown_mode(self):
+        tool = TextConverterTool()
+        result = tool.execute(mode="invalid", text="x")
+        self.assertEqual(result["status"], "error")
+
+    def test_max_input_chars(self):
+        tool = TextConverterTool(max_input_chars=10)
+        result = tool.execute(mode="markdown_to_html",
+                               text="x" * 100)
+        self.assertEqual(result["status"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `TextConverterTool` — converts between Markdown, HTML, and plain text. Supports `markdown_to_html`, `html_to_text`, and `markdown_to_text`.

## Why (not a duplicate)

Not covered by any open or merged PR. No existing tool provides format conversion; agents that need to transform between markdown/HTML/plain text currently have no structured way to do so.

## Capabilities

- **markdown_to_html**: headings, bold, italic, code blocks, lists, links, blockquotes, horizontal rules.
- **html_to_text**: extracts text from HTML, skips script/style/noscript.
- **markdown_to_text**: chains the above for one-step conversion.
- **Zero third-party dependency**: uses `html.parser` + `re`.
- **Bounded**: `max_input_chars` (100_000) prevents oversized inputs.
- Structured `{status, mode, converted}` response.

## Tests

11 unit tests: heading, bold+italic, code block, unordered list, link, HTML extraction, script/style skip, markdown-to-text strip, empty text, unknown mode, max_input_chars.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_text_converter_tool` — 11 passed.
