### PR TITLE
feat: add JSONFormatterTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/json_formatter_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/json_formatter_tool.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: json_formatter_tool.py
+
+"""
+JSON Formatter Tool — beautify, minify, validate, and extract JSON.
+
+A dependency-free JSON utility for agent workflows. The tool wraps the Python
+standard library ``json`` module with bounds checking, structured error
+reporting, and a small set of operations that cover the common cases where an
+agent must clean up, shrink, or sanity-check a JSON payload produced by another
+tool, an LLM, or a downstream service.
+
+Operations (``mode``):
+
+- **beautify** — re-serialize JSON with consistent indentation so it is easy
+  for a human to read. The indent width is configurable via ``indent``.
+- **minify** — remove all optional whitespace to produce the most compact
+  representation. Useful before storing or transmitting a payload.
+- **validate** — parse the input and report whether it is well-formed JSON.
+  The result includes the top-level type and, for objects, the number of
+  keys. No output text is produced; this is a pure sanity check.
+- **extract** — scan an arbitrary text (for example an LLM response or a log
+  line) and return the first balanced JSON value found. Fences and leading
+  prose are tolerated. This is handy when a model emits JSON embedded inside
+  markdown.
+
+The tool is deliberately strict about input size (``max_input_chars``) and
+returns every result as a structured dict so that agents can branch on the
+``status`` field rather than parsing free-form text. All exceptions are caught
+and converted to ``{"status": "error", ...}`` payloads; the tool never raises.
+
+Addresses #252 (common utility tools).
+"""
+
+import json
+import re
+from typing import Any, List, Optional
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+# Public execute() converts validation/parsing exceptions into structured
+# tool responses instead of raising.
+# ruff: noqa: TRY003
+
+# Bump this when a new mode is added so callers can feature-detect.
+_SUPPORTED_MODES = ("beautify", "minify", "validate", "extract")
+
+# A markdown fence that often wraps model-generated JSON.
+_FENCE_RE = re.compile(r"^[\s\S]*?```(?:json|JSON)?\s*\n([\s\S]*?)\n?```", re.MULTILINE)
+
+# Reasonable upper bound. Anything larger almost certainly indicates a caller
+# mistake (for example passing a file path instead of contents).
+_DEFAULT_MAX_INPUT_CHARS = 100_000
+_DEFAULT_INDENT = 2
+
+
+class JSONFormatterTool(Tool):
+    """Beautify, minify, validate, and extract JSON payloads.
+
+    Attributes:
+        max_input_chars: Hard limit on the size of the ``input`` string.
+            Inputs longer than this are rejected with ``validation_error``.
+            Defaults to 100000.
+        indent: Number of spaces used by ``beautify``. Must be a positive
+            integer. Defaults to 2.
+    """
+
+    name: str = "json_formatter_tool"
+    description: Optional[str] = (
+        "Beautify, minify, validate, and extract JSON payloads using only "
+        "the Python standard library."
+    )
+    input_keys: Optional[List[str]] = ["mode", "input"]
+
+    max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS
+    indent: int = _DEFAULT_INDENT
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    def execute(self, mode: str, input: str, **_: Any) -> dict:
+        """Run a JSON formatting operation.
+
+        Args:
+            mode: One of ``beautify``, ``minify``, ``validate``, ``extract``.
+            input: The JSON text (or, for ``extract``, text that may contain
+                JSON) to process.
+
+        Returns:
+            A dict with at least a ``status`` key (``success`` or ``error``).
+            Successful ``beautify``/``minify`` results carry an ``output``
+            key; ``validate`` carries ``valid`` and ``type`` keys; ``extract``
+            carries ``output``, ``start``, and ``end`` keys.
+        """
+        try:
+            self._validate_config()
+            operation = self._normalize_mode(mode)
+            self._validate_input(input)
+            if operation == "beautify":
+                return self._beautify(input)
+            if operation == "minify":
+                return self._minify(input)
+            if operation == "validate":
+                return self._validate(input)
+            return self._extract(input)
+        except json.JSONDecodeError as exc:
+            # Must precede ValueError — JSONDecodeError subclasses it.
+            return self._error(
+                "json_error",
+                f"Invalid JSON: {exc.msg} at line {exc.lineno} column {exc.colno}",
+                mode,
+            )
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc), mode)
+        except Exception as exc:  # pragma: no cover - defensive catch-all
+            return self._error("operation_error", f"JSON operation failed: {exc}", mode)
+
+    # ------------------------------------------------------------------
+    # Configuration / validation helpers
+    # ------------------------------------------------------------------
+    def _validate_config(self) -> None:
+        for name in ("max_input_chars", "indent"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.max_input_chars > 10_000_000:
+            raise ValueError("max_input_chars must not exceed 10000000")
+
+    @staticmethod
+    def _normalize_mode(mode: Any) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        operation = mode.strip().lower()
+        if operation not in _SUPPORTED_MODES:
+            raise ValueError(
+                "mode must be one of: " + ", ".join(_SUPPORTED_MODES)
+            )
+        return operation
+
+    def _validate_input(self, value: Any) -> None:
+        if not isinstance(value, str):
+            raise TypeError("input must be a string")
+        if len(value) > self.max_input_chars:
+            raise ValueError(
+                f"input length ({len(value)}) exceeds max_input_chars "
+                f"({self.max_input_chars})"
+            )
+
+    # ------------------------------------------------------------------
+    # Operations
+    # ------------------------------------------------------------------
+    def _beautify(self, text: str) -> dict:
+        """Re-serialize JSON with indentation for readability."""
+        data = json.loads(text)
+        output = json.dumps(data, indent=self.indent, ensure_ascii=False)
+        return {
+            "status": "success",
+            "mode": "beautify",
+            "output": output,
+            "input_chars": len(text),
+            "output_chars": len(output),
+        }
+
+    def _minify(self, text: str) -> dict:
+        """Re-serialize JSON with all optional whitespace removed."""
+        data = json.loads(text)
+        # ``separators`` with trailing commas suppressed produces minimal JSON.
+        output = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+        return {
+            "status": "success",
+            "mode": "minify",
+            "output": output,
+            "input_chars": len(text),
+            "output_chars": len(output),
+        }
+
+    def _validate(self, text: str) -> dict:
+        """Check whether ``text`` is well-formed JSON and report its shape."""
+        stripped = text.strip()
+        if not stripped:
+            return {
+                "status": "success",
+                "mode": "validate",
+                "valid": False,
+                "type": None,
+                "error": "empty input",
+            }
+        data = json.loads(stripped)
+        return {
+            "status": "success",
+            "mode": "validate",
+            "valid": True,
+            "type": _classify(data),
+            "size": _describe_size(data),
+        }
+
+    def _extract(self, text: str) -> dict:
+        """Find and return the first balanced JSON value in ``text``.
+
+        Tries, in order: a fenced code block, a direct parse of the whole
+        string, and a brace/bracket scan. Returns an error payload if no JSON
+        value can be located.
+        """
+        # 1. Markdown-fenced JSON (```json ... ```).
+        match = _FENCE_RE.search(text)
+        if match:
+            candidate = match.group(1)
+            value, start, end = self._try_extract(candidate, match.start(1) - match.start())
+            if value is not None:
+                return self._extract_success(value, start + match.start(), end + match.start())
+
+        # 2. Whole-string parse (handles strings that are pure JSON).
+        whole = self._try_extract(text, 0)
+        if whole[0] is not None:
+            return self._extract_success(whole[0], whole[1], whole[2])
+
+        # 3. Brace/bracket scan for the first balanced structure.
+        for opener in ("{", "["):
+            value, start, end = self._scan_balanced(text, opener)
+            if value is not None:
+                return self._extract_success(value, start, end)
+
+        return self._error(
+            "json_error",
+            "No JSON value could be extracted from the input.",
+            "extract",
+        )
+
+    def _try_extract(self, text: str, offset: int):
+        """Attempt to parse ``text`` as JSON. Returns (data, start, end) or (None, ...)."""
+        try:
+            data = json.loads(text.strip())
+        except (json.JSONDecodeError, ValueError):
+            return None, 0, 0
+        start = offset + len(text) - len(text.lstrip())
+        end = offset + len(text.rstrip())
+        return data, start, end
+
+    @staticmethod
+    def _scan_balanced(text: str, opener: str):
+        """Scan ``text`` for the first balanced ``{...}`` or ``[...]`` block.
+
+        Performs a lightweight scan that respects string literals and escape
+        sequences so that braces inside strings do not break balancing.
+        """
+        closer = "}" if opener == "{" else "]"
+        start = text.find(opener)
+        if start == -1:
+            return None, 0, 0
+
+        depth = 0
+        in_string = False
+        escape = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+                continue
+            if char == opener:
+                depth += 1
+            elif char == closer:
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start : index + 1]
+                    try:
+                        import json as _json
+
+                        return _json.loads(candidate), start, index + 1
+                    except (ValueError, json.JSONDecodeError):
+                        return None, 0, 0
+        return None, 0, 0
+
+    @staticmethod
+    def _extract_success(data: Any, start: int, end: int) -> dict:
+        return {
+            "status": "success",
+            "mode": "extract",
+            "output": json.dumps(data, ensure_ascii=False),
+            "type": _classify(data),
+            "start": start,
+            "end": end,
+        }
+
+    # ------------------------------------------------------------------
+    # Error helper
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _error(kind: str, message: str, mode: Optional[str]) -> dict:
+        result: dict = {"status": "error", "error_type": kind, "error": message}
+        if mode is not None:
+            result["mode"] = mode
+        return result
+
+
+# ----------------------------------------------------------------------
+# Module-level helpers
+# ----------------------------------------------------------------------
+def _classify(value: Any) -> str:
+    """Return a human-readable type name for a parsed JSON value."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _describe_size(value: Any) -> dict:
+    """Return a small summary of the structure's size."""
+    if isinstance(value, dict):
+        return {"keys": len(value)}
+    if isinstance(value, list):
+        return {"items": len(value)}
+    if isinstance(value, str):
+        return {"chars": len(value)}
+    return {}

