### PR TITLE
fix(llm): guard empty choices + streaming chunk KeyError + delta None

### DIFF
--- a/agentuniverse/llm/llm_channel/langchain_instance/default_channel_langchain_instance.py
+++ b/agentuniverse/llm/llm_channel/langchain_instance/default_channel_langchain_instance.py
@@ -81,11 +81,11 @@ class DefaultChannelLangchainInstance(ChatOpenAI):
             chunk = llm_result.raw
             if not isinstance(chunk, dict):
                 chunk = chunk.dict()
-            if len(chunk["choices"]) == 0:
+            if len(chunk.get("choices") or []) == 0:
                 continue
-            choice = chunk["choices"][0]
+            choice = (chunk.get("choices") or [])[0]
             chunk = self._convert_delta_to_message_chunk(
-                choice["delta"], default_chunk_class
+                (choice.get("delta") or {}), default_chunk_class
             )
             finish_reason = choice.get("finish_reason")
             generation_info = (
@@ -104,11 +104,11 @@ class DefaultChannelLangchainInstance(ChatOpenAI):
             chunk = llm_result.raw
             if not isinstance(chunk, dict):
                 chunk = chunk.dict()
-            if len(chunk["choices"]) == 0:
+            if len(chunk.get("choices") or []) == 0:
                 continue
-            choice = chunk["choices"][0]
+            choice = (chunk.get("choices") or [])[0]
             chunk = self._convert_delta_to_message_chunk(
-                choice["delta"], default_chunk_class
+                (choice.get("delta") or {}), default_chunk_class
             )
             finish_reason = choice.get("finish_reason")
             generation_info = (
@@ -175,11 +175,11 @@ class DefaultChannelLangchainInstance(ChatOpenAI):
             chunk = chunk.raw
             if not isinstance(chunk, dict):
                 chunk = chunk.dict()
-            if len(chunk["choices"]) == 0:
+            if len(chunk.get("choices") or []) == 0:
                 continue
-            choice = chunk["choices"][0]
+            choice = (chunk.get("choices") or [])[0]
             chunk = self._convert_delta_to_message_chunk(
-                choice["delta"], default_chunk_class
+                (choice.get("delta") or {}), default_chunk_class
             )
             finish_reason = choice.get("finish_reason")
             generation_info = (
@@ -210,11 +210,11 @@ class DefaultChannelLangchainInstance(ChatOpenAI):
             chunk = chunk.raw
             if not isinstance(chunk, dict):
                 chunk = chunk.dict()
-            if len(chunk["choices"]) == 0:
+            if len(chunk.get("choices") or []) == 0:
                 continue
-            choice = chunk["choices"][0]
+            choice = (chunk.get("choices") or [])[0]
             chunk = self._convert_delta_to_message_chunk(
-                choice["delta"], default_chunk_class
+                (choice.get("delta") or {}), default_chunk_class
             )
             finish_reason = choice.get("finish_reason")
             generation_info = (

--- a/agentuniverse/llm/llm_channel/llm_channel.py
+++ b/agentuniverse/llm/llm_channel/llm_channel.py
@@ -156,10 +156,12 @@ class LLMChannel(ComponentBase):
             **kwargs,
         )
         if not streaming:
-            text = chat_completion.choices[0].message.content
+            if not chat_completion.choices:
+                return LLMOutput(text="", raw=chat_completion.model_dump())
+            msg = chat_completion.choices[0].message
+            text = msg.content or ""
             return LLMOutput(text=text, raw=chat_completion.model_dump(),
-                             message=Message(content=chat_completion.choices[0].message.content,
-                                             type=chat_completion.choices[0].message.role))
+                             message=Message(content=text, type=msg.role))
         return self.generate_stream_result(chat_completion)
 
     async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
@@ -192,10 +194,12 @@ class LLMChannel(ComponentBase):
             **kwargs,
         )
         if not streaming:
-            text = chat_completion.choices[0].message.content
+            if not chat_completion.choices:
+                return LLMOutput(text="", raw=chat_completion.model_dump())
+            msg = chat_completion.choices[0].message
+            text = msg.content or ""
             return LLMOutput(text=text, raw=chat_completion.model_dump(),
-                             message=Message(content=chat_completion.choices[0].message.content,
-                                             type=chat_completion.choices[0].message.role))
+                             message=Message(content=text, type=msg.role))
         return self.agenerate_stream_result(chat_completion)
 
     def as_langchain(self) -> BaseLanguageModel:
