### PR TITLE
fix(toolkit): avoid config init prints

### DIFF
--- a/agentuniverse/agent/action/toolkit/toolkit.py
+++ b/agentuniverse/agent/action/toolkit/toolkit.py
@@ -10,6 +10,7 @@ from agentuniverse.base.config.application_configer.application_config_manager i
     ApplicationConfigManager
 from agentuniverse.base.config.component_configer.component_configer import \
     ComponentConfiger
+from agentuniverse.base.util.logging.logging_util import LOGGER
 
 
 class Toolkit(ComponentBase):
@@ -64,7 +65,7 @@ class Toolkit(ComponentBase):
                 if key != 'metadata':
                     setattr(self, key, value)
         except Exception as e:
-            print(f"Error during configuration initialization: {str(e)}")
+            LOGGER.error(f"Error during toolkit configuration initialization: {str(e)}")
         if component_configer.name:
             self.name = component_configer.name
         if component_configer.description:

--- a/tests/test_agentuniverse/unit/agent/action/test_toolkit.py
+++ b/tests/test_agentuniverse/unit/agent/action/test_toolkit.py
@@ -1,0 +1,39 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+from agentuniverse.agent.action.toolkit.toolkit import Toolkit
+
+
+class _BrokenValue:
+    def items(self):
+        raise RuntimeError("bad config")
+
+
+class _TestToolkit(Toolkit):
+    def _initialize_by_component_configer(self, component_configer):
+        return self
+
+
+class ToolkitTest(unittest.TestCase):
+
+    def test_initialize_config_error_does_not_print_to_stdout(self):
+        toolkit = _TestToolkit()
+        configer = SimpleNamespace(
+            configer=SimpleNamespace(value=_BrokenValue()),
+            name="toolkit",
+            description="description",
+            include=[],
+        )
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            toolkit.initialize_by_component_configer(configer)
+
+        self.assertEqual("", stdout.getvalue())
+        self.assertEqual("toolkit", toolkit.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace the direct `print` in `Toolkit.initialize_by_component_configer` with project logger error output.
- Keep the existing fallback behavior after a config initialization error.
- Add regression coverage that exercises the error path and verifies stdout remains clean.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/test_toolkit.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/toolkit/toolkit.py tests/test_agentuniverse/unit/agent/action/test_toolkit.py`: passed.
- `python -m unittest tests.test_agentuniverse.unit.agent.action.test_toolkit`: not run to completion locally because this environment is missing project dependency `langchain`.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.