### PR TITLE
feat: add ContentTypeFilter (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.py
@@ -1,0 +1,191 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: content_type_filter.py
+
+"""
+Content-type filter — a knowledge post-processing DocProcessor.
+
+Filters recalled documents by the ``content_type`` field stored in their
+metadata. This is useful for multi-modal or mixed-format knowledge bases
+where an agent should only receive documents of a particular kind (for
+example, only ``text`` chunks, only ``code``, or only ``table`` rows).
+
+The filter is intentionally simple and dependency-free:
+
+- Documents whose ``content_type`` is **in** ``allowed_types`` are kept.
+- Documents whose ``content_type`` is present but **not** in
+  ``allowed_types`` are dropped.
+- Documents that have **no** ``content_type`` (or whose metadata is
+  missing / the configured key is absent) follow ``default_policy``:
+  ``"keep"`` retains them, ``"drop"`` removes them. Default is ``"keep"``
+  (conservative — prefer false-keep over false-drop).
+
+This mirrors the structure of ``LanguageFilter``: it subclasses
+``DocProcessor``, reads its configuration from the component configer, and
+exposes a pure-Python ``_process_docs`` implementation.
+
+Addresses #248 (knowledge post-processing components).
+"""
+
+import logging
+from typing import Any, List, Optional, Set
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_VALID_POLICIES = ("keep", "drop")
+_DEFAULT_TYPE_KEY = "content_type"
+_DEFAULT_POLICY = "keep"
+
+
+class ContentTypeFilter(DocProcessor):
+    """Filter documents by their ``content_type`` metadata field.
+
+    Attributes:
+        allowed_types: Set of content-type strings to keep. Documents whose
+            content type is in this set are retained. Default empty — when
+            empty, the filter keeps everything (a no-op), which makes it
+            safe to enable before configuring.
+        type_key: Metadata key that holds the content type. Defaults to
+            ``"content_type"``.
+        default_policy: Policy for documents that have no content type.
+            ``"keep"`` (default) retains them; ``"drop"`` removes them.
+        case_sensitive: If True, content-type matching is case sensitive.
+            Default False — content types like ``Text`` and ``text`` are
+            treated as equal.
+    """
+
+    allowed_types: Set[str] = set()
+    type_key: str = _DEFAULT_TYPE_KEY
+    default_policy: str = _DEFAULT_POLICY
+    case_sensitive: bool = False
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    # ------------------------------------------------------------------
+    # Public DocProcessor entry point
+    # ------------------------------------------------------------------
+    def process_docs(self, origin_docs: List[Document],
+                     query: Query = None) -> List[Document]:
+        """Filter documents by content type, returning the kept subset."""
+        self._validate_config()
+        if not origin_docs:
+            return []
+        # An empty allow-list is a no-op (keep everything) so that enabling
+        # the filter before populating allowed_types is safe.
+        if not self.allowed_types:
+            return list(origin_docs)
+
+        normalized_allow = self._normalize_set(self.allowed_types)
+        kept: List[Document] = []
+        dropped = 0
+        for doc in origin_docs:
+            if self._should_keep(doc, normalized_allow):
+                kept.append(doc)
+            else:
+                dropped += 1
+
+        if dropped > 0:
+            logger.debug(
+                "ContentTypeFilter: dropped %d/%d documents "
+                "(allowed: %s, policy for missing: %s)",
+                dropped, len(origin_docs), normalized_allow, self.default_policy,
+            )
+        return kept
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Implement the abstract DocProcessor method (delegates to process_docs)."""
+        return self.process_docs(origin_docs, query)
+
+    # ------------------------------------------------------------------
+    # Decision logic
+    # ------------------------------------------------------------------
+    def _should_keep(self, doc: Document, normalized_allow: Set[str]) -> bool:
+        """Return True if ``doc`` should be kept given the allow-list."""
+        content_type = self._extract_content_type(doc)
+        if content_type is None:
+            # Missing content type -> apply default policy.
+            return self.default_policy == "keep"
+        value = content_type if self.case_sensitive else content_type.lower()
+        return value in normalized_allow
+
+    def _extract_content_type(self, doc: Document) -> Optional[str]:
+        """Read the content type from the document's metadata.
+
+        Returns the raw string value, or None when the field is absent or
+        not a string. Leading/trailing whitespace is stripped.
+        """
+        metadata = getattr(doc, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        if self.type_key not in metadata:
+            return None
+        value = metadata[self.type_key]
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        # Non-string scalars (int/float) are coerced to string so that a
+        # numeric content-type id still works; everything else is ignored.
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+        return None
+
+    # ------------------------------------------------------------------
+    # Validation / normalization helpers
+    # ------------------------------------------------------------------
+    def _validate_config(self) -> None:
+        if not isinstance(self.type_key, str) or not self.type_key.strip():
+            raise ValueError("type_key must be a non-empty string")
+        if self.default_policy not in _VALID_POLICIES:
+            raise ValueError(
+                f"default_policy must be one of {_VALID_POLICIES}, "
+                f"got {self.default_policy!r}"
+            )
+        if not isinstance(self.case_sensitive, bool):
+            raise ValueError("case_sensitive must be a boolean")
+
+    def _normalize_set(self, values: Any) -> Set[str]:
+        """Normalize the allowed set to comparable strings."""
+        result: Set[str] = set()
+        for value in values:
+            if isinstance(value, str):
+                normalized = value.strip()
+                if not normalized:
+                    continue
+                result.add(normalized if self.case_sensitive else normalized.lower())
+        return result
+
+    # ------------------------------------------------------------------
+    # Component configuration
+    # ------------------------------------------------------------------
+    def _initialize_by_component_configer(
+        self, doc_processor_configer: ComponentConfiger
+    ) -> "ContentTypeFilter":
+        """Initialize the filter from a component configer (YAML)."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+        allowed = getattr(doc_processor_configer, "allowed_types", None)
+        if allowed is not None:
+            self.allowed_types = set(allowed)
+        type_key = getattr(doc_processor_configer, "type_key", None)
+        if type_key is not None:
+            self.type_key = type_key
+        policy = getattr(doc_processor_configer, "default_policy", None)
+        if policy is not None:
+            self.default_policy = policy
+        case_sensitive = getattr(doc_processor_configer, "case_sensitive", None)
+        if case_sensitive is not None:
+            self.case_sensitive = case_sensitive
+        self._validate_config()
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.yaml
@@ -1,0 +1,16 @@
+name: 'content_type_filter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.content_type_filter'
+  class: 'ContentTypeFilter'
+description: >-
+  Filters documents by the content_type metadata field, keeping only the
+  allowed content types. Documents without a content type follow
+  default_policy (keep or drop).
+allowed_types:
+  - 'text'
+  - 'code'
+  - 'table'
+type_key: 'content_type'
+default_policy: 'keep'
+case_sensitive: false

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,32 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [ContentTypeFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.yaml)
+
+This component filters recalled documents by the `content_type` field stored in their metadata, keeping only those whose content type is in `allowed_types`. It is useful for multi-modal or mixed-format knowledge bases where an agent should only receive documents of a particular kind (for example, only `text` chunks, only `code`, or only `table` rows). It addresses the *content-type filtering* direction of issue #248.
+
+Matching is deterministic and dependency-free. Documents whose content type is in `allowed_types` are kept; documents whose content type is present but not allowed are dropped; documents with no content type (missing metadata, missing key, or blank value) follow `default_policy` — `keep` (default) retains them conservatively while `drop` removes them. An empty `allowed_types` set is a no-op (keeps everything), so the filter is safe to enable before configuring it.
+
+```yaml
+name: 'content_type_filter'
+description: 'keep only documents whose content_type is in allowed_types'
+allowed_types: ['text', 'code', 'table']
+type_key: 'content_type'
+default_policy: 'keep'      # keep | drop — policy for documents without a content_type
+case_sensitive: false       # case-insensitive matching by default
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.content_type_filter'
+  class: 'ContentTypeFilter'
+```
+- allowed_types: Set of content-type strings to keep. Empty keeps everything.
+- type_key: Metadata key holding the content type (default `content_type`).
+- default_policy: Policy for documents without a content type — `keep` (default) or `drop`.
+- case_sensitive: When false (default), content types are matched case-insensitively; numeric content types are coerced to strings and surrounding whitespace is stripped.
+
+## ContentTypeFilter / 内容类型过滤器
+
+`ContentTypeFilter`（内容类型过滤器）按文档元数据中的 `content_type` 字段过滤召回的文档，仅保留其内容类型属于 `allowed_types` 的文档。适用于多模态或混合格式的知识库——例如代理只应接收 `text` 文本块、`code` 代码或 `table` 表格行。对应 issue #248 中“按内容类型过滤”的方向。
+
+匹配过程为确定性、无依赖：内容类型在允许集合中的文档被保留；内容类型存在但不在允许集合中的文档被丢弃；没有内容类型（缺少元数据、缺少该键或值为空白）的文档按 `default_policy` 处理——`keep`（默认，保守保留）或 `drop`（丢弃）。当 `allowed_types` 为空时，过滤器为空操作（保留全部），因此可以在配置前安全启用。匹配默认大小写不敏感，数字类型会被强制转为字符串，首尾空白会被去除。

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,27 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [ContentTypeFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.yaml)
+
+该组件按文档元数据中的 `content_type` 字段过滤召回的文档，仅保留内容类型属于 `allowed_types` 的文档。适用于多模态或混合格式的知识库——例如代理只应接收 `text` 文本块、`code` 代码或 `table` 表格行。对应 issue #248 中“按内容类型过滤”的方向。
+
+匹配过程为确定性、无第三方依赖：内容类型在允许集合中的文档被保留；内容类型存在但不在允许集合中的文档被丢弃；没有内容类型（缺少元数据、缺少该键或值为空白）的文档按 `default_policy` 处理——`keep`（默认，保守保留）或 `drop`（丢弃）。当 `allowed_types` 为空时，过滤器为空操作（保留全部），因此可在配置前安全启用。
+
+组件定义文件如下：
+```yaml
+name: 'content_type_filter'
+description: '仅保留 content_type 属于 allowed_types 的文档'
+allowed_types: ['text', 'code', 'table']
+type_key: 'content_type'
+default_policy: 'keep'      # keep | drop —— 对没有 content_type 的文档的策略
+case_sensitive: false       # 默认大小写不敏感
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.content_type_filter'
+  class: 'ContentTypeFilter'
+```
+- allowed_types：要保留的内容类型字符串集合。为空时保留全部。
+- type_key：存放内容类型的元数据键（默认 `content_type`）。
+- default_policy：对没有内容类型的文档的策略——`keep`（默认）或 `drop`。
+- case_sensitive：为假时（默认）大小写不敏感匹配；数字类型会被强制转为字符串，首尾空白会被去除。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_content_type_filter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_content_type_filter.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for ContentTypeFilter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.content_type_filter \
+    import ContentTypeFilter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+def _doc(text, content_type=None, key="content_type"):
+    metadata = {} if content_type is None else {key: content_type}
+    return Document(text=text, metadata=metadata)
+
+
+class ContentTypeFilterTest(unittest.TestCase):
+    def _filter(self, docs, allowed, **kwargs):
+        proc = ContentTypeFilter(allowed_types=set(allowed), **kwargs)
+        return proc.process_docs(docs, None)
+
+    def test_keeps_allowed_type(self):
+        docs = [_doc("hello", "text")]
+        result = self._filter(docs, {"text"})
+        self.assertEqual(len(result), 1)
+
+    def test_drops_disallowed_type(self):
+        docs = [_doc("hello", "text"), _doc("x=1", "code")]
+        result = self._filter(docs, {"text"})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].metadata["content_type"], "text")
+
+    def test_multiple_allowed_types(self):
+        docs = [
+            _doc("hello", "text"),
+            _doc("x=1", "code"),
+            _doc("| a | b |", "table"),
+        ]
+        result = self._filter(docs, {"text", "code"})
+        self.assertEqual(len(result), 2)
+
+    def test_missing_type_kept_by_default(self):
+        docs = [_doc("no metadata here")]
+        result = self._filter(docs, {"text"})
+        self.assertEqual(len(result), 1)
+
+    def test_missing_type_dropped_when_policy_drop(self):
+        docs = [_doc("no metadata here")]
+        result = self._filter(docs, {"text"}, default_policy="drop")
+        self.assertEqual(len(result), 0)
+
+    def test_empty_allowed_keeps_all(self):
+        docs = [_doc("a", "text"), _doc("b", "code"), _doc("c", "table")]
+        result = self._filter(docs, set())
+        self.assertEqual(len(result), 3)
+
+    def test_empty_input(self):
+        proc = ContentTypeFilter(allowed_types={"text"})
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_case_insensitive_by_default(self):
+        docs = [_doc("Hello", "TEXT"), _doc("Bye", "text")]
+        result = self._filter(docs, {"text"})
+        self.assertEqual(len(result), 2)
+
+    def test_case_sensitive_mode(self):
+        docs = [_doc("Hello", "TEXT"), _doc("Bye", "text")]
+        result = self._filter(docs, {"TEXT"}, case_sensitive=True)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].metadata["content_type"], "TEXT")
+
+    def test_custom_type_key(self):
+        docs = [_doc("hello", "text", key="kind")]
+        result = self._filter(docs, {"text"}, type_key="kind")
+        self.assertEqual(len(result), 1)
+
+    def test_whitespace_in_type_is_stripped(self):
+        docs = [_doc("hello", "  text  ")]
+        result = self._filter(docs, {"text"})
+        self.assertEqual(len(result), 1)
+
+    def test_numeric_content_type_coerced(self):
+        docs = [_doc("hello", 1)]
+        result = self._filter(docs, {"1"})
+        self.assertEqual(len(result), 1)
+
+    def test_invalid_default_policy_raises(self):
+        proc = ContentTypeFilter(allowed_types={"text"}, default_policy="maybe")
+        with self.assertRaises(ValueError):
+            proc.process_docs([_doc("hi", "text")], None)
+
+    def test_blank_type_treated_as_missing(self):
+        # A whitespace-only content type is treated as missing.
+        docs = [_doc("hello", "   ")]
+        kept = self._filter(docs, {"text"})
+        self.assertEqual(len(kept), 1)  # default policy keep
+        dropped = self._filter(docs, {"text"}, default_policy="drop")
+        self.assertEqual(len(dropped), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `ContentTypeFilter`, a knowledge post-processing DocProcessor that filters recalled documents by their `content_type` metadata field. Closes #248.

## What's included

- `agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.py` — the processor (191 lines)
- `agentuniverse/agent/action/knowledge/doc_processor/content_type_filter.yaml` — config
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_content_type_filter.py` — 14 unit tests
- Docs appended to:
  - `docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md`
  - `docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md`

## Behavior

`ContentTypeFilter` follows the structure of `LanguageFilter`: it subclasses `DocProcessor`, reads its configuration from the component configer, and exposes a dependency-free `_process_docs` implementation.

- Documents whose `content_type` is **in** `allowed_types` are kept.
- Documents whose `content_type` is present but **not** allowed are dropped.
- Documents with **no** `content_type` (missing metadata, missing key, or blank value) follow `default_policy`: `"keep"` (default, conservative) or `"drop"`.
- An empty `allowed_types` set is a no-op (keeps everything), so the filter is safe to enable before configuration.

## Fields

- `allowed_types` (default `set()`) — content-type strings to keep.
- `type_key` (default `"content_type"`) — metadata key holding the content type.
- `default_policy` (default `"keep"`) — `keep` or `drop` for documents without a content type.
- `case_sensitive` (default `False`) — case-insensitive matching by default; numeric content types are coerced to strings and whitespace is stripped.

## Test plan

```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_content_type_filter
```

All 14 tests pass, covering: keep allowed, drop disallowed, multiple allowed, missing-type kept by default, missing-type dropped with `drop` policy, empty-allow no-op, empty input, case-insensitive matching, case-sensitive mode, custom `type_key`, whitespace stripping, numeric coercion, invalid-policy validation, and blank-type-treated-as-missing.
