### PR TITLE
feat: add UnitConverterTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/unit_converter_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/unit_converter_tool.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: unit_converter_tool.py
+
+"""
+Unit Converter Tool — convert values across unit categories.
+
+A dependency-free unit conversion utility for agent workflows. It supports
+the common physical quantities an agent is likely to encounter: length,
+weight/mass, temperature, data size, and time. Each category has a complete
+table of conversion factors relative to a canonical base unit, except
+temperature, which is converted via dedicated offset formulas because it is
+not a simple multiplicative scale.
+
+The tool exposes a single ``execute`` method that takes ``value``,
+``from_unit``, ``to_unit`` and ``category`` and returns a structured dict.
+All results carry a ``status`` field (``success`` or ``error``); errors are
+returned, never raised, so agents can branch on the response rather than
+catch exceptions.
+
+Supported categories and units (case-insensitive aliases accepted):
+
+- **length** (base: metre): m, km, mile, ft, in, cm, mm, yd, mi(=mile).
+- **weight** (base: kilogram): kg, g, lb, oz, t (metric tonne), mg.
+- **temperature** (special): c (Celsius), f (Fahrenheit), k (Kelvin).
+- **data** (base: byte, binary 1024): b, kb, mb, gb, tb, pb.
+- **time** (base: second): s, min, h, day, ms, week.
+
+Addresses #252 (common utility tools).
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+# Public execute() converts validation exceptions into structured tool
+# responses instead of raising.
+# ruff: noqa: TRY003
+
+# Hard ceiling on the magnitude of the input value. Anything larger almost
+# certainly indicates a caller mistake (for example passing an exponent or a
+# file size in bytes instead of a number).
+_MAX_ABS_VALUE = 1e18
+
+
+# ----------------------------------------------------------------------
+# Conversion factor tables
+# ----------------------------------------------------------------------
+# Each table maps a canonical lower-cased unit symbol to its multiplicative
+# factor relative to the category's base unit. To convert value V from unit A
+# to unit B: result = V * table[A] / table[B].
+_LENGTH_FACTORS: Dict[str, float] = {
+    "mm": 0.001,
+    "cm": 0.01,
+    "m": 1.0,
+    "km": 1000.0,
+    "in": 0.0254,
+    "ft": 0.3048,
+    "yd": 0.9144,
+    "mile": 1609.344,
+    "mi": 1609.344,  # alias for mile
+}
+
+_WEIGHT_FACTORS: Dict[str, float] = {
+    "mg": 1e-6,
+    "g": 0.001,
+    "kg": 1.0,
+    "t": 1000.0,  # metric tonne
+    "oz": 0.028349523125,
+    "lb": 0.45359237,
+}
+
+# Data sizes use binary multiples (1024). The base unit is the byte.
+_DATA_FACTORS: Dict[str, float] = {
+    "b": 1.0,
+    "kb": 1024.0,
+    "mb": 1024.0 ** 2,
+    "gb": 1024.0 ** 3,
+    "tb": 1024.0 ** 4,
+    "pb": 1024.0 ** 5,
+}
+
+_TIME_FACTORS: Dict[str, float] = {
+    "ms": 0.001,
+    "s": 1.0,
+    "min": 60.0,
+    "h": 3600.0,
+    "day": 86400.0,
+    "week": 604800.0,
+}
+
+# Temperature has no single base-unit factor table. It is handled by a pair
+# of to/from-Celsius functions because of the non-zero offsets.
+_SUPPORTED_TEMPERATURE_UNITS = ("c", "f", "k")
+
+# Map category -> factor table. Temperature is deliberately absent.
+_FACTOR_TABLES: Dict[str, Dict[str, float]] = {
+    "length": _LENGTH_FACTORS,
+    "weight": _WEIGHT_FACTORS,
+    "data": _DATA_FACTORS,
+    "time": _TIME_FACTORS,
+}
+
+
+# ----------------------------------------------------------------------
+# Temperature conversion helpers
+# ----------------------------------------------------------------------
+def _to_celsius(value: float, unit: str) -> float:
+    """Convert ``value`` in ``unit`` to degrees Celsius."""
+    if unit == "c":
+        return value
+    if unit == "f":
+        return (value - 32.0) * 5.0 / 9.0
+    if unit == "k":
+        return value - 273.15
+    raise ValueError(f"Unknown temperature unit: {unit!r}")
+
+
+def _from_celsius(celsius: float, unit: str) -> float:
+    """Convert ``celsius`` to ``unit``."""
+    if unit == "c":
+        return celsius
+    if unit == "f":
+        return celsius * 9.0 / 5.0 + 32.0
+    if unit == "k":
+        return celsius + 273.15
+    raise ValueError(f"Unknown temperature unit: {unit!r}")
+
+
+def _convert_temperature(value: float, from_unit: str, to_unit: str) -> float:
+    """Convert a temperature value between any two supported units."""
+    celsius = _to_celsius(value, from_unit)
+    return _from_celsius(celsius, to_unit)
+
+
+class UnitConverterTool(Tool):
+    """Convert numeric values between units within a physical category.
+
+    Attributes:
+        precision: Number of decimal places to round the result to. Set to
+            ``None`` or a non-positive integer to disable rounding. Default 6.
+        max_abs_value: Largest absolute input magnitude accepted. Inputs
+            whose absolute value exceeds this are rejected with a
+            ``validation_error``. Default 1e18.
+    """
+
+    name: str = "unit_converter_tool"
+    description: Optional[str] = (
+        "Convert values across unit categories (length, weight, "
+        "temperature, data size, time). Pure Python, no dependencies."
+    )
+    input_keys: Optional[List[str]] = ["category", "value", "from_unit", "to_unit"]
+
+    precision: Optional[int] = 6
+    max_abs_value: float = _MAX_ABS_VALUE
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    def execute(
+        self,
+        category: str,
+        value: Any,
+        from_unit: str,
+        to_unit: str,
+        **_: Any,
+    ) -> dict:
+        """Convert ``value`` from ``from_unit`` to ``to_unit`` in ``category``.
+
+        Returns a structured dict. On success it carries ``result`` (the
+        converted number) and ``expression`` (a readable string). On error it
+        carries ``error_type`` and ``error``.
+        """
+        try:
+            self._validate_config()
+            cat = self._normalize_category(category)
+            numeric_value = self._coerce_value(value)
+            src = self._normalize_unit(from_unit)
+            dst = self._normalize_unit(to_unit)
+            if cat == "temperature":
+                result = self._convert_temperature(cat, numeric_value, src, dst)
+            else:
+                result = self._convert_linear(cat, numeric_value, src, dst)
+            result = self._round(result)
+            return {
+                "status": "success",
+                "category": cat,
+                "value": numeric_value,
+                "from_unit": src,
+                "to_unit": dst,
+                "result": result,
+                "expression": f"{numeric_value} {src} = {result} {dst}",
+            }
+        except (TypeError, ValueError) as exc:
+            return self._error("validation_error", str(exc), category)
+        except Exception as exc:  # pragma: no cover - defensive catch-all
+            return self._error("operation_error", f"Conversion failed: {exc}", category)
+
+    # ------------------------------------------------------------------
+    # Category / unit normalization
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_category(category: Any) -> str:
+        if not isinstance(category, str):
+            raise TypeError("category must be a string")
+        cat = category.strip().lower()
+        supported = set(_FACTOR_TABLES) | {"temperature"}
+        if cat not in supported:
+            raise ValueError(
+                f"Unsupported category {category!r}. Supported: "
+                + ", ".join(sorted(supported))
+            )
+        return cat
+
+    @staticmethod
+    def _normalize_unit(unit: Any) -> str:
+        if not isinstance(unit, str):
+            raise TypeError("unit must be a string")
+        return unit.strip().lower()
+
+    def _coerce_value(self, value: Any) -> float:
+        """Coerce ``value`` to a finite float, rejecting bad inputs."""
+        if isinstance(value, bool):
+            # bool is a subclass of int but is almost certainly a mistake here.
+            raise TypeError("value must be a number, not a boolean")
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError("value must not be an empty string")
+            try:
+                numeric = float(stripped)
+            except ValueError as exc:
+                raise ValueError(f"value {value!r} is not a valid number") from exc
+        elif isinstance(value, (int, float)):
+            numeric = float(value)
+        else:
+            raise TypeError("value must be a number or numeric string")
+        if numeric != numeric:  # NaN check
+            raise ValueError("value must not be NaN")
+        if numeric in (float("inf"), float("-inf")):
+            raise ValueError("value must be finite")
+        if abs(numeric) > self.max_abs_value:
+            raise ValueError(
+                f"|value| ({abs(numeric)}) exceeds max_abs_value "
+                f"({self.max_abs_value})"
+            )
+        return numeric
+
+    def _validate_config(self) -> None:
+        if self.precision is not None:
+            if isinstance(self.precision, bool) or not isinstance(self.precision, int):
+                raise ValueError("precision must be an integer or None")
+            if self.precision < 0:
+                raise ValueError("precision must be non-negative")
+        if isinstance(self.max_abs_value, bool) or not isinstance(self.max_abs_value, (int, float)):
+            raise ValueError("max_abs_value must be a number")
+        if self.max_abs_value <= 0:
+            raise ValueError("max_abs_value must be positive")
+
+    # ------------------------------------------------------------------
+    # Conversion logic
+    # ------------------------------------------------------------------
+    def _convert_linear(
+        self,
+        category: str,
+        value: float,
+        from_unit: str,
+        to_unit: str,
+    ) -> float:
+        """Convert using the category's multiplicative factor table."""
+        table = _FACTOR_TABLES[category]
+        if from_unit not in table:
+            raise ValueError(
+                f"Unknown unit {from_unit!r} for category {category!r}. "
+                f"Supported: {', '.join(sorted(table))}"
+            )
+        if to_unit not in table:
+            raise ValueError(
+                f"Unknown unit {to_unit!r} for category {category!r}. "
+                f"Supported: {', '.join(sorted(table))}"
+            )
+        if from_unit == to_unit:
+            return value
+        # value -> base unit -> target unit
+        base = value * table[from_unit]
+        return base / table[to_unit]
+
+    def _convert_temperature(
+        self,
+        category: str,
+        value: float,
+        from_unit: str,
+        to_unit: str,
+    ) -> float:
+        """Convert a temperature value between c / f / k."""
+        if from_unit not in _SUPPORTED_TEMPERATURE_UNITS:
+            raise ValueError(
+                f"Unknown unit {from_unit!r} for category 'temperature'. "
+                f"Supported: {', '.join(_SUPPORTED_TEMPERATURE_UNITS)}"
+            )
+        if to_unit not in _SUPPORTED_TEMPERATURE_UNITS:
+            raise ValueError(
+                f"Unknown unit {to_unit!r} for category 'temperature'. "
+                f"Supported: {', '.join(_SUPPORTED_TEMPERATURE_UNITS)}"
+            )
+        if from_unit == to_unit:
+            return value
+        return _convert_temperature(value, from_unit, to_unit)
+
+    def _round(self, value: float) -> float:
+        """Round the result according to ``precision`` and tidy -0.0 to 0.0."""
+        if self.precision is not None and self.precision > 0:
+            rounded = round(value, self.precision)
+        else:
+            rounded = value
+        # Avoid "-0.0" in output for cosmetic reasons.
+        if rounded == 0:
+            return 0.0
+        return rounded
+
+    # ------------------------------------------------------------------
+    # Error helper
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _error(kind: str, message: str, category: Optional[str]) -> dict:
+        result: dict = {"status": "error", "error_type": kind, "error": message}
+        if category is not None:
+            result["category"] = category
+        return result
+
+
+# ----------------------------------------------------------------------
+# Public helper: list supported units per category (useful for tool schemas)
+# ----------------------------------------------------------------------
+def supported_categories() -> List[str]:
+    """Return the list of supported category names."""
+    return sorted(set(_FACTOR_TABLES) | {"temperature"})
+
+
+def supported_units(category: str) -> List[str]:
+    """Return the list of supported unit symbols for ``category``."""
+    cat = category.strip().lower()
+    if cat == "temperature":
+        return list(_SUPPORTED_TEMPERATURE_UNITS)
+    if cat in _FACTOR_TABLES:
+        return sorted(_FACTOR_TABLES[cat])
+    raise ValueError(f"Unknown category: {category!r}")

