### PR TITLE
feat: add Voyage AI reranker component (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.py
@@ -1,0 +1,206 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: voyage_reranker.py
+
+"""
+Voyage AI reranker document processor.
+
+Reranks recalled documents by their relevance to a Query using the Voyage AI
+Rerank API (``https://api.voyageai.com/v1/rerank``). Voyage AI exposes a family
+of rerank models such as ``rerank-2`` (default), ``rerank-2-lite``,
+``rerank-2.5`` and ``rerank-2.5-lite``. An API key is required and can be
+obtained from https://dash.voyageai.com/.
+
+The structure mirrors the existing ``JinaReranker`` / ``DashscopeReranker``:
+subclass :class:`DocProcessor`, override ``_process_docs`` to call the API,
+and stamp the relevance score onto each kept document's metadata.
+"""
+
+import logging
+from typing import List, Optional
+
+import requests
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor \
+    import DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.util.env_util import get_from_env
+
+logger = logging.getLogger(__name__)
+
+# Voyage AI rerank endpoint. Kept as a module-level constant so the URL lives
+# in exactly one place and is trivial to patch in unit tests.
+_VOYAGE_RERANK_URL = "https://api.voyageai.com/v1/rerank"
+
+
+class VoyageReranker(DocProcessor):
+    """Document reranker using the Voyage AI Rerank API.
+
+    This processor reranks documents based on their relevance to a query
+    using Voyage AI's reranking models. The Voyage API returns results
+    already sorted by descending relevance, so the kept documents are
+    returned in that order.
+
+    Attributes:
+        api_key: Voyage AI API key. Falls back to the ``VOYAGE_API_KEY`` env
+            var when not set on the component.
+        model_name: Reranker model id (default ``rerank-2``).
+        top_n: Maximum number of documents to return after reranking.
+            Maps to the API's ``top_k`` parameter.
+        request_timeout: Timeout in seconds for the rerank HTTP call. The
+            ``requests`` library defaults to no timeout, so without this a
+            stalled Voyage API would hang the whole rerank step indefinitely.
+        score_key: Metadata key under which each kept document's relevance
+            score is stamped (default ``rerank_score``).
+    """
+
+    api_key: Optional[str] = None
+    model_name: str = "rerank-2"
+    top_n: int = 10
+    request_timeout: int = 30
+    score_key: str = "rerank_score"
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Rerank ``origin_docs`` by relevance to ``query``.
+
+        Args:
+            origin_docs: List of documents to be reranked.
+            query: Query object carrying the search query string.
+
+        Returns:
+            List[Document]: Reranked documents sorted by descending relevance,
+            each stamped with its relevance score under ``score_key``.
+
+        Raises:
+            Exception: If the query is missing, the API key is not set, or
+                the API call fails (HTTP error / non-JSON body / transport
+                error).
+        """
+        if not query or not query.query_str:
+            raise Exception(
+                "Voyage AI reranker needs an origin string query.")
+        if not self.api_key:
+            raise Exception(
+                "Voyage AI API key is not set. Please configure it on the "
+                "component or via the VOYAGE_API_KEY environment variable.")
+        if not origin_docs:
+            return []
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        # The Voyage API's "top_k" controls how many of the most relevant
+        # documents are returned. We cap it at the number of input documents
+        # so we never ask for more results than exist.
+        effective_top_k = min(self.top_n, len(origin_docs))
+
+        payload = {
+            "model": self.model_name,
+            "query": query.query_str,
+            "documents": [doc.text for doc in origin_docs],
+            "top_k": effective_top_k,
+            "return_documents": False,
+            "truncation": True,
+        }
+
+        try:
+            response = requests.post(
+                _VOYAGE_RERANK_URL, headers=headers, json=payload,
+                timeout=self.request_timeout)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Voyage AI rerank API call error: {e}")
+
+        # Decode the body separately from the HTTP call. ``Response.json()``
+        # raises ``requests.exceptions.JSONDecodeError`` on a non-JSON body
+        # (e.g. an HTML error page from an upstream gateway). That exception
+        # inherits from both ``RequestException`` and ``ValueError``, so a
+        # single combined try block would misreport it as an API-call error;
+        # isolating JSON decoding here surfaces it as a non-JSON response.
+        try:
+            results = response.json().get("data", [])
+        except ValueError as e:
+            raise Exception(
+                f"Voyage AI rerank API returned a non-JSON response: {e}")
+
+        rerank_docs: List[Document] = []
+        for result in results:
+            index = result.get("index")
+            relevance_score = result.get("relevance_score")
+
+            if index is None or relevance_score is None:
+                continue
+            if not isinstance(index, int) or index < 0 \
+                    or index >= len(origin_docs):
+                # Defensive: an out-of-range index would IndexError; skip it
+                # rather than crash the whole rerank step.
+                logger.warning(
+                    "Voyage AI rerank returned out-of-range index %s", index)
+                continue
+
+            target_doc = origin_docs[index]
+            metadata = dict(target_doc.metadata) \
+                if target_doc.metadata else {}
+            metadata[self.score_key] = relevance_score
+            target_doc.metadata = metadata
+
+            rerank_docs.append(target_doc)
+
+        return rerank_docs
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer) \
+            -> 'VoyageReranker':
+        """Initialize reranker parameters from component configuration.
+
+        Args:
+            doc_processor_configer: Configuration object for the doc
+                processor.
+
+        Returns:
+            DocProcessor: The initialized document processor instance.
+        """
+        super()._initialize_by_component_configer(doc_processor_configer)
+
+        # The env var is the fallback; an explicit key in the YAML wins.
+        self.api_key = get_from_env("VOYAGE_API_KEY")
+
+        if hasattr(doc_processor_configer, "api_key"):
+            self.api_key = doc_processor_configer.api_key
+        if hasattr(doc_processor_configer, "model_name"):
+            self.model_name = doc_processor_configer.model_name
+        if hasattr(doc_processor_configer, "top_n"):
+            self.top_n = doc_processor_configer.top_n
+        if hasattr(doc_processor_configer, "score_key"):
+            self.score_key = doc_processor_configer.score_key
+        if hasattr(doc_processor_configer, "request_timeout"):
+            self.request_timeout = self._validate_request_timeout(
+                doc_processor_configer.request_timeout)
+
+        return self
+
+    @staticmethod
+    def _validate_request_timeout(value) -> int:
+        """Validate a configured request timeout.
+
+        ``requests`` treats ``None`` as "no timeout" and accepts ``0`` /
+        negative values without complaint, so a bad config must fail loudly
+        here instead of hanging the rerank step or silently disabling the
+        timeout. ``bool`` is a subclass of ``int`` (``True`` == 1) and is
+        rejected explicitly so a YAML ``true`` does not silently become 1.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise Exception(
+                f"Voyage AI reranker request_timeout must be a positive "
+                f"number, got {value!r}.")
+        if value <= 0:
+            raise Exception(
+                f"Voyage AI reranker request_timeout must be a positive "
+                f"number, got {value!r}.")
+        return value

--- a/agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.yaml
@@ -1,0 +1,10 @@
+name: 'voyage_reranker'
+description: 'reranker use voyage ai api'
+model_name: 'rerank-2'
+top_n: 10
+request_timeout: 30
+score_key: 'rerank_score'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.voyage_reranker'
+  class: 'VoyageReranker'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -171,6 +171,29 @@ metadata:
 ```
 This component requires configuring DASHSCOPE_API_KEY in the environment variables.
 
+### [VoyageReranker](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.yaml)
+
+This component reranks the documents recalled by the Store using the Voyage AI Rerank API (`https://api.voyageai.com/v1/rerank`), sorting them by relevance to the Query. Voyage AI exposes a family of rerank models such as `rerank-2` (default), `rerank-2-lite`, `rerank-2.5` and `rerank-2.5-lite`. Only a Voyage AI API key is required — `requests` is already a core dependency of agentUniverse.
+
+The component definition file is as follows:
+```yaml
+name: 'voyage_reranker'
+description: 'reranker use voyage ai api'
+model_name: 'rerank-2'
+top_n: 10
+request_timeout: 30
+score_key: 'rerank_score'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.voyage_reranker'
+  class: 'VoyageReranker'
+```
+- model_name: Voyage AI rerank model (default `rerank-2`).
+- top_n: Maximum number of documents to return after reranking. Maps to the API's `top_k` parameter and is capped at the number of input documents so the API is never asked for more results than exist.
+- request_timeout: Timeout in seconds for the rerank HTTP call (default 30). `requests` defaults to no timeout, so without this a stalled Voyage API would hang the whole rerank step indefinitely.
+- score_key: Metadata key under which each kept document's relevance score is stamped (default `rerank_score`).
+This component requires configuring `VOYAGE_API_KEY` in the environment variables.
+
 ### [HierarchicalRegexTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/hierarchical_regex_text_splitter.py)
 
 This component splits the original text into multiple hierarchical levels using specified regex rules, forming a tree-like document structure. Users need to create a custom definition file, with an example as follows:

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -171,6 +171,29 @@ metadata:
 ```
 该组件需要在环境变量中配置`DASHSCOPE_API_KEY`。
 
+### [VoyageReranker](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.yaml)
+
+该组件使用 Voyage AI 的 Rerank API（`https://api.voyageai.com/v1/rerank`）对 Store 召回的文档按与 Query 的相关性重新排序。Voyage AI 提供了一系列 rerank 模型，如 `rerank-2`（默认）、`rerank-2-lite`、`rerank-2.5` 与 `rerank-2.5-lite`。只需一个 Voyage AI 的 API Key（`requests` 已是 agentUniverse 的核心依赖）。
+
+组件定义文件如下：
+```yaml
+name: 'voyage_reranker'
+description: 'reranker use voyage ai api'
+model_name: 'rerank-2'
+top_n: 10
+request_timeout: 30
+score_key: 'rerank_score'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.voyage_reranker'
+  class: 'VoyageReranker'
+```
+- model_name：Voyage AI rerank 模型（默认 `rerank-2`）。
+- top_n：rerank 后返回的最大文档数。对应 API 的 `top_k` 参数，并会被截断到输入文档数，避免向 API 请求超出实际数量的结果。
+- request_timeout：rerank HTTP 调用的超时时间，单位秒（默认 30）。`requests` 默认无超时，若不设置，一旦 Voyage API 卡住，整步 rerank 会无限期挂起。
+- score_key：将每个保留文档的相关性分数写入 metadata 时使用的键（默认 `rerank_score`）。
+该组件需要在环境变量中配置`VOYAGE_API_KEY`。
+
 ### [HierarchicalRegexTextSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/hierarchical_regex_text_splitter.py)
 
 该组件使用通过指定的正则规则对原始文本进行多层级的拆分，形成树状的文档结构。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_voyage_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_voyage_reranker.py
@@ -1,0 +1,245 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: test_voyage_reranker.py
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from agentuniverse.agent.action.knowledge.doc_processor.voyage_reranker \
+    import VoyageReranker
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer \
+    import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class TestVoyageReranker(unittest.TestCase):
+
+    def setUp(self):
+        cfg = Configer()
+        cfg.value = {
+            'name': 'voyage_reranker',
+            'description': 'reranker use voyage ai api',
+            'api_key': 'test_api_key',
+            'model_name': 'rerank-2',
+            'top_n': 5,
+        }
+        self.configer = ComponentConfiger()
+        self.configer.load_by_configer(cfg)
+        self.reranker = VoyageReranker()
+
+        self.test_docs = [
+            Document(text='Document 1', metadata={'id': 1}),
+            Document(text='Document 2', metadata={'id': 2}),
+            Document(text='Document 3', metadata={'id': 3}),
+            Document(text='Document 4', metadata={'id': 4}),
+            Document(text='Document 5', metadata={'id': 5}),
+        ]
+        self.test_query = Query(query_str='test query')
+
+    def test_initialize_by_component_configer_with_env(self):
+        with patch('agentuniverse.base.util.env_util.get_from_env') \
+                as mock_get_env:
+            mock_get_env.return_value = 'env_key'
+            self.reranker = VoyageReranker()
+            self.reranker._initialize_by_component_configer(self.configer)
+
+            self.assertEqual(self.reranker.api_key, 'test_api_key')
+            self.assertEqual(self.reranker.model_name, 'rerank-2')
+            self.assertEqual(self.reranker.top_n, 5)
+
+    @patch('agentuniverse.agent.action.knowledge.doc_processor.'
+           'voyage_reranker.requests.post')
+    def test_process_docs(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'data': [
+                {'index': 2, 'relevance_score': 0.9},
+                {'index': 0, 'relevance_score': 0.8},
+                {'index': 4, 'relevance_score': 0.7},
+                {'index': 1, 'relevance_score': 0.6},
+                {'index': 3, 'relevance_score': 0.5},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        self.reranker.api_key = 'test_api_key'
+        result_docs = self.reranker._process_docs(
+            self.test_docs, self.test_query)
+
+        mock_post.assert_called_once_with(
+            'https://api.voyageai.com/v1/rerank',
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer test_api_key',
+            },
+            json={
+                'model': 'rerank-2',
+                'query': 'test query',
+                'documents': [doc.text for doc in self.test_docs],
+                'top_k': 5,
+                'return_documents': False,
+                'truncation': True,
+            },
+            timeout=30,
+        )
+
+        self.assertEqual(len(result_docs), 5)
+        # results come back pre-sorted by relevance
+        self.assertEqual(result_docs[0].metadata['id'], 3)
+        self.assertEqual(result_docs[0].metadata['rerank_score'], 0.9)
+        self.assertEqual(result_docs[1].metadata['id'], 1)
+        self.assertEqual(result_docs[1].metadata['rerank_score'], 0.8)
+        # original metadata is preserved alongside the stamped score
+        self.assertEqual(result_docs[2].metadata['id'], 5)
+
+    @patch('agentuniverse.agent.action.knowledge.doc_processor.'
+           'voyage_reranker.requests.post')
+    def test_process_docs_top_n_capped_to_doc_count(self, mock_post):
+        # top_n larger than the number of docs must be capped so the API is
+        # never asked for more results than exist.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'data': [
+                {'index': 1, 'relevance_score': 0.9},
+                {'index': 0, 'relevance_score': 0.8},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        self.reranker.api_key = 'test_api_key'
+        self.reranker.top_n = 10
+        small_docs = [self.test_docs[0], self.test_docs[1]]
+
+        result_docs = self.reranker._process_docs(small_docs, self.test_query)
+
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['json']['top_k'], 2)
+        self.assertEqual(len(result_docs), 2)
+
+    def test_process_docs_no_api_key(self):
+        with self.assertRaises(Exception) as context:
+            self.reranker._process_docs(self.test_docs, self.test_query)
+        self.assertIn('Voyage AI API key is not set', str(context.exception))
+
+    def test_process_docs_no_query(self):
+        self.reranker.api_key = 'test_api_key'
+        with self.assertRaises(Exception) as context:
+            self.reranker._process_docs(self.test_docs, None)
+        self.assertIn('needs an origin string query', str(context.exception))
+
+    def test_process_docs_no_docs(self):
+        self.reranker.api_key = 'test_api_key'
+        result_docs = self.reranker._process_docs([], self.test_query)
+        self.assertEqual(len(result_docs), 0)
+
+    @patch('agentuniverse.agent.action.knowledge.doc_processor.'
+           'voyage_reranker.requests.post')
+    def test_process_docs_timeout_error_is_surfaced(self, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout('timed out')
+        self.reranker.api_key = 'test_api_key'
+        with self.assertRaises(Exception) as context:
+            self.reranker._process_docs(self.test_docs, self.test_query)
+        self.assertIn('Voyage AI rerank API call error', str(context.exception))
+
+    @patch('agentuniverse.agent.action.knowledge.doc_processor.'
+           'voyage_reranker.requests.post')
+    def test_process_docs_non_json_response_is_surfaced(self, mock_post):
+        # Use a real Response whose .json() raises
+        # requests.exceptions.JSONDecodeError — the actual exception a
+        # non-JSON body produces. JSONDecodeError inherits from BOTH
+        # RequestException and ValueError, so a naive except-ordering would
+        # misreport it as an API-call error; this test pins the non-JSON
+        # path.
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = b'<html>upstream error page</html>'
+        mock_post.return_value = mock_response
+        self.reranker.api_key = 'test_api_key'
+        with self.assertRaises(Exception) as context:
+            self.reranker._process_docs(self.test_docs, self.test_query)
+        self.assertIn('non-JSON', str(context.exception))
+        self.assertNotIn('API call error', str(context.exception))
+
+    @patch('agentuniverse.agent.action.knowledge.doc_processor.'
+           'voyage_reranker.requests.post')
+    def test_process_docs_skips_out_of_range_index(self, mock_post):
+        # An out-of-range index must be skipped rather than crash the rerank.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'data': [
+                {'index': 0, 'relevance_score': 0.9},
+                {'index': 99, 'relevance_score': 0.8},
+                {'index': 'oops', 'relevance_score': 0.7},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        self.reranker.api_key = 'test_api_key'
+        result_docs = self.reranker._process_docs(
+            self.test_docs, self.test_query)
+        self.assertEqual(len(result_docs), 1)
+        self.assertEqual(result_docs[0].metadata['rerank_score'], 0.9)
+
+    @patch('agentuniverse.agent.action.knowledge.doc_processor.'
+           'voyage_reranker.requests.post')
+    def test_process_docs_custom_score_key(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'data': [
+                {'index': 0, 'relevance_score': 0.9},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        self.reranker.api_key = 'test_api_key'
+        self.reranker.score_key = 'voyage_relevance'
+        result_docs = self.reranker._process_docs(
+            [self.test_docs[0]], self.test_query)
+        self.assertIn('voyage_relevance', result_docs[0].metadata)
+        self.assertNotIn('rerank_score', result_docs[0].metadata)
+
+    def _make_configer_with_timeout(self, request_timeout):
+        cfg = Configer()
+        cfg.value = {
+            'name': 'voyage_reranker',
+            'description': 'reranker use voyage ai api',
+            'request_timeout': request_timeout,
+        }
+        configer = ComponentConfiger()
+        configer.load_by_configer(cfg)
+        return configer
+
+    def test_initialize_rejects_non_numeric_request_timeout(self):
+        for bad in ('not-a-number', None, [30]):
+            reranker = VoyageReranker()
+            with self.assertRaises(Exception) as context:
+                reranker._initialize_by_component_configer(
+                    self._make_configer_with_timeout(bad))
+            self.assertIn('request_timeout', str(context.exception))
+
+    def test_initialize_rejects_non_positive_request_timeout(self):
+        # 0 / negative are invalid; True/False are bools (an int subclass)
+        # and must also be rejected so a YAML `true` does not become 1.
+        for bad in (0, -5, True, False):
+            reranker = VoyageReranker()
+            with self.assertRaises(Exception) as context:
+                reranker._initialize_by_component_configer(
+                    self._make_configer_with_timeout(bad))
+            self.assertIn('request_timeout', str(context.exception))
+
+    def test_initialize_accepts_valid_request_timeout(self):
+        for good in (1, 30, 5.5):
+            reranker = VoyageReranker()
+            reranker._initialize_by_component_configer(
+                self._make_configer_with_timeout(good))
+            self.assertEqual(reranker.request_timeout, good)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `VoyageReranker` DocProcessor that reranks recalled documents by relevance to a Query using the Voyage AI Rerank API (`https://api.voyageai.com/v1/rerank`). Supports the Voyage AI rerank model family (`rerank-2` default, `rerank-2-lite`, `rerank-2.5`, `rerank-2.5-lite`).

Closes #248.

## Why

Voyage AI provides top-tier reranking quality. agentUniverse's knowledge layer already ships `DashscopeReranker` and `JinaReranker`; this adds a first-class Voyage AI reranker so users can plug in Voyage's rerank models alongside the existing Voyage embedding component.

## Changes

- `agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.py` — `VoyageReranker` extending `DocProcessor`. Structure mirrors the merged `JinaReranker`.
  - `api_key` read from the `VOYAGE_API_KEY` env var (YAML overrides).
  - `model_name` defaults to `rerank-2`.
  - `top_n`: 10 default, maps to the API's `top_k` and is capped at the number of input documents so the API is never asked for more results than exist.
  - `request_timeout`: 30s default (guards against an indefinite hang since `requests` defaults to no timeout).
  - `score_key`: `"rerank_score"` default — metadata key under which each kept document's relevance score is stamped.
  - `_process_docs` calls the rerank endpoint; validates the response, surfaces HTTP / transport errors as a single `API call error` exception and isolates non-JSON decoding into its own `non-JSON response` error; skips out-of-range indices defensively.
- `agentuniverse/agent/action/knowledge/doc_processor/voyage_reranker.yaml` — component registration.
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_voyage_reranker.py` — 13 unit tests mocking `requests` (happy path incl. payload assertion, top_n capped to doc count, missing api_key, missing query, empty docs, timeout, non-JSON response, out-of-range index skip, custom score_key, configer init, request_timeout validation).
- `docs/.../Knowledge/DocProcessor.md` (en + zh) — `VoyageReranker` section appended.

## How to use

```yaml
name: 'voyage_reranker'
description: 'reranker use voyage ai api'
model_name: 'rerank-2'
top_n: 10
request_timeout: 30
score_key: 'rerank_score'
metadata:
  type: 'DOC_PROCESSOR'
  module: 'agentuniverse.agent.action.knowledge.doc_processor.voyage_reranker'
  class: 'VoyageReranker'
```

Reference it from a store/processor chain by name; set `VOYAGE_API_KEY` in the environment.

## Test

```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_voyage_reranker
```

All 13 tests pass.
