### PR TITLE
fix(tracing,template): bare except in instrumentor + None.get guards in agent templates

### DIFF
--- a/agentuniverse/agent/template/openai_protocol_template.py
+++ b/agentuniverse/agent/template/openai_protocol_template.py
@@ -146,7 +146,7 @@ class OpenAIProtocolTemplate(AgentTemplate):
         output_stream = input_object.get_data('output_stream')
         callbacks.append(OpenAIProtocolStreamOutPutCallbackHandler(output_stream, agent_info=self.agent_model.info))
         callbacks.append(InvokeCallbackHandler(source=self.agent_model.info.get('name'),
-                                               llm_name=self.agent_model.profile.get('llm_model').get('name')))
+                                               llm_name=self.agent_model.profile.get('llm_model', {}).get('name')))
         config.setdefault("callbacks", callbacks)
         return config
 

--- a/agentuniverse/agent/template/react_agent_template.py
+++ b/agentuniverse/agent/template/react_agent_template.py
@@ -184,7 +184,7 @@ class ReActAgentTemplate(AgentTemplate):
         output_stream = input_object.get_data('output_stream')
         callbacks.append(StreamOutPutCallbackHandler(output_stream, agent_info=self.agent_model.info))
         callbacks.append(InvokeCallbackHandler(source=self.agent_model.info.get('name'),
-                                               llm_name=self.agent_model.profile.get('llm_model').get('name')))
+                                               llm_name=self.agent_model.profile.get('llm_model', {}).get('name')))
         config.setdefault("callbacks", callbacks)
         return config
 

--- a/agentuniverse/agent/template/slave_rag_agent_template.py
+++ b/agentuniverse/agent/template/slave_rag_agent_template.py
@@ -72,8 +72,11 @@ class SlaveRagAgentTemplate(AgentTemplate):
         version_prompt: Prompt = PromptManager().get_instance_obj(agent_input['prompt_name'])
 
         if version_prompt is None and not profile_prompt_model:
-            raise Exception("Either the `prompt_version` or `introduction & target & instruction`"
-                            " in agent profile configuration should be provided.")
+            agent_name = (self.agent_model.info or {}).get("name") or "<unnamed>"
+            raise ValueError(
+                f"[{agent_name}] Either the `prompt_version` or "
+                "`introduction & target & instruction` in agent profile "
+                "configuration should be provided.")
         if version_prompt:
             version_prompt_model: AgentPromptModel = AgentPromptModel(
                 introduction=getattr(version_prompt, 'introduction', ''),

--- a/agentuniverse/base/tracing/otel/instrumentation/llm/llm_instrumentor.py
+++ b/agentuniverse/base/tracing/otel/instrumentation/llm/llm_instrumentor.py
@@ -95,7 +95,7 @@ class LLMSpanManager:
                     get_current_token_usage(self.span.context.span_id),
                     self.span.parent.span_id
                 )
-            except:
+            except Exception:
                 pass
             self.span.end()
             self.span = None

--- a/tests/test_agentuniverse/unit/agent/template/test_template_none_guard_and_instrumentor.py
+++ b/tests/test_agentuniverse/unit/agent/template/test_template_none_guard_and_instrumentor.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for agent template None.get guards + instrumentor bare except fix."""
+
+import unittest
+
+
+class TestAgentTemplateNoneGuard(unittest.TestCase):
+
+    def test_react_agent_template_uses_safe_get(self):
+        import inspect
+        from agentuniverse.agent.template.react_agent_template import \
+            ReActAgentTemplate
+        src = inspect.getsource(ReActAgentTemplate)
+        self.assertIn("profile.get('llm_model', {})", src)
+        # The old unsafe form should not appear in code lines.
+        code_lines = [l for l in src.split("\n")
+                      if l.strip() and not l.strip().startswith("#")]
+        for line in code_lines:
+            self.assertNotIn(
+                "profile.get('llm_model').get('name')", line,
+                f"react_agent_template must use safe .get: {line!r}")
+
+    def test_openai_protocol_template_uses_safe_get(self):
+        import inspect
+        from agentuniverse.agent.template.openai_protocol_template import \
+            OpenAIProtocolTemplate
+        src = inspect.getsource(OpenAIProtocolTemplate)
+        self.assertIn("profile.get('llm_model', {})", src)
+
+    def test_slave_rag_template_uses_value_error(self):
+        import inspect
+        from agentuniverse.agent.template.slave_rag_agent_template import \
+            SlaveRagAgentTemplate
+        src = inspect.getsource(SlaveRagAgentTemplate)
+        self.assertIn("ValueError", src)
+        self.assertNotIn("raise Exception(", src)
+
+
+class TestLLMInstrumentorBareExcept(unittest.TestCase):
+
+    def test_cleanup_uses_specific_except(self):
+        import os
+        # Walk up from this test file to find the repo root, then navigate
+        # to the llm_instrumentor source.
+        here = os.path.dirname(os.path.abspath(__file__))
+        for _ in range(10):
+            candidate = os.path.join(
+                here, "agentuniverse", "base", "tracing", "otel",
+                "instrumentation", "llm", "llm_instrumentor.py")
+            if os.path.exists(candidate):
+                filepath = candidate
+                break
+            here = os.path.dirname(here)
+        else:
+            self.skipTest("Could not locate llm_instrumentor.py")
+
+        with open(filepath, encoding="utf-8") as f:
+            src = f.read()
+        start = src.index("def cleanup(self):")
+        end = src.index("def ", start + 10)
+        cleanup_src = src[start:end]
+        self.assertNotIn("except:", cleanup_src,
+                          "LLMSpanManager.cleanup must not use bare except:")
+        self.assertIn("except Exception", cleanup_src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Four fixes across the OTel instrumentor and agent templates.

## Changes

### 1. LLMSpanManager.cleanup — bare `except:`
`except:` caught `KeyboardInterrupt`/`SystemExit` alongside token-usage errors during span cleanup. Narrowed to `except Exception:`.

### 2. react_agent_template.py — None.get crash
`profile.get('llm_model').get('name')` crashes when `llm_model` is not configured. Now uses `.get('llm_model', {})`.

### 3. openai_protocol_template.py — same None.get chain, same fix.

### 4. slave_rag_agent_template.py — bare `Exception` with no agent name
`raise Exception(...)` on missing prompt config gave no hint which agent was misconfigured. Now `raise ValueError` naming the agent.

## Tests

4 regressions (source-contract tests verifying each fix is in place).

`python -m unittest tests.test_agentuniverse.unit.agent.template.test_template_none_guard_and_instrumentor` — 4 passed.
