### PR TITLE
fix(reader): avoid Feishu fetch prints

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/feishu_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/feishu_reader.py
@@ -7,9 +7,13 @@
 # @FileName: feishu_reader.py
 
 from bs4 import BeautifulSoup
+import logging
 import time
 from typing import Dict,List
 from agentuniverse.agent.action.knowledge.store.document import Document
+
+logger = logging.getLogger(__name__)
+
 
 class PublicFeishuReader:
     """Feishu public document reader using Selenium
@@ -60,7 +64,7 @@ class PublicFeishuReader:
             soup = BeautifulSoup(page_source, 'html.parser')
             return self._parse_content(soup)
         except Exception as e:
-            print(f"Error fetching document: {e}")
+            logger.warning("Failed to fetch Feishu document from %s: %s", url, e)
             return ""
 
     def _parse_content(self, soup: BeautifulSoup) -> str:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_feishu_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_feishu_reader.py
@@ -1,0 +1,29 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.cloud_file_reader.feishu_reader import PublicFeishuReader
+
+
+class _FailingDriver:
+    def get(self, url):
+        raise RuntimeError("network unavailable")
+
+
+class PublicFeishuReaderTest(unittest.TestCase):
+
+    def test_fetch_document_failure_does_not_print_to_stdout(self):
+        reader = object.__new__(PublicFeishuReader)
+        reader.driver = _FailingDriver()
+        stdout = io.StringIO()
+
+        with patch("time.sleep", return_value=None), redirect_stdout(stdout):
+            content = reader._fetch_document_content("https://example.feishu.cn/docx/demo")
+
+        self.assertEqual("", content)
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace the unconditional `print` in `PublicFeishuReader._fetch_document_content` with module-level warning logging.
- Keep the existing failure behavior of returning an empty string when Selenium fetching fails.
- Add regression coverage that simulates a fetch error and verifies stdout remains clean.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_feishu_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/cloud_file_reader/feishu_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/test_feishu_reader.py`: passed.
- `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.reader.test_feishu_reader`: not run to completion locally because this environment is missing project dependency `bs4`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.