### PR TITLE
feat(tool): RegexTool — match/extract/replace/split (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/regex_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/regex_tool.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Regex pattern matching tool.
+
+Provides match, extract, replace, and split operations using Python's
+built-in ``re`` module. Zero third-party dependency. Bounded: max matches
+returned, max input length enforced. Addresses #252.
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import logging
+import re
+from typing import Any
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class RegexTool(Tool):
+    """Regex operations tool: match, extract, replace, split.
+
+    Attributes:
+        max_input_chars: Maximum input text length (default 100_000).
+        max_matches: Maximum number of matches returned (default 1000).
+    """
+
+    max_input_chars: int = 100_000
+    max_matches: int = 1000
+
+    def execute(self, mode: str, pattern: str = "", text: str = "",
+                replacement: str = "", flags: str = "",
+                **kwargs) -> dict:
+        try:
+            op = self._normalize_mode(mode)
+            if not pattern:
+                return self._error("validation_error", "pattern is required")
+            if not isinstance(text, str):
+                return self._error("validation_error", "text must be a string")
+            if len(text) > self.max_input_chars:
+                return self._error("validation_error",
+                                   f"Input exceeds max_input_chars ({self.max_input_chars})")
+
+            re_flags = self._parse_flags(flags)
+            try:
+                compiled = re.compile(pattern, re_flags)
+            except re.error as exc:
+                return self._error("validation_error",
+                                   f"Invalid regex pattern: {exc}")
+
+            if op == "match":
+                return self._match(compiled, text)
+            if op == "extract":
+                return self._extract(compiled, text)
+            if op == "replace":
+                return self._replace(compiled, text, replacement)
+            if op == "split":
+                return self._split(compiled, text)
+            return self._error("validation_error", f"Unknown mode: {mode}")
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("operation_error", str(exc))
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        normalized = mode.strip().lower()
+        allowed = {"match", "extract", "replace", "split"}
+        if normalized not in allowed:
+            raise ValueError(f"mode must be one of: {', '.join(sorted(allowed))}")
+        return normalized
+
+    @staticmethod
+    def _parse_flags(flags_str: str) -> int:
+        flags_map = {
+            "i": re.IGNORECASE,
+            "m": re.MULTILINE,
+            "s": re.DOTALL,
+            "x": re.VERBOSE,
+            "a": re.ASCII,
+        }
+        result = 0
+        for char in (flags_str or "").lower():
+            result |= flags_map.get(char, 0)
+        return result
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}
+
+    @staticmethod
+    def _ok(**kwargs) -> dict:
+        return {"status": "success", **kwargs}
+
+    def _match(self, compiled: re.Pattern, text: str) -> dict:
+        m = compiled.search(text)
+        if m is None:
+            return self._ok(mode="match", matched=False)
+        groups = [g if g is not None else "" for g in m.groups()]
+        return self._ok(
+            mode="match", matched=True,
+            match=m.group(0),
+            start=m.start(), end=m.end(),
+            groups=groups,
+        )
+
+    def _extract(self, compiled: re.Pattern, text: str) -> dict:
+        matches = []
+        for i, m in enumerate(compiled.finditer(text)):
+            if i >= self.max_matches:
+                break
+            matches.append({
+                "match": m.group(0),
+                "start": m.start(),
+                "end": m.end(),
+                "groups": [g if g is not None else "" for g in m.groups()],
+            })
+        return self._ok(
+            mode="extract",
+            matches=matches,
+            count=len(matches),
+            truncated=len(matches) >= self.max_matches,
+        )
+
+    def _replace(self, compiled: re.Pattern, text: str,
+                 replacement: str) -> dict:
+        count_before = len(compiled.findall(text))
+        result = compiled.sub(replacement, text)
+        return self._ok(
+            mode="replace",
+            result=result,
+            replacements_made=count_before,
+        )
+
+    def _split(self, compiled: re.Pattern, text: str) -> dict:
+        parts = compiled.split(text)
+        return self._ok(mode="split", parts=parts, count=len(parts))
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) \
+            -> "RegexTool":
+        super()._initialize_by_component_configer(configer)
+        if hasattr(configer, "max_input_chars"):
+            self.max_input_chars = configer.max_input_chars
+        if hasattr(configer, "max_matches"):
+            self.max_matches = configer.max_matches
+        return self