--- a/agentuniverse/agent/action/tool/common_tool/json_formatter_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/json_formatter_tool.yaml.example
@@ -1,0 +1,32 @@
+name: json_formatter_tool
+description: >-
+  Beautify, minify, validate, and extract JSON payloads using only the Python
+  standard library. Useful for cleaning up model output, shrinking payloads
+  before storage, and sanity-checking JSON produced by other tools.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.json_formatter_tool
+  class: JSONFormatterTool
+input_keys:
+  - mode
+  - input
+max_input_chars: 100000
+indent: 2
+args_model:
+  mode: {type: string, required: true}
+  input: {type: string, required: true}
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: [beautify, minify, validate, extract]
+      description: Operation to perform on the input.
+    input:
+      type: string
+      description: >-
+        The JSON text to process. For ``extract`` this may be arbitrary text
+        that contains an embedded JSON value.
+  required: [mode, input]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -330,4 +330,26 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 
 ## 4. PDF Tool
 
-The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentuniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## JSONFormatterTool
+
+`JSONFormatterTool` is a dependency-free JSON utility for cleaning up, shrinking, and sanity-checking JSON payloads. It supports four modes: `beautify` (re-indent with a configurable `indent` width), `minify` (strip all optional whitespace), `validate` (report whether the input is well-formed JSON plus its top-level type), and `extract` (pull the first balanced JSON value out of arbitrary text such as an LLM response or a fenced markdown block).
+
+```python
+from agentuniverse.agent.action.tool.common_tool.json_formatter_tool import JSONFormatterTool
+
+tool = JSONFormatterTool()  # max_input_chars=100000, indent=2
+tool.execute(mode="beautify", input='{"a":1,"b":[2,3]}')
+tool.execute(mode="minify", input='{"a": 1, "b": [2, 3]}')
+tool.execute(mode="validate", input='{"a": 1}')
+tool.execute(mode="extract", input='Here is the data:\n```json\n{"a": 1}\n```')
+```
+
+The tool relies only on the Python standard library `json` module. Every result is a structured dict with a `status` field (`success` or `error`); beautify/minify results carry `output`, validate results carry `valid`/`type`/`size`, and extract results carry `output`/`type`/`start`/`end`. Inputs longer than `max_input_chars` are rejected, and all parsing errors are surfaced as `json_error` payloads rather than raised exceptions.
+
+## JSONFormatterTool / JSON 格式化工具
+
+`JSONFormatterTool`（JSON 格式化工具）是一个无第三方依赖的 JSON 工具，用于美化、压缩和校验 JSON 数据，以及从文本中提取 JSON 片段。支持四种模式：`beautify`（按指定缩进重新格式化）、`minify`（去除所有可选空白）、`validate`（校验是否为合法 JSON 并返回顶层类型）、`extract`（从大段文本，如大模型输出或带 ```json 代码块的内容中，抽取第一个完整的 JSON 值）。
+
+工具仅依赖 Python 标准库 `json` 模块。所有返回结果均为结构化字典，包含 `status` 字段（`success` 或 `error`）：beautify/minify 结果包含 `output`，validate 结果包含 `valid`/`type`/`size`，extract 结果包含 `output`/`type`/`start`/`end`。当输入超过 `max_input_chars` 时会被拒绝，所有解析错误会以 `json_error` 形式返回而非抛出异常。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_json_formatter_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_json_formatter_tool.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for JSONFormatterTool."""
+
+import os
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool import json_formatter_tool as module
+from agentuniverse.agent.action.tool.common_tool.json_formatter_tool import JSONFormatterTool
+
+YAML_PATH = os.path.join(os.path.dirname(module.__file__), "json_formatter_tool.yaml.example")
+
+
+class JSONFormatterToolTest(unittest.TestCase):
+    def setUp(self):
+        self.tool = JSONFormatterTool()
+
+    # --- beautify -------------------------------------------------------
+    def test_beautify_indents_object(self):
+        result = self.tool.execute(mode="beautify", input='{"a":1,"b":2}')
+        self.assertEqual(result["status"], "success")
+        self.assertIn('"a": 1', result["output"])
+        self.assertIn("\n", result["output"])
+
+    def test_beautify_preserves_unicode(self):
+        result = self.tool.execute(mode="beautify", input='{"name":"中文"}')
+        self.assertEqual(result["status"], "success")
+        self.assertIn("中文", result["output"])
+
+    def test_beautify_respects_custom_indent(self):
+        tool = JSONFormatterTool(indent=4)
+        result = tool.execute(mode="beautify", input='{"a":1}')
+        self.assertIn('    "a"', result["output"])
+
+    # --- minify ---------------------------------------------------------
+    def test_minify_removes_whitespace(self):
+        result = self.tool.execute(mode="minify", input='{"a": 1, "b": [1, 2]}')
+        self.assertEqual(result["output"], '{"a":1,"b":[1,2]}')
+        self.assertLess(result["output_chars"], result["input_chars"])
+
+    def test_minify_on_already_minimal(self):
+        result = self.tool.execute(mode="minify", input='{"a":1}')
+        self.assertEqual(result["output"], '{"a":1}')
+
+    # --- validate -------------------------------------------------------
+    def test_validate_accepts_valid_json(self):
+        result = self.tool.execute(mode="validate", input='{"a": 1, "b": [1,2]}')
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["type"], "object")
+        self.assertEqual(result["size"]["keys"], 2)
+
+    def test_validate_reports_top_level_type(self):
+        cases = {
+            "42": "integer",
+            "3.14": "number",
+            '"hi"': "string",
+            "true": "boolean",
+            "null": "null",
+            "[1, 2, 3]": "array",
+        }
+        for raw, expected in cases.items():
+            result = self.tool.execute(mode="validate", input=raw)
+            self.assertTrue(result["valid"], msg=raw)
+            self.assertEqual(result["type"], expected, msg=raw)
+
+    def test_validate_rejects_empty_input(self):
+        result = self.tool.execute(mode="validate", input="   ")
+        self.assertFalse(result["valid"])
+
+    def test_validate_rejects_invalid_json(self):
+        result = self.tool.execute(mode="validate", input="{not json}")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "json_error")
+
+    # --- extract --------------------------------------------------------
+    def test_extract_from_fenced_block(self):
+        text = 'Here is the data:\n```json\n{"a": 1}\n```\nThanks!'
+        result = self.tool.execute(mode="extract", input=text)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["type"], "object")
+        self.assertIn('"a"', result["output"])
+
+    def test_extract_from_prose_braces(self):
+        text = 'The answer is {"x": 10, "y": 20} as shown above.'
+        result = self.tool.execute(mode="extract", input=text)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["type"], "object")
+        self.assertGreaterEqual(result["end"], result["start"])
+
+    def test_extract_array(self):
+        text = 'prefix [1, 2, 3] suffix'
+        result = self.tool.execute(mode="extract", input=text)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["type"], "array")
+
+    def test_extract_none_found(self):
+        result = self.tool.execute(mode="extract", input="no json here at all")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "json_error")
+
+    def test_extract_brace_inside_string_does_not_confuse_scan(self):
+        # A brace inside a JSON string value must not break balancing.
+        text = 'noise {"msg": "hello {world}"} trailing'
+        result = self.tool.execute(mode="extract", input=text)
+        self.assertEqual(result["status"], "success")
+        self.assertIn("hello {world}", result["output"])
+
+    # --- config / errors ------------------------------------------------
+    def test_invalid_mode(self):
+        result = self.tool.execute(mode="compress", input="{}")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("mode must be", result["error"])
+
+    def test_input_too_large(self):
+        tool = JSONFormatterTool(max_input_chars=10)
+        result = tool.execute(mode="beautify", input="x" * 50)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("max_input_chars", result["error"])
+
+    def test_non_string_input(self):
+        result = self.tool.execute(mode="beautify", input={"not": "a string"})
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_invalid_indent_config(self):
+        tool = JSONFormatterTool(indent=0)
+        result = tool.execute(mode="beautify", input="{}")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("indent", result["error"])
+
+
+class JSONFormatterYamlTest(unittest.TestCase):
+    def test_yaml_example_exists(self):
+        self.assertTrue(os.path.isfile(YAML_PATH))
+
+    def test_yaml_example_has_required_fields(self):
+        import yaml
+
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "json_formatter_tool")
+        self.assertEqual(data["metadata"]["class"], "JSONFormatterTool")
+        self.assertIn("mode", data["input_keys"])
+        self.assertEqual(data["max_input_chars"], 100000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `JSONFormatterTool`, a dependency-free JSON utility tool for agent workflows. Closes #252.

## What's included

- `agentuniverse/agent/action/tool/common_tool/json_formatter_tool.py` — the tool (337 lines)
- `agentuniverse/agent/action/tool/common_tool/json_formatter_tool.yaml.example` — config example
- `tests/test_agentuniverse/unit/agent/action/tool/test_json_formatter_tool.py` — 20 unit tests
- Docs appended to `docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md`

## Operations

The tool supports four modes, all backed by the Python standard library `json` module:

| Mode       | Description                                                        |
|------------|--------------------------------------------------------------------|
| `beautify` | Re-serialize JSON with consistent indentation (`indent` width).    |
| `minify`   | Remove all optional whitespace to produce the most compact form.   |
| `validate` | Report whether the input is well-formed JSON plus its top-level type. |
| `extract`  | Pull the first balanced JSON value out of arbitrary text (handles markdown fences, embedded prose, and braces inside strings). |

## Fields

- `max_input_chars` (default `100000`) — hard limit on input size.
- `indent` (default `2`) — indent width for `beautify`.

All results are structured dicts with a `status` field (`success` / `error`). Parsing failures are returned as `json_error` payloads rather than raised exceptions, so the tool never throws.

## Test plan

```
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_json_formatter_tool
```

All 20 tests pass, covering beautify (indent, unicode, custom width), minify, validate (all top-level types, empty input, invalid JSON), extract (fenced block, prose, array, brace-in-string edge case, not-found), config validation, and YAML example structure.
