### PR TITLE
feat: add ImageResizerTool (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/image_resizer_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/image_resizer_tool.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: image_resizer_tool.py
+
+"""
+Image Resizer Tool — resize, scale, crop, convert, and inspect images.
+
+A bounded image-manipulation utility for agent workflows. It wraps Pillow
+(the ``PIL`` package) with strict path confinement, size budgets, format
+allow-listing, and structured error reporting. Pillow is imported lazily so
+that the tool can be imported and configured even when the dependency is not
+installed — the ``ImportError`` is surfaced as a structured ``dependency_error``
+only when an operation actually needs it.
+
+Operations (``mode``):
+
+- **resize** — produce an image of exactly ``width`` x ``height`` pixels.
+  The default resampling filter is Lanczos (high quality).
+- **scale** — multiply the existing dimensions by ``factor`` (e.g. 0.5 to
+  halve each axis, 2.0 to double). The factor must be strictly positive.
+- **crop** — extract a rectangular region defined by ``box`` (left, top,
+  right, bottom). The box must lie within the source dimensions.
+- **convert** — re-encode the image in another format (jpg/png/webp) with
+  an optional quality setting for lossy formats.
+- **info** — report the image's format, dimensions, and byte size without
+  writing anything.
+
+All file paths are confined to ``base_dir`` via ``resolve_safe_path``, so
+traversal attempts (``../``) and absolute paths outside the base are
+rejected. Input and output byte sizes are bounded by ``max_input_bytes``
+and ``max_output_bytes``; output formats are restricted to
+``allowed_formats``. Writes are atomic: the encoded image is written to a
+same-directory temporary file and size-checked before replacing the target,
+so a failed write never corrupts an existing file.
+
+Addresses #252 (common utility tools).
+"""
+
+import os
+import tempfile
+from typing import Any, Optional, cast
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import \
+    resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+
+# Public execute() converts validation/dependency exceptions into structured
+# tool responses instead of raising.
+# ruff: noqa: TRY003
+
+# Modes exposed by the tool. Kept as a tuple for fast membership testing.
+_SUPPORTED_MODES = ("resize", "scale", "crop", "convert", "info")
+
+# Output formats Pillow can encode that we allow by default. GIF/TIFF/BMP
+# are deliberately omitted to keep the surface small; users may extend
+# allowed_formats in config.
+_DEFAULT_ALLOWED_FORMATS = ("jpg", "jpeg", "png", "webp")
+
+# Map canonical output tokens to (Pillow format name, file extension).
+# JPEG shares the "JPEG" format name across jpg/jpeg extensions.
+_FORMAT_TABLE = {
+    "jpg": ("JPEG", ".jpg"),
+    "jpeg": ("JPEG", ".jpeg"),
+    "png": ("PNG", ".png"),
+    "webp": ("WEBP", ".webp"),
+}
+
+# Sensible defaults. Inputs/outputs are capped to protect the host from
+# runaway payloads.
+_DEFAULT_MAX_INPUT_BYTES = 25 * 1024 * 1024   # 25 MiB
+_DEFAULT_MAX_OUTPUT_BYTES = 25 * 1024 * 1024  # 25 MiB
+_MAX_DIMENSION = 20_000  # Pillow's own ceiling is near here; stay below it.
+_MIN_FACTOR = 0.01
+_MAX_FACTOR = 100.0
+_DEFAULT_QUALITY = 85
+
+
+class ImageResizerTool(Tool):
+    """Resize, scale, crop, convert, and inspect image files with Pillow.
+
+    Attributes:
+        base_dir: Root directory that all paths are confined to.
+        max_input_bytes: Maximum size of an input image file.
+        max_output_bytes: Maximum size of a generated image file.
+        allowed_formats: Output formats the tool is permitted to write
+            (jpg, jpeg, png, webp by default).
+    """
+
+    name: str = "image_resizer_tool"
+    description: Optional[str] = (
+        "Resize, scale, crop, convert, and inspect images using Pillow. "
+        "Paths are confined to base_dir; input/output sizes are bounded."
+    )
+    input_keys: Optional[list] = ["mode", "file_path"]
+
+    base_dir: str = "."
+    max_input_bytes: int = _DEFAULT_MAX_INPUT_BYTES
+    max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES
+    allowed_formats: tuple = _DEFAULT_ALLOWED_FORMATS
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    def execute(
+        self,
+        mode: str,
+        file_path: str,
+        output_path: Optional[str] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        factor: Optional[float] = None,
+        box: Optional[list] = None,
+        target_format: Optional[str] = None,
+        quality: int = _DEFAULT_QUALITY,
+        overwrite: bool = False,
+        **_: Any,
+    ) -> dict:
+        """Run an image operation.
+
+        Returns a structured dict. Successful ``resize``/``scale``/``crop``/
+        ``convert`` results carry ``output_path``, the new ``width`` and
+        ``height``, ``format``, and ``file_size``; ``info`` carries the same
+        metadata without writing a file. Errors carry ``error_type`` and
+        ``error``.
+        """
+        try:
+            self._validate_config()
+            operation = self._normalize_mode(mode)
+            source = self._resolve_input(file_path)
+            self._check_input_size(source)
+            image = self._open(source)
+            if operation == "info":
+                return self._info_result(source, image)
+            if operation == "resize":
+                return self._resize(image, source, output_path, width, height, overwrite, target_format, quality)
+            if operation == "scale":
+                return self._scale(image, source, output_path, factor, overwrite, target_format, quality)
+            if operation == "crop":
+                return self._crop(image, source, output_path, box, overwrite, target_format, quality)
+            return self._convert(image, source, output_path, target_format, quality, overwrite)
+        except ImportError as exc:
+            return self._error(file_path, "dependency_error",
+                               "Pillow (PIL) is required. Install with: pip install Pillow", str(exc))
+        except (TypeError, ValueError) as exc:
+            return self._error(file_path, "validation_error", str(exc))
+        except Exception as exc:  # pragma: no cover - defensive catch-all
+            return self._error(file_path, "operation_error", f"Image operation failed: {exc}")
+
+    # ------------------------------------------------------------------
+    # Configuration / validation helpers
+    # ------------------------------------------------------------------
+    def _validate_config(self) -> None:
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+        for name in ("max_input_bytes", "max_output_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not isinstance(self.allowed_formats, (list, tuple)) or not self.allowed_formats:
+            raise ValueError("allowed_formats must be a non-empty list/tuple")
+        for fmt in self.allowed_formats:
+            if not isinstance(fmt, str) or fmt.lower() not in _FORMAT_TABLE:
+                raise ValueError(f"allowed_formats contains unsupported format: {fmt!r}")
+
+    @staticmethod
+    def _normalize_mode(mode: Any) -> str:
+        if not isinstance(mode, str):
+            raise TypeError("mode must be a string")
+        operation = mode.strip().lower()
+        if operation not in _SUPPORTED_MODES:
+            raise ValueError(
+                "mode must be one of: " + ", ".join(_SUPPORTED_MODES)
+            )
+        return operation
+
+    def _resolve_input(self, file_path: Any) -> str:
+        if not isinstance(file_path, str) or not file_path:
+            raise ValueError("file_path must be a non-empty string")
+        path = cast(str, resolve_safe_path(file_path, self.base_dir))
+        if not os.path.isfile(path):
+            raise ValueError(f"file_path does not exist: {path}")
+        return path
+
+    def _resolve_output(self, output_path: Any) -> str:
+        if not isinstance(output_path, str) or not output_path:
+            raise ValueError("output_path must be a non-empty string")
+        return cast(str, resolve_safe_path(output_path, self.base_dir))
+
+    def _check_input_size(self, path: str) -> None:
+        size = os.path.getsize(path)
+        if size > self.max_input_bytes:
+            raise ValueError(
+                f"input file size ({size}) exceeds max_input_bytes ({self.max_input_bytes})"
+            )
+
+    # ------------------------------------------------------------------
+    # Pillow helpers (lazy import)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _pil():
+        """Lazily import Pillow and return the Image module."""
+        try:
+            from PIL import Image  # type: ignore
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise ImportError("No module named 'PIL'") from exc
+        return Image
+
+    def _open(self, path: str) -> Any:
+        Image = self._pil()
+        try:
+            image = Image.open(path)
+            image.load()  # force read so truncated files fail here
+        except Exception as exc:
+            raise ValueError(f"Could not read image: {exc}") from exc
+        # Guard against absurdly large dimensions.
+        if image.width > _MAX_DIMENSION or image.height > _MAX_DIMENSION:
+            raise ValueError(
+                f"image dimensions ({image.width}x{image.height}) exceed "
+                f"the maximum ({_MAX_DIMENSION})"
+            )
+        return image
+
+    # ------------------------------------------------------------------
+    # Output encoding (shared)
+    # ------------------------------------------------------------------
+    def _save(
+        self,
+        image: Any,
+        destination: str,
+        target_format: Optional[str],
+        quality: int,
+        overwrite: bool,
+        source_path: str,
+    ) -> dict:
+        """Encode ``image`` to ``destination`` atomically and return metadata."""
+        self._check_overwrite(destination, overwrite)
+        pil_format, extension = self._resolve_format(destination, target_format)
+        if pil_format.lower() not in {f.lower() for f in self.allowed_formats}:
+            raise ValueError(
+                f"target format {pil_format!r} is not in allowed_formats "
+                f"({list(self.allowed_formats)})"
+            )
+        if not isinstance(quality, int) or not 1 <= quality <= 100:
+            raise ValueError("quality must be an integer between 1 and 100")
+        # Normalize modes that JPEG cannot store (JPEG has no alpha channel).
+        out_image = self._normalize_for_format(image, pil_format)
+        directory = os.path.dirname(destination) or "."
+        os.makedirs(directory, exist_ok=True)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=".img-", suffix=extension, dir=directory, delete=False
+            ) as handle:
+                temporary = handle.name
+                save_kwargs = self._save_kwargs(pil_format, quality)
+                out_image.save(handle, format=pil_format, **save_kwargs)
+            if os.path.getsize(temporary) > self.max_output_bytes:
+                raise ValueError(
+                    f"generated image exceeds max_output_bytes ({self.max_output_bytes})"
+                )
+            os.replace(temporary, destination)
+            temporary = None
+        finally:
+            if temporary and os.path.exists(temporary):
+                os.unlink(temporary)
+        return {
+            "status": "success",
+            "output_path": destination,
+            "width": out_image.width,
+            "height": out_image.height,
+            "format": pil_format,
+            "file_size": os.path.getsize(destination),
+        }
+
+    def _resolve_format(self, destination: str, target_format: Optional[str]) -> tuple:
+        if target_format is not None:
+            if not isinstance(target_format, str):
+                raise TypeError("target_format must be a string")
+            key = target_format.strip().lower()
+            if key not in _FORMAT_TABLE:
+                raise ValueError(
+                    f"target_format {target_format!r} is not supported. "
+                    f"Allowed: {', '.join(sorted(_FORMAT_TABLE))}"
+                )
+            return _FORMAT_TABLE[key]
+        # Infer from extension.
+        ext = os.path.splitext(destination)[1].lower().lstrip(".")
+        if ext in _FORMAT_TABLE:
+            return _FORMAT_TABLE[ext]
+        raise ValueError(
+            f"Cannot infer format from output extension {ext!r}; pass target_format explicitly"
+        )
+
+    @staticmethod
+    def _normalize_for_format(image: Any, pil_format: str) -> Any:
+        """Return a copy of ``image`` compatible with ``pil_format``."""
+        if pil_format == "JPEG":
+            # Flatten alpha onto white, drop palettes -> RGB.
+            if image.mode in ("RGBA", "LA") or (image.mode == "P" and "transparency" in image.info):
+                background = image.convert("RGBA").convert("RGB")
+                return background
+            if image.mode != "RGB":
+                return image.convert("RGB")
+        return image
+
+    @staticmethod
+    def _save_kwargs(pil_format: str, quality: int) -> dict:
+        if pil_format in ("JPEG", "WEBP"):
+            return {"quality": quality}
+        return {}
+
+    @staticmethod
+    def _check_overwrite(path: str, overwrite: bool) -> None:
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        if os.path.exists(path) and not overwrite:
+            raise ValueError(f"file exists: {path}; set overwrite=true")
+
+    # ------------------------------------------------------------------
+    # Operations
+    # ------------------------------------------------------------------
+    def _resize(self, image, source, output_path, width, height, overwrite, target_format, quality):
+        if width is None or height is None:
+            raise ValueError("resize requires both width and height")
+        if isinstance(width, bool) or not isinstance(width, int) or width <= 0:
+            raise ValueError("width must be a positive integer")
+        if isinstance(height, bool) or not isinstance(height, int) or height <= 0:
+            raise ValueError("height must be a positive integer")
+        if width > _MAX_DIMENSION or height > _MAX_DIMENSION:
+            raise ValueError(f"width/height must not exceed {_MAX_DIMENSION}")
+        Image = self._pil()
+        resized = image.resize((width, height), Image.LANCZOS)
+        destination = self._resolve_output(output_path)
+        result = self._save(resized, destination, target_format, quality, overwrite, source)
+        result["mode"] = "resize"
+        return result
+
+    def _scale(self, image, source, output_path, factor, overwrite, target_format, quality):
+        if factor is None:
+            raise ValueError("scale requires factor")
+        if isinstance(factor, bool) or not isinstance(factor, (int, float)):
+            raise TypeError("factor must be a number")
+        factor = float(factor)
+        if factor <= 0:
+            raise ValueError("factor must be strictly positive")
+        if not _MIN_FACTOR <= factor <= _MAX_FACTOR:
+            raise ValueError(f"factor must be between {_MIN_FACTOR} and {_MAX_FACTOR}")
+        new_width = max(1, round(image.width * factor))
+        new_height = max(1, round(image.height * factor))
+        Image = self._pil()
+        scaled = image.resize((new_width, new_height), Image.LANCZOS)
+        destination = self._resolve_output(output_path)
+        result = self._save(scaled, destination, target_format, quality, overwrite, source)
+        result["mode"] = "scale"
+        result["factor"] = factor
+        return result
+
+    def _crop(self, image, source, output_path, box, overwrite, target_format, quality):
+        if box is None:
+            raise ValueError("crop requires box")
+        if not isinstance(box, list) or len(box) != 4:
+            raise ValueError("box must be a list of four integers [left, top, right, bottom]")
+        for value in box:
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError("box coordinates must be integers")
+        left, top, right, bottom = box
+        if left < 0 or top < 0 or right > image.width or bottom > image.height:
+            raise ValueError(
+                f"box ({left},{top},{right},{bottom}) is outside the image bounds "
+                f"({image.width}x{image.height})"
+            )
+        if right <= left or bottom <= top:
+            raise ValueError("box right must exceed left and bottom must exceed top")
+        cropped = image.crop((left, top, right, bottom))
+        destination = self._resolve_output(output_path)
+        result = self._save(cropped, destination, target_format, quality, overwrite, source)
+        result["mode"] = "crop"
+        return result
+
+    def _convert(self, image, source, output_path, target_format, quality, overwrite):
+        if target_format is None:
+            raise ValueError("convert requires target_format")
+        destination = self._resolve_output(output_path)
+        result = self._save(image, destination, target_format, quality, overwrite, source)
+        result["mode"] = "convert"
+        return result
+
+    def _info_result(self, path: str, image: Any) -> dict:
+        return {
+            "status": "success",
+            "mode": "info",
+            "file_path": path,
+            "format": image.format,
+            "width": image.width,
+            "height": image.height,
+            "mode_channel": image.mode,
+            "file_size": os.path.getsize(path),
+        }
+
+    # ------------------------------------------------------------------
+    # Error helper
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _error(path: Any, kind: str, message: str, detail: Optional[str] = None) -> dict:
+        result: dict = {"status": "error", "error_type": kind, "error": message, "file_path": path}
+        if detail:
+            result["detail"] = detail
+        return result

--- a/agentuniverse/agent/action/tool/common_tool/image_resizer_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/image_resizer_tool.yaml.example
@@ -1,0 +1,75 @@
+name: image_resizer_tool
+description: >-
+  Resize, scale, crop, convert, and inspect images using Pillow. All paths
+  are confined to base_dir; input/output byte sizes and output formats are
+  bounded. Pillow is imported lazily.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.image_resizer_tool
+  class: ImageResizerTool
+input_keys:
+  - mode
+  - file_path
+base_dir: .
+max_input_bytes: 26214400
+max_output_bytes: 26214400
+allowed_formats: [jpg, jpeg, png, webp]
+args_model:
+  mode: {type: string, required: true}
+  file_path: {type: string, required: true}
+  output_path: {type: string, required: false}
+  width: {type: integer, required: false}
+  height: {type: integer, required: false}
+  factor: {type: number, required: false}
+  box: {type: array, required: false}
+  target_format: {type: string, required: false}
+  quality: {type: integer, required: false, default: 85}
+  overwrite: {type: boolean, required: false, default: false}
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: [resize, scale, crop, convert, info]
+      description: Image operation to perform.
+    file_path:
+      type: string
+      description: Path to the source image, relative to base_dir.
+    output_path:
+      type: string
+      description: Destination path, relative to base_dir (ignored for info).
+    width:
+      type: integer
+      minimum: 1
+      description: Target width in pixels (resize mode).
+    height:
+      type: integer
+      minimum: 1
+      description: Target height in pixels (resize mode).
+    factor:
+      type: number
+      exclusiveMinimum: 0
+      description: Scale factor (scale mode), e.g. 0.5 halves each axis.
+    box:
+      type: array
+      items: {type: integer}
+      minItems: 4
+      maxItems: 4
+      description: Crop rectangle [left, top, right, bottom] in pixels.
+    target_format:
+      type: string
+      enum: [jpg, jpeg, png, webp]
+      description: Output format (required for convert; inferred from extension otherwise).
+    quality:
+      type: integer
+      minimum: 1
+      maximum: 100
+      default: 85
+      description: Quality for lossy formats (JPEG, WEBP).
+    overwrite:
+      type: boolean
+      default: false
+      description: Allow replacing an existing output file.
+  required: [mode, file_path]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -330,4 +330,31 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 
 ## 4. PDF Tool
 
-The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentuniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## ImageResizerTool
+
+`ImageResizerTool` resizes, scales, crops, converts, and inspects images using Pillow (`PIL`). Install `agentuniverse[image_ext]` or `Pillow`. It is well suited to agent workflows that need to normalize, thumbnail, or re-encode images before storage, display, or downstream vision-model ingestion.
+
+```python
+from agentuniverse.agent.action.tool.common_tool.image_resizer_tool import ImageResizerTool
+
+tool = ImageResizerTool(base_dir="/srv/agent-images")
+tool.execute(mode="info", file_path="photo.png")
+tool.execute(mode="resize", file_path="photo.png", output_path="small.png", width=256, height=256)
+tool.execute(mode="scale", file_path="photo.png", output_path="half.png", factor=0.5)
+tool.execute(mode="crop", file_path="photo.png", output_path="face.png", box=[10, 10, 210, 210])
+tool.execute(mode="convert", file_path="photo.png", output_path="photo.jpg", target_format="jpg", quality=85)
+```
+
+Operations (`mode`): `resize` (exact `width` x `height` via Lanczos), `scale` (multiply each axis by `factor`, strictly positive), `crop` (extract a `[left, top, right, bottom]` box that must lie within the source bounds), `convert` (re-encode to a `target_format` of jpg/jpeg/png/webp with an optional lossy `quality`), and `info` (report format, dimensions, channel mode, and byte size without writing).
+
+All file paths are confined to `base_dir` via `resolve_safe_path`, so traversal attempts and absolute paths outside the base are rejected. Input and output byte sizes are bounded by `max_input_bytes`/`max_output_bytes` (default 25 MiB each), output formats are restricted to `allowed_formats` (default jpg/jpeg/png/webp), and image dimensions are capped. JPEG encoding automatically flattens alpha/transparency to RGB. Pillow is imported lazily, so a missing dependency is surfaced as a `dependency_error` only when an operation actually needs it. Writes are atomic: the encoded image is written to a same-directory temporary file and size-checked before replacing the target, and existing files are never overwritten unless `overwrite=true` is explicit.
+
+## ImageResizerTool / 图片缩放工具
+
+`ImageResizerTool`（图片缩放工具）基于 Pillow（`PIL`）对图片进行缩放、按比例缩放、裁剪、格式转换和信息查看。安装 `agentuniverse[image_ext]` 或 `Pillow`。适用于代理在存储、展示或送入视觉模型前对图片进行归一化、生成缩略图或重新编码的场景。
+
+操作（`mode`）：`resize`（按 `width` x `height` 精确尺寸，使用 Lanczos 重采样）、`scale`（按 `factor` 系数缩放各轴，系数必须严格为正）、`crop`（裁剪 `[left, top, right, bottom]` 矩形区域，必须在原图范围内）、`convert`（转换为 jpg/jpeg/png/webp 的 `target_format`，可选有损 `quality`）、`info`（查看格式、尺寸、通道模式和字节大小，不写文件）。
+
+所有文件路径通过 `resolve_safe_path` 限制在 `base_dir` 下，可拒绝目录穿越（`../`）和越界的绝对路径。输入输出字节大小分别受 `max_input_bytes`/`max_output_bytes`（默认各 25 MiB）限制，输出格式限定在 `allowed_formats`（默认 jpg/jpeg/png/webp），图片尺寸也有上限。JPEG 编码会自动将透明度/Alpha 通道合并为 RGB。Pillow 采用懒加载，仅在实际需要时若依赖缺失会以 `dependency_error` 形式返回。写入为原子操作：先写入同目录临时文件并通过大小校验后再替换目标文件，且在未显式设置 `overwrite=true` 时不会覆盖已存在文件。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_image_resizer_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_image_resizer_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for ImageResizerTool."""
+
+import os
+import tempfile
+import unittest
+
+from PIL import Image  # noqa: F401 - asserts Pillow is available in the test env
+
+from agentuniverse.agent.action.tool.common_tool import image_resizer_tool as module
+from agentuniverse.agent.action.tool.common_tool.image_resizer_tool import ImageResizerTool
+
+YAML_PATH = os.path.join(os.path.dirname(module.__file__), "image_resizer_tool.yaml.example")
+
+
+class ImageResizerToolTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.tool = ImageResizerTool(base_dir=self.directory.name)
+        self.make_image("src.png", 100, 60, "RGBA")
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def make_image(self, name, width, height, mode="RGB"):
+        path = os.path.join(self.directory.name, name)
+        Image.new(mode, (width, height), (10, 20, 30, 255) if mode == "RGBA" else (10, 20, 30)).save(path)
+        return path
+
+    # --- info -----------------------------------------------------------
+    def test_info(self):
+        result = self.tool.execute(mode="info", file_path="src.png")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["width"], 100)
+        self.assertEqual(result["height"], 60)
+        self.assertEqual(result["format"], "PNG")
+
+    # --- resize ---------------------------------------------------------
+    def test_resize(self):
+        result = self.tool.execute(mode="resize", file_path="src.png",
+                                   output_path="out.png", width=50, height=30)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["width"], 50)
+        self.assertEqual(result["height"], 30)
+        with Image.open(result["output_path"]) as opened:
+            self.assertEqual(opened.size, (50, 30))
+
+    def test_resize_requires_width_and_height(self):
+        result = self.tool.execute(mode="resize", file_path="src.png", output_path="o.png", width=50)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("width and height", result["error"])
+
+    # --- scale ----------------------------------------------------------
+    def test_scale_halves_dimensions(self):
+        result = self.tool.execute(mode="scale", file_path="src.png",
+                                   output_path="half.png", factor=0.5)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["width"], 50)
+        self.assertEqual(result["height"], 30)
+
+    def test_scale_rejects_non_positive_factor(self):
+        result = self.tool.execute(mode="scale", file_path="src.png",
+                                   output_path="o.png", factor=0)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("positive", result["error"])
+
+    # --- crop -----------------------------------------------------------
+    def test_crop(self):
+        result = self.tool.execute(mode="crop", file_path="src.png",
+                                   output_path="c.png", box=[10, 10, 60, 50])
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["width"], 50)
+        self.assertEqual(result["height"], 40)
+
+    def test_crop_out_of_bounds(self):
+        result = self.tool.execute(mode="crop", file_path="src.png",
+                                   output_path="c.png", box=[0, 0, 200, 200])
+        self.assertEqual(result["status"], "error")
+        self.assertIn("bounds", result["error"])
+
+    def test_crop_inverted_box(self):
+        result = self.tool.execute(mode="crop", file_path="src.png",
+                                   output_path="c.png", box=[50, 50, 10, 10])
+        self.assertEqual(result["status"], "error")
+        self.assertIn("right must exceed left", result["error"])
+
+    # --- convert --------------------------------------------------------
+    def test_convert_png_to_jpeg_flattens_alpha(self):
+        result = self.tool.execute(mode="convert", file_path="src.png",
+                                   output_path="out.jpg", target_format="jpg", overwrite=False)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["format"], "JPEG")
+        with Image.open(result["output_path"]) as converted:
+            self.assertEqual(converted.mode, "RGB")
+
+    def test_convert_requires_target_format(self):
+        result = self.tool.execute(mode="convert", file_path="src.png", output_path="o.jpg")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("target_format", result["error"])
+
+    def test_convert_disallowed_format(self):
+        tool = ImageResizerTool(base_dir=self.directory.name, allowed_formats=("png",))
+        result = tool.execute(mode="convert", file_path="src.png", output_path="o.jpg", target_format="jpg")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("allowed_formats", result["error"])
+
+    # --- path safety / overwrite ---------------------------------------
+    def test_path_confined_to_base_dir(self):
+        result = self.tool.execute(mode="info", file_path="../../../etc/passwd")
+        self.assertEqual(result["status"], "error")
+        # Either rejected as escaping base_dir or as not existing under it.
+        self.assertTrue("error" in result)
+
+    def test_refuses_overwrite(self):
+        self.make_image("exists.png", 10, 10)
+        result = self.tool.execute(mode="resize", file_path="src.png",
+                                   output_path="exists.png", width=5, height=5)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("overwrite=true", result["error"])
+
+    def test_overwrite_allowed(self):
+        self.make_image("exists.png", 10, 10)
+        result = self.tool.execute(mode="resize", file_path="src.png",
+                                   output_path="exists.png", width=5, height=5, overwrite=True)
+        self.assertEqual(result["status"], "success")
+
+    # --- errors ---------------------------------------------------------
+    def test_missing_file(self):
+        result = self.tool.execute(mode="info", file_path="nope.png")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_invalid_mode(self):
+        result = self.tool.execute(mode="rotate", file_path="src.png")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("mode must be", result["error"])
+
+    def test_input_too_large(self):
+        tool = ImageResizerTool(base_dir=self.directory.name, max_input_bytes=10)
+        result = tool.execute(mode="info", file_path="src.png")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("max_input_bytes", result["error"])
+
+    def test_quality_out_of_range(self):
+        result = self.tool.execute(mode="convert", file_path="src.png",
+                                   output_path="o.jpg", target_format="jpg", quality=200)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("quality", result["error"])
+
+
+class ImageResizerYamlTest(unittest.TestCase):
+    def test_yaml_example_exists(self):
+        self.assertTrue(os.path.isfile(YAML_PATH))
+
+    def test_yaml_example_has_required_fields(self):
+        import yaml
+
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "image_resizer_tool")
+        self.assertEqual(data["metadata"]["class"], "ImageResizerTool")
+        self.assertIn("mode", data["input_keys"])
+        self.assertEqual(data["allowed_formats"], ["jpg", "jpeg", "png", "webp"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `ImageResizerTool`, a bounded image-manipulation tool that resizes, scales, crops, converts, and inspects images using Pillow. Closes #252.

## What's included

- `agentuniverse/agent/action/tool/common_tool/image_resizer_tool.py` — the tool (410 lines)
- `agentuniverse/agent/action/tool/common_tool/image_resizer_tool.yaml.example` — config example
- `tests/test_agentuniverse/unit/agent/action/tool/test_image_resizer_tool.py` — 20 unit tests (use real generated images)
- Docs appended to `docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md`

## Operations (`mode`)

| Mode       | Description                                                                          |
|------------|--------------------------------------------------------------------------------------|
| `resize`   | Produce an exact `width` x `height` image (Lanczos resampling).                      |
| `scale`    | Multiply each axis by `factor` (strictly positive, e.g. 0.5 to halve).               |
| `crop`     | Extract a `[left, top, right, bottom]` box that must lie within source bounds.       |
| `convert`  | Re-encode to `target_format` (jpg/jpeg/png/webp) with optional lossy `quality`.      |
| `info`     | Report format, dimensions, channel mode, and byte size without writing.              |

## Fields

- `base_dir` — root directory all paths are confined to.
- `max_input_bytes` / `max_output_bytes` (default 25 MiB each) — size budgets.
- `allowed_formats` (default jpg/jpeg/png/webp) — output formats the tool may write.

## Safety / design

- All paths are confined to `base_dir` via `resolve_safe_path`, so traversal (`../`) and out-of-base absolute paths are rejected.
- Input/output byte sizes and image dimensions are bounded; output formats are restricted to `allowed_formats`.
- **Pillow is imported lazily** — a missing dependency is surfaced as a `dependency_error` only when an operation actually needs it.
- JPEG encoding automatically flattens alpha/transparency to RGB.
- Writes are atomic: the encoded image is written to a same-directory temp file and size-checked before replacing the target. Existing files are never overwritten unless `overwrite=true` is explicit.
- Every result is a structured dict with a `status` field; errors carry `error_type`/`error` and are returned, never raised.

## Test plan

```
python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_image_resizer_tool
```

All 20 tests pass, covering: info, resize (+missing args), scale (+non-positive factor), crop (+out-of-bounds, +inverted box), convert (+alpha-flatten to JPEG, +missing target_format, +disallowed format), path confinement, overwrite refusal/permission, missing file, invalid mode, oversized input, out-of-range quality, and YAML example structure.