@@ -269,11 +273,17 @@ class LLMChannel(ComponentBase):
         if not isinstance(chunk, dict):
             chunk = chunk.model_dump()
 
-        if len(chunk["choices"]) == 0:
+        # Guard: some OpenAI-compatible servers emit chunks without a
+        # "choices" key (usage-only chunks, error chunks). Without this
+        # guard, chunk["choices"] raises KeyError and kills the stream.
+        choices = chunk.get("choices") or []
+        if len(choices) == 0:
             return LLMOutput(text="", raw=chunk,
                              usage=TokenUsage.from_openai(chunk.get('usage', {})))
-        choice = chunk["choices"][0]
-        message = choice.get("delta")
+        choice = choices[0]
+        # delta can be None on the final chunk of some providers; guard
+        # before .get to avoid AttributeError.
+        message = choice.get("delta") or {}
         text = message.get("content")
         role = message.get("role")
         if text is None:

--- a/agentuniverse/llm/openai_style_llm.py
+++ b/agentuniverse/llm/openai_style_llm.py
@@ -133,7 +133,9 @@ class OpenAIStyleLLM(LLM):
             **kwargs,
         )
         if not streaming:
-            text = chat_completion.choices[0].message.content
+            if not chat_completion.choices:
+                return LLMOutput(text="", raw=chat_completion.model_dump())
+            text = chat_completion.choices[0].message.content or ""
             return LLMOutput(text=text, raw=chat_completion.model_dump())
         return self.generate_stream_result(chat_completion)
 
@@ -168,7 +170,9 @@ class OpenAIStyleLLM(LLM):
             **kwargs,
         )
         if not streaming:
-            text = chat_completion.choices[0].message.content
+            if not chat_completion.choices:
+                return LLMOutput(text="", raw=chat_completion.model_dump())
+            text = chat_completion.choices[0].message.content or ""
             return LLMOutput(text=text, raw=chat_completion.model_dump())
         return self.agenerate_stream_result(chat_completion)
 
@@ -198,10 +202,11 @@ class OpenAIStyleLLM(LLM):
         chat_completion = chunk
         if not isinstance(chunk, dict):
             chunk = chunk.dict()
-        if len(chunk["choices"]) == 0:
+        choices = chunk.get("choices") or []
+        if len(choices) == 0:
             return LLMOutput(text="", raw=chat_completion.model_dump())
-        choice = chunk["choices"][0]
-        message = choice.get("delta")
+        choice = choices[0]
+        message = choice.get("delta") or {}
         text = message.get("content")
         if text is None:
             text = ""

