### PR TITLE
fix(memory): accept Chroma type filter iterables

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
@@ -146,10 +146,13 @@ class ChromaMemoryStorage(MemoryStorage):
         if source:
             filters["$and"].append({'source': source})
         if kwargs.get('type'):
-            if isinstance(kwargs.get('type'), list):
-                types = kwargs.get('type')
-            elif isinstance(kwargs.get('type'), str):
-                types = [kwargs.get('type')]
+            type_value = kwargs.get('type')
+            if isinstance(type_value, str):
+                types = [type_value]
+            elif isinstance(type_value, (list, tuple, set)):
+                types = list(type_value)
+            else:
+                types = [type_value]
             filters["$and"].append({'type': {'$in': types}})
         if len(filters["$and"]) < 2:
             filters = filters["$and"][0] if len(filters["$and"]) == 1 else {}

--- a/tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_type_filter.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_type_filter.py
@@ -1,0 +1,52 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class _Collection:
+    pass
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.where = None
+
+    def get(self, where):
+        self.where = where
+        return {"ids": [], "metadatas": [], "documents": []}
+
+
+def _install_chromadb_stub():
+    chromadb_module = types.SimpleNamespace(Client=lambda settings: None)
+    config_module = types.SimpleNamespace(Settings=lambda **kwargs: kwargs)
+    collection_module = types.SimpleNamespace(Collection=_Collection)
+    return patch.dict(
+        sys.modules,
+        {
+            "chromadb": chromadb_module,
+            "chromadb.config": config_module,
+            "chromadb.api": types.SimpleNamespace(),
+            "chromadb.api.models": types.SimpleNamespace(),
+            "chromadb.api.models.Collection": collection_module,
+        },
+    )
+
+
+class ChromaMemoryTypeFilterTest(unittest.TestCase):
+
+    def test_get_accepts_tuple_type_filter(self):
+        with _install_chromadb_stub():
+            from agentuniverse.agent.memory.memory_storage.chroma_memory_storage import ChromaMemoryStorage
+
+        collection = _FakeCollection()
+        storage = ChromaMemoryStorage()
+        storage._collection = collection
+
+        storage.get(type=("human", "ai"))
+
+        self.assertEqual({"type": {"$in": ["human", "ai"]}}, collection.where)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Allow `ChromaMemoryStorage.get(..., type=...)` to accept tuple and set values in addition to strings and lists.
- Normalize iterable type filters into a Chroma `$in` list instead of leaving `types` undefined for non-list iterables.
- Add regression coverage for a tuple type filter.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_type_filter.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_type_filter.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.