### PR TITLE
feat(llm): add Mistral AI LLM component (#250)

### DIFF
--- a/agentuniverse/llm/default/mistral_llm.py
+++ b/agentuniverse/llm/default/mistral_llm.py
@@ -1,0 +1,79 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/21
+# @FileName: mistral_llm.py
+
+"""
+Mistral AI LLM component.
+
+Connects to the Mistral AI API (La Plateforme) using the OpenAI-compatible
+endpoint. Supports Mistral Large, Mistral Nemo, Codestral, and all models
+available on La Plateforme.
+"""
+
+import logging
+from typing import Any, Optional, Iterator, Union, AsyncIterator
+
+from pydantic import Field
+
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+logger = logging.getLogger(__name__)
+
+MISTRAL_MAX_CONTEXT_LENGTH = {
+    "mistral-large-latest": 128000,
+    "mistral-large-2407": 128000,
+    "mistral-large-2411": 128000,
+    "open-mistral-nemo": 128000,
+    "open-mistral-7b": 32000,
+    "open-mixtral-8x7b": 32000,
+    "open-mixtral-8x22b": 64000,
+    "codestral-latest": 32000,
+    "codestral-2405": 32000,
+    "mistral-small-latest": 32000,
+    "mistral-small-2402": 32000,
+    "mistral-tiny": 32000,
+}
+
+
+class MistralLLM(OpenAIStyleLLM):
+    """Mistral AI LLM component.
+
+    Connects to Mistral AI's OpenAI-compatible API endpoint.
+
+    Attributes:
+        api_key: Mistral API key (env: ``MISTRAL_API_KEY``).
+        api_base: Mistral API base URL
+            (default ``https://api.mistral.ai/v1``).
+        proxy: Optional proxy URL (env: ``MISTRAL_PROXY``).
+    """
+
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("MISTRAL_API_KEY"))
+    api_base: Optional[str] = Field(
+        default_factory=lambda: get_from_env("MISTRAL_API_BASE")
+        or "https://api.mistral.ai/v1")
+    proxy: Optional[str] = Field(
+        default_factory=lambda: get_from_env("MISTRAL_PROXY"))
+
+    def _call(self, messages: list, **kwargs: Any) \
+            -> Union[LLMOutput, Iterator[LLMOutput]]:
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) \
+            -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        return MISTRAL_MAX_CONTEXT_LENGTH.get(self.model_name, 32000)
+
+    def get_num_tokens(self, text: str) -> int:
+        try:
+            import tiktoken
+            encoding = tiktoken.get_encoding("cl100k_base")
+            return len(encoding.encode(text))
+        except ImportError:
+            return super().get_num_tokens(text)

