### PR TITLE
fix(reader): avoid Confluence debug prints

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud/confluence_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud/confluence_reader.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Dict
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.util.logging.logging_util import LOGGER
 
 
 class ConfluenceReader(Reader):
@@ -19,9 +20,9 @@ class ConfluenceReader(Reader):
     """
 
     def _load_data(self, page_id: str, ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: ConfluenceReader start load page_id={page_id}")
         if not page_id:
             raise ValueError("ConfluenceReader requires page_id")
+        LOGGER.debug("ConfluenceReader start loading page.")
 
         site_url, username, token = self._resolve_cred(ext_info)
         try:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_confluence_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_confluence_reader.py
@@ -1,0 +1,42 @@
+import io
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.cloud.confluence_reader import ConfluenceReader
+
+
+class _FakeConfluence:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_page_by_id(self, *args, **kwargs):
+        return {
+            "title": "Demo",
+            "version": {"number": 1},
+            "body": {"view": {"value": "<p>Hello</p>"}},
+        }
+
+
+class ConfluenceReaderTest(unittest.TestCase):
+
+    def test_load_data_does_not_print_page_id(self):
+        reader = ConfluenceReader()
+        stdout = io.StringIO()
+        atlassian_module = types.SimpleNamespace(Confluence=_FakeConfluence)
+
+        with patch.object(reader, "_resolve_cred", return_value=("https://example.com", "user", "token")), \
+                patch.object(reader, "_html_to_text", return_value="Hello"), \
+                patch.dict(sys.modules, {"atlassian": atlassian_module}), \
+                redirect_stdout(stdout):
+            documents = reader._load_data("secret-page-id")
+
+        self.assertEqual("Hello", documents[0].text)
+        self.assertNotIn("secret-page-id", stdout.getvalue())
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Remove the unconditional debug print from `ConfluenceReader._load_data`.
- Use the project logger for internal load tracing so caller stdout is not polluted.
- Add regression coverage that loads a Confluence page with a mocked client and verifies the page id is not printed.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_confluence_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/cloud/confluence_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_confluence_reader.py`: passed.
- `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.test_confluence_reader`: not run to completion locally because this environment is missing project dependency `langchain_core`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.