### PR TITLE
feat: add Voyage AI embedding component (#250)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/voyage_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/voyage_embedding.py
@@ -1,0 +1,215 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: voyage_embedding.py
+
+"""
+Voyage AI embedding component.
+
+Generates text embeddings using the Voyage AI embeddings API
+(``https://api.voyageai.com/v1/embeddings``). Voyage AI provides a family of
+state-of-the-art embedding models such as ``voyage-3``, ``voyage-3-lite``,
+``voyage-3-large`` and ``voyage-large-2``. An API key is required and can be
+obtained from https://dash.voyageai.com/.
+
+This component only depends on ``requests`` (already a core dependency of
+agentUniverse) — no extra install is required.
+"""
+
+import logging
+from typing import Any, List, Optional
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
+from agentuniverse.base.util.env_util import get_from_env
+
+logger = logging.getLogger(__name__)
+
+# Voyage AI embeddings endpoint. The host and path are fixed by the public API
+# contract; keeping them as a module-level constant makes the URL easy to
+# discover from a single place and trivial to patch in unit tests.
+_VOYAGE_EMBED_URL = "https://api.voyageai.com/v1/embeddings"
+
+# Voyage AI recommends telling the API whether each call is embedding
+# documents for storage or a query for retrieval. Only these two values are
+# accepted by the API; anything else falls back to the component default.
+_VALID_INPUT_TYPES = ("document", "query")
+
+
+class VoyageEmbedding(Embedding):
+    """Embedding component backed by the Voyage AI embeddings API.
+
+    Attributes:
+        embedding_model_name: Voyage AI embedding model
+            (default ``voyage-3``).
+        api_key: Voyage AI API key (env: ``VOYAGE_API_KEY``).
+        input_type: ``"document"`` or ``"query"`` — Voyage AI recommends
+            specifying this for best retrieval quality. Defaults to
+            ``"document"`` and can be overridden per-call via ``text_type``.
+        request_timeout: Timeout in seconds for the HTTP call (default 30).
+            ``requests`` defaults to no timeout, so without this a stalled
+            Voyage API would hang the whole embed step indefinitely.
+        client: Reserved for testing / dependency injection. When set, the
+            value's ``post`` callable is used instead of ``requests.post``.
+    """
+
+    embedding_model_name: str = "voyage-3"
+    api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("VOYAGE_API_KEY"))
+    input_type: str = "document"
+    request_timeout: int = 30
+    client: Any = None
+
+    def _resolve_input_type(self, text_type: Optional[str]) -> str:
+        """Pick the effective ``input_type`` for a single embed call.
+
+        A per-call ``text_type`` wins when it is one of the API-accepted
+        values; otherwise we fall back to the component-level ``input_type``
+        so a stray kwarg never produces an invalid request body.
+        """
+        if text_type in _VALID_INPUT_TYPES:
+            return text_type
+        return self.input_type if self.input_type in _VALID_INPUT_TYPES \
+            else "document"
+
+    def get_embeddings(self, texts: List[str],
+                       input_type: str = "document",
+                       **kwargs) -> List[List[float]]:
+        """Return embeddings for ``texts`` via the Voyage AI API.
+
+        Args:
+            texts: List of input strings to embed. An empty list short-circuits
+                to an empty result without calling the API.
+            input_type: ``"document"`` (default) or ``"query"``. Falls back to
+                the component-level ``input_type`` when invalid.
+            **kwargs: Reserved for forward compatibility — currently unused.
+
+        Returns:
+            A list of embedding vectors, one per input text, preserving the
+            input order. On timeout an empty-vector list is returned so a
+            single slow request does not crash a whole ingestion pipeline.
+
+        Raises:
+            ValueError: If ``api_key`` is missing.
+            RuntimeError: If the API returns a non-2xx status or a body that
+                cannot be decoded as JSON.
+        """
+        if not texts:
+            return []
+        if not self.api_key:
+            raise ValueError(
+                "VoyageEmbedding requires an api_key. Set it on the component "
+                "or via the VOYAGE_API_KEY environment variable.")
+
+        effective_type = self._resolve_input_type(input_type)
+        post_callable = self.client.post if self.client is not None \
+            else requests.post
+
+        try:
+            response = post_callable(
+                _VOYAGE_EMBED_URL,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self.embedding_model_name,
+                    "inputs": texts,
+                    "input_type": effective_type,
+                    "truncation": True,
+                },
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+        except requests.exceptions.Timeout:
+            logger.warning("Voyage AI embed request timed out.")
+            return [[] for _ in texts]
+        except requests.exceptions.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None \
+                else "?"
+            raise RuntimeError(
+                f"Voyage AI embed API returned status {status}") from exc
+        except requests.exceptions.RequestException as exc:
+            raise RuntimeError(
+                f"Voyage AI embed API call failed: {exc}") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Voyage AI embed API returned non-JSON: {exc}") from exc
+
+        embeddings_list = data.get("data", [])
+        if not embeddings_list:
+            logger.warning("Voyage AI embed returned empty embeddings list")
+            return [[] for _ in texts]
+        return [list(item.get("embedding", [])) for item in embeddings_list]
+
+    async def async_get_embeddings(self, texts: List[str],
+                                   input_type: str = "document",
+                                   **kwargs) -> List[List[float]]:
+        """Asynchronously return embeddings for ``texts``.
+
+        The Voyage AI public API does not currently expose a dedicated async
+        endpoint, so this delegates to the synchronous implementation. The
+        signature is async to satisfy the ``Embedding`` base contract and to
+        allow a future swap to an async HTTP client without breaking callers.
+        """
+        return self.get_embeddings(texts, input_type=input_type, **kwargs)
+
+    def as_langchain(self):
+        """Wrap this component as a langchain-compatible Embeddings object."""
+        from langchain_core.embeddings import Embeddings as LCEmbeddings
+
+        outer = self
+
+        class _VoyageLangchainEmbedding(LCEmbeddings):
+            """Langchain adapter delegating to ``VoyageEmbedding``."""
+
+            def embed_documents(self, texts: List[str]) -> List[List[float]]:
+                return outer.get_embeddings(texts, input_type="document")
+
+            def embed_query(self, text: str) -> List[float]:
+                return outer.get_embeddings(
+                    [text], input_type="query")[0]
+
+        return _VoyageLangchainEmbedding()
+
+    def _initialize_by_component_configer(
+            self, embedding_configer) -> 'VoyageEmbedding':
+        """Initialize the component from a ComponentConfiger.
+
+        Honours the base embedding fields (name, description,
+        embedding_model_name, embedding_dims) and the Voyage-specific fields
+        declared on the YAML.
+        """
+        super()._initialize_by_component_configer(embedding_configer)
+        if hasattr(embedding_configer, "api_key"):
+            self.api_key = embedding_configer.api_key
+        if hasattr(embedding_configer, "input_type"):
+            self.input_type = embedding_configer.input_type
+        if hasattr(embedding_configer, "request_timeout"):
+            self.request_timeout = self._validate_request_timeout(
+                embedding_configer.request_timeout)
+        return self
+
+    @staticmethod
+    def _validate_request_timeout(value) -> int:
+        """Validate a configured request timeout.
+
+        ``requests`` treats ``None`` as "no timeout" and accepts ``0`` /
+        negative values without complaint, so a bad config must fail loudly
+        here instead of silently hanging the embed step.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"VoyageEmbedding request_timeout must be a positive number, "
+                f"got {value!r}.")
+        if value <= 0:
+            raise ValueError(
+                f"VoyageEmbedding request_timeout must be a positive number, "
+                f"got {value!r}.")
+        return value

--- a/agentuniverse/agent/action/knowledge/embedding/voyage_embedding.yaml
+++ b/agentuniverse/agent/action/knowledge/embedding/voyage_embedding.yaml
@@ -1,0 +1,9 @@
+name: 'voyage_embedding'
+description: 'embedding via Voyage AI embeddings API'
+embedding_model_name: 'voyage-3'
+input_type: 'document'
+request_timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.voyage_embedding'
+  class: 'VoyageEmbedding'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
@@ -1,0 +1,26 @@
+# Embedding
+
+agentUniverse provides several built-in embedding components used by the Knowledge store and doc processors to vectorise text. Each component is registered with `metadata.type: EMBEDDING` and exposes `get_embeddings(texts, input_type=...)` together with its async counterpart.
+
+## VoyageEmbedding
+
+`VoyageEmbedding` generates text embeddings using the Voyage AI embeddings API (`https://api.voyageai.com/v1/embeddings`). It supports the Voyage AI embedding family, including `voyage-3` (default), `voyage-3-lite`, `voyage-3-large` and `voyage-large-2`. No extra install is required — `requests` is already a core dependency of agentUniverse — only a Voyage AI API key.
+
+Register a component pointing at `agentuniverse.agent.action.knowledge.embedding.voyage_embedding.VoyageEmbedding`, then reference it by name from a store or processor (e.g. `embedding_model: voyage_embedding`). The API key is read from the `VOYAGE_API_KEY` environment variable.
+
+```yaml
+name: 'voyage_embedding'
+description: 'embedding via Voyage AI embeddings API'
+embedding_model_name: 'voyage-3'
+input_type: 'document'
+request_timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.voyage_embedding'
+  class: 'VoyageEmbedding'
+```
+- embedding_model_name: Voyage AI embedding model (default `voyage-3`).
+- input_type: `document` or `query` — Voyage AI recommends specifying this for best retrieval quality (default `document`).
+- request_timeout: Timeout in seconds for the HTTP call (default 30). `requests` defaults to no timeout, so without this a stalled Voyage API would hang the whole embed step indefinitely.
+
+Voyage AI recommends telling the API whether each call is embedding documents for storage or a query for retrieval. The `input_type` on the component sets the default; pass `input_type='query'` to `get_embeddings` to override it per call. On timeout the call returns one empty vector per input text so a single slow request does not crash an ingestion pipeline; HTTP errors and non-JSON responses are surfaced as `RuntimeError`, and a missing API key raises `ValueError`.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
@@ -1,0 +1,26 @@
+# Embedding
+
+agentUniverse 提供了多个内置的 embedding 组件，供 Knowledge 的 store 与 doc processor 对文本进行向量化。每个组件都以 `metadata.type: EMBEDDING` 注册，并对外提供 `get_embeddings(texts, input_type=...)` 及其异步版本。
+
+## VoyageEmbedding
+
+`VoyageEmbedding` 通过 Voyage AI 的 embeddings API（`https://api.voyageai.com/v1/embeddings`）生成文本向量。它支持 Voyage AI 的 embedding 模型家族，包括 `voyage-3`（默认）、`voyage-3-lite`、`voyage-3-large` 与 `voyage-large-2`。无需额外安装（`requests` 已是 agentUniverse 的核心依赖），仅需一个 Voyage AI 的 API Key。
+
+注册一个指向 `agentuniverse.agent.action.knowledge.embedding.voyage_embedding.VoyageEmbedding` 的组件，然后在 store 或 processor 中按名称引用（例如 `embedding_model: voyage_embedding`）。API Key 从环境变量 `VOYAGE_API_KEY` 读取。
+
+```yaml
+name: 'voyage_embedding'
+description: 'embedding via Voyage AI embeddings API'
+embedding_model_name: 'voyage-3'
+input_type: 'document'
+request_timeout: 30
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.voyage_embedding'
+  class: 'VoyageEmbedding'
+```
+- embedding_model_name：Voyage AI embedding 模型（默认 `voyage-3`）。
+- input_type：`document` 或 `query`——Voyage AI 建议显式指定以获得最佳检索质量（默认 `document`）。
+- request_timeout：HTTP 调用超时时间，单位秒（默认 30）。`requests` 默认无超时，若不设置，一旦 Voyage API 卡住，整步 embedding 会无限期挂起。
+
+Voyage AI 建议告知 API 本次调用是为入库的文档生成向量，还是为检索的查询生成向量。组件上的 `input_type` 设置默认值；调用 `get_embeddings` 时可传 `input_type='query'` 进行覆盖。发生超时时，调用会为每条输入文本返回一个空向量，避免单次慢请求拖垮整条入库链路；HTTP 错误与非 JSON 响应会以 `RuntimeError` 抛出，缺少 API Key 则抛出 `ValueError`。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_voyage_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_voyage_embedding.py
@@ -1,0 +1,210 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: test_voyage_embedding.py
+
+import asyncio
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from agentuniverse.agent.action.knowledge.embedding.voyage_embedding import \
+    VoyageEmbedding
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+def _mock_response(payload, status_code=200):
+    """Build a MagicMock response carrying ``payload`` and a status code."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+
+    def _raise_for_status():
+        if status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"{status_code} error", response=resp)
+
+    resp.raise_for_status = _raise_for_status
+    return resp
+
+
+class TestVoyageEmbedding(unittest.TestCase):
+    """Unit tests for the VoyageEmbedding component (mocks requests)."""
+
+    def setUp(self):
+        self.embedding = VoyageEmbedding(
+            embedding_model_name='voyage-3',
+            embedding_dims=1024,
+            api_key='test_api_key',
+        )
+        self.sample_payload = {
+            'data': [
+                {'embedding': [0.1, 0.2, 0.3]},
+                {'embedding': [0.4, 0.5, 0.6]},
+            ]
+        }
+
+    # 1. happy-path sync embed
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_returns_vectors(self, mock_post):
+        mock_post.return_value = _mock_response(self.sample_payload)
+
+        result = self.embedding.get_embeddings(['hello', 'world'])
+
+        self.assertEqual(result, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['json']['model'], 'voyage-3')
+        self.assertEqual(kwargs['json']['inputs'], ['hello', 'world'])
+        self.assertEqual(kwargs['json']['input_type'], 'document')
+        self.assertEqual(kwargs['timeout'], 30)
+        self.assertEqual(kwargs['headers']['Authorization'],
+                         'Bearer test_api_key')
+
+    # 2. empty input short-circuits without an HTTP call
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_empty_input(self, mock_post):
+        self.assertEqual(self.embedding.get_embeddings([]), [])
+        mock_post.assert_not_called()
+
+    # 3. input_type override per call
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_input_type_override(self, mock_post):
+        mock_post.return_value = _mock_response(self.sample_payload)
+
+        self.embedding.get_embeddings(['q'], input_type='query')
+
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['json']['input_type'], 'query')
+
+    # 4. invalid per-call input_type falls back to component default
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_invalid_input_type_falls_back(self, mock_post):
+        mock_post.return_value = _mock_response(self.sample_payload)
+
+        self.embedding.get_embeddings(['q'], input_type='weird')
+
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['json']['input_type'], 'document')
+
+    # 5. missing api_key raises ValueError
+    def test_get_embeddings_missing_api_key(self):
+        emb = VoyageEmbedding(api_key=None)
+        with self.assertRaises(ValueError) as ctx:
+            emb.get_embeddings(['hello'])
+        self.assertIn('api_key', str(ctx.exception))
+
+    # 6. timeout returns empty vectors instead of raising
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_timeout_returns_empty_vectors(self, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout('timed out')
+
+        result = self.embedding.get_embeddings(['a', 'b'])
+
+        self.assertEqual(result, [[], []])
+
+    # 7. HTTP error surfaces as RuntimeError
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_http_error(self, mock_post):
+        mock_post.return_value = _mock_response({}, status_code=500)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.embedding.get_embeddings(['a'])
+        self.assertIn('500', str(ctx.exception))
+
+    # 8. non-JSON body surfaces as RuntimeError
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_get_embeddings_non_json_response(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.side_effect = ValueError('not json')
+        mock_post.return_value = resp
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.embedding.get_embeddings(['a'])
+        self.assertIn('non-JSON', str(ctx.exception))
+
+    # 9. async wraps sync
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_async_get_embeddings(self, mock_post):
+        mock_post.return_value = _mock_response(self.sample_payload)
+
+        result = asyncio.run(
+            self.embedding.async_get_embeddings(['hello', 'world']))
+
+        self.assertEqual(result, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+    # 10. langchain adapter
+    @patch('agentuniverse.agent.action.knowledge.embedding.'
+           'voyage_embedding.requests.post')
+    def test_as_langchain(self, mock_post):
+        mock_post.return_value = _mock_response(self.sample_payload)
+
+        lc = self.embedding.as_langchain()
+        docs = lc.embed_documents(['a', 'b'])
+        query = lc.embed_query('q')
+
+        self.assertEqual(docs, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        self.assertEqual(query, [0.1, 0.2, 0.3])
+        # embed_documents -> input_type document, embed_query -> query
+        types = [c.kwargs['json']['input_type']
+                 for c in mock_post.call_args_list]
+        self.assertEqual(types, ['document', 'query'])
+
+    # 11. configer initialization
+    def test_initialize_by_component_configer(self):
+        cfg = Configer()
+        cfg.value = {
+            'name': 'voyage_embedding',
+            'description': 'voyage embedding',
+            'embedding_model_name': 'voyage-large-2',
+            'input_type': 'query',
+            'request_timeout': 12,
+        }
+        configer = ComponentConfiger()
+        configer.load_by_configer(cfg)
+
+        emb = VoyageEmbedding()
+        with patch('agentuniverse.base.util.env_util.get_from_env') \
+                as mock_env:
+            mock_env.return_value = 'env_key'
+            emb._initialize_by_component_configer(configer)
+
+        self.assertEqual(emb.name, 'voyage_embedding')
+        self.assertEqual(emb.embedding_model_name, 'voyage-large-2')
+        self.assertEqual(emb.input_type, 'query')
+        self.assertEqual(emb.request_timeout, 12)
+
+    # 12. invalid request_timeout rejected at init
+    def test_initialize_rejects_invalid_request_timeout(self):
+        for bad in (-1, 0, True, 'oops', None):
+            cfg = Configer()
+            cfg.value = {
+                'name': 'voyage_embedding',
+                'description': 'voyage embedding',
+                'request_timeout': bad,
+            }
+            configer = ComponentConfiger()
+            configer.load_by_configer(cfg)
+
+            emb = VoyageEmbedding()
+            with self.assertRaises(ValueError) as ctx:
+                emb._initialize_by_component_configer(configer)
+            self.assertIn('request_timeout', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `VoyageEmbedding` component that generates text embeddings via the Voyage AI embeddings API (`https://api.voyageai.com/v1/embeddings`), supporting the Voyage AI embedding model family (`voyage-3`, `voyage-3-lite`, `voyage-3-large`, `voyage-large-2`).

Closes #250.

## Why

Voyage AI is a top-tier embedding provider with state-of-the-art retrieval quality. agentUniverse's knowledge layer (store + doc processors) needs a first-class embedding component for Voyage AI, on par with the existing OpenAI / Gemini / Dashscope / Cohere embedders.

## Changes

- `agentuniverse/agent/action/knowledge/embedding/voyage_embedding.py` — `VoyageEmbedding` extending `Embedding`.
  - `api_key` read from the `VOYAGE_API_KEY` env var.
  - `embedding_model_name` defaults to `voyage-3`.
  - `input_type`: `"document"` / `"query"` (Voyage AI recommends specifying this), overridable per call.
  - `request_timeout`: 30s default (guards against an indefinite hang since `requests` defaults to no timeout).
  - Sync `get_embeddings` + async `async_get_embeddings`, plus a langchain adapter.
  - Uses `requests.post` against the Voyage AI embeddings endpoint; validates the response and surfaces HTTP / non-JSON errors as `RuntimeError`.
- `agentuniverse/agent/action/knowledge/embedding/voyage_embedding.yaml` — component registration.
- `tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_voyage_embedding.py` — 12 unit tests mocking `requests` (happy path, empty input, input_type override, invalid input_type fallback, missing api_key, timeout, HTTP error, non-JSON, async, langchain adapter, configer init, invalid request_timeout).
- `docs/.../Knowledge/Embedding.md` (en + zh) — new doc page describing the component.

## How to use

```yaml
name: 'voyage_embedding'
description: 'embedding via Voyage AI embeddings API'
embedding_model_name: 'voyage-3'
input_type: 'document'
request_timeout: 30
metadata:
  type: 'EMBEDDING'
  module: 'agentuniverse.agent.action.knowledge.embedding.voyage_embedding'
  class: 'VoyageEmbedding'
```

```python
emb = VoyageEmbedding(api_key='...')
vectors = emb.get_embeddings(['hello', 'world'], input_type='document')
```

## Test

```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.embedding.test_voyage_embedding
```

All 12 tests pass.