--- a/agentuniverse/agent/action/tool/common_tool/unit_converter_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/unit_converter_tool.yaml.example
@@ -1,0 +1,41 @@
+name: unit_converter_tool
+description: >-
+  Convert values across unit categories (length, weight, temperature, data
+  size, time). Pure Python, no third-party dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.unit_converter_tool
+  class: UnitConverterTool
+input_keys:
+  - category
+  - value
+  - from_unit
+  - to_unit
+precision: 6
+max_abs_value: 1000000000000000000
+args_model:
+  category: {type: string, required: true}
+  value: {type: number, required: true}
+  from_unit: {type: string, required: true}
+  to_unit: {type: string, required: true}
+args_model_schema:
+  type: object
+  properties:
+    category:
+      type: string
+      enum: [length, weight, temperature, data, time]
+      description: Physical category of the units being converted.
+    value:
+      oneOf:
+        - {type: number}
+        - {type: string}
+      description: Numeric value to convert (number or numeric string).
+    from_unit:
+      type: string
+      description: Source unit symbol (case-insensitive, e.g. km, lb, c).
+    to_unit:
+      type: string
+      description: Target unit symbol (case-insensitive, e.g. mile, kg, f).
+  required: [category, value, from_unit, to_unit]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -330,4 +330,47 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 
 ## 4. PDF Tool
 
