### PR TITLE
fix(util): avoid system util error prints

### DIFF
--- a/agentuniverse/base/util/system_util.py
+++ b/agentuniverse/base/util/system_util.py
@@ -7,6 +7,7 @@
 # @FileName: system_util.py
 import ast
 import inspect
+import logging
 import os
 from pathlib import Path
 import importlib
@@ -16,6 +17,7 @@ from agentuniverse.base.component.component_base import ComponentBase
 from agentuniverse.base.component.component_enum import ComponentEnum
 
 PROJECT_ROOT_PATH = None
+logger = logging.getLogger(__name__)
 
 
 def get_project_root_path() -> Path:
@@ -236,7 +238,7 @@ def is_system_builtin(component_instance: ComponentBase) -> bool:
         # Check if the system path is part of the normalized config path
         return system_path in normalized_config_path
     except Exception as e:
-        print(f"An error occurred while checking if the component is system-built-in: {str(e)}")
+        logger.warning("An error occurred while checking if the component is system-built-in: %s", e)
         return False
 
 
@@ -288,5 +290,5 @@ def find_default_llm_config(package_list: list[str]):
                     continue
         return None
     except Exception as e:
-        print(f"An error occurred: {e}")
+        logger.warning("An error occurred while finding default LLM config: %s", e)
         return None

--- a/tests/test_agentuniverse/unit/base/util/test_system_util_logging.py
+++ b/tests/test_agentuniverse/unit/base/util/test_system_util_logging.py
@@ -1,0 +1,48 @@
+import importlib
+import io
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+
+class _BrokenComponent:
+    @property
+    def component_type(self):
+        raise RuntimeError("bad component")
+
+
+def _install_component_stubs():
+    component_base_module = types.SimpleNamespace(ComponentBase=object)
+    component_enum_module = types.SimpleNamespace(
+        ComponentEnum=types.SimpleNamespace(
+            LLM=types.SimpleNamespace(value="llm"),
+            TOOL=types.SimpleNamespace(value="tool"),
+        )
+    )
+    return patch.dict(
+        sys.modules,
+        {
+            "agentuniverse.base.component.component_base": component_base_module,
+            "agentuniverse.base.component.component_enum": component_enum_module,
+        },
+    )
+
+
+class SystemUtilLoggingTest(unittest.TestCase):
+
+    def test_is_system_builtin_error_does_not_print_to_stdout(self):
+        with _install_component_stubs():
+            system_util = importlib.import_module("agentuniverse.base.util.system_util")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            result = system_util.is_system_builtin(_BrokenComponent())
+
+        self.assertFalse(result)
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace direct `print` calls in `system_util` exception fallbacks with module logger warnings.
- Keep the existing return values for system built-in detection and default LLM config lookup failures.
- Add regression coverage confirming `is_system_builtin` does not write to stdout on errors.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/base/util/test_system_util_logging.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/base/util/system_util.py tests/test_agentuniverse/unit/base/util/test_system_util_logging.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.