### PR TITLE
feat(embedding): SentenceTransformerEmbedding — local on-device embedding (#250)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/sentence_transformer_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/sentence_transformer_embedding.py
@@ -1,0 +1,83 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: sentence_transformer_embedding.py
+
+"""
+Sentence-Transformers embedding component.
+
+Generates text embeddings using locally-hosted sentence-transformers models
+(via the ``sentence-transformers`` package). No API key or network connection
+required — models run entirely on-device. Ideal for development, testing,
+privacy-sensitive deployments, and offline use.
+"""
+
+import logging
+from typing import List, Optional
+
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
+
+logger = logging.getLogger(__name__)
+
+
+class SentenceTransformerEmbedding(Embedding):
+    """Embedding component backed by locally-hosted sentence-transformers.
+
+    Attributes:
+        embedding_model_name: The model name or path
+            (default ``all-MiniLM-L6-v2``).
+        device: Device to run the model on (``"cpu"``, ``"cuda"``,
+            ``"mps"``). Default ``"cpu"``.
+        normalize_embeddings: If True, L2-normalise the output vectors
+            (default True — recommended for cosine similarity).
+        batch_size: Batch size for encoding (default 32).
+    """
+
+    embedding_model_name: str = "all-MiniLM-L6-v2"
+    device: str = "cpu"
+    normalize_embeddings: bool = True
+    batch_size: int = 32
+
+    _model: Optional[object] = None
+
+    def _get_model(self):
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise ImportError(
+                "sentence-transformers is not installed. Install it with "
+                "'pip install sentence-transformers'.") from exc
+        self._model = SentenceTransformer(
+            self.embedding_model_name, device=self.device)
+        logger.info("Loaded sentence-transformers model %s on %s",
+                     self.embedding_model_name, self.device)
+        return self._model
+
+    def get_embeddings(self, texts: List[str],
+                       text_type: str = "document") -> List[List[float]]:
+        if not texts:
+            return []
+        model = self._get_model()
+        try:
+            embeddings = model.encode(
+                texts,
+                normalize_embeddings=self.normalize_embeddings,
+                batch_size=self.batch_size,
+            )
+            # Convert numpy array to list of lists.
+            if hasattr(embeddings, "tolist"):
+                embeddings = embeddings.tolist()
+            return [list(emb) for emb in embeddings]
+        except Exception as exc:
+            logger.warning("SentenceTransformer embedding failed: %s", exc)
+            return [[] for _ in texts]
+
+    async def async_get_embeddings(self, texts: List[str],
+                                   text_type: str = "document") -> List[List[float]]:
+        # sentence-transformers is CPU-bound (no native async); reuse sync.
+        return self.get_embeddings(texts, text_type)

--- a/agentuniverse/agent/action/knowledge/embedding/sentence_transformer_embedding.yaml.example
+++ b/agentuniverse/agent/action/knowledge/embedding/sentence_transformer_embedding.yaml.example
@@ -1,0 +1,10 @@
+name: 'sentence_transformer_embedding'
+description: 'Embedding component backed by local sentence-transformers models (all-MiniLM-L6-v2, BGE, etc.), runs on CPU or CUDA.'
+embedding_model_name: 'all-MiniLM-L6-v2'
+device: 'cpu'
+normalize_embeddings: true
+batch_size: 32
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.sentence_transformer_embedding'
+  class: 'SentenceTransformerEmbedding'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
@@ -1,0 +1,26 @@
+# Embedding
+
+agentUniverse provides several built-in embedding components used by the Knowledge store and doc processors to vectorise text. Each component is registered with `metadata.type: EMBEDDING` and exposes `get_embeddings(texts, text_type=...)`.
+
+## SentenceTransformerEmbedding
+
+`SentenceTransformerEmbedding` generates text embeddings using locally-hosted sentence-transformers models (via the `sentence-transformers` package). No API key or network connection is required — models run entirely on-device, which makes this component ideal for development, testing, privacy-sensitive deployments, and offline use. Install the package with `pip install sentence-transformers`.
+
+Register a component pointing at `agentuniverse.agent.action.knowledge.embedding.sentence_transformer_embedding.SentenceTransformerEmbedding`, then reference it by name from a store or processor (e.g. `embedding_model: sentence_transformer_embedding`).
+
+```yaml
+name: 'sentence_transformer_embedding'
+description: 'local embedding via sentence-transformers'
+embedding_model_name: 'all-MiniLM-L6-v2'
+device: 'cpu'
+normalize_embeddings: true
+batch_size: 32
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.sentence_transformer_embedding'
+  class: 'SentenceTransformerEmbedding'
+```
+- embedding_model_name: The model name or path (default `all-MiniLM-L6-v2`).
+- device: Device to run the model on — `cpu`, `cuda`, or `mps` (default `cpu`).
+- normalize_embeddings: When `true` (default), L2-normalise the output vectors — recommended for cosine similarity.
+- batch_size: Batch size for encoding (default 32).

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
@@ -1,0 +1,26 @@
+# Embedding（向量化）
+
+agentUniverse 提供若干内置 embedding 组件，供知识库 store 与文档处理器对文本向量化。每个组件以 `metadata.type: EMBEDDING` 注册，并暴露 `get_embeddings(texts, text_type=...)` 方法。
+
+## SentenceTransformerEmbedding
+
+`SentenceTransformerEmbedding` 使用本地托管的 sentence-transformers 模型（通过 `sentence-transformers` 包）生成文本向量。无需 API Key、无需联网——模型完全在本地运行，非常适合开发、测试、对隐私敏感的部署以及离线场景。安装包：`pip install sentence-transformers`。
+
+注册一个指向 `agentuniverse.agent.action.knowledge.embedding.sentence_transformer_embedding.SentenceTransformerEmbedding` 的组件，然后在 store 或处理器中按名引用（如 `embedding_model: sentence_transformer_embedding`）。
+
+```yaml
+name: 'sentence_transformer_embedding'
+description: 'local embedding via sentence-transformers'
+embedding_model_name: 'all-MiniLM-L6-v2'
+device: 'cpu'
+normalize_embeddings: true
+batch_size: 32
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.sentence_transformer_embedding'
+  class: 'SentenceTransformerEmbedding'
+```
+- embedding_model_name：模型名或路径（默认 `all-MiniLM-L6-v2`）。
+- device：运行模型的设备——`cpu`、`cuda` 或 `mps`（默认 `cpu`）。
+- normalize_embeddings：为 `true`（默认）时对输出向量做 L2 归一化——推荐用于余弦相似度。
+- batch_size：编码时的批大小（默认 32）。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_sentence_transformer_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_sentence_transformer_embedding.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for SentenceTransformerEmbedding."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.embedding.sentence_transformer_embedding \
+    import SentenceTransformerEmbedding
+
+
+class TestSentenceTransformerEmbedding(unittest.TestCase):
+
+    def test_get_embeddings_single(self):
+        emb = SentenceTransformerEmbedding()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = MagicMock(
+            tolist=lambda: [[0.1, 0.2, 0.3]])
+        emb._model = mock_model
+
+        result = emb.get_embeddings(["hello"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], [0.1, 0.2, 0.3])
+
+    def test_get_embeddings_multiple(self):
+        emb = SentenceTransformerEmbedding()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = MagicMock(
+            tolist=lambda: [[0.1], [0.2], [0.3]])
+        emb._model = mock_model
+
+        result = emb.get_embeddings(["a", "b", "c"])
+        self.assertEqual(len(result), 3)
+
+    def test_empty_input(self):
+        emb = SentenceTransformerEmbedding()
+        self.assertEqual(emb.get_embeddings([]), [])
+
+    def test_error_returns_empty_vectors(self):
+        emb = SentenceTransformerEmbedding()
+        mock_model = MagicMock()
+        mock_model.encode.side_effect = RuntimeError("model crashed")
+        emb._model = mock_model
+
+        result = emb.get_embeddings(["text"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], [])
+
+    def test_normalize_embeddings_passed_to_model(self):
+        emb = SentenceTransformerEmbedding(normalize_embeddings=True)
+        mock_model = MagicMock()
+        mock_model.encode.return_value = MagicMock(
+            tolist=lambda: [[0.1]])
+        emb._model = mock_model
+
+        emb.get_embeddings(["text"])
+        call_kwargs = mock_model.encode.call_args.kwargs
+        self.assertTrue(call_kwargs["normalize_embeddings"])
+
+    def test_batch_size_passed(self):
+        emb = SentenceTransformerEmbedding(batch_size=64)
+        mock_model = MagicMock()
+        mock_model.encode.return_value = MagicMock(
+            tolist=lambda: [[0.1]])
+        emb._model = mock_model
+
+        emb.get_embeddings(["text"])
+        call_kwargs = mock_model.encode.call_args.kwargs
+        self.assertEqual(call_kwargs["batch_size"], 64)
+
+    def test_default_model_name(self):
+        emb = SentenceTransformerEmbedding()
+        self.assertEqual(emb.embedding_model_name, "all-MiniLM-L6-v2")
+
+    def test_default_device_cpu(self):
+        emb = SentenceTransformerEmbedding()
+        self.assertEqual(emb.device, "cpu")
+
+    def test_model_lazy_load(self):
+        """Model should not be loaded until get_embeddings is called."""
+        emb = SentenceTransformerEmbedding()
+        self.assertIsNone(emb._model)
+
+    def test_numpy_array_without_tolist(self):
+        """If encode returns a plain list, it should still work."""
+        emb = SentenceTransformerEmbedding()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = [[0.1, 0.2], [0.3, 0.4]]
+        emb._model = mock_model
+
+        result = emb.get_embeddings(["a", "b"])
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], [0.1, 0.2])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `SentenceTransformerEmbedding` — generates text embeddings using locally-hosted sentence-transformers models. No API key or network connection required — models run entirely on-device.

## Why (not a duplicate)

Not covered by any open or merged PR. The framework has cloud-based embeddings (OpenAI, Gemini, Cohere, etc.) but no local/offline option. `SentenceTransformerEmbedding` is ideal for development, testing, privacy-sensitive deployments, and offline use.

## Capabilities

- Uses the `sentence-transformers` package (lazy import; optional dependency).
- Configurable model (default `all-MiniLM-L6-v2`), device (`cpu`/`cuda`/`mps`), batch size.
- L2 normalisation toggle (`normalize_embeddings=True` by default — recommended for cosine similarity).
- Model loaded lazily on first `get_embeddings` call.
- Error graceful degradation (returns empty vectors for failed texts).

## Tests

10 unit tests: single/multiple embeddings, empty input, error fallback, normalize_embeddings passed, batch_size passed, default model name, default device, lazy load verification, numpy array without tolist.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.embedding.test_sentence_transformer_embedding` — 10 passed.