-The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentuniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## UnitConverterTool
+
+`UnitConverterTool` converts numeric values between units within a physical category. It has no third-party dependencies and covers the common quantities an agent is likely to need.
+
+```python
+from agentuniverse.agent.action.tool.common_tool.unit_converter_tool import UnitConverterTool
+
+tool = UnitConverterTool()  # precision=6
+tool.execute(category="length", value=10, from_unit="km", to_unit="mile")      # 6.213727
+tool.execute(category="weight", value=1, from_unit="kg", to_unit="lb")         # 2.204624
+tool.execute(category="temperature", value=100, from_unit="c", to_unit="f")    # 212.0
+tool.execute(category="data", value=2048, from_unit="kb", to_unit="mb")        # 2.0
+tool.execute(category="time", value=2, from_unit="h", to_unit="min")           # 120.0
+```
+
+Supported categories and units (case-insensitive):
+
+| Category        | Units (canonical base in **bold**)                                       |
+|-----------------|--------------------------------------------------------------------------|
+| `length`        | mm, cm, **m**, km, in, ft, yd, mile (alias `mi`)                         |
+| `weight`        | mg, g, **kg**, t (metric tonne), oz, lb                                  |
+| `temperature`   | c (Celsius), f (Fahrenheit), k (Kelvin) — non-linear offset conversions  |
+| `data`          | **b**, kb, mb, gb, tb, pb (binary multiples of 1024)                     |
+| `time`          | ms, **s**, min, h, day, week                                             |
+
+Each linear category uses a multiplicative factor table relative to its base unit; temperature is converted through dedicated Celsius offset formulas. The `value` argument accepts a number or a numeric string, results are rounded to `precision` decimals (default 6), and every result is a structured dict with a `status` field and a human-readable `expression`. Unknown categories, unknown units, and non-numeric values are returned as `validation_error` payloads rather than raised exceptions.
+
+## UnitConverterTool / 单位换算工具
+
+`UnitConverterTool`（单位换算工具）用于在同一物理量类别下进行单位换算，无第三方依赖，覆盖代理常见的物理量。
+
+支持类别与单位（大小写不敏感）：
+
+| 类别            | 单位（粗体为基准单位）                                                  |
+|-----------------|------------------------------------------------------------------------|
+| `length` 长度   | mm, cm, **m**, km, in, ft, yd, mile（别名 `mi`）                       |
+| `weight` 重量   | mg, g, **kg**, t（公吨）, oz, lb                                       |
+| `temperature`   | c（摄氏）、f（华氏）、k（开尔文）——非线性偏移换算                       |
+| `data` 数据     | **b**, kb, mb, gb, tb, pb（以 1024 为底的二进制倍数）                   |
+| `time` 时间     | ms, **s**, min, h, day, week                                           |
+
+线性类别使用相对于基准单位的乘法因子表进行换算；温度则通过专门的摄氏度偏移公式换算。`value` 参数支持数字或数字字符串，结果按 `precision`（默认 6）位小数四舍五入，所有返回均为包含 `status` 字段的结构化字典，并附带可读的 `expression`。未知的类别、单位或非数字值会以 `validation_error` 形式返回而非抛出异常。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_unit_converter_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_unit_converter_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for UnitConverterTool."""
+
+import math
+import os
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool import unit_converter_tool as module
+from agentuniverse.agent.action.tool.common_tool.unit_converter_tool import (
+    UnitConverterTool,
+    supported_categories,
+    supported_units,
+)
+
+YAML_PATH = os.path.join(os.path.dirname(module.__file__), "unit_converter_tool.yaml.example")
+
+
+class UnitConverterToolTest(unittest.TestCase):
+    def setUp(self):
+        self.tool = UnitConverterTool()
+
+    # --- length ---------------------------------------------------------
+    def test_km_to_mile(self):
+        result = self.tool.execute(category="length", value=10, from_unit="km", to_unit="mile")
+        self.assertEqual(result["status"], "success")
+        self.assertAlmostEqual(result["result"], 6.21371, places=4)
+
+    def test_length_round_trip(self):
+        result = self.tool.execute(category="length", value=1, from_unit="mile", to_unit="m")
+        self.assertAlmostEqual(result["result"], 1609.344, places=3)
+        back = self.tool.execute(category="length", value=result["result"], from_unit="m", to_unit="mile")
+        self.assertAlmostEqual(back["result"], 1.0, places=3)
+
+    def test_length_alias_mi_equals_mile(self):
+        r1 = self.tool.execute(category="length", value=5, from_unit="mi", to_unit="m")
+        r2 = self.tool.execute(category="length", value=5, from_unit="mile", to_unit="m")
+        self.assertEqual(r1["result"], r2["result"])
+
+    # --- weight ---------------------------------------------------------
+    def test_kg_to_lb(self):
+        result = self.tool.execute(category="weight", value=1, from_unit="kg", to_unit="lb")
+        self.assertAlmostEqual(result["result"], 2.20462, places=3)
+
+    def test_weight_oz_to_g(self):
+        result = self.tool.execute(category="weight", value=1, from_unit="oz", to_unit="g")
+        self.assertAlmostEqual(result["result"], 28.3495, places=2)
+
+    # --- temperature (non-linear) --------------------------------------
+    def test_celsius_to_fahrenheit(self):
+        result = self.tool.execute(category="temperature", value=0, from_unit="c", to_unit="f")
+        self.assertAlmostEqual(result["result"], 32.0, places=6)
+        boil = self.tool.execute(category="temperature", value=100, from_unit="c", to_unit="f")
+        self.assertAlmostEqual(boil["result"], 212.0, places=6)
+
+    def test_fahrenheit_to_celsius(self):
+        result = self.tool.execute(category="temperature", value=98.6, from_unit="f", to_unit="c")
+        self.assertAlmostEqual(result["result"], 37.0, places=4)
+
+    def test_kelvin_round_trip(self):
+        # 0 C = 273.15 K
+        k = self.tool.execute(category="temperature", value=0, from_unit="c", to_unit="k")
+        self.assertAlmostEqual(k["result"], 273.15, places=4)
+        back = self.tool.execute(category="temperature", value=k["result"], from_unit="k", to_unit="c")
+        self.assertAlmostEqual(back["result"], 0.0, places=4)
+
+    def test_negative_zero_temperature(self):
+        # -40 is the same in C and F; ensure -0.0 is tidied to 0.0.
+        result = self.tool.execute(category="temperature", value=-40, from_unit="c", to_unit="f")
+        self.assertAlmostEqual(result["result"], -40.0, places=6)
+        zero = self.tool.execute(category="temperature", value=32, from_unit="f", to_unit="c")
+        self.assertEqual(zero["result"], 0.0)
+        self.assertEqual(math.copysign(1.0, zero["result"]), 1.0)
+
+    # --- data -----------------------------------------------------------
+    def test_data_kb_to_mb(self):
+        result = self.tool.execute(category="data", value=2048, from_unit="kb", to_unit="mb")
+        self.assertAlmostEqual(result["result"], 2.0, places=6)
+
+    def test_data_gb_to_bytes(self):
+        result = self.tool.execute(category="data", value=1, from_unit="gb", to_unit="b")
+        self.assertEqual(result["result"], 1073741824.0)
+
+    # --- time -----------------------------------------------------------
+    def test_time_hours_to_seconds(self):
+        result = self.tool.execute(category="time", value=1, from_unit="h", to_unit="s")
+        self.assertEqual(result["result"], 3600.0)
+
+    def test_time_days_to_minutes(self):
+        result = self.tool.execute(category="time", value=1, from_unit="day", to_unit="min")
+        self.assertAlmostEqual(result["result"], 1440.0, places=6)
+
+    # --- input flexibility ---------------------------------------------
+    def test_value_as_numeric_string(self):
+        result = self.tool.execute(category="length", value="  42 ", from_unit="m", to_unit="cm")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["result"], 4200.0)
+
+    def test_same_unit_returns_value(self):
+        result = self.tool.execute(category="weight", value=5, from_unit="kg", to_unit="kg")
+        self.assertEqual(result["result"], 5.0)
+
+    def test_case_insensitive_units(self):
+        result = self.tool.execute(category="length", value=1, from_unit="KM", to_unit="M")
+        self.assertEqual(result["result"], 1000.0)
+
+    # --- errors ---------------------------------------------------------
+    def test_unknown_unit(self):
+        result = self.tool.execute(category="length", value=1, from_unit="smoot", to_unit="m")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("Unknown unit", result["error"])
+
+    def test_unknown_category(self):
+        result = self.tool.execute(category="currency", value=1, from_unit="usd", to_unit="eur")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Unsupported category", result["error"])
+
+    def test_non_numeric_value(self):
+        result = self.tool.execute(category="length", value="abc", from_unit="m", to_unit="cm")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("not a valid number", result["error"])
+
+    def test_boolean_value_rejected(self):
+        result = self.tool.execute(category="length", value=True, from_unit="m", to_unit="cm")
+        self.assertEqual(result["status"], "error")
+
+    def test_expression_field_readable(self):
+        result = self.tool.execute(category="time", value=2, from_unit="h", to_unit="min")
+        self.assertEqual(result["expression"], "2.0 h = 120.0 min")
+
+
+class UnitConverterHelpersTest(unittest.TestCase):
+    def test_supported_categories(self):
+        cats = supported_categories()
+        for expected in ("length", "weight", "temperature", "data", "time"):
+            self.assertIn(expected, cats)
+
+    def test_supported_units_length(self):
+        units = supported_units("length")
+        for expected in ("m", "km", "mile", "ft", "in", "cm"):
+            self.assertIn(expected, units)
+
+    def test_supported_units_temperature(self):
+        self.assertEqual(set(supported_units("temperature")), {"c", "f", "k"})
+
+    def test_supported_units_unknown_category(self):
+        with self.assertRaises(ValueError):
+            supported_units("nope")
+
+
+class UnitConverterYamlTest(unittest.TestCase):
+    def test_yaml_example_exists(self):
+        self.assertTrue(os.path.isfile(YAML_PATH))
+
+    def test_yaml_example_has_required_fields(self):
+        import yaml
+
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "unit_converter_tool")
+        self.assertEqual(data["metadata"]["class"], "UnitConverterTool")
+        self.assertEqual(data["precision"], 6)
+        self.assertIn("category", data["input_keys"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `UnitConverterTool`, a dependency-free unit conversion tool for agent workflows. Closes #252.

## What's included

- `agentuniverse/agent/action/tool/common_tool/unit_converter_tool.py` — the tool (349 lines)
- `agentuniverse/agent/action/tool/common_tool/unit_converter_tool.yaml.example` — config example
- `tests/test_agentuniverse/unit/agent/action/tool/test_unit_converter_tool.py` — 27 unit tests
- Docs appended to `docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md`

## Supported categories

| Category        | Units                                                                    |
|-----------------|--------------------------------------------------------------------------|
| `length`        | mm, cm, m, km, in, ft, yd, mile (alias `mi`)                             |
| `weight`        | mg, g, kg, t (metric tonne), oz, lb                                      |
| `temperature`   | c (Celsius), f (Fahrenheit), k (Kelvin) — non-linear offset conversions  |
| `data`          | b, kb, mb, gb, tb, pb (binary multiples of 1024)                         |
| `time`          | ms, s, min, h, day, week                                                 |

## Usage

```python
from agentuniverse.agent.action.tool.common_tool.unit_converter_tool import UnitConverterTool

tool = UnitConverterTool()  # precision=6
tool.execute(category="length", value=10, from_unit="km", to_unit="mile")   # 6.213727
tool.execute(category="temperature", value=100, from_unit="c", to_unit="f") # 212.0
```

Each linear category uses a multiplicative factor table relative to its base unit; temperature is converted through dedicated Celsius offset formulas (handled separately because it is not a simple multiplicative scale). The `value` argument accepts a number or a numeric string, results are rounded to `precision` decimals (default 6), and every result is a structured dict with a `status` field and a human-readable `expression`. Unknown categories/units and non-numeric values are returned as `validation_error` payloads rather than raised.

## Test plan

```
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_unit_converter_tool
```

All 27 tests pass, covering all five categories (including temperature round-trips and the non-linear C/F/K offsets), round-trip conversions, unit aliases (`mi`/`mile`), case insensitivity, numeric-string values, same-unit identity, `-0.0` tidying, error handling (unknown unit/category, non-numeric/boolean values), the `expression` field, helper functions, and YAML example structure.
