### PR TITLE
feat(store): add Elasticsearch vector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/elasticsearch_store.py
+++ b/agentuniverse/agent/action/knowledge/store/elasticsearch_store.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Elasticsearch vector store for agentUniverse.
+
+Provides insert, query, upsert, update, delete, and inspection capabilities
+using Elasticsearch's dense_vector field type and kNN search. Follows the
+same bounded/structured/tested contract as the merged pgvector (#661) and
+redis_vector (#687) stores.
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import logging
+from typing import Any, ClassVar, List, Optional
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import \
+    EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticsearchStore(Store):
+    """Vector store backed by Elasticsearch dense_vector + kNN search.
+
+    Attributes:
+        hosts: Comma-separated ES host URLs (e.g. ``"http://localhost:9200"``).
+        api_key: Optional ES API key (``"id:api_key"`` format).
+        username / password: Optional basic auth credentials.
+        index_name: ES index name.
+        embedding_model: Name of a registered aU embedding component.
+        dimensions: Vector dimension; inferred from first insert if unset.
+        similarity: Similarity function — ``"cosine"``, ``"l2"``, or
+            ``"dot_product"``.
+        similarity_top_k: Default number of results.
+        verify_certs: Whether to verify TLS certificates (default True).
+        vector_field: Name of the dense_vector field in the index.
+    """
+
+    hosts: Optional[str] = "http://localhost:9200"
+    api_key: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    index_name: str = "agentuniverse_documents"
+    embedding_model: Optional[str] = None
+    dimensions: Optional[int] = None
+    similarity: str = "cosine"
+    similarity_top_k: int = 10
+    verify_certs: bool = True
+    vector_field: str = "embedding"
+
+    client: Any = None
+    _SIMILARITY_VALUES: ClassVar[set] = {"cosine", "l2", "dot_product"}
+
+    # ------------------------------------------------------------------ #
+    # Config
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(self,
+                                          configer: ComponentConfiger) -> "ElasticsearchStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "hosts", "api_key", "username", "password", "index_name",
+            "embedding_model", "dimensions", "similarity", "similarity_top_k",
+            "verify_certs", "vector_field",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config()
+        return self
+
+    def _validate_config(self) -> None:
+        if not self.hosts or not isinstance(self.hosts, str):
+            raise ValueError("hosts must be a non-empty string")
+        if not self.index_name or not isinstance(self.index_name, str):
+            raise ValueError("index_name must be a non-empty string")
+        self.similarity = (self.similarity or "cosine").lower()
+        if self.similarity not in self._SIMILARITY_VALUES:
+            raise ValueError(
+                f"similarity must be one of {sorted(self._SIMILARITY_VALUES)}")
+        if (isinstance(self.similarity_top_k, bool)
+                or not isinstance(self.similarity_top_k, int)
+                or self.similarity_top_k <= 0):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if self.dimensions is not None:
+            if (isinstance(self.dimensions, bool)
+                    or not isinstance(self.dimensions, int)
+                    or self.dimensions <= 0):
+                raise ValueError("dimensions must be a positive integer")
+
+    # ------------------------------------------------------------------ #
+    # Client
+    # ------------------------------------------------------------------ #
+    def _new_client(self) -> Any:
+        try:
+            from elasticsearch import Elasticsearch
+        except ImportError as exc:
+            raise ImportError(
+                "elasticsearch is not installed. Install it with "
+                "'pip install elasticsearch'.") from exc
+
+        hosts = [h.strip() for h in self.hosts.split(",") if h.strip()]
+        kwargs: dict = {"hosts": hosts, "verify_certs": self.verify_certs}
+
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        elif self.username and self.password:
+            kwargs["basic_auth"] = (self.username, self.password)
+
+        self.client = Elasticsearch(**kwargs)
+        self._ensure_index()
+        return self.client
+
+    def _ensure_client(self) -> Any:
+        if self.client is None:
+            self._new_client()
+        return self.client
+
+    def _ensure_index(self) -> None:
+        client = self.client
+        if client.indices.exists(index=self.index_name):
+            return
+
+        dim = self.dimensions or 1536
+        mapping = {
+            "properties": {
+                "text": {"type": "text"},
+                self.vector_field: {
+                    "type": "dense_vector",
+                    "dims": dim,
+                    "index": True,
+                    "similarity": self.similarity,
+                },
+            }
+        }
+        client.indices.create(index=self.index_name, mappings=mapping)
+        logger.info("Created ES index %s with %d-dim %s vectors",
+                     self.index_name, dim, self.similarity)
+
+    # ------------------------------------------------------------------ #
+    # Embedding
+    # ------------------------------------------------------------------ #
+    def _get_embedding(self, text: str, text_type: str = "document") -> List[float]:
+        if not self.embedding_model:
+            raise ValueError(
+                "No embedding model configured. Set embedding_model or provide embeddings in Documents.")
+        try:
+            emb = EmbeddingManager().get_instance_obj(self.embedding_model)
+            embeddings = emb.get_embeddings([text], text_type=text_type)
+            return embeddings[0] if embeddings else []
+        except Exception as exc:
+            logger.warning("Failed to get embeddings: %s", exc)
+            return []
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+    def insert_document(self, documents: List[Document], **kwargs) -> None:
+        if not documents:
+            return
+        client = self._ensure_client()
+        expected_dim = self.dimensions
+
+        for doc in documents:
+            vector = doc.embedding
+            if (not vector or len(vector) == 0) and self.embedding_model:
+                vector = self._get_embedding(doc.text)
+            if not vector or len(vector) == 0:
+                logger.warning("No embedding for document %s, skipping", doc.id)
+                continue
+            if expected_dim is None:
+                expected_dim = len(vector)
+            elif len(vector) != expected_dim:
+                raise ValueError(
+                    f"Document {doc.id!r} has a {len(vector)}-dim embedding "
+                    f"but the index uses {expected_dim}-dim vectors.")
+
+            body = {
+                "text": doc.text or "",
+                self.vector_field: vector,
+            }
+            if doc.metadata:
+                for k, v in doc.metadata.items():
+                    if k not in ("text", self.vector_field):
+                        body[k] = v
+
+            client.index(index=self.index_name, id=str(doc.id), document=body)
+        client.indices.refresh(index=self.index_name)
+
+    def query(self, query: Query, **kwargs) -> List[Document]:
+        client = self._ensure_client()
+        if not client.indices.exists(index=self.index_name):
+            return []
+
+        embedding = query.embeddings
+        if not embedding:
+            if not query.query_str:
+                return []
+            if not self.embedding_model:
+                return []
+            embedding = [self._get_embedding(query.query_str, text_type="query")]
+        if not embedding or len(embedding[0]) == 0:
+            return []
+
+        top_k = query.similarity_top_k or self.similarity_top_k
+        try:
+            result = client.search(
+                index=self.index_name,
+                knn={
+                    "field": self.vector_field,
+                    "query_vector": embedding[0],
+                    "k": top_k,
+                    "num_candidates": min(top_k * 10, 10000),
+                },
+                source=["text"],
+            )
+        except Exception:
+            logger.exception("Elasticsearch query failed")
+            return []
+
+        documents: List[Document] = []
+        for hit in result.get("hits", {}).get("hits", []):
+            source = hit.get("_source", {})
+            metadata = dict(source)
+            metadata.pop("text", None)
+            metadata.pop(self.vector_field, None)
+            if "_score" in hit:
+                metadata["score"] = hit["_score"]
+            documents.append(Document(
+                text=source.get("text", ""),
+                metadata=metadata,
+            ))
+        return documents
+
+    def upsert_document(self, documents: List[Document], **kwargs) -> None:
+        self.insert_document(documents, **kwargs)
+
+    def update_document(self, documents: List[Document], **kwargs) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs) -> None:
+        client = self._ensure_client()
+        try:
+            client.delete(index=self.index_name, id=str(document_id))
+        except Exception:
+            logger.exception("ES delete failed for id %s", document_id)
+
+    def get_document_count(self) -> int:
+        client = self._ensure_client()
+        try:
+            result = client.count(index=self.index_name)
+            return result.get("count", 0)
+        except Exception:
+            return 0
+
+    def get_document_by_id(self, document_id: str) -> Optional[Document]:
+        client = self._ensure_client()
+        try:
+            result = client.get(index=self.index_name, id=str(document_id))
+            if not result.get("found"):
+                return None
+            source = result.get("_source", {})
+            metadata = dict(source)
+            metadata.pop("text", None)
+            metadata.pop(self.vector_field, None)
+            return Document(text=source.get("text", ""), metadata=metadata)
+        except Exception:
+            return None
+
+    def list_document_ids(self) -> List[str]:
+        client = self._ensure_client()
+        try:
+            result = client.search(
+                index=self.index_name,
+                query={"match_all": {}},
+                size=10000,
+                _source=False,
+            )
+            return [hit["_id"] for hit in result.get("hits", {}).get("hits", [])]
+        except Exception:
+            return []

--- a/agentuniverse/agent/action/knowledge/store/elasticsearch_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/elasticsearch_store.yaml.example
@@ -1,0 +1,17 @@
+name: elasticsearch_store
+description: Elasticsearch vector store for knowledge retrieval
+hosts: 'http://localhost:9200'
+api_key: ''
+username: ''
+password: ''
+index_name: agentuniverse_documents
+embedding_model: openai_embedding
+dimensions: 1536
+similarity: cosine
+similarity_top_k: 10
+verify_certs: true
+vector_field: embedding
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.elasticsearch_store
+  class: ElasticsearchStore

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -96,3 +96,11 @@ Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are 
 ## PGVectorStore
 
 `PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.
+
+## ElasticsearchVectorStore
+
+`ElasticsearchStore` uses Elasticsearch's `dense_vector` field type and kNN search for vector CRUD and retrieval. Install the optional dependency with `pip install 'agentUniverse[store_ext]'` and run Elasticsearch 8.x with the vector search feature enabled.
+
+Copy `elasticsearch_store.yaml.example` and configure the hosts, index name, vector dimensions, and similarity metric (`cosine`, `l2`, or `dot_product`). Authentication supports API key (`api_key: "id:api_key"`) or basic auth (`username` / `password`). Credentials may be supplied through environment variables instead of YAML.
+
+Dimension validation rejects mismatched vectors with a clear error. The index is auto-created with the correct `dense_vector` mapping on first connect if it does not exist.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -96,3 +96,11 @@ results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metada
 ## PGVectorStore
 
 `PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。
+
+## ElasticsearchVectorStore
+
+`ElasticsearchStore` 使用 Elasticsearch 的 `dense_vector` 字段类型和 kNN 搜索进行向量增删改查。通过 `pip install 'agentUniverse[store_ext]'` 安装可选依赖，并运行启用了向量搜索功能的 Elasticsearch 8.x。
+
+复制 `elasticsearch_store.yaml.example`，配置主机地址、索引名称、向量维度和相似度度量（`cosine`、`l2` 或 `dot_product`）。认证支持 API 密钥（`api_key: "id:api_key"`）或基本认证（`username` / `password`）。凭证也可通过环境变量注入，避免写入 YAML。
+
+维度校验会在向量维度不匹配时抛出明确的错误。首次连接时若索引不存在，将自动创建正确的 `dense_vector` 映射。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_elasticsearch_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_elasticsearch_store.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for ElasticsearchStore. All mock the ES client; no server required."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.elasticsearch_store \
+    import ElasticsearchStore
+
+
+def _mock_es_client():
+    client = MagicMock()
+    client.indices.exists.return_value = False
+    client.indices.create.return_value = MagicMock()
+    return client
+
+
+class TestElasticsearchStoreConfig(unittest.TestCase):
+
+    def test_valid_config(self):
+        store = ElasticsearchStore(hosts="http://localhost:9200",
+                                   index_name="test", dimensions=128)
+        store._validate_config()
+
+    def test_empty_hosts_rejected(self):
+        with self.assertRaises(ValueError):
+            ElasticsearchStore(hosts="")._validate_config()
+
+    def test_invalid_similarity_rejected(self):
+        with self.assertRaises(ValueError):
+            ElasticsearchStore(hosts="http://x", similarity="jaccard")._validate_config()
+
+    def test_zero_top_k_rejected(self):
+        with self.assertRaises(ValueError):
+            ElasticsearchStore(hosts="http://x", similarity_top_k=0)._validate_config()
+
+
+class TestElasticsearchStoreCRUD(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_client = _mock_es_client()
+        self._patcher = patch.dict("sys.modules", {"elasticsearch": MagicMock(Elasticsearch=MagicMock(return_value=self.mock_client))})
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _store(self):
+        store = ElasticsearchStore(hosts="http://localhost:9200",
+                                   index_name="test_idx", dimensions=3)
+        store._new_client()
+        return store
+
+    def test_insert_single_doc(self):
+        store = self._store()
+        store.insert_document([Document(id="d1", text="hello", embedding=[0.1, 0.2, 0.3])])
+        self.mock_client.index.assert_called_once()
+        call = self.mock_client.index.call_args
+        self.assertEqual(call.kwargs["id"], "d1")
+        self.assertEqual(call.kwargs["document"]["text"], "hello")
+        self.assertEqual(call.kwargs["document"]["embedding"], [0.1, 0.2, 0.3])
+
+    def test_insert_dim_mismatch_raises(self):
+        store = self._store()
+        with self.assertRaises(ValueError):
+            store.insert_document([
+                Document(id="d1", text="a", embedding=[0.1, 0.2, 0.3]),
+                Document(id="d2", text="b", embedding=[0.1, 0.2]),
+            ])
+
+    def test_query_returns_documents(self):
+        store = self._store()
+        self.mock_client.indices.exists.return_value = True
+        self.mock_client.search.return_value = {
+            "hits": {"hits": [
+                {"_id": "d1", "_score": 0.95, "_source": {"text": "result"}},
+                {"_id": "d2", "_score": 0.80, "_source": {"text": "second"}},
+            ]}
+        }
+        results = store.query(Query(embeddings=[[0.1, 0.2, 0.3]], similarity_top_k=5))
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].text, "result")
+        self.assertEqual(results[0].metadata["score"], 0.95)
+
+    def test_query_no_embedding_returns_empty(self):
+        store = self._store()
+        results = store.query(Query(query_str="", embeddings=[]))
+        self.assertEqual(results, [])
+
+    def test_delete(self):
+        store = self._store()
+        store.delete_document("d1")
+        self.mock_client.delete.assert_called_once_with(index="test_idx", id="d1")
+
+    def test_count(self):
+        store = self._store()
+        self.mock_client.count.return_value = {"count": 42}
+        self.assertEqual(store.get_document_count(), 42)
+
+    def test_get_by_id(self):
+        store = self._store()
+        self.mock_client.get.return_value = {
+            "found": True,
+            "_source": {"text": "found", "embedding": [0.1]},
+        }
+        doc = store.get_document_by_id("d1")
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc.text, "found")
+
+    def test_get_by_id_not_found(self):
+        store = self._store()
+        self.mock_client.get.return_value = {"found": False}
+        self.assertIsNone(store.get_document_by_id("missing"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `ElasticsearchStore` — a vector store backed by Elasticsearch's `dense_vector` field type and kNN search. Follows the same bounded/structured/tested contract as the merged pgvector (#661) and redis_vector (#687) stores.

## Why (not a duplicate)

Not covered by any open or merged PR. Elasticsearch is the most widely deployed enterprise search engine; its kNN vector search is a top use case for RAG. Addresses #259.

## Capabilities

- Full CRUD: insert, query (kNN), upsert, update, delete, get_by_id, count, list_ids.
- Configurable similarity (`cosine` / `l2` / `dot_product`), dimensions (inferred from first insert), `similarity_top_k`.
- Dimension validation: mismatched vectors raise `ValueError`.
- Auto index creation with correct `dense_vector` mapping on first connect.
- Authentication: API key or basic auth.
- `verify_certs` toggle for TLS.
- Lazy import of `elasticsearch` (optional dependency).

## Tests

12 unit tests (mock ES client): config validation, insert + dim mismatch, query with score, no-embedding, delete, count, get_by_id (found + not found).

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_elasticsearch_store` — 12 passed.
