### PR TITLE
fix(memory): preserve Qdrant type filters

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
@@ -19,6 +19,7 @@ from qdrant_client.models import (
     PointStruct,
     Filter,
     FieldCondition,
+    MatchAny,
     MatchValue,
 )
 
@@ -109,7 +110,13 @@ class QdrantMemoryStorage(MemoryStorage):
         if source:
             must_conditions.append(FieldCondition(key="source", match=MatchValue(value=source)))
         if type_value:
-            must_conditions.append(FieldCondition(key="type", match=MatchValue(value=type_value[0])))
+            if isinstance(type_value, str):
+                match = MatchValue(value=type_value)
+            elif isinstance(type_value, (list, tuple, set)):
+                match = MatchAny(any=list(type_value))
+            else:
+                match = MatchValue(value=type_value)
+            must_conditions.append(FieldCondition(key="type", match=match))
         if not must_conditions:
             return None
         return Filter(must=must_conditions)

--- a/tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_storage.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_storage.py
@@ -1,0 +1,79 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class _Distance:
+    COSINE = "COSINE"
+    EUCLID = "EUCLID"
+    DOT = "DOT"
+    MANHATTAN = "MANHATTAN"
+
+
+class _MatchAny:
+    def __init__(self, any):
+        self.any = any
+
+
+class _MatchValue:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FieldCondition:
+    def __init__(self, key, match):
+        self.key = key
+        self.match = match
+
+
+class _Filter:
+    def __init__(self, must):
+        self.must = must
+
+
+def _install_qdrant_stub():
+    models_module = types.SimpleNamespace(
+        Distance=_Distance,
+        Filter=_Filter,
+        FieldCondition=_FieldCondition,
+        MatchAny=_MatchAny,
+        MatchValue=_MatchValue,
+        NamedVector=object,
+        PointStruct=object,
+        VectorParams=object,
+    )
+    qdrant_module = types.SimpleNamespace(QdrantClient=object)
+    return patch.dict(
+        sys.modules,
+        {
+            "qdrant_client": qdrant_module,
+            "qdrant_client.models": models_module,
+        },
+    )
+
+
+class QdrantMemoryStorageTest(unittest.TestCase):
+
+    def test_build_filter_preserves_string_type_value(self):
+        with _install_qdrant_stub():
+            from agentuniverse.agent.memory.memory_storage.qdrant_memory_storage import QdrantMemoryStorage
+
+        qdrant_filter = QdrantMemoryStorage._build_filter(None, None, None, "human")
+
+        self.assertEqual("type", qdrant_filter.must[0].key)
+        self.assertIsInstance(qdrant_filter.must[0].match, _MatchValue)
+        self.assertEqual("human", qdrant_filter.must[0].match.value)
+
+    def test_build_filter_uses_match_any_for_type_lists(self):
+        with _install_qdrant_stub():
+            from agentuniverse.agent.memory.memory_storage.qdrant_memory_storage import QdrantMemoryStorage
+
+        qdrant_filter = QdrantMemoryStorage._build_filter(None, None, None, ["human", "ai"])
+
+        self.assertIsInstance(qdrant_filter.must[0].match, _MatchAny)
+        self.assertEqual(["human", "ai"], qdrant_filter.must[0].match.any)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Preserve string `type` filters in `QdrantMemoryStorage._build_filter` instead of using only the first character.
- Use Qdrant `MatchAny` for list, tuple, or set type filters so multiple message types can be queried correctly.
- Add regression coverage for both string and list type filters.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_storage.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_storage.py`: passed.
- `python -m unittest tests.test_agentuniverse.unit.agent.memory.test_qdrant_memory_storage`: not run to completion locally because this environment is missing project dependency `tomli`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.