### PR TITLE
feat(llm): add Together LLM component (#250)

### DIFF
--- a/agentuniverse/llm/default/together_llm.py
+++ b/agentuniverse/llm/default/together_llm.py
@@ -1,0 +1,173 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: together_llm.py
+
+"""
+Together AI LLM.
+
+Together AI (https://www.together.ai) is a hosted inference platform that
+serves 200+ open-source large language models - including Llama, Mixtral,
+Qwen, DeepSeek, DBRX, Falcon and many others - through a single,
+OpenAI-compatible Chat Completions API exposed at
+``https://api.together.xyz/v1``.
+
+Because the API is OpenAI-compatible, this component only needs to extend
+:class:`OpenAIStyleLLM` and wire up the Together credentials, the API base
+URL and a per-model maximum context length table. Streaming, tool calling,
+the async interface and the LangChain bridge are all inherited unchanged
+from the parent class.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Optional, Union
+
+import tiktoken
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+# The maximum context length (input + output tokens) supported by a selection
+# of the most popular models hosted on Together AI. Together constantly adds
+# new models; when a model you rely on is missing simply add an entry here.
+# The values are taken from the official Together models catalogue
+# (https://docs.together.ai/docs/inference-models).
+TOGETHER_MAX_CONTEXT_LENGTH = {
+    # ---- Meta Llama family ----
+    "meta-llama/Llama-3.3-70B-Instruct-Turbo": 131072,
+    "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": 131072,
+    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": 131072,
+    "meta-llama/Meta-Llama-3-70B-Instruct-Lite": 8192,
+    "meta-llama/Meta-Llama-3-8B-Instruct-Lite": 8192,
+    "meta-llama/Llama-2-70b-chat-hf": 4096,
+    "meta-llama/Llama-2-13b-chat-hf": 4096,
+    "meta-llama/Llama-2-7b-chat-hf": 4096,
+    # ---- Mistral / Mixtral family ----
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": 32768,
+    "mistralai/Mistral-7B-Instruct-v0.1": 4096,
+    "mistralai/Mistral-7B-Instruct-v0.2": 32768,
+    "mistralai/Mistral-7B-Instruct-v0.3": 32768,
+    "mistralai/Mistral-Large-Instruct-2411": 131072,
+    # ---- Qwen family ----
+    "Qwen/Qwen2.5-72B-Instruct-Turbo": 131072,
+    "Qwen/Qwen2.5-7B-Instruct-Turbo": 131072,
+    "Qwen/Qwen1.5-110B-Chat": 32768,
+    "Qwen/Qwen1.5-72B-Chat": 32768,
+    # ---- DeepSeek family ----
+    "deepseek-ai/DeepSeek-V3": 131072,
+    "deepseek-ai/DeepSeek-R1": 131072,
+    # ---- databricks / NVIDIA ----
+    "databricks/dbrx-instruct": 32768,
+    "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": 131072,
+}
+
+# Conservative fallback returned for models that are not yet listed in the
+# table above. The majority of Together-hosted models expose at least an 8k
+# window, so 8192 is a safe default.
+TOGETHER_DEFAULT_CONTEXT_LENGTH = 8192
+
+
+class TogetherLLM(OpenAIStyleLLM):
+    """Together AI LLM, an OpenAI-compatible wrapper around the Together API.
+
+    Together AI hosts 200+ open-source models (Llama, Mixtral, Qwen,
+    DeepSeek, ...) behind a single OpenAI-compatible endpoint. This class
+    therefore only customises the credential/base-url plumbing and the model
+    context-length lookup table while inheriting the full request,
+    streaming and langchain-bridge implementation from
+    :class:`OpenAIStyleLLM`.
+
+    Attributes:
+        api_key: Together AI API key. Loaded from the ``TOGETHER_API_KEY``
+            environment variable when not supplied explicitly. Generate one
+            at https://api.together.ai/settings/api-keys.
+        api_base: Together OpenAI-compatible API base URL. Defaults to
+            ``https://api.together.xyz/v1`` unless overridden through the
+            ``TOGETHER_API_BASE`` environment variable.
+        proxy: Optional HTTP(S) proxy used for outbound requests.
+        organization: Optional organization id forwarded to the client.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("TOGETHER_API_KEY"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("TOGETHER_API_BASE") or
+                                    "https://api.together.xyz/v1")
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("TOGETHER_PROXY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("TOGETHER_ORGANIZATION"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call to the Together chat completions endpoint.
+
+        Users may override this method to customise the interaction; the
+        default implementation delegates to the OpenAI-style parent which
+        builds and dispatches the request against the Together API base URL.
+
+        Args:
+            messages (list): The chat messages to send to Together AI.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                client, e.g. ``temperature``, ``top_p``, ``max_tokens`` ...
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an iterator of
+            :class:`LLMOutput` chunks when ``stream=True`` is supplied.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call to the Together chat completions endpoint.
+
+        Args:
+            messages (list): The chat messages to send to Together AI.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                async client.
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an async
+            iterator of :class:`LLMOutput` chunks when ``stream=True``.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Together model.
+
+        The combined length of the input prompt and the generated completion
+        must fit within this window. The value is resolved in the following
+        order:
+
+        1. If a context length was explicitly injected through the YAML
+           configuration (``max_context_length`` field) that value wins.
+        2. Otherwise the model name is looked up in
+           :data:`TOGETHER_MAX_CONTEXT_LENGTH`.
+        3. As a last resort :data:`TOGETHER_DEFAULT_CONTEXT_LENGTH` is
+           returned.
+        """
+        if super().max_context_length():
+            return super().max_context_length()
+        return TOGETHER_MAX_CONTEXT_LENGTH.get(self.model_name, TOGETHER_DEFAULT_CONTEXT_LENGTH)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate the number of tokens that ``text`` will consume.
+
+        Together AI serves a heterogeneous catalogue of open-weight models,
+        each with its own tokenizer. Because those tokenizers are not always
+        registered in ``tiktoken`` by name, we fall back to the widely used
+        ``cl100k_base`` encoding which yields a good approximation suitable
+        for prompt-window budgeting.
+
+        Args:
+            text: The raw string to tokenize.
+
+        Returns:
+            The integer number of tokens the text would be encoded into.
+        """
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            # Together models (llama, mixtral, qwen, ...) are generally not
+            # registered in tiktoken by name; cl100k_base is a robust generic
+            # fallback that is accurate enough for budget checks.
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))