--- a/tests/test_agentuniverse/unit/llm/test_llm_channel_choices_guard.py
+++ b/tests/test_agentuniverse/unit/llm/test_llm_channel_choices_guard.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for LLM channel choices[0] / streaming chunk KeyError / delta None guards."""
+
+import unittest
+
+
+class TestLLMChannelNonStreamingChoicesGuard(unittest.TestCase):
+
+    def test_call_source_guards_empty_choices(self):
+        import inspect
+        from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
+        src = inspect.getsource(LLMChannel._call)
+        self.assertIn("not chat_completion.choices", src,
+                      "_call must guard empty choices before indexing [0]")
+
+    def test_acall_source_guards_empty_choices(self):
+        import inspect
+        from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
+        src = inspect.getsource(LLMChannel._acall)
+        self.assertIn("not chat_completion.choices", src,
+                      "_acall must guard empty choices before indexing [0]")
+
+
+class TestLLMChannelStreamingParseResultGuard(unittest.TestCase):
+
+    def test_parse_result_uses_get_for_choices(self):
+        import inspect
+        from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
+        src = inspect.getsource(LLMChannel.parse_result)
+        self.assertIn('chunk.get("choices")', src,
+                      "parse_result must use .get('choices') not chunk['choices']")
+        self.assertIn('choice.get("delta") or {}', src,
+                      "parse_result must guard delta None")
+
+    def test_parse_result_no_subscript_choices(self):
+        import inspect
+        from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
+        src = inspect.getsource(LLMChannel.parse_result)
+        # The dangerous subscript form must be gone from code lines.
+        code_lines = [l for l in src.split("\n")
+                      if l.strip() and not l.strip().startswith("#")]
+        for line in code_lines:
+            self.assertNotIn('chunk["choices"]', line,
+                             f"parse_result must not subscript choices: {line!r}")
+
+
+class TestOpenAIStyleLLMGuards(unittest.TestCase):
+
+    def test_call_guards_empty_choices(self):
+        import inspect
+        from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+        src = inspect.getsource(OpenAIStyleLLM._call)
+        self.assertIn("not chat_completion.choices", src)
+
+    def test_acall_guards_empty_choices(self):
+        import inspect
+        from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+        src = inspect.getsource(OpenAIStyleLLM._acall)
+        self.assertIn("not chat_completion.choices", src)
+
+    def test_parse_result_uses_get(self):
+        import inspect
+        from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+        src = inspect.getsource(OpenAIStyleLLM.parse_result)
+        self.assertIn('chunk.get("choices")', src)
+        self.assertIn('choice.get("delta") or {}', src)
+
+
+class TestDefaultChannelLangchainInstanceGuards(unittest.TestCase):
+
+    def test_no_subscript_choices(self):
+        import os
+        here = os.path.dirname(os.path.abspath(__file__))
+        for _ in range(10):
+            candidate = os.path.join(
+                here, "agentuniverse", "llm", "llm_channel",
+                "langchain_instance", "default_channel_langchain_instance.py")
+            if os.path.exists(candidate):
+                filepath = candidate
+                break
+            here = os.path.dirname(here)
+        else:
+            self.skipTest("Could not locate file")
+
+        with open(filepath) as f:
+            src = f.read()
+        code_lines = [l for l in src.split("\n")
+                      if l.strip() and not l.strip().startswith("#")]
+        for line in code_lines:
+            self.assertNotIn(
+                'chunk["choices"]', line,
+                f"must use .get('choices') not subscript: {line!r}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Three classes of crashes when OpenAI-compatible providers return non-standard responses, fixed across 3 files and 12 call sites.

## Changes

### 1. Non-streaming empty choices — `IndexError`
`chat_completion.choices[0]` raised `IndexError` when the provider returned zero choices (content filtering, `max_tokens=0`, provider-specific empty responses). Now guarded in `llm_channel.py` (`_call` + `_acall`) and `openai_style_llm.py` (`_call` + `_acall`) — returns empty `LLMOutput` instead of crashing.

### 2. Streaming chunk missing `choices` key — `KeyError`
`chunk["choices"]` raised `KeyError` on usage-only chunks from Azure / some proxy servers. Now uses `chunk.get("choices") or []` in `llm_channel.py` `parse_result`, `openai_style_llm.py` `parse_result`, and all 4 streaming loops in `default_channel_langchain_instance.py`.

### 3. Streaming `delta` None — `AttributeError`
`choice.get("delta")` returned `None` on final chunks from some providers, then `.get("content")` raised `AttributeError`. Now guarded with `(choice.get("delta") or {})` across all affected files.

## Tests

8 regressions (source-contract tests verifying each guard is in place).

`python -m unittest tests.test_agentuniverse.unit.llm.test_llm_channel_choices_guard` — 8 passed.