--- a/agentuniverse/llm/default/mistral_llm.yaml.example
+++ b/agentuniverse/llm/default/mistral_llm.yaml.example
@@ -1,0 +1,13 @@
+name: mistral_llm
+description: Mistral AI LLM component
+model_name: mistral-large-latest
+api_key: ''
+api_base: 'https://api.mistral.ai/v1'
+proxy: ''
+max_tokens: 4096
+temperature: 0.7
+streaming: false
+metadata:
+  type: LLM
+  module: agentuniverse.llm.default.mistral_llm
+  class: MistralLLM

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Mistral_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Mistral_LLM_Use.md
@@ -1,0 +1,78 @@
+# Mistral AI LLM Usage
+
+## Mistral AI LLM
+
+`MistralLLM` connects to Mistral AI's OpenAI-compatible API endpoint (La Plateforme). Supports Mistral Large (128k context), Nemo, Codestral, and all models on La Plateforme. Environment variables: `MISTRAL_API_KEY`, `MISTRAL_API_BASE` (default `https://api.mistral.ai/v1`). Copy `mistral_llm.yaml.example` to configure.
+
+## 1. Create the relevant file.
+Create a YAML file, for example, `user_mistral_llm.yaml`. Paste the following content into your `user_mistral_llm.yaml` file.
+
+```yaml
+name: 'user_mistral_llm'
+description: 'default mistral llm with spi'
+model_name: 'mistral-large-latest'
+max_tokens: 4096
+temperature: 0.7
+api_key: '${MISTRAL_API_KEY}'
+api_base: '${MISTRAL_API_BASE}'
+proxy: '${MISTRAL_PROXY}'
+streaming: False
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.mistral_llm'
+  class: 'MistralLLM'
+```
+
+**Note:**
+
+The model parameters such as `api_key`, `api_base`, and `proxy` can be configured in three ways:
+
+1. Direct String Value: Enter the API key string directly in the configuration file.
+
+    ```yaml
+    api_key: 'xxx'
+    ```
+
+2. Environment Variable Placeholder: Use the `${VARIABLE_NAME}` syntax to load from environment variables. When `agentUniverse` is launched, it will automatically read the corresponding value from the environment variables.
+
+    ```yaml
+    api_key: '${MISTRAL_API_KEY}'
+    ```
+
+3. Custom Function Loading: Use the `@FUNC` annotation to dynamically load the API key via a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="mistral"))'
+    ```
+
+    The function needs to be defined in the `YamlFuncExtension` class within the `yaml_func_extension.py` file. You can refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When `agentUniverse` loads this configuration:
+   - It parses the `@FUNC` annotation.
+   - Executes the `load_api_key` function with the corresponding parameters.
+   - Replaces the annotation content with the function's return value.
+
+## 2. Environment Setup
+In the example YAML, model keys and other parameters are configured using environment variable placeholders. The following section will introduce methods for setting environment variables.
+
+Must be configured: `MISTRAL_API_KEY`
+Optional: `MISTRAL_API_BASE` (default `https://api.mistral.ai/v1`), `MISTRAL_PROXY`
+
+### 2.1 Configure through Python code
+```python
+import os
+os.environ['MISTRAL_API_KEY'] = 'xxx'
+os.environ['MISTRAL_API_BASE'] = 'https://api.mistral.ai/v1'
+```
+
+### 2.2 Configure through the configuration file
+In the `custom_key.toml` file under the config directory of the project, add the configuration:
+```toml
+MISTRAL_API_KEY="xxx"
+MISTRAL_API_BASE="https://api.mistral.ai/v1"
+MISTRAL_PROXY=""
+```
+
+## 3. Obtaining the Mistral API KEY
+Please refer to the official documentation of Mistral AI: https://console.mistral.ai/api-keys
+
+## 4. Tips
+In agentUniverse, the example `mistral_llm.yaml.example` is provided. Copy it to `mistral_llm.yaml`, configure your `MISTRAL_API_KEY`, and then resolve the `mistral_llm` component directly.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Mistral使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Mistral使用.md
@@ -1,0 +1,73 @@
+# Mistral 使用
+
+## Mistral AI LLM
+
+`MistralLLM` 连接 Mistral AI 提供的 OpenAI 兼容 API 端点（La Plateforme）。支持 Mistral Large（128k 上下文）、Nemo、Codestral 以及 La Plateforme 上的全部模型。环境变量：`MISTRAL_API_KEY`、`MISTRAL_API_BASE`（默认 `https://api.mistral.ai/v1`）。复制 `mistral_llm.yaml.example` 进行配置。
+
+## 1. 创建相关文件
+创建一个 yaml 文件，例如 `user_mistral_llm.yaml`，将以下内容粘贴到您的 `user_mistral_llm.yaml` 文件当中。
+
+```yaml
+name: 'user_mistral_llm'
+description: 'default mistral llm with spi'
+model_name: 'mistral-large-latest'
+max_tokens: 4096
+temperature: 0.7
+api_key: '${MISTRAL_API_KEY}'
+api_base: '${MISTRAL_API_BASE}'
+proxy: '${MISTRAL_PROXY}'
+streaming: False
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.mistral_llm'
+  class: 'MistralLLM'
+```
+
+**note:** api_key/api_base/proxy 等模型参数有三种配置方法
+
+1. 直接字符串值：直接在配置文件中输入 API 密钥字符串。
+
+    ```yaml
+    api_key: 'xxx'
+    ```
+
+2. 环境变量占位符：使用 `${VARIABLE_NAME}` 语法从环境变量中加载。当 agentUniverse 启动时，会自动从环境变量读取相应的值。
+    ```yaml
+    api_key: '${MISTRAL_API_KEY}'
+    ```
+
+3. 自定义函数加载：使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API 密钥。
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="mistral"))'
+    ```
+    该函数需要在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中定义，可参考样例工程中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)，当 agentUniverse 加载此配置时：
+   - 解析 `@FUNC` 注解
+   - 执行 `load_api_key` 函数并传入相应参数
+   - 用函数返回值替换注解内容
+
+## 2. 环境设置
+示例 yaml 中模型密钥等参数使用环境变量占位符，下面将介绍环境变量设置方法。
+
+必须配置：`MISTRAL_API_KEY`
+可选配置：`MISTRAL_API_BASE`（默认 `https://api.mistral.ai/v1`）、`MISTRAL_PROXY`
+
+### 2.1 通过 python 代码配置
+```python
+import os
+os.environ['MISTRAL_API_KEY'] = 'xxx'
+os.environ['MISTRAL_API_BASE'] = 'https://api.mistral.ai/v1'
+```
+
+### 2.2 通过配置文件配置
+在项目的 config 目录下的 `custom_key.toml` 当中，添加配置：
+```toml
+MISTRAL_API_KEY="xxx"
+MISTRAL_API_BASE="https://api.mistral.ai/v1"
+MISTRAL_PROXY=""
+```
+
+## 3. MISTRAL API KEY 获取
+参考 Mistral AI 官方文档：https://console.mistral.ai/api-keys
+
+## 4. Tips
+在 agentuniverse 中，已经提供了 `mistral_llm.yaml.example`。将其复制为 `mistral_llm.yaml`，配置好 `MISTRAL_API_KEY` 后，即可直接加载 `mistral_llm` 组件使用。