--- a/agentuniverse/llm/default/together_llm.yaml.example
+++ b/agentuniverse/llm/default/together_llm.yaml.example
@@ -1,0 +1,14 @@
+name: 'default_together_llm'
+description: 'default together llm hosted on the Together AI platform'
+model_name: 'meta-llama/Llama-3.3-70B-Instruct-Turbo'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${TOGETHER_API_KEY}'
+api_base: 'https://api.together.xyz/v1'
+organization: '${TOGETHER_ORGANIZATION}'
+proxy: '${TOGETHER_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.together_llm'
+  class: 'TogetherLLM'

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Together_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Together_LLM_Use.md
@@ -1,0 +1,147 @@
+# Together LLM Use
+
+`TogetherLLM` integrates the [Together AI](https://www.together.ai) hosted inference platform into agentUniverse. Together AI serves **200+ open-source large language models** - including Meta Llama, Mistral/Mixtral, Qwen, DeepSeek, DBRX, Falcon and many others - behind a single, fully **OpenAI-compatible** Chat Completions API exposed at `https://api.together.xyz/v1`.
+
+Because the API is OpenAI-compatible, the `TogetherLLM` component simply extends `OpenAIStyleLLM` and only wires up the Together credentials, API base URL and a per-model context-length table. Streaming, tool/function calling, the async interface and the LangChain bridge all work out of the box without any extra code.
+
+---
+
+## 1. Create the configuration file
+
+Create a YAML file, for example `user_together_llm.yaml`, and paste the following content into it.
+
+```yaml
+name: 'user_together_llm'
+description: 'user together llm hosted on the Together AI platform'
+model_name: 'meta-llama/Llama-3.3-70B-Instruct-Turbo'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${TOGETHER_API_KEY}'
+api_base: 'https://api.together.xyz/v1'
+organization: '${TOGETHER_ORGANIZATION}'
+proxy: '${TOGETHER_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.together_llm'
+  class: 'TogetherLLM'
+```
+
+**Note:** Model parameters such as `api_key`, `api_base`, `organization` and `proxy` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+
+    ```yaml
+    api_key: 'a1b2c3***'
+    ```
+
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax to load the value from an environment variable. When agentUniverse starts it will automatically read the corresponding value.
+
+    ```yaml
+    api_key: '${TOGETHER_API_KEY}'
+    ```
+
+3. **Custom function loading** - use the `@FUNC` annotation to dynamically load the API key through a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="together"))'
+    ```
+
+    The function must be defined in the `YamlFuncExtension` class inside the `yaml_func_extension.py` file. Refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When agentUniverse loads this configuration it parses the `@FUNC` annotation, executes the `load_api_key` function with the supplied arguments, and replaces the annotation with the function's return value.
+
+---
+
+## 2. Pick a model
+
+Together AI hosts an ever-growing catalogue of models. Below are some of the most commonly used ones together with their context window (input + output tokens). The same values are hard-coded inside `TogetherLLM.max_context_length`, so agentUniverse can budget prompts correctly even without a live API call.
+
+| Model name                                            | Context length |
+| ----------------------------------------------------- | -------------- |
+| `meta-llama/Llama-3.3-70B-Instruct-Turbo`             | 131072 (128k)  |
+| `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`         | 131072 (128k)  |
+| `meta-llama/Meta-Llama-3-70B-Instruct-Lite`           | 8192           |
+| `mistralai/Mixtral-8x7B-Instruct-v0.1`                | 32768          |
+| `mistralai/Mistral-7B-Instruct-v0.2`                  | 32768          |
+| `mistralai/Mistral-Large-Instruct-2411`               | 131072         |
+| `Qwen/Qwen2.5-72B-Instruct-Turbo`                     | 131072         |
+| `Qwen/Qwen1.5-72B-Chat`                               | 32768          |
+| `deepseek-ai/DeepSeek-V3`                             | 131072         |
+| `deepseek-ai/DeepSeek-R1`                             | 131072         |
+| `databricks/dbrx-instruct`                            | 32768          |
+
+Always confirm the latest list on the [Together AI models documentation](https://docs.together.ai/docs/inference-models) page. If a model is not present in the table above, `TogetherLLM` falls back to a conservative default of 8192 tokens.
+
+---
+
+## 3. Environment setup
+
+The example YAML uses environment variable placeholders. The following section describes how to set those variables.
+
+Required: `TOGETHER_API_KEY`
+Optional: `TOGETHER_API_BASE`, `TOGETHER_PROXY`, `TOGETHER_ORGANIZATION`
+
+### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['TOGETHER_API_KEY'] = 'a1b2c3***'
+os.environ['TOGETHER_API_BASE'] = 'https://api.together.xyz/v1'
+```
+
+### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory, add the following entries:
+
+```toml
+TOGETHER_API_KEY="a1b2c3******"
+TOGETHER_API_BASE="https://api.together.xyz/v1"
+TOGETHER_ORGANIZATION=""
+TOGETHER_PROXY=""
+```
+
+---
+
+## 4. Obtaining the Together AI API key
+
+1. Sign in at [https://api.together.ai](https://api.together.ai).
+2. Navigate to **Settings** -> **API Keys** and click **Create API Key**.
+3. Copy the generated key (e.g. `a1b2c3...`) and assign it to `TOGETHER_API_KEY`.
+
+New accounts receive free credits to get started; pricing for each model is listed at [https://www.together.ai/pricing](https://www.together.ai/pricing).
+
+---
+
+## 5. Using the LLM in code
+
+After the configuration is loaded by agentUniverse you can obtain the LLM instance and call it directly:
+
+```python
+from agentuniverse.llm.default.together_llm import TogetherLLM
+
+llm = TogetherLLM(model_name='meta-llama/Llama-3.3-70B-Instruct-Turbo')
+
+# Non-streaming
+output = llm.call(messages=[{"role": "user", "content": "Hello!"}])
+print(output.text)
+
+# Streaming
+for chunk in llm.call(messages=[{"role": "user", "content": "Count 1 to 5."}], streaming=True):
+    print(chunk.text, end='')
+
+# Async
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "Hello!"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+Because Together AI is OpenAI-compatible, every feature supported by `OpenAIStyleLLM` - tool calling, LangChain integration, tracing - is available without any extra work.
+
+---
+
+## 6. Tips
+
+- agentUniverse ships with a ready-to-use instance named `default_together_llm`. After configuring the `TOGETHER_API_KEY` environment variable you can reference it directly from your agents.
+- Together AI's key advantage is breadth: a single API key unlocks hundreds of open-source models, which makes it easy to A/B test different model families without changing integrations.
+- Model availability and naming evolve over time. Before standardising on a particular model, check the [Together AI models page](https://docs.together.ai/docs/inference-models) for the authoritative list and any deprecation notices.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Together使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Together使用.md
@@ -1,0 +1,150 @@
+# Together 使用
+
+`TogetherLLM` 将 [Together AI](https://www.together.ai) 托管推理平台接入 agentUniverse。Together AI 提供了 **200+ 开源大模型** 的统一托管服务，涵盖 Meta Llama、Mistral/Mixtral、Qwen、DeepSeek、DBRX、Falcon 等，并对外暴露完全 **兼容 OpenAI** 的 Chat Completions API（地址为 `https://api.together.xyz/v1`）。
+
+由于 API 兼容 OpenAI 协议，`TogetherLLM` 组件只需继承 `OpenAIStyleLLM`，并配置 Together 的鉴权信息、API 基础地址以及各模型的上下文长度表即可。流式输出、工具/函数调用、异步接口以及 LangChain 桥接等能力均可直接复用，无需额外开发。
+
+---
+
+## 1. 创建相关文件
+
+创建一个 yaml 文件，例如 `user_together_llm.yaml`，将以下内容粘贴进去：
+
+```yaml
+name: 'user_together_llm'
+description: 'user together llm hosted on the Together AI platform'
+model_name: 'meta-llama/Llama-3.3-70B-Instruct-Turbo'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${TOGETHER_API_KEY}'
+api_base: 'https://api.together.xyz/v1'
+organization: '${TOGETHER_ORGANIZATION}'
+proxy: '${TOGETHER_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.together_llm'
+  class: 'TogetherLLM'
+```
+
+**note:** `api_key` / `api_base` / `organization` / `proxy` 等模型参数有三种配置方法：
+
+1. **直接字符串值**：直接在配置文件中输入 API 密钥字符串。
+
+    ```yaml
+    api_key: 'a1b2c3***'
+    ```
+
+2. **环境变量占位符**：使用 `${VARIABLE_NAME}` 语法从环境变量中加载。当 agentUniverse 启动时，会自动从环境变量读取相应的值。
+
+    ```yaml
+    api_key: '${TOGETHER_API_KEY}'
+    ```
+
+3. **自定义函数加载**：使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API 密钥。
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="together"))'
+    ```
+
+    该函数需要在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中定义，可参考样例工程中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)。当 agentUniverse 加载此配置时：
+    - 解析 `@FUNC` 注解
+    - 执行 `load_api_key` 函数并传入相应参数
+    - 用函数返回值替换注解内容
+
+---
+
+## 2. 选择模型
+
+Together AI 的模型列表会持续更新。下表列出了常用模型及其上下文窗口大小（输入 + 输出 token）。这些数值同样硬编码在 `TogetherLLM.max_context_length` 中，这样 agentUniverse 即使不发起真实请求也能正确估算 prompt 预算。
+
+| 模型名称                                               | 上下文长度      |
+| ----------------------------------------------------- | --------------- |
+| `meta-llama/Llama-3.3-70B-Instruct-Turbo`             | 131072 (128k)   |
+| `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`         | 131072 (128k)   |
+| `meta-llama/Meta-Llama-3-70B-Instruct-Lite`           | 8192            |
+| `mistralai/Mixtral-8x7B-Instruct-v0.1`                | 32768           |
+| `mistralai/Mistral-7B-Instruct-v0.2`                  | 32768           |
+| `mistralai/Mistral-Large-Instruct-2411`               | 131072          |
+| `Qwen/Qwen2.5-72B-Instruct-Turbo`                     | 131072          |
+| `Qwen/Qwen1.5-72B-Chat`                               | 32768           |
+| `deepseek-ai/DeepSeek-V3`                             | 131072          |
+| `deepseek-ai/DeepSeek-R1`                             | 131072          |
+| `databricks/dbrx-instruct`                            | 32768           |
+
+请以 [Together AI 官方模型文档](https://docs.together.ai/docs/inference-models) 公布的最新列表为准。如果某个模型不在上表中，`TogetherLLM` 会保守地回退到 8192 token。
+
+---
+
+## 3. 环境设置
+
+示例 yaml 中模型密钥等参数使用了环境变量占位符，下面介绍环境变量的设置方法。
+
+必须配置：`TOGETHER_API_KEY`
+可选配置：`TOGETHER_API_BASE`、`TOGETHER_PROXY`、`TOGETHER_ORGANIZATION`
+
+### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['TOGETHER_API_KEY'] = 'a1b2c3***'
+os.environ['TOGETHER_API_BASE'] = 'https://api.together.xyz/v1'
+```
+
+### 3.2 通过配置文件配置
+
+在项目的 `config` 目录下的 `custom_key.toml` 当中，添加配置：
+
+```toml
+TOGETHER_API_KEY="a1b2c3******"
+TOGETHER_API_BASE="https://api.together.xyz/v1"
+TOGETHER_ORGANIZATION=""
+TOGETHER_PROXY=""
+```
+
+---
+
+## 4. TOGETHER API KEY 获取
+
+1. 登录 [https://api.together.ai](https://api.together.ai)。
+2. 进入 **Settings** -> **API Keys**，点击 **Create API Key**。
+3. 复制生成的密钥（例如 `a1b2c3...`），并赋值给 `TOGETHER_API_KEY`。
+
+新账号注册后会赠送一定免费额度，各模型的具体计费详见 [https://www.together.ai/pricing](https://www.together.ai/pricing)。
+
+---
+
+## 5. 在代码中使用
+
+配置被 agentUniverse 加载后，您可以直接获取 LLM 实例并调用：
+
+```python
+from agentuniverse.llm.default.together_llm import TogetherLLM
+
+llm = TogetherLLM(model_name='meta-llama/Llama-3.3-70B-Instruct-Turbo')
+
+# 非流式
+output = llm.call(messages=[{"role": "user", "content": "你好！"}])
+print(output.text)
+
+# 流式
+for chunk in llm.call(messages=[{"role": "user", "content": "从 1 数到 5。"}], streaming=True):
+    print(chunk.text, end='')
+
+# 异步
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "你好！"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+由于 Together AI 兼容 OpenAI 协议，`OpenAIStyleLLM` 支持的所有能力（工具调用、LangChain 集成、链路追踪等）都可以直接使用。
+
+---
+
+## 6. Tips
+
+- agentuniverse 已经内置了一个 name 为 `default_together_llm` 的 llm，用户在配置 `TOGETHER_API_KEY` 之后可以直接使用。
+- Together AI 最大的特点是模型覆盖广：一把 API 密钥即可访问数百个开源模型，方便在不改动集成代码的前提下对不同模型家族进行 A/B 测试。
+- 模型的可用性和命名会随时间变化，在正式选型前请先到 [Together AI 模型页面](https://docs.together.ai/docs/inference-models) 确认可用模型及废弃公告。

--- a/tests/test_agentuniverse/unit/llm/test_together_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_together_llm.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the Together AI LLM component.
+
+These tests exercise the parts of :class:`TogetherLLM` that do not require a
+live Together AI API key: credential/base-url wiring, the per-model context
+length table and the token estimator. The network-bound call/acall/stream
+tests are kept but commented out so the full suite runs in CI without any
+external dependency.
+"""
+
+import asyncio
+import unittest
+
+from agentuniverse.llm.default.together_llm import (
+    TOGETHER_DEFAULT_CONTEXT_LENGTH,
+    TOGETHER_MAX_CONTEXT_LENGTH,
+    TogetherLLM,
+)
+
+
+class TestTogetherLLM(unittest.TestCase):
+    """Test suite for the TogetherLLM component."""
+
+    def setUp(self) -> None:
+        """Build a TogetherLLM instance with dummy credentials."""
+        self.llm = TogetherLLM(
+            model_name='meta-llama/Llama-3.3-70B-Instruct-Turbo',
+            api_key='dummy-together-key',
+            api_base='https://api.together.xyz/v1',
+            max_tokens=512,
+            temperature=0.7,
+        )
+
+    def test_initialization(self) -> None:
+        """LLM must accept and persist the constructor parameters."""
+        self.assertEqual(self.llm.model_name, 'meta-llama/Llama-3.3-70B-Instruct-Turbo')
+        self.assertEqual(self.llm.api_key, 'dummy-together-key')
+        self.assertEqual(self.llm.api_base, 'https://api.together.xyz/v1')
+        self.assertEqual(self.llm.max_tokens, 512)
+        self.assertEqual(self.llm.temperature, 0.7)
+
+    def test_default_api_base(self) -> None:
+        """When no api_base is provided the Together endpoint must be used."""
+        llm = TogetherLLM(model_name='meta-llama/Llama-3.3-70B-Instruct-Turbo', api_key='dummy')
+        self.assertEqual(llm.api_base, 'https://api.together.xyz/v1')
+
+    def test_max_context_length_known_models(self) -> None:
+        """Known models must resolve to their documented context window."""
+        known = [
+            ('meta-llama/Llama-3.3-70B-Instruct-Turbo', 131072),
+            ('meta-llama/Meta-Llama-3-8B-Instruct-Lite', 8192),
+            ('mistralai/Mixtral-8x7B-Instruct-v0.1', 32768),
+            ('Qwen/Qwen2.5-72B-Instruct-Turbo', 131072),
+            ('deepseek-ai/DeepSeek-V3', 131072),
+        ]
+        for model_name, expected in known:
+            llm = TogetherLLM(model_name=model_name, api_key='dummy')
+            self.assertEqual(
+                llm.max_context_length(),
+                expected,
+                f'Context length mismatch for {model_name}',
+            )
+
+    def test_max_context_length_unknown_model(self) -> None:
+        """Unknown models must fall back to the default context length."""
+        llm = TogetherLLM(model_name='some-future-together-model', api_key='dummy')
+        self.assertEqual(llm.max_context_length(), TOGETHER_DEFAULT_CONTEXT_LENGTH)
+
+    def test_max_context_length_table_consistency(self) -> None:
+        """Every entry in the table must be a positive integer."""
+        for model_name, length in TOGETHER_MAX_CONTEXT_LENGTH.items():
+            self.assertIsInstance(length, int, f'{model_name} length not int')
+            self.assertGreater(length, 0, f'{model_name} length not positive')
+
+    def test_get_num_tokens(self) -> None:
+        """The token estimator must return a sensible positive count."""
+        text = 'Hello Together AI, please introduce yourself.'
+        num_tokens = self.llm.get_num_tokens(text)
+        self.assertIsInstance(num_tokens, int)
+        self.assertGreater(num_tokens, 0)
+        # The estimator must be deterministic for the same input.
+        self.assertEqual(num_tokens, self.llm.get_num_tokens(text))
+
+    def test_get_num_tokens_empty_string(self) -> None:
+        """An empty string must cost zero tokens."""
+        self.assertEqual(self.llm.get_num_tokens(''), 0)
+
+    # ========== Integration tests (require a real TOGETHER_API_KEY) ==========
+    # Uncomment and set TOGETHER_API_KEY in the environment to exercise the
+    # live Together AI API.
+
+    # def test_call(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = self.llm.call(messages=messages, streaming=False)
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_acall(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_call_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #     chunks = []
+    #     for chunk in self.llm.call(messages=messages, streaming=True):
+    #         chunks.append(chunk.text)
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_acall_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #
+    #     async def _run():
+    #         result = []
+    #         async for chunk in await self.llm.acall(messages=messages, streaming=True):
+    #             result.append(chunk.text)
+    #         return result
+    #
+    #     chunks = asyncio.run(_run())
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_as_langchain(self) -> None:
+    #     from langchain.chains.conversation.base import ConversationChain
+    #     langchain_llm = self.llm.as_langchain()
+    #     llm_chain = ConversationChain(llm=langchain_llm)
+    #     res = llm_chain.predict(input='Say hello')
+    #     self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new **TogetherLLM** component that integrates the [Together AI](https://www.together.ai) hosted inference platform into agentUniverse. Closes #250.

Together AI serves 200+ open-source large language models (Meta Llama, Mistral/Mixtral, Qwen, DeepSeek, DBRX, ...) behind a single, fully OpenAI-compatible Chat Completions API at `https://api.together.xyz/v1`. Because of that compatibility this component simply extends `OpenAIStyleLLM`, so streaming, async, tool calling and the LangChain bridge all work out of the box.

## Changes

- `agentuniverse/llm/default/together_llm.py` — `TogetherLLM` class extending `OpenAIStyleLLM`.
  - `api_key` loaded from `TOGETHER_API_KEY`
  - `api_base` defaults to `https://api.together.xyz/v1` (overridable via `TOGETHER_API_BASE`)
  - `TOGETHER_MAX_CONTEXT_LENGTH` table for common models (Llama 3.3/3.1, Mixtral, Qwen2.5, DeepSeek-V3/R1, DBRX, etc.)
  - `get_num_tokens` using `tiktoken` with a `cl100k_base` fallback.
- `agentuniverse/llm/default/together_llm.yaml.example` — example configuration.
- `tests/test_agentuniverse/unit/llm/test_together_llm.py` — 7 unit tests (init, default api_base, context-length lookup for known/unknown models, table consistency, token counting, empty string). All pass without a live API key.
- `docs/guidebook/en/In-Depth_Guides/Components/LLMs/Together_LLM_Use.md` — English documentation.
- `docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Together使用.md` — Chinese documentation.

## Test

```
python -m unittest tests.test_agentuniverse.unit.llm.test_together_llm -v
```

```
Ran 7 tests in 0.06s
OK
```

## Checklist

- [x] Component follows the existing `OpenAIStyleLLM` pattern (qwen/deepseek style)
- [x] Unit tests added and passing
- [x] Documentation added in both English and Chinese