--- a/agentuniverse/agent/action/tool/common_tool/regex_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/regex_tool.yaml.example
@@ -1,0 +1,12 @@
+name: regex_tool
+description: Bounded regular-expression tool — match, find_all, search, and sub (replace) with input length and match-count bounds.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.regex_tool
+  class: RegexTool
+input_keys:
+  - mode
+  - pattern
+max_input_chars: 100000
+max_matches: 1000

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,9 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## 5. Text Tools
+
+### RegexTool
+
+`RegexTool` provides match, extract, replace, and split operations using Python's built-in `re` module — zero third-party dependency. Resolve the built-in `regex_tool` component. Operations: `match` (first match with groups), `extract` (all matches, bounded by `max_matches`), `replace` (supports group references like `\1`), `split`. Flags: `i` (case-insensitive), `m` (multiline), `s` (dotall), `x` (verbose). Invalid patterns return a structured error.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,9 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## 5. 文本工具
+
+### RegexTool
+
+`RegexTool` 提供正则匹配、提取、替换和分割操作，使用 Python 内置的 `re` 模块——零第三方依赖。加载内置 `regex_tool` 组件。操作模式：`match`（首个匹配 + 分组）、`extract`（所有匹配，受 `max_matches` 限制）、`replace`（支持分组引用如 `\1`）、`split`。标志位：`i`（忽略大小写）、`m`（多行）、`s`（dotall）、`x`（详细模式）。无效正则返回结构化错误。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_regex_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_regex_tool.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for RegexTool."""
+
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool.regex_tool import RegexTool
+
+
+class TestRegexMatch(unittest.TestCase):
+
+    def test_match_found(self):
+        tool = RegexTool()
+        result = tool.execute(mode="match", pattern=r"(\d+)-(\w+)", text="123-abc")
+        self.assertTrue(result["matched"])
+        self.assertEqual(result["match"], "123-abc")
+        self.assertEqual(result["groups"], ["123", "abc"])
+
+    def test_match_not_found(self):
+        tool = RegexTool()
+        result = tool.execute(mode="match", pattern="xyz", text="hello")
+        self.assertFalse(result["matched"])
+
+    def test_match_case_insensitive(self):
+        tool = RegexTool()
+        result = tool.execute(mode="match", pattern="hello", text="HELLO", flags="i")
+        self.assertTrue(result["matched"])
+
+
+class TestRegexExtract(unittest.TestCase):
+
+    def test_extract_all_emails(self):
+        tool = RegexTool()
+        result = tool.execute(
+            mode="extract",
+            pattern=r"[\w.]+@[\w.]+",
+            text="alice@test.com bob@example.org")
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(result["matches"][0]["match"], "alice@test.com")
+
+    def test_extract_truncates_at_max(self):
+        tool = RegexTool(max_matches=3)
+        result = tool.execute(mode="extract", pattern=r"\d", text="123456789")
+        self.assertEqual(result["count"], 3)
+        self.assertTrue(result["truncated"])
+
+
+class TestRegexReplace(unittest.TestCase):
+
+    def test_replace_simple(self):
+        tool = RegexTool()
+        result = tool.execute(mode="replace", pattern=r"cat", text="cat dog cat", replacement="bird")
+        self.assertEqual(result["result"], "bird dog bird")
+        self.assertEqual(result["replacements_made"], 2)
+
+    def test_replace_with_groups(self):
+        tool = RegexTool()
+        result = tool.execute(mode="replace", pattern=r"(\w+)@(\w+)", text="alice@test", replacement=r"\2.\1")
+        self.assertEqual(result["result"], "test.alice")
+
+
+class TestRegexSplit(unittest.TestCase):
+
+    def test_split_by_comma(self):
+        tool = RegexTool()
+        result = tool.execute(mode="split", pattern=r",\s*", text="a, b,c,  d")
+        self.assertEqual(result["parts"], ["a", "b", "c", "d"])
+
+
+class TestRegexValidation(unittest.TestCase):
+
+    def test_empty_pattern(self):
+        tool = RegexTool()
+        result = tool.execute(mode="match", pattern="", text="x")
+        self.assertEqual(result["status"], "error")
+
+    def test_invalid_pattern(self):
+        tool = RegexTool()
+        result = tool.execute(mode="match", pattern="[invalid", text="x")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Invalid regex", result["error"])
+
+    def test_unknown_mode(self):
+        tool = RegexTool()
+        result = tool.execute(mode="fuzzy", pattern="x", text="x")
+        self.assertEqual(result["status"], "error")
+
+    def test_max_input_chars(self):
+        tool = RegexTool(max_input_chars=10)
+        result = tool.execute(mode="match", pattern="x", text="x" * 100)
+        self.assertEqual(result["status"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `RegexTool` — provides match, extract, replace, and split operations using Python's built-in `re` module. Zero third-party dependency.

## Why (not a duplicate)

Not covered by any open or merged PR. No existing tool provides regex operations; agents that need pattern matching / structured extraction currently have no way to do so.

## Capabilities

- **match**: search for first match with group capture.
- **extract**: find all matches with positions and groups (bounded by `max_matches`).
- **replace**: replace all occurrences (supports group references like `\1`).
- **split**: split text by pattern.
- Flags: `i` (case-insensitive), `m` (multiline), `s` (dotall), `x` (verbose), `a` (ASCII).
- Bounded: `max_input_chars` (100_000), `max_matches` (1000).
- Invalid patterns return structured error, not crash.

## Tests

12 unit tests: match (found/not found/case-insensitive), extract (all/truncated), replace (simple/group refs), split, validation (empty pattern/invalid pattern/unknown mode/max_input_chars).

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_regex_tool` — 12 passed.
