### PR TITLE
feat(tool): EmailSenderTool — bounded SMTP sender with opt-in gate (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/email_sender_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/email_sender_tool.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Email sender tool with bounded safety.
+
+Sends plain-text or HTML emails via SMTP. Supports TLS, authentication,
+and optional file attachments. All operations are gated behind an explicit
+``allow_send`` opt-in (default False) so the tool cannot send emails
+without the integrator's knowledge — same spirit as RunCommandTool (#657)
+and PythonREPL (#608).
+
+Uses Python's built-in ``smtplib`` and ``email`` modules — zero third-party
+dependency. Addresses #252.
+"""
+
+# ruff: noqa: TRY003, TRY004
+
+import logging
+import mimetypes
+import os
+import smtplib
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any, ClassVar, List, Optional
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import \
+    resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class EmailSenderTool(Tool):
+    """Bounded email sender tool gated behind ``allow_send`` opt-in.
+
+    Attributes:
+        smtp_host: SMTP server hostname.
+        smtp_port: SMTP server port (default 587 for STARTTLS).
+        smtp_username: SMTP username.
+        smtp_password: SMTP password.
+        use_tls: Whether to use STARTTLS (default True).
+        use_ssl: Whether to use SSL (default False; mutually exclusive with TLS).
+        sender_email: Default sender email address.
+        allow_send: Opt-in gate. If False (default), the tool refuses to send
+            and returns a clear error. Set to True to enable.
+        max_attachment_bytes: Maximum total attachment size in bytes (default 10 MB).
+        max_recipients: Maximum number of recipients (default 50).
+        base_dir: Base directory for resolving attachment paths.
+    """
+
+    smtp_host: Optional[str] = None
+    smtp_port: int = 587
+    smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
+    use_tls: bool = True
+    use_ssl: bool = False
+    sender_email: Optional[str] = None
+    allow_send: bool = False
+    max_attachment_bytes: int = 10 * 1024 * 1024
+    max_recipients: int = 50
+    base_dir: str = "."
+
+    def execute(self, mode: str = "send", to: str = "", subject: str = "",
+                body: str = "", html: bool = False,
+                attachments: Optional[List[str]] = None,
+                cc: str = "", bcc: str = "",
+                **kwargs) -> dict:
+        try:
+            op = self._normalize_mode(mode)
+            if op == "send":
+                return self._send(to, subject, body, html, attachments, cc, bcc)
+            return self._error("validation_error", f"Unknown mode: {mode}")
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            return self._error("operation_error", str(exc))
+
+    @staticmethod
+    def _normalize_mode(mode: str) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        normalized = mode.strip().lower()
+        if normalized != "send":
+            raise ValueError("mode must be 'send'")
+        return normalized
+
+    @staticmethod
+    def _error(error_type: str, message: str) -> dict:
+        return {"status": "error", "error_type": error_type, "error": message}
+
+    @staticmethod
+    def _ok(**kwargs) -> dict:
+        return {"status": "success", **kwargs}
+
+    def _send(self, to: str, subject: str, body: str,
+              html: bool, attachments: Optional[List[str]],
+              cc: str, bcc: str) -> dict:
+        if not self.allow_send:
+            return self._error(
+                "permission_error",
+                "EmailSenderTool is disabled by default. Set allow_send: true "
+                "on the component to enable email sending.")
+        if not self.smtp_host:
+            return self._error("validation_error",
+                               "smtp_host must be configured")
+        if not to:
+            return self._error("validation_error",
+                               "at least one recipient (to) is required")
+        if not self.sender_email:
+            return self._error("validation_error",
+                               "sender_email must be configured")
+
+        # Parse and bound recipients.
+        recipients = [r.strip() for r in to.split(",") if r.strip()]
+        cc_list = [r.strip() for r in cc.split(",") if cc and r.strip()]
+        bcc_list = [r.strip() for r in bcc.split(",") if bcc and r.strip()]
+        all_recipients = recipients + cc_list + bcc_list
+        if len(all_recipients) > self.max_recipients:
+            return self._error("validation_error",
+                               f"Total recipients ({len(all_recipients)}) exceed "
+                               f"max_recipients ({self.max_recipients})")
+
+        # Build message.
+        msg = MIMEMultipart()
+        msg["From"] = self.sender_email
+        msg["To"] = ", ".join(recipients)
+        if cc_list:
+            msg["Cc"] = ", ".join(cc_list)
+        msg["Subject"] = subject or "(no subject)"
+
+        content_type = "html" if html else "plain"
+        msg.attach(MIMEText(body or "", content_type))
+
+        # Attachments.
+        total_attach_size = 0
+        if attachments:
+            for path_str in attachments:
+                safe_path = resolve_safe_path(path_str, self.base_dir)
+                if not os.path.isfile(safe_path):
+                    return self._error("validation_error",
+                                       f"Attachment not found: {path_str}")
+                file_size = os.path.getsize(safe_path)
+                total_attach_size += file_size
+                if total_attach_size > self.max_attachment_bytes:
+                    return self._error(
+                        "validation_error",
+                        f"Total attachment size ({total_attach_size} bytes) exceeds "
+                        f"max_attachment_bytes ({self.max_attachment_bytes})")
+                with open(safe_path, "rb") as f:
+                    part = MIMEApplication(f.read(), Name=os.path.basename(safe_path))
+                part["Content-Disposition"] = (
+                    f'attachment; filename="{os.path.basename(safe_path)}"')
+                msg.attach(part)
+
+        # Send via SMTP.
+        try:
+            if self.use_ssl:
+                server = smtplib.SMTP_SSL(self.smtp_host, self.smtp_port)
+            else:
+                server = smtplib.SMTP(self.smtp_host, self.smtp_port)
+                if self.use_tls:
+                    server.starttls()
+            try:
+                if self.smtp_username and self.smtp_password:
+                    server.login(self.smtp_username, self.smtp_password)
+                server.sendmail(self.sender_email, all_recipients, msg.as_string())
+            finally:
+                server.quit()
+        except smtplib.SMTPException as exc:
+            return self._error("operation_error",
+                               f"SMTP error: {exc}")
+
+        return self._ok(
+            mode="send",
+            recipients=recipients,
+            cc=cc_list,
+            bcc=bcc_list,
+            subject=subject,
+            attachments=len(attachments) if attachments else 0,
+        )
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) \
+            -> "EmailSenderTool":
+        super()._initialize_by_component_configer(configer)
+        for field in ("smtp_host", "smtp_port", "smtp_username", "smtp_password",
+                      "use_tls", "use_ssl", "sender_email", "allow_send",
+                      "max_attachment_bytes", "max_recipients", "base_dir"):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        return self

--- a/agentuniverse/agent/action/tool/common_tool/email_sender_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/email_sender_tool.yaml.example
@@ -1,0 +1,23 @@
+name: email_sender_tool
+description: Bounded SMTP email-sender tool — send plain-text or HTML email with opt-in send gate, bounded attachments, and recipient limits.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.email_sender_tool
+  class: EmailSenderTool
+input_keys:
+  - mode
+  - to
+  - subject
+  - body
+smtp_host: ''
+smtp_port: 587
+smtp_username: ''
+smtp_password: ''
+use_tls: true
+use_ssl: false
+sender_email: ''
+allow_send: false
+max_attachment_bytes: 10485760
+max_recipients: 50
+base_dir: '.'

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,9 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## 5. Communication Tools
+
+### EmailSenderTool
+
+`EmailSenderTool` sends plain-text or HTML emails via SMTP with optional file attachments. Uses Python's built-in `smtplib` — zero third-party dependency. **Opt-in required**: set `allow_send: true` on the component (default False). Supports TLS/SSL, CC/BCC, and attachment size limits via `max_attachment_bytes`. Attachment paths are confined to `base_dir` through `resolve_safe_path`.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,9 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## 5. 通信工具
+
+### EmailSenderTool
+
+`EmailSenderTool` 通过 SMTP 发送纯文本或 HTML 邮件，支持可选的文件附件。使用 Python 内置的 `smtplib`——零第三方依赖。**需显式开启（opt-in）**：在组件上设置 `allow_send: true`（默认为 False）。支持 TLS/SSL、抄送/密送（CC/BCC），以及通过 `max_attachment_bytes` 限制附件大小。附件路径通过 `resolve_safe_path` 限制在 `base_dir` 内。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_email_sender_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_email_sender_tool.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for EmailSenderTool."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.tool.common_tool.email_sender_tool \
+    import EmailSenderTool
+
+
+class TestEmailSenderToolOptIn(unittest.TestCase):
+
+    def test_disabled_by_default(self):
+        tool = EmailSenderTool()
+        result = tool.execute(to="a@b.com", subject="test", body="hello")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "permission_error")
+
+    def test_enabled_sends(self):
+        tool = EmailSenderTool(
+            allow_send=True, smtp_host="smtp.test.com",
+            sender_email="bot@test.com")
+        with patch("smtplib.SMTP") as mock_smtp:
+            server = MagicMock()
+            mock_smtp.return_value = server
+            result = tool.execute(to="a@b.com", subject="test", body="hello")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["recipients"], ["a@b.com"])
+
+
+class TestEmailSenderValidation(unittest.TestCase):
+
+    def _tool(self):
+        return EmailSenderTool(
+            allow_send=True, smtp_host="smtp.test.com",
+            sender_email="bot@test.com")
+
+    def test_missing_smtp_host(self):
+        tool = EmailSenderTool(allow_send=True, sender_email="b@t.com")
+        result = tool.execute(to="a@b.com", body="x")
+        self.assertEqual(result["status"], "error")
+
+    def test_missing_recipient(self):
+        tool = self._tool()
+        result = tool.execute(to="", body="x")
+        self.assertEqual(result["status"], "error")
+
+    def test_missing_sender(self):
+        tool = EmailSenderTool(allow_send=True, smtp_host="smtp.test.com")
+        result = tool.execute(to="a@b.com", body="x")
+        self.assertEqual(result["status"], "error")
+
+    def test_too_many_recipients(self):
+        tool = self._tool()
+        tool.max_recipients = 2
+        result = tool.execute(to="a@b.com,c@d.com,e@f.com", body="x")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("max_recipients", result["error"])
+
+    def test_unknown_mode(self):
+        tool = self._tool()
+        result = tool.execute(mode="receive")
+        self.assertEqual(result["status"], "error")
+
+
+class TestEmailSenderSend(unittest.TestCase):
+
+    def _tool(self):
+        return EmailSenderTool(
+            allow_send=True, smtp_host="smtp.test.com",
+            sender_email="bot@test.com", smtp_username="user",
+            smtp_password="pass", use_tls=True)
+
+    def test_send_with_cc_and_bcc(self):
+        tool = self._tool()
+        with patch("smtplib.SMTP") as mock_smtp:
+            server = MagicMock()
+            mock_smtp.return_value = server
+            result = tool.execute(
+                to="a@b.com", cc="c@d.com", bcc="e@f.com",
+                subject="test", body="hello")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["cc"]), 1)
+        self.assertEqual(len(result["bcc"]), 1)
+
+    def test_send_html(self):
+        tool = self._tool()
+        with patch("smtplib.SMTP") as mock_smtp:
+            server = MagicMock()
+            mock_smtp.return_value = server
+            result = tool.execute(
+                to="a@b.com", subject="test", body="<b>hello</b>", html=True)
+        self.assertEqual(result["status"], "success")
+
+    def test_send_with_attachment(self):
+        import tempfile, os
+        tool = self._tool()
+        # Set base_dir to system temp so resolve_safe_path accepts the temp file.
+        tmp_dir = tempfile.mkdtemp()
+        tool.base_dir = tmp_dir
+        att_path = os.path.join(tmp_dir, "test.txt")
+        with open(att_path, "w") as f:
+            f.write("attachment content")
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                server = MagicMock()
+                mock_smtp.return_value = server
+                result = tool.execute(
+                    to="a@b.com", subject="test", body="hello",
+                    attachments=[att_path])
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(result["attachments"], 1)
+        finally:
+            import shutil; shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_attachment_too_large(self):
+        import tempfile, os
+        tool = self._tool()
+        tool.max_attachment_bytes = 5
+        tmp_dir = tempfile.mkdtemp()
+        tool.base_dir = tmp_dir
+        att_path = os.path.join(tmp_dir, "big.txt")
+        with open(att_path, "w") as f:
+            f.write("x" * 100)
+        try:
+            result = tool.execute(
+                to="a@b.com", subject="test", body="hello",
+                attachments=[att_path])
+            self.assertEqual(result["status"], "error")
+            self.assertIn("max_attachment_bytes", result["error"])
+        finally:
+            import shutil; shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_smtp_error_returns_structured(self):
+        import smtplib
+        tool = self._tool()
+        with patch("smtplib.SMTP") as mock_smtp:
+            server = MagicMock()
+            server.login.side_effect = smtplib.SMTPAuthenticationError(
+                code=535, msg=b"auth failed")
+            mock_smtp.return_value = server
+            result = tool.execute(to="a@b.com", body="x")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "operation_error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `EmailSenderTool` — sends plain-text or HTML emails via SMTP with optional file attachments. Uses Python's built-in `smtplib` — zero third-party dependency.

## Why (not a duplicate)

Not covered by any open or merged PR. The existing `EmailDocumentTool` (#686) reads/parses `.eml` files; this tool *sends* emails via SMTP. Complementary, not overlapping.

## Capabilities

- **Opt-in gate**: `allow_send` (default False) — same spirit as RunCommandTool (#657) and PythonREPL (#608). The tool refuses to send until the integrator explicitly opts in.
- Plain text and HTML body support.
- TLS (STARTTLS) and SSL support.
- Optional file attachments, bounded by `max_attachment_bytes` (10 MB) and confined to `base_dir` via `resolve_safe_path`.
- CC / BCC support.
- Bounded recipients: `max_recipients` (50).
- SMTP errors return structured `{status: "error", error_type: "operation_error"}`.

## Tests

12 unit tests: opt-in disabled/enabled, missing smtp_host/recipient/sender, too many recipients, unknown mode, send with CC+BCC, HTML body, attachment send, attachment too large, SMTP auth error.

`python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_email_sender_tool` — 12 passed.
