### PR TITLE
fix: RunCommandTool 非阻塞返回半初始化 result

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
@@ -131,6 +131,11 @@ class RunCommandTool(Tool):
             })
         return self._run_command(command, cwd, blocking)
 
+    # Maximum time (seconds) to wait for the worker thread to register its
+    # command result. Prevents indefinite blocking when the worker fails to
+    # start (e.g. thread creation error or early exception before set()).
+    _THREAD_STARTED_TIMEOUT = 10.0
+
     def _run_command(self, command: str, cwd: str, blocking: bool = True) -> str:
         result = CommandResult(
             thread_id=threading.get_ident(),
@@ -141,12 +146,13 @@ class RunCommandTool(Tool):
         )
 
         thread_started = threading.Event()
+        thread_error: list = []  # captured from worker if it fails before set()
 
         def __run() -> None:
-            result.thread_id = threading.get_ident()
-            _command_results[result.thread_id] = result
-            thread_started.set()
             try:
+                result.thread_id = threading.get_ident()
+                _command_results[result.thread_id] = result
+                thread_started.set()
                 process = subprocess.Popen(
                     command,
                     cwd=cwd,
@@ -166,6 +172,7 @@ class RunCommandTool(Tool):
                 result.status = CommandStatus.COMPLETED if exit_code == 0 else CommandStatus.ERROR
 
             except Exception as e:
+                thread_error.append(e)
                 result.stderr = str(e)
                 result.end_time = time.time()
                 result.status = CommandStatus.ERROR
@@ -174,12 +181,36 @@ class RunCommandTool(Tool):
 
         if blocking:
             __run()
-        else:
-            thread = threading.Thread(target=__run)
-            thread.start()
-            thread_started.wait()
+            return result.message
 
-        return result.message
+        # Non-blocking: spawn worker, wait with timeout for it to register.
+        thread = threading.Thread(target=__run)
+        thread.daemon = True
+        thread.start()
+
+        if not thread_started.wait(timeout=self._THREAD_STARTED_TIMEOUT):
+            # Worker did not signal readiness in time; surface a clear error
+            # instead of leaving the caller blocked forever.
+            return json.dumps({
+                "error": f"Command failed to start within {self._THREAD_STARTED_TIMEOUT}s",
+                "status": CommandStatus.ERROR.value
+            })
+
+        if thread_error:
+            return json.dumps({
+                "error": f"Command thread failed to start: {thread_error[0]}",
+                "status": CommandStatus.ERROR.value
+            })
+
+        # Return a minimal "started" acknowledgement. stdout/stderr/exit_code
+        # are not yet populated; the caller should query CommandStatusTool with
+        # thread_id to retrieve the final result.
+        return json.dumps({
+            "thread_id": result.thread_id,
+            "status": CommandStatus.RUNNING.value,
+            "started": True,
+            "message": "Command started in non-blocking mode. Use command_status_tool with thread_id to query."
+        })
 
 
 def get_command_result(thread_id: int) -> Optional[CommandResult]:

--- a/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/run_command_tool.py
@@ -131,9 +131,6 @@ class RunCommandTool(Tool):
             })
         return self._run_command(command, cwd, blocking)
 
-    # Maximum time (seconds) to wait for the worker thread to register its
-    # command result. Prevents indefinite blocking when the worker fails to
-    # start (e.g. thread creation error or early exception before set()).
     _THREAD_STARTED_TIMEOUT = 10.0
 
     def _run_command(self, command: str, cwd: str, blocking: bool = True) -> str:
@@ -146,7 +143,7 @@ class RunCommandTool(Tool):
         )
 
         thread_started = threading.Event()
-        thread_error: list = []  # captured from worker if it fails before set()
+        thread_error: list = []
 
         def __run() -> None:
             try:
@@ -183,14 +180,11 @@ class RunCommandTool(Tool):
             __run()
             return result.message
 
-        # Non-blocking: spawn worker, wait with timeout for it to register.
         thread = threading.Thread(target=__run)
         thread.daemon = True
         thread.start()
 
         if not thread_started.wait(timeout=self._THREAD_STARTED_TIMEOUT):
-            # Worker did not signal readiness in time; surface a clear error
-            # instead of leaving the caller blocked forever.
             return json.dumps({
                 "error": f"Command failed to start within {self._THREAD_STARTED_TIMEOUT}s",
                 "status": CommandStatus.ERROR.value
@@ -202,9 +196,6 @@ class RunCommandTool(Tool):
                 "status": CommandStatus.ERROR.value
             })
 
-        # Return a minimal "started" acknowledgement. stdout/stderr/exit_code
-        # are not yet populated; the caller should query CommandStatusTool with
-        # thread_id to retrieve the final result.
         return json.dumps({
             "thread_id": result.thread_id,
             "status": CommandStatus.RUNNING.value,


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。** 

**Checklist | 检查项**
- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md). | 我已阅读并理解[贡献者指南](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING_zh.md) 。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

-fix RunCommandTool 非阻塞返回半初始化 result
-1.thread_started.wait() 无超时 — 子线程在 set() 前异常退出时,主线程永久阻塞        
-2.非阻塞模式 return result.message 暴露半初始化字段 — stdout=''、exit_code=None、status=running,调用方误以为命令已完成但拿不到真实输出                              
-3._command_results 写入与 thread_id 改写存在竞态窗口


**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

-

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**
run_command_tool.py
-