### PR TITLE
fix(memory): avoid Qdrant conversion prints

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
@@ -26,6 +26,7 @@ from agentuniverse.agent.action.knowledge.embedding.embedding_manager import Emb
 from agentuniverse.agent.memory.memory_storage.memory_storage import MemoryStorage
 from agentuniverse.agent.memory.message import Message
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.util.logging.logging_util import LOGGER
 
 
 DEFAULT_CONNECTION_ARGS: Dict[str, Any] = {
@@ -234,5 +235,5 @@ class QdrantMemoryStorage(MemoryStorage):
                 )
                 message_list.append(msg)
         except Exception as e:
-            print("QdrantMemoryStorage.to_messages failed, exception= " + str(e))
+            LOGGER.error(f"QdrantMemoryStorage.to_messages failed, exception= {e}")
         return message_list

--- a/tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_logging.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_logging.py
@@ -1,0 +1,59 @@
+import io
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+
+class _Distance:
+    COSINE = "COSINE"
+    EUCLID = "EUCLID"
+    DOT = "DOT"
+    MANHATTAN = "MANHATTAN"
+
+
+class _BadPoint:
+    @property
+    def payload(self):
+        raise RuntimeError("bad payload")
+
+
+def _install_qdrant_stub():
+    models_module = types.SimpleNamespace(
+        Distance=_Distance,
+        Filter=object,
+        FieldCondition=object,
+        MatchValue=object,
+        NamedVector=object,
+        PointStruct=object,
+        VectorParams=object,
+    )
+    qdrant_module = types.SimpleNamespace(QdrantClient=object)
+    return patch.dict(
+        sys.modules,
+        {
+            "qdrant_client": qdrant_module,
+            "qdrant_client.models": models_module,
+        },
+    )
+
+
+class QdrantMemoryLoggingTest(unittest.TestCase):
+
+    def test_to_messages_conversion_error_does_not_print(self):
+        with _install_qdrant_stub():
+            from agentuniverse.agent.memory.memory_storage.qdrant_memory_storage import QdrantMemoryStorage
+
+        storage = QdrantMemoryStorage()
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            messages = storage.to_messages([_BadPoint()])
+
+        self.assertEqual([], messages)
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace the direct `print` in `QdrantMemoryStorage.to_messages` with project logger output.
- Keep the existing fallback behavior of returning the successfully converted messages.
- Add regression coverage that simulates a conversion error and verifies stdout remains clean.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_logging.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py tests/test_agentuniverse/unit/agent/memory/test_qdrant_memory_logging.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.