### PR TITLE
fix(agent,context): judge_chain_stream RunnableBinding detection + context manager @singleton

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -356,6 +356,23 @@ class Agent(ComponentBase, ABC):
                            chain: RunnableSerializable[Any, str]) -> bool:
         streaming = False
         for _step in chain.steps:
+            # The chain is built as prompt | llm.as_langchain_runnable(params).
+            # The second element is a RunnableBinding (from .bind()), which
+            # exposes .bound (the underlying runnable) and .kwargs. It does NOT
+            # have .llm or .llm_channel attributes, so the previous detection
+            # always fell through to ``return False``, silently disabling
+            # streaming even when the LLM was configured with streaming: true.
+            #
+            # Check for RunnableBinding first, then unwrap to find the LLM.
+            if hasattr(_step, "kwargs") and "streaming" in (_step.kwargs or {}):
+                return bool(_step.kwargs.get("streaming"))
+            if hasattr(_step, "bound"):
+                inner = _step.bound
+                if hasattr(inner, "streaming"):
+                    return bool(inner.streaming)
+                if hasattr(inner, "llm") and hasattr(inner.llm, "streaming"):
+                    return bool(inner.llm.streaming)
+            # Direct attribute check (for non-bound runnables).
             if hasattr(_step, "llm"):
                 return _step.kwargs.get('streaming', _step.llm.streaming)
             if hasattr(_step, "llm_channel"):

--- a/agentuniverse/agent/context/context_manager_manager.py
+++ b/agentuniverse/agent/context/context_manager_manager.py
@@ -6,10 +6,12 @@
 # @FileName: context_manager_manager.py
 """Context manager manager singleton."""
 
+from agentuniverse.base.annotation.singleton import singleton
 from agentuniverse.base.component.component_manager_base import ComponentManagerBase
 from agentuniverse.base.component.component_enum import ComponentEnum
 
 
+@singleton
 class ContextManagerManager(ComponentManagerBase):
     """Manager for ContextManager instances (Singleton pattern).
 

--- a/agentuniverse/agent/context/context_store_manager.py
+++ b/agentuniverse/agent/context/context_store_manager.py
@@ -6,10 +6,12 @@
 # @FileName: context_store_manager.py
 """Context store manager singleton."""
 
+from agentuniverse.base.annotation.singleton import singleton
 from agentuniverse.base.component.component_manager_base import ComponentManagerBase
 from agentuniverse.base.component.component_enum import ComponentEnum
 
 
+@singleton
 class ContextStoreManager(ComponentManagerBase):
     """Manager for ContextStore instances (Singleton pattern).
 

--- a/tests/test_agentuniverse/unit/agent/context/test_judge_stream_and_singleton.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_judge_stream_and_singleton.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+"""Tests for judge_chain_stream RunnableBinding detection + context manager @singleton."""
+
+import unittest
+
+
+class TestJudgeChainStream(unittest.TestCase):
+
+    def test_source_handles_runnable_binding(self):
+        import inspect
+        from agentuniverse.agent.agent import Agent
+        src = inspect.getsource(Agent.judge_chain_stream)
+        # Must check for RunnableBinding (.bound) and .kwargs['streaming']
+        self.assertIn('"bound"', src,
+                      "judge_chain_stream must unwrap RunnableBinding.bound")
+        self.assertIn('"streaming"', src,
+                      "judge_chain_stream must check kwargs for streaming flag")
+
+
+class TestContextStoreManagerSingleton(unittest.TestCase):
+
+    def test_has_singleton_decorator(self):
+        import inspect
+        from agentuniverse.agent.context.context_store_manager import \
+            ContextStoreManager
+        src = inspect.getsource(ContextStoreManager)
+        # The module-level decorator must be present.
+        import agentuniverse.agent.context.context_store_manager as mod
+        mod_src = inspect.getsource(mod)
+        self.assertIn("@singleton", mod_src,
+                      "ContextStoreManager must be decorated with @singleton")
+
+
+class TestContextManagerManagerSingleton(unittest.TestCase):
+
+    def test_has_singleton_decorator(self):
+        import inspect
+        import agentuniverse.agent.context.context_manager_manager as mod
+        mod_src = inspect.getsource(mod)
+        self.assertIn("@singleton", mod_src,
+                      "ContextManagerManager must be decorated with @singleton")
+
+
+class TestSingletonInstanceSharing(unittest.TestCase):
+
+    def test_context_store_manager_returns_same_instance(self):
+        from agentuniverse.agent.context.context_store_manager import \
+            ContextStoreManager
+        a = ContextStoreManager()
+        b = ContextStoreManager()
+        self.assertIs(a, b,
+                      "ContextStoreManager() must return the same instance "
+                      "(singleton)")
+
+    def test_context_manager_manager_returns_same_instance(self):
+        from agentuniverse.agent.context.context_manager_manager import \
+            ContextManagerManager
+        a = ContextManagerManager()
+        b = ContextManagerManager()
+        self.assertIs(a, b,
+                      "ContextManagerManager() must return the same instance "
+                      "(singleton)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Two bugs: `judge_chain_stream` silently disabled streaming for every agent, and `ContextStoreManager`/`ContextManagerManager` were missing `@singleton` so the entire context subsystem was a no-op.

## Changes

### 1. judge_chain_stream — streaming always False
The chain is built as `prompt | llm.as_langchain_runnable(params)`, where the LLM element is a `RunnableBinding` (from `.bind()`) that exposes `.bound` and `.kwargs` — **not** `.llm` or `.llm_channel`. So `hasattr(_step, "llm")` was always `False`, and the function returned `False` even when the LLM was configured with `streaming: true`. The token streaming callback (`output_stream` queue) never triggered. Fixed by checking `.kwargs['streaming']` first, then unwrapping `.bound`.

### 2. ContextStoreManager / ContextManagerManager — missing @singleton
Every other manager (`KnowledgeManager`, `ToolManager`, `LLMManager`, etc.) has `@singleton`. These two did not, so `ContextStoreManager()` returned a fresh empty instance every time. `get_instance_obj` always returned `None`, making every `add_context`/`get_context`/`search_context` a silent no-op. Added `@singleton`.

## Tests

5 regressions: `judge_chain_stream` source handles `RunnableBinding`, both managers have `@singleton` in source, both managers return the same instance.

`python -m unittest tests.test_agentuniverse.unit.agent.context.test_judge_stream_and_singleton` — 5 passed.
