### PR TITLE
fix(memory): sort Chroma messages without metadata

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
@@ -219,7 +219,7 @@ class ChromaMemoryStorage(MemoryStorage):
                 # order by gmt_created asc
                 message_list = sorted(
                     message_list,
-                    key=lambda msg: msg.metadata.get('gmt_created', ''),
+                    key=lambda msg: (msg.metadata or {}).get('gmt_created', ''),
                 )
         except Exception as e:
             print('ChromaMemory.to_messages failed, exception= ' + str(e))

--- a/tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_sort.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_sort.py
@@ -1,0 +1,46 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class _Collection:
+    pass
+
+
+def _install_chromadb_stub():
+    chromadb_module = types.SimpleNamespace(Client=lambda settings: None)
+    config_module = types.SimpleNamespace(Settings=lambda **kwargs: kwargs)
+    collection_module = types.SimpleNamespace(Collection=_Collection)
+    return patch.dict(
+        sys.modules,
+        {
+            "chromadb": chromadb_module,
+            "chromadb.config": config_module,
+            "chromadb.api": types.SimpleNamespace(),
+            "chromadb.api.models": types.SimpleNamespace(),
+            "chromadb.api.models.Collection": collection_module,
+        },
+    )
+
+
+class ChromaMemorySortTest(unittest.TestCase):
+
+    def test_to_messages_sorts_when_metadata_is_none(self):
+        with _install_chromadb_stub():
+            from agentuniverse.agent.memory.memory_storage.chroma_memory_storage import ChromaMemoryStorage
+
+        storage = ChromaMemoryStorage()
+        result = {
+            "ids": ["1", "2"],
+            "documents": ["without metadata", "with metadata"],
+            "metadatas": [None, {"gmt_created": "2026-01-01T00:00:00"}],
+        }
+
+        messages = storage.to_messages(result, sort_by_time=True)
+
+        self.assertEqual(["1", "2"], [message.id for message in messages])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Make `ChromaMemoryStorage.to_messages(..., sort_by_time=True)` tolerate messages whose metadata is `None`.
- Sort with `(msg.metadata or {})` so missing metadata does not raise `AttributeError`.
- Add regression coverage for sorting mixed messages with and without metadata.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_sort.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py tests/test_agentuniverse/unit/agent/memory/test_chroma_memory_sort.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.