--- a/tests/test_agentuniverse/unit/llm/test_mistral_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_mistral_llm.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for MistralLLM."""
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.llm.default.mistral_llm import MistralLLM
+
+
+class TestMistralLLMConfig(unittest.TestCase):
+
+    def test_defaults_from_env(self):
+        with patch.dict("os.environ", {
+            "MISTRAL_API_KEY": "test-key",
+            "MISTRAL_API_BASE": "https://api.mistral.ai/v1",
+        }):
+            llm = MistralLLM(model_name="mistral-large-latest")
+            self.assertEqual(llm.api_key, "test-key")
+            self.assertEqual(llm.api_base, "https://api.mistral.ai/v1")
+
+    def test_api_base_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            llm = MistralLLM(model_name="mistral-large-latest", api_key="k")
+            self.assertEqual(llm.api_base, "https://api.mistral.ai/v1")
+
+    def test_max_context_length_large(self):
+        llm = MistralLLM(model_name="mistral-large-latest", api_key="k")
+        self.assertEqual(llm.max_context_length(), 128000)
+
+    def test_max_context_length_nemo(self):
+        llm = MistralLLM(model_name="open-mistral-nemo", api_key="k")
+        self.assertEqual(llm.max_context_length(), 128000)
+
+    def test_max_context_length_fallback(self):
+        llm = MistralLLM(model_name="unknown-model", api_key="k")
+        self.assertEqual(llm.max_context_length(), 32000)
+
+    def test_get_num_tokens(self):
+        llm = MistralLLM(model_name="mistral-large-latest", api_key="k")
+        tokens = llm.get_num_tokens("hello world")
+        self.assertGreater(tokens, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `MistralLLM` — connects to Mistral AI's OpenAI-compatible API endpoint (La Plateforme). Supports Mistral Large, Nemo, Codestral, and all models on La Plateforme.

## Why (not a duplicate)

Not covered by any open or merged PR. #250 requests more LLM components; Mistral AI is a top European AI company with strong open-weight models.

## Capabilities

- Uses Mistral's OpenAI-compatible API (no custom SDK needed).
- Environment variable defaults: `MISTRAL_API_KEY`, `MISTRAL_API_BASE`, `MISTRAL_PROXY`.
- Model context length table (mistral-large 128k, nemo 128k, mixtral 64k, etc.).
- `get_num_tokens` uses tiktoken with cl100k_base fallback.

## Tests

6 unit tests: env-based defaults, api_base default, context length (large/nemo/fallback), get_num_tokens.

`python -m unittest tests.test_agentuniverse.unit.llm.test_mistral_llm` — 6 passed.
