### PR TITLE
feat(store): add MongoDB Atlas vector backend (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/mongodb_atlas_store.py
+++ b/agentuniverse/agent/action/knowledge/store/mongodb_atlas_store.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""MongoDB Atlas Vector Search knowledge store.
+
+MongoDB Atlas (https://www.mongodb.com/atlas) provides vector search via the
+``$vectorSearch`` aggregation pipeline stage. This store wraps the ``pymongo``
+client to provide insert, query, upsert, update, delete, and inspection
+capabilities with configurable vector dimensions, similarity functions
+(``cosine`` / ``euclidean`` / ``dotProduct``), optional on-demand embedding
+through a registered aU embedding component, optional metadata filtering,
+and bounded resource usage (``similarity_top_k``).
+
+The collection is expected to live on a cluster with a configured Atlas
+Vector Search index named ``vector_index`` over the configured
+``vector_field``. The store will create the underlying collection if it does
+not exist; the search index itself must be provisioned in the Atlas UI / via
+the Atlas Administration API.
+"""
+
+# Validation failures surface as ValueError at the public boundary.
+# ruff: noqa: TRY003
+
+import json
+import logging
+import os
+from typing import Any, ClassVar, List, Optional
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import \
+    EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+
+class MongoDBAtlasStore(Store):
+    """Vector store backed by MongoDB Atlas Vector Search.
+
+    Attributes:
+        connection_url: MongoDB connection string. If not set, the
+            ``MONGODB_ATLAS_URI`` environment variable is used.
+        database_name: MongoDB database that holds the collection.
+        collection_name: MongoDB collection used to store documents.
+        embedding_model: Name of a registered aU embedding component used to
+            embed documents / queries on demand.
+        dimensions: Vector dimension. If ``None``, inferred from the first
+            inserted document.
+        similarity: Similarity function used by ``$vectorSearch`` —
+            ``cosine``, ``euclidean``, or ``dotProduct``.
+        similarity_top_k: Default number of results returned by ``query``.
+        vector_field: Field name that stores the embedding vector.
+        text_field: Field name that stores the document text.
+        index_name: Name of the Atlas Vector Search index (default
+            ``vector_index``).
+    """
+
+    connection_url: Optional[str] = None
+    database_name: str = "agentuniverse"
+    collection_name: str = "documents"
+    embedding_model: Optional[str] = None
+    dimensions: Optional[int] = None
+    similarity: str = "cosine"
+    similarity_top_k: int = 10
+    vector_field: str = "embedding"
+    text_field: str = "text"
+    index_name: str = "vector_index"
+
+    client: Any = None
+    _collection: Any = None
+
+    _SIMILARITIES: ClassVar[dict] = {
+        "cosine": "cosine",
+        "euclidean": "euclidean",
+        "dotproduct": "dotProduct",
+        "dot": "dotProduct",
+    }
+
+    # ------------------------------------------------------------------ #
+    # Configuration & lifecycle
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(self,
+                                          configer: ComponentConfiger) \
+            -> "MongoDBAtlasStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "connection_url", "database_name", "collection_name",
+            "embedding_model", "dimensions", "similarity",
+            "similarity_top_k", "vector_field", "text_field", "index_name",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config()
+        return self
+
+    def _validate_config(self) -> None:
+        if not self.database_name or not isinstance(self.database_name, str):
+            raise ValueError("database_name must be a non-empty string")
+        if not self.collection_name or not isinstance(self.collection_name, str):
+            raise ValueError("collection_name must be a non-empty string")
+        self.similarity = (self.similarity or "").lower()
+        if self.similarity not in self._SIMILARITIES:
+            raise ValueError(
+                f"similarity must be one of {list(self._SIMILARITIES.keys())}, "
+                f"got {self.similarity!r}")
+        if (isinstance(self.similarity_top_k, bool)
+                or not isinstance(self.similarity_top_k, int)
+                or self.similarity_top_k <= 0):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if self.dimensions is not None:
+            if (isinstance(self.dimensions, bool)
+                    or not isinstance(self.dimensions, int)
+                    or self.dimensions <= 0):
+                raise ValueError("dimensions must be a positive integer")
+        for name in ("vector_field", "text_field", "index_name"):
+            value = getattr(self, name)
+            if not value or not isinstance(value, str):
+                raise ValueError(f"{name} must be a non-empty string")
+
+    # ------------------------------------------------------------------ #
+    # Client management
+    # ------------------------------------------------------------------ #
+    def _resolve_connection_url(self) -> str:
+        value = self.connection_url or os.getenv("MONGODB_ATLAS_URI")
+        if not value:
+            raise ValueError(
+                "connection_url is required; set it in YAML or the "
+                "MONGODB_ATLAS_URI environment variable")
+        return value
+
+    def _new_client(self) -> Any:
+        try:
+            from pymongo import MongoClient
+        except ImportError as exc:  # pragma: no cover - lazy import
+            raise ImportError(
+                "pymongo is not installed. Install it with "
+                "'pip install pymongo'.") from exc
+        self.client = MongoClient(self._resolve_connection_url())
+        # Trigger a cheap round-trip so connection errors surface early.
+        try:
+            self.client.admin.command("ping")
+        except Exception:  # pragma: no cover - network-dependent
+            logger.exception("MongoDB Atlas ping failed")
+        database = self.client[self.database_name]
+        # Create the collection lazily; insert will create it implicitly, but
+        # we materialise it so list_collection_names / counts behave.
+        if self.collection_name not in database.list_collection_names():
+            try:
+                database.create_collection(self.collection_name)
+            except Exception:  # pragma: no cover - already exists race
+                pass
+        self._collection = database[self.collection_name]
+        return self.client
+
+    def _ensure_client(self) -> Any:
+        if self.client is None:
+            self._new_client()
+        return self.client
+
+    @property
+    def collection(self) -> Any:
+        if self._collection is None:
+            self._ensure_client()
+        return self._collection
+
+    # ------------------------------------------------------------------ #
+    # Embedding resolution & dimension validation
+    # ------------------------------------------------------------------ #
+    def _get_embedding(self, text: str, text_type: str = "document") \
+            -> List[float]:
+        if not self.embedding_model:
+            raise ValueError(
+                "No embedding model configured. Set embedding_model on the "
+                "MongoDBAtlasStore component or provide embeddings in "
+                "Documents.")
+        emb = EmbeddingManager().get_instance_obj(self.embedding_model,
+                                                  strict=True)
+        embeddings = emb.get_embeddings([text], text_type=text_type)
+        if not embeddings:
+            raise ValueError("Embedding model returned no vectors")
+        return embeddings[0]
+
+    def _check_vector(self, vector: Any) -> None:
+        if (not isinstance(vector, list)
+                or not vector
+                or any(isinstance(v, bool) or not isinstance(v, (int, float))
+                       for v in vector)):
+            raise ValueError("embedding must be a non-empty numeric list")
+        if self.dimensions is None:
+            self.dimensions = len(vector)
+        if len(vector) != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {len(vector)} does not match configured "
+                f"dimensions {self.dimensions}")
+
+    def _vectors_for_documents(self, documents: List[Document]) \
+            -> List[List[float]]:
+        missing = [i for i, d in enumerate(documents) if not d.embedding]
+        if missing:
+            if not self.embedding_model:
+                raise ValueError(
+                    "documents without embeddings require embedding_model")
+            model = EmbeddingManager().get_instance_obj(self.embedding_model,
+                                                        strict=True)
+            generated = model.get_embeddings(
+                [documents[i].text or "" for i in missing])
+            for i, vec in zip(missing, generated, strict=True):
+                documents[i].embedding = vec
+        vectors = [d.embedding for d in documents]
+        for vec in vectors:
+            self._check_vector(vec)
+        return vectors
+
+    def _embedding_for_query(self, query: Query) -> List[float]:
+        if query.embeddings:
+            vector = query.embeddings[0]
+        elif self.embedding_model and query.query_str:
+            vector = self._get_embedding(query.query_str, text_type="query")
+        else:
+            raise ValueError(
+                "query requires embeddings or an embedding_model plus "
+                "query_str")
+        self._check_vector(vector)
+        return vector
+
+    def _top_k(self, query: Query) -> int:
+        value = query.similarity_top_k or self.similarity_top_k
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError("similarity_top_k must be a positive integer")
+        return value
+
+    # ------------------------------------------------------------------ #
+    # Document <-> BSON mapping
+    # ------------------------------------------------------------------ #
+    def _to_doc(self, document: Document, vector: List[float]) -> dict:
+        return {
+            "_id": str(document.id),
+            self.text_field: document.text or "",
+            self.vector_field: [float(v) for v in vector],
+            "metadata_json": json.dumps(document.metadata or {},
+                                        default=str, ensure_ascii=False),
+        }
+
+    @staticmethod
+    def _decode_metadata(raw: Any) -> dict:
+        if not raw:
+            return {}
+        if isinstance(raw, dict):
+            return raw
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+
+    def _from_doc(self, record: dict, score: Any = None) -> Document:
+        metadata = self._decode_metadata(record.get("metadata_json"))
+        if score is not None:
+            metadata["score"] = score
+        return Document(
+            id=str(record.get("_id")) if record.get("_id") is not None else None,
+            text=record.get(self.text_field, "") or "",
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+    def insert_document(self, documents: List[Document], **kwargs) -> None:
+        if not documents:
+            return
+        self.upsert_document(documents, **kwargs)
+
+    def upsert_document(self, documents: List[Document], **kwargs) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        collection = self.collection
+        for document, vector in zip(documents, vectors, strict=True):
+            doc = self._to_doc(document, vector)
+            collection.replace_one(
+                {"_id": doc["_id"]}, doc, upsert=True)
+
+    def update_document(self, documents: List[Document], **kwargs) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    def query(self, query: Query, **kwargs) -> List[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        collection = self.collection
+        filter_expr = kwargs.get("metadata_filter")
+        pre_filter: Optional[dict] = None
+        if filter_expr is not None:
+            if not isinstance(filter_expr, dict):
+                raise TypeError("metadata_filter must be an object")
+            pre_filter = {"metadata_json": json.dumps(filter_expr)}
+        pipeline = self._vector_search_pipeline(
+            vector=vector, top_k=top_k, pre_filter=pre_filter)
+        try:
+            cursor = collection.aggregate(pipeline)
+        except Exception:
+            logger.exception("MongoDB Atlas vector search failed")
+            return []
+        documents: List[Document] = []
+        for record in cursor:
+            score = record.get("score")
+            documents.append(self._from_doc(record, score=score))
+        return documents
+
+    def _vector_search_pipeline(self, vector: List[float], top_k: int,
+                                pre_filter: Optional[dict]) -> List[dict]:
+        vector_search: dict = {
+            "index": self.index_name,
+            "path": self.vector_field,
+            "queryVector": [float(v) for v in vector],
+            "numCandidates": max(top_k * 10, top_k),
+            "limit": top_k,
+        }
+        if pre_filter is not None:
+            vector_search["filter"] = pre_filter
+        return [
+            {"$vectorSearch": vector_search},
+            {"$project": {
+                "_id": 1,
+                self.text_field: 1,
+                "metadata_json": 1,
+                "score": {"$meta": "vectorSearchScore"},
+            }},
+        ]
+
+    def delete_document(self, document_id: str, **kwargs) -> None:
+        collection = self.collection
+        try:
+            collection.delete_one({"_id": str(document_id)})
+        except Exception:
+            logger.exception("MongoDB delete failed for id %s", document_id)
+
+    def get_document_count(self) -> int:
+        collection = self.collection
+        try:
+            return collection.count_documents({})
+        except Exception:
+            logger.exception("MongoDB count_documents failed")
+            return 0
+
+    def get_document_by_id(self, document_id: str) -> Optional[Document]:
+        collection = self.collection
+        try:
+            record = collection.find_one({"_id": str(document_id)})
+        except Exception:
+            logger.exception("MongoDB find_one failed for %s", document_id)
+            return None
+        if record is None:
+            return None
+        return self._from_doc(record)
+
+    def list_document_ids(self) -> List[str]:
+        collection = self.collection
+        try:
+            cursor = collection.find({}, {"_id": 1})
+            return [str(record["_id"]) for record in cursor
+                    if record.get("_id") is not None]
+        except Exception:
+            logger.exception("MongoDB list ids failed")
+            return []

--- a/agentuniverse/agent/action/knowledge/store/mongodb_atlas_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/mongodb_atlas_store.yaml.example
@@ -1,0 +1,16 @@
+name: mongodb_atlas_store
+description: MongoDB Atlas Vector Search store for knowledge retrieval
+connection_url: ''
+database_name: agentuniverse
+collection_name: documents
+embedding_model: openai_embedding
+dimensions: 1536
+similarity: cosine
+similarity_top_k: 10
+vector_field: embedding
+text_field: text
+index_name: vector_index
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.mongodb_atlas_store
+  class: MongoDBAtlasStore

--- a/agentuniverse/llm/default/groq_llm.py
+++ b/agentuniverse/llm/default/groq_llm.py
@@ -1,0 +1,165 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: groq_llm.py
+
+"""
+Groq Cloud LLM.
+
+Groq (https://groq.com) is an inference engine built on top of its custom
+LPU (Language Processing Unit) hardware that delivers extremely fast
+token generation for a curated set of open-source large language models
+such as Meta's Llama family, Google's Gemma, and Mistral's Mixtral.
+
+Groq exposes an OpenAI-compatible Chat Completions API at
+``https://api.groq.com/openai/v1``. Because of that compatibility this
+component simply extends :class:`OpenAIStyleLLM` and only needs to wire up
+the correct default environment variables, the Groq API base URL and the
+per-model maximum context length table.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Optional, Union
+
+import tiktoken
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+# The maximum context length (input + output tokens) supported by the
+# models currently available on the Groq Cloud API. The values are sourced
+# from the official Groq documentation (https://console.groq.com/docs/models).
+# When Groq ships a new model it is sufficient to add an entry here, the rest
+# of the component keeps working unchanged.
+GROQ_MAX_CONTEXT_LENGTH = {
+    # ---- Meta Llama family ----
+    "llama-3.3-70b-versatile": 131072,
+    "llama-3.3-70b-instruct": 131072,
+    "llama3-groq-70b-8192-tool-use-preview": 8192,
+    "llama3-groq-70b-tool-use-preview": 8192,
+    "llama-3.1-8b-instant": 131072,
+    "llama-3.1-70b-versatile": 131072,
+    "llama-3.1-8b-versatile": 131072,
+    "llama3-70b-8192": 8192,
+    "llama3-8b-8192": 8192,
+    # ---- Google Gemma family ----
+    "gemma2-9b-it": 8192,
+    "gemma-7b-it": 8192,
+    # ---- Mistral family ----
+    "mixtral-8x7b-32768": 32768,
+    # ---- OpenAI whisper (audio) ----
+    "whisper-large-v3": 8000,
+    "whisper-large-v3-turbo": 8000,
+    "distil-whisper-large-v3-en": 8000,
+}
+
+# Sensible default context length returned for models that are not yet listed
+# in the table above. Groq models very commonly expose an 8k window, so 8192
+# is a safe conservative fallback.
+GROQ_DEFAULT_CONTEXT_LENGTH = 8192
+
+
+class GroqLLM(OpenAIStyleLLM):
+    """Groq Cloud LLM, an OpenAI-compatible wrapper around the Groq inference API.
+
+    Groq runs popular open-weight models (Llama 3.x, Mixtral, Gemma 2, ...)
+    on its dedicated LPU hardware which produces near-instant token
+    generation. The Groq API is fully OpenAI-compatible, therefore this
+    class only customises the credential/base-url plumbing and the model
+    context-length lookup table while inheriting the complete request,
+    streaming and langchain-bridge implementation from
+    :class:`OpenAIStyleLLM`.
+
+    Attributes:
+        api_key: Groq API key. Loaded from the ``GROQ_API_KEY`` environment
+            variable when not provided explicitly. Create one at
+            https://console.groq.com/keys.
+        api_base: Groq OpenAI-compatible API base URL. Defaults to
+            ``https://api.groq.com/openai/v1`` unless overridden through the
+            ``GROQ_API_BASE`` environment variable.
+        proxy: Optional HTTP(S) proxy used for outbound requests.
+        organization: Optional organization id forwarded to the client.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_KEY"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_BASE") or
+                                    "https://api.groq.com/openai/v1")
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_PROXY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_ORGANIZATION"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call to the Groq chat completions endpoint.
+
+        Users may override this method to customise the interaction, the
+        default implementation simply delegates to the OpenAI-style parent
+        which constructs and dispatches the request against the Groq API
+        base URL.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                client, e.g. ``temperature``, ``top_p``, ``max_tokens`` ...
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an iterator of
+            :class:`LLMOutput` chunks when ``stream=True`` is supplied.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call to the Groq chat completions endpoint.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                async client.
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an async
+            iterator of :class:`LLMOutput` chunks when ``stream=True``.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Groq model.
+
+        The combined length of the input prompt and the generated completion
+        must fit within this window. The value is resolved in the following
+        order:
+
+        1. If a context length was explicitly injected through the YAML
+           configuration (``max_context_length`` field) that value wins.
+        2. Otherwise the model name is looked up in
+           :data:`GROQ_MAX_CONTEXT_LENGTH`.
+        3. As a last resort :data:`GROQ_DEFAULT_CONTEXT_LENGTH` is returned.
+        """
+        if super().max_context_length():
+            return super().max_context_length()
+        return GROQ_MAX_CONTEXT_LENGTH.get(self.model_name, GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate the number of tokens that ``text`` will consume.
+
+        Groq serves a heterogeneous set of models, each with its own
+        tokenizer. Because all of them are open-weight models whose
+        tokenizers are not always registered in ``tiktoken`` by name, we
+        fall back to the widely used ``cl100k_base`` encoding which gives a
+        good approximation suitable for budget/prompt-window checks.
+
+        Args:
+            text: The raw string to tokenize.
+
+        Returns:
+            The integer number of tokens the text would be encoded into.
+        """
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            # Most Groq models (llama-3, mixtral, gemma) are not registered
+            # in tiktoken by name; cl100k_base is a robust generic fallback.
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))

--- a/agentuniverse/llm/default/groq_llm.yaml.example
+++ b/agentuniverse/llm/default/groq_llm.yaml.example
@@ -1,0 +1,14 @@
+name: 'default_groq_llm'
+description: 'default groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
@@ -1,0 +1,144 @@
+# Groq LLM Use
+
+`GroqLLM` integrates the [Groq Cloud](https://groq.com) inference engine into agentUniverse. Groq runs a curated set of popular open-weight large language models (Meta Llama 3.x, Google Gemma 2, Mistral Mixtral, ...) on its custom **LPU (Language Processing Unit)** hardware, which delivers order-of-magnitude faster token generation than typical GPU based endpoints.
+
+Groq exposes a fully **OpenAI-compatible** Chat Completions API at `https://api.groq.com/openai/v1`, so the `GroqLLM` component simply extends `OpenAIStyleLLM` and only wires up the Groq credentials, API base URL and per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge all work out of the box.
+
+---
+
+## 1. Create the configuration file
+
+Create a YAML file, for example `user_groq_llm.yaml`, and paste the following content into it.
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**Note:** Model parameters such as `api_key`, `api_base`, `organization` and `proxy` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax to load the value from an environment variable. When agentUniverse starts it will automatically read the corresponding value.
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **Custom function loading** - use the `@FUNC` annotation to dynamically load the API key through a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    The function must be defined in the `YamlFuncExtension` class inside the `yaml_func_extension.py` file. Refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When agentUniverse loads this configuration it parses the `@FUNC` annotation, executes the `load_api_key` function with the supplied arguments, and replaces the annotation with the function's return value.
+
+---
+
+## 2. Pick a model
+
+Groq regularly rotates its model catalogue. Below are the most commonly used models together with their context window (input + output tokens). The same values are hard-coded inside `GroqLLM.max_context_length`, so agentUniverse can budget prompts correctly even without a live API call.
+
+| Model name                       | Context length |
+| -------------------------------- | -------------- |
+| `llama-3.3-70b-versatile`        | 131072 (128k)  |
+| `llama-3.1-8b-instant`           | 131072 (128k)  |
+| `llama-3.1-70b-versatile`        | 131072 (128k)  |
+| `llama3-70b-8192`                | 8192           |
+| `llama3-8b-8192`                 | 8192           |
+| `mixtral-8x7b-32768`             | 32768          |
+| `gemma2-9b-it`                   | 8192           |
+| `gemma-7b-it`                    | 8192           |
+
+Always confirm the latest list on the [Groq models documentation](https://console.groq.com/docs/models) page. If a model is not present in the table above, `GroqLLM` falls back to a conservative default of 8192 tokens.
+
+---
+
+## 3. Environment setup
+
+The example YAML uses environment variable placeholders. The following section describes how to set those variables.
+
+Required: `GROQ_API_KEY`
+Optional: `GROQ_API_BASE`, `GROQ_PROXY`, `GROQ_ORGANIZATION`
+
+### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory, add the following entries:
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. Obtaining the Groq API key
+
+1. Sign in at [https://console.groq.com](https://console.groq.com).
+2. Navigate to **API Keys** -> **Create API Key**.
+3. Copy the generated `gsk_...` key and assign it to `GROQ_API_KEY`.
+
+Groq offers a generous free tier for development; rate limits and pricing for production usage are documented at [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits).
+
+---
+
+## 5. Using the LLM in code
+
+After the configuration is loaded by agentUniverse you can obtain the LLM instance and call it directly:
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# Non-streaming
+output = llm.call(messages=[{"role": "user", "content": "Hello!"}])
+print(output.text)
+
+# Streaming
+for chunk in llm.call(messages=[{"role": "user", "content": "Count 1 to 5."}], streaming=True):
+    print(chunk.text, end='')
+
+# Async
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "Hello!"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+Because Groq is OpenAI-compatible, every feature supported by `OpenAIStyleLLM` - tool calling, LangChain integration, tracing - is available without any extra work.
+
+---
+
+## 6. Tips
+
+- agentUniverse ships with a ready-to-use instance named `default_groq_llm`. After configuring the `GROQ_API_KEY` environment variable you can reference it directly from your agents.
+- Groq's standout feature is latency: a 70B model can stream hundreds of tokens per second, which makes it an excellent choice for interactive agents and rapid prototyping.
+- Groq does not yet support every model offered by upstream providers, so before standardising on a particular model check the [Groq models page](https://console.groq.com/docs/models) for availability and deprecation notices.

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -96,3 +96,43 @@ Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are 
 ## PGVectorStore
 
 `PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.
+
+## MongoDBAtlasStore
+
+`MongoDBAtlasStore` is a vector store backed by MongoDB Atlas Vector Search. It uses the ``$vectorSearch`` aggregation pipeline stage to provide insert, query, upsert, update, delete, and inspection with `cosine` / `euclidean` / `dotProduct` similarity functions, configurable vector dimensions, optional on-demand embedding through a registered aU embedding component, optional metadata filtering, and bounded resource usage (`similarity_top_k`). Install the optional dependency with `pip install 'agentUniverse[store_ext]'` (or `pip install pymongo`) and provision a MongoDB Atlas cluster with a Vector Search index.
+
+Copy `agentuniverse/agent/action/knowledge/store/mongodb_atlas_store.yaml.example` into the application configuration directory and resolve the built-in `mongodb_atlas_store` component. Set `connection_url` in that copy (or via the `MONGODB_ATLAS_URI` environment variable); `embedding_model` names a registered aU embedding component used to embed documents and queries on demand. The Atlas Vector Search index (default name `vector_index`) must be configured over the `vector_field` via the Atlas UI / Administration API.
+
+```yaml
+name: mongodb_atlas_store
+description: MongoDB Atlas Vector Search store for knowledge retrieval
+connection_url: ''
+database_name: agentuniverse
+collection_name: documents
+embedding_model: openai_embedding
+dimensions: 1536
+similarity: cosine
+similarity_top_k: 10
+vector_field: embedding
+text_field: text
+index_name: vector_index
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.mongodb_atlas_store
+  class: MongoDBAtlasStore
+```
+- connection_url: MongoDB connection string; falls back to the `MONGODB_ATLAS_URI` environment variable.
+- database_name: MongoDB database that holds the collection.
+- collection_name: MongoDB collection used to store documents.
+- embedding_model: Registered aU embedding component used to embed documents / queries on demand.
+- dimensions: Vector dimension; if `null`, inferred from the first inserted document.
+- similarity: Similarity function for `$vectorSearch` — `cosine`, `euclidean`, or `dotProduct`.
+- similarity_top_k: Default number of results returned by `query`.
+- vector_field: Field name that stores the embedding vector.
+- text_field: Field name that stores the document text.
+- index_name: Name of the Atlas Vector Search index.
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2, 0.3])])
+results = store.query(Query(embeddings=[[0.1, 0.2, 0.3]], similarity_top_k=5), metadata_filter={"tenant": "acme"})
+```

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -96,3 +96,43 @@ results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metada
 ## PGVectorStore
 
 `PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。
+
+## MongoDBAtlasStore
+
+`MongoDBAtlasStore` 是基于 MongoDB Atlas Vector Search 的向量存储。通过 ``$vectorSearch`` 聚合管道阶段提供插入、查询、upsert、更新、删除及巡检能力，支持 cosine / euclidean / dotProduct 相似度函数、可配置向量维度、通过已注册 aU embedding 组件按需向量化、可选 metadata 过滤，以及受控的资源使用（`similarity_top_k`）。安装可选依赖 `pip install 'agentUniverse[store_ext]'`（或 `pip install pymongo`），并准备一个配置了 Vector Search 索引的 MongoDB Atlas 集群。
+
+将 `agentuniverse/agent/action/knowledge/store/mongodb_atlas_store.yaml.example` 复制到应用配置目录，加载内置 `mongodb_atlas_store` 组件。在该配置副本中设置 `connection_url`（或通过 `MONGODB_ATLAS_URI` 环境变量提供）；`embedding_model` 指定一个已注册的 aU embedding 组件，用于按需对文档和查询向量化。Atlas Vector Search 索引（默认名 `vector_index`）需通过 Atlas 控制台 / 管理 API 在 `vector_field` 上配置。
+
+```yaml
+name: mongodb_atlas_store
+description: MongoDB Atlas Vector Search store for knowledge retrieval
+connection_url: ''
+database_name: agentuniverse
+collection_name: documents
+embedding_model: openai_embedding
+dimensions: 1536
+similarity: cosine
+similarity_top_k: 10
+vector_field: embedding
+text_field: text
+index_name: vector_index
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.mongodb_atlas_store
+  class: MongoDBAtlasStore
+```
+- connection_url: MongoDB 连接串；未设置时回退到 `MONGODB_ATLAS_URI` 环境变量。
+- database_name: 存放集合的 MongoDB 数据库。
+- collection_name: 存放文档的 MongoDB 集合。
+- embedding_model: 用于按需对文档/查询向量化的已注册 aU embedding 组件名。
+- dimensions: 向量维度；为 `null` 时由首条插入文档推断。
+- similarity: `$vectorSearch` 相似度函数——`cosine`、`euclidean` 或 `dotProduct`。
+- similarity_top_k: `query` 默认返回的结果数。
+- vector_field: 存储向量 embedding 的字段名。
+- text_field: 存储文档文本的字段名。
+- index_name: Atlas Vector Search 索引名。
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"tenant": "acme"}, embedding=[0.1, 0.2, 0.3])])
+results = store.query(Query(embeddings=[[0.1, 0.2, 0.3]], similarity_top_k=5), metadata_filter={"tenant": "acme"})
+```

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
@@ -1,0 +1,147 @@
+# Groq 使用
+
+`GroqLLM` 将 [Groq Cloud](https://groq.com) 推理引擎接入 agentUniverse。Groq 基于自研的 **LPU（Language Processing Unit）** 硬件运行一批主流开源大模型（Meta Llama 3.x、Google Gemma 2、Mistral Mixtral 等），其 token 生成速度通常比传统 GPU 推理服务快一个数量级。
+
+Groq 提供了完全 **兼容 OpenAI** 的 Chat Completions API（地址为 `https://api.groq.com/openai/v1`），因此 `GroqLLM` 组件只需继承 `OpenAIStyleLLM`，并在其基础上配置 Groq 的鉴权信息、API 基础地址以及各模型的上下文长度表即可。流式输出、工具调用、异步接口以及 LangChain 桥接等能力均可直接复用，无需额外开发。
+
+---
+
+## 1. 创建相关文件
+
+创建一个 yaml 文件，例如 `user_groq_llm.yaml`，将以下内容粘贴进去：
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**note:** `api_key` / `api_base` / `organization` / `proxy` 等模型参数有三种配置方法：
+
+1. **直接字符串值**：直接在配置文件中输入 API 密钥字符串。
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **环境变量占位符**：使用 `${VARIABLE_NAME}` 语法从环境变量中加载。当 agentUniverse 启动时，会自动从环境变量读取相应的值。
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **自定义函数加载**：使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API 密钥。
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    该函数需要在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中定义，可参考样例工程中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)。当 agentUniverse 加载此配置时：
+    - 解析 `@FUNC` 注解
+    - 执行 `load_api_key` 函数并传入相应参数
+    - 用函数返回值替换注解内容
+
+---
+
+## 2. 选择模型
+
+Groq 会不定期轮换其支持的模型列表。下表列出了常用模型及其上下文窗口大小（输入 + 输出 token）。这些数值同样硬编码在 `GroqLLM.max_context_length` 中，这样 agentUniverse 即使不发起真实请求也能正确估算 prompt 预算。
+
+| 模型名称                          | 上下文长度      |
+| --------------------------------- | --------------- |
+| `llama-3.3-70b-versatile`         | 131072 (128k)   |
+| `llama-3.1-8b-instant`            | 131072 (128k)   |
+| `llama-3.1-70b-versatile`         | 131072 (128k)   |
+| `llama3-70b-8192`                 | 8192            |
+| `llama3-8b-8192`                  | 8192            |
+| `mixtral-8x7b-32768`              | 32768           |
+| `gemma2-9b-it`                    | 8192            |
+| `gemma-7b-it`                     | 8192            |
+
+请以 [Groq 官方模型文档](https://console.groq.com/docs/models) 公布的最新列表为准。如果某个模型不在上表中，`GroqLLM` 会保守地回退到 8192 token。
+
+---
+
+## 3. 环境设置
+
+示例 yaml 中模型密钥等参数使用了环境变量占位符，下面介绍环境变量的设置方法。
+
+必须配置：`GROQ_API_KEY`
+可选配置：`GROQ_API_BASE`、`GROQ_PROXY`、`GROQ_ORGANIZATION`
+
+### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 通过配置文件配置
+
+在项目的 `config` 目录下的 `custom_key.toml` 当中，添加配置：
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. GROQ API KEY 获取
+
+1. 登录 [https://console.groq.com](https://console.groq.com)。
+2. 进入 **API Keys** -> **Create API Key**。
+3. 复制生成的 `gsk_...` 密钥，并赋值给 `GROQ_API_KEY`。
+
+Groq 为开发阶段提供了较为充裕的免费额度，生产环境的速率限制与计费规则详见 [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits)。
+
+---
+
+## 5. 在代码中使用
+
+配置被 agentUniverse 加载后，您可以直接获取 LLM 实例并调用：
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# 非流式
+output = llm.call(messages=[{"role": "user", "content": "你好！"}])
+print(output.text)
+
+# 流式
+for chunk in llm.call(messages=[{"role": "user", "content": "从 1 数到 5。"}], streaming=True):
+    print(chunk.text, end='')
+
+# 异步
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "你好！"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+由于 Groq 兼容 OpenAI 协议，`OpenAIStyleLLM` 支持的所有能力（工具调用、LangChain 集成、链路追踪等）都可以直接使用。
+
+---
+
+## 6. Tips
+
+- agentuniverse 已经内置了一个 name 为 `default_groq_llm` 的 llm，用户在配置 `GROQ_API_KEY` 之后可以直接使用。
+- Groq 最大的特点是延迟极低：70B 级别的模型也能以每秒数百 token 的速度流式输出，非常适合交互式 Agent 和快速原型验证。
+- Groq 目前并不支持上游厂商的全部模型，在正式选型前请先到 [Groq 模型页面](https://console.groq.com/docs/models) 确认可用模型及废弃公告。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_mongodb_atlas_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_mongodb_atlas_store.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for MongoDBAtlasStore.
+
+All tests mock the pymongo client so no server or network access is
+required. Covers config validation, dimension checking, insert / upsert /
+query round-trip, delete, count, fetch-by-id, list-ids, and error paths.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.mongodb_atlas_store import \
+    MongoDBAtlasStore
+from agentuniverse.agent.action.knowledge.store.query import Query
+
+
+def _mock_pymongo():
+    """Build a mock pymongo module + client for patching sys.modules."""
+    mock_mod = MagicMock()
+    mock_mod.__version__ = "4.6.0"
+
+    client = MagicMock()
+    client.admin.command.return_value = {"ok": 1}
+
+    database = MagicMock()
+    database.list_collection_names.return_value = ["documents"]
+    collection = MagicMock()
+    database.__getitem__.return_value = collection
+    database.create_collection.return_value = collection
+    client.__getitem__.return_value = database
+
+    mock_mod.MongoClient = MagicMock(return_value=client)
+
+    return mock_mod, client, collection
+
+
+class TestMongoDBAtlasStoreConfig(unittest.TestCase):
+
+    def test_valid_config_is_accepted(self):
+        store = MongoDBAtlasStore(
+            database_name="db", collection_name="docs",
+            dimensions=128, similarity="cosine",
+        )
+        store._validate_config()
+
+    def test_invalid_similarity_rejected(self):
+        store = MongoDBAtlasStore(database_name="db", collection_name="docs",
+                                  similarity="manhattan")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_zero_top_k_rejected(self):
+        store = MongoDBAtlasStore(database_name="db", collection_name="docs",
+                                  similarity_top_k=0)
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_negative_dimensions_rejected(self):
+        store = MongoDBAtlasStore(database_name="db", collection_name="docs",
+                                  dimensions=-1)
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_empty_database_name_rejected(self):
+        store = MongoDBAtlasStore(database_name="", collection_name="docs")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_empty_collection_name_rejected(self):
+        store = MongoDBAtlasStore(database_name="db", collection_name="")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+    def test_all_supported_similarities_accepted(self):
+        for s in ("cosine", "euclidean", "dotProduct", "dotproduct", "dot"):
+            store = MongoDBAtlasStore(database_name="db",
+                                      collection_name="docs", similarity=s)
+            store._validate_config()
+
+    def test_empty_vector_field_rejected(self):
+        store = MongoDBAtlasStore(database_name="db", collection_name="docs",
+                                  vector_field="")
+        with self.assertRaises(ValueError):
+            store._validate_config()
+
+
+class _MongoPatchMixin:
+
+    def setUp(self):
+        self.mock_mod, self.mock_client, self.mock_collection = _mock_pymongo()
+        self._patcher = patch.dict("sys.modules", {"pymongo": self.mock_mod})
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _store(self, **overrides):
+        params = dict(
+            connection_url="mongodb://localhost:27017",
+            database_name="test_db",
+            collection_name="test_docs",
+            dimensions=3,
+            embedding_model=None,
+        )
+        params.update(overrides)
+        store = MongoDBAtlasStore(**params)
+        store._new_client()
+        return store
+
+
+class TestMongoDBAtlasStoreInsert(_MongoPatchMixin, unittest.TestCase):
+
+    def test_insert_single_document_upserts(self):
+        store = self._store()
+        doc = Document(id="d1", text="hello", embedding=[0.1, 0.2, 0.3])
+        store.insert_document([doc])
+        self.mock_collection.replace_one.assert_called_once()
+        args = self.mock_collection.replace_one.call_args
+        # replace_one is called positionally: replace_one(filter, replacement, upsert=True)
+        self.assertEqual(args[0][0], {"_id": "d1"})
+        replacement = args[0][1]
+        self.assertEqual(replacement["_id"], "d1")
+        self.assertEqual(replacement["text"], "hello")
+        self.assertEqual(replacement["embedding"], [0.1, 0.2, 0.3])
+        self.assertTrue(args.kwargs.get("upsert"))
+
+    def test_upsert_dimension_mismatch_raises(self):
+        store = self._store()
+        docs = [
+            Document(id="d1", text="a", embedding=[0.1, 0.2, 0.3]),
+            Document(id="d2", text="b", embedding=[0.1, 0.2]),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            store.upsert_document(docs)
+        self.assertIn("dimension", str(ctx.exception).lower())
+
+    def test_insert_empty_list_is_noop(self):
+        store = self._store()
+        store.insert_document([])
+        self.mock_collection.replace_one.assert_not_called()
+
+    def test_update_document_delegates_to_upsert(self):
+        store = self._store()
+        doc = Document(id="d1", text="updated", embedding=[0.1, 0.2, 0.3])
+        store.update_document([doc])
+        self.mock_collection.replace_one.assert_called_once()
+
+
+class TestMongoDBAtlasStoreQuery(_MongoPatchMixin, unittest.TestCase):
+
+    def test_query_returns_documents_with_score(self):
+        store = self._store()
+        self.mock_collection.aggregate.return_value = iter([
+            {"_id": "m1", "text": "result",
+             "metadata_json": json.dumps({"k": "v"}), "score": 0.95},
+            {"_id": "m2", "text": "second",
+             "metadata_json": "{}", "score": 0.80},
+        ])
+        results = store.query(
+            Query(embeddings=[[0.1, 0.2, 0.3]], similarity_top_k=5))
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].text, "result")
+        self.assertEqual(results[0].metadata["k"], "v")
+        self.assertEqual(results[0].metadata["score"], 0.95)
+
+    def test_query_builds_vector_search_pipeline(self):
+        store = self._store()
+        self.mock_collection.aggregate.return_value = iter([])
+        store.query(Query(embeddings=[[0.1, 0.2, 0.3]], similarity_top_k=4))
+        pipeline = self.mock_collection.aggregate.call_args[0][0]
+        self.assertIn("$vectorSearch", pipeline[0])
+        vs = pipeline[0]["$vectorSearch"]
+        self.assertEqual(vs["limit"], 4)
+        self.assertEqual(vs["path"], "embedding")
+        self.assertGreaterEqual(vs["numCandidates"], 4)
+
+    def test_query_with_metadata_filter_adds_filter(self):
+        store = self._store()
+        self.mock_collection.aggregate.return_value = iter([])
+        store.query(Query(embeddings=[[0.1, 0.2, 0.3]]),
+                    metadata_filter={"tenant": "acme"})
+        pipeline = self.mock_collection.aggregate.call_args[0][0]
+        vs = pipeline[0]["$vectorSearch"]
+        self.assertIn("filter", vs)
+
+    def test_query_invalid_filter_type_raises(self):
+        store = self._store()
+        with self.assertRaises(TypeError):
+            store.query(Query(embeddings=[[0.1, 0.2, 0.3]]),
+                        metadata_filter="not-a-dict")
+
+    def test_query_no_embedding_and_no_model_raises(self):
+        store = self._store()
+        with self.assertRaises(ValueError):
+            store.query(Query(query_str="hi", embeddings=[]))
+
+    def test_query_handles_corrupt_metadata_gracefully(self):
+        store = self._store()
+        self.mock_collection.aggregate.return_value = iter([
+            {"_id": "m1", "text": "ok",
+             "metadata_json": "not-json{", "score": 0.5},
+        ])
+        results = store.query(Query(embeddings=[[0.1, 0.2, 0.3]]))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "ok")
+        self.assertEqual(results[0].metadata["score"], 0.5)
+
+
+class TestMongoDBAtlasStoreDeleteAndInspect(_MongoPatchMixin, unittest.TestCase):
+
+    def test_delete_calls_delete_one(self):
+        store = self._store()
+        store.delete_document("doc-123")
+        self.mock_collection.delete_one.assert_called_once_with(
+            {"_id": "doc-123"})
+
+    def test_count_returns_count_documents(self):
+        store = self._store()
+        self.mock_collection.count_documents.return_value = 42
+        self.assertEqual(store.get_document_count(), 42)
+
+    def test_count_on_error_returns_zero(self):
+        store = self._store()
+        self.mock_collection.count_documents.side_effect = RuntimeError(
+            "connection lost")
+        self.assertEqual(store.get_document_count(), 0)
+
+    def test_get_document_by_id_found(self):
+        store = self._store()
+        self.mock_collection.find_one.return_value = {
+            "_id": "d1", "text": "found", "metadata_json": '{"k":"v"}'}
+        doc = store.get_document_by_id("d1")
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc.text, "found")
+        self.assertEqual(doc.metadata, {"k": "v"})
+
+    def test_get_document_by_id_not_found_returns_none(self):
+        store = self._store()
+        self.mock_collection.find_one.return_value = None
+        self.assertIsNone(store.get_document_by_id("missing"))
+
+    def test_list_document_ids_returns_ids(self):
+        store = self._store()
+        self.mock_collection.find.return_value = iter([
+            {"_id": "a"}, {"_id": "b"}, {"_id": "c"},
+        ])
+        ids = store.list_document_ids()
+        self.assertEqual(ids, ["a", "b", "c"])
+
+
+class TestMongoDBAtlasStoreConnection(unittest.TestCase):
+
+    def test_resolve_connection_url_from_env(self):
+        store = MongoDBAtlasStore(connection_url=None)
+        with patch.dict("os.environ", {"MONGODB_ATLAS_URI": "mongodb://env"}):
+            self.assertEqual(store._resolve_connection_url(), "mongodb://env")
+
+    def test_resolve_connection_url_missing_raises(self):
+        store = MongoDBAtlasStore(connection_url=None)
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError):
+                store._resolve_connection_url()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_agentuniverse/unit/llm/test_groq_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_groq_llm.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the Groq Cloud LLM component.
+
+These tests exercise the parts of :class:`GroqLLM` that do not require a
+live Groq API key: credential/base-url wiring, the per-model context length
+table and the token estimator. The network-bound call/acall/stream tests
+are kept but commented out so that the full suite can run in CI without
+any external dependency.
+"""
+
+import asyncio
+import unittest
+
+from agentuniverse.llm.default.groq_llm import (
+    GROQ_DEFAULT_CONTEXT_LENGTH,
+    GROQ_MAX_CONTEXT_LENGTH,
+    GroqLLM,
+)
+
+
+class TestGroqLLM(unittest.TestCase):
+    """Test suite for the GroqLLM component."""
+
+    def setUp(self) -> None:
+        """Build a GroqLLM instance with dummy credentials."""
+        self.llm = GroqLLM(
+            model_name='llama-3.3-70b-versatile',
+            api_key='dummy-groq-key',
+            api_base='https://api.groq.com/openai/v1',
+            max_tokens=512,
+            temperature=0.7,
+        )
+
+    def test_initialization(self) -> None:
+        """LLM must accept and persist the constructor parameters."""
+        self.assertEqual(self.llm.model_name, 'llama-3.3-70b-versatile')
+        self.assertEqual(self.llm.api_key, 'dummy-groq-key')
+        self.assertEqual(self.llm.api_base, 'https://api.groq.com/openai/v1')
+        self.assertEqual(self.llm.max_tokens, 512)
+        self.assertEqual(self.llm.temperature, 0.7)
+
+    def test_default_api_base(self) -> None:
+        """When no api_base is provided the Groq endpoint must be used."""
+        llm = GroqLLM(model_name='llama-3.3-70b-versatile', api_key='dummy')
+        self.assertEqual(llm.api_base, 'https://api.groq.com/openai/v1')
+
+    def test_max_context_length_known_models(self) -> None:
+        """Known models must resolve to their documented context window."""
+        known = [
+            ('llama-3.3-70b-versatile', 131072),
+            ('llama-3.1-8b-instant', 131072),
+            ('mixtral-8x7b-32768', 32768),
+            ('gemma2-9b-it', 8192),
+        ]
+        for model_name, expected in known:
+            llm = GroqLLM(model_name=model_name, api_key='dummy')
+            self.assertEqual(
+                llm.max_context_length(),
+                expected,
+                f'Context length mismatch for {model_name}',
+            )
+
+    def test_max_context_length_unknown_model(self) -> None:
+        """Unknown models must fall back to the default context length."""
+        llm = GroqLLM(model_name='some-future-groq-model', api_key='dummy')
+        self.assertEqual(llm.max_context_length(), GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def test_max_context_length_table_consistency(self) -> None:
+        """Every entry in the table must be a positive integer."""
+        for model_name, length in GROQ_MAX_CONTEXT_LENGTH.items():
+            self.assertIsInstance(length, int, f'{model_name} length not int')
+            self.assertGreater(length, 0, f'{model_name} length not positive')
+
+    def test_get_num_tokens(self) -> None:
+        """The token estimator must return a sensible positive count."""
+        text = 'Hello Groq, please introduce yourself.'
+        num_tokens = self.llm.get_num_tokens(text)
+        self.assertIsInstance(num_tokens, int)
+        self.assertGreater(num_tokens, 0)
+        # The estimator must be deterministic for the same input.
+        self.assertEqual(num_tokens, self.llm.get_num_tokens(text))
+
+    def test_get_num_tokens_empty_string(self) -> None:
+        """An empty string must cost zero tokens."""
+        self.assertEqual(self.llm.get_num_tokens(''), 0)
+
+    # ========== Integration tests (require a real GROQ_API_KEY) ==========
+    # Uncomment and set GROQ_API_KEY in the environment to exercise the
+    # live Groq API.
+
+    # def test_call(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = self.llm.call(messages=messages, streaming=False)
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_acall(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_call_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #     chunks = []
+    #     for chunk in self.llm.call(messages=messages, streaming=True):
+    #         chunks.append(chunk.text)
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_acall_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #
+    #     async def _run():
+    #         result = []
+    #         async for chunk in await self.llm.acall(messages=messages, streaming=True):
+    #             result.append(chunk.text)
+    #         return result
+    #
+    #     chunks = asyncio.run(_run())
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_as_langchain(self) -> None:
+    #     from langchain.chains.conversation.base import ConversationChain
+    #     langchain_llm = self.llm.as_langchain()
+    #     llm_chain = ConversationChain(llm=langchain_llm)
+    #     res = llm_chain.predict(input='Say hello')
+    #     self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds `MongoDBAtlasStore` — a vector store backed by MongoDB Atlas Vector Search using `$vectorSearch` aggregation.

## Capabilities

- Full CRUD: insert, query ($vectorSearch), upsert, update, delete, get_by_id, count, list_ids.
- Dimension validation: mismatched vectors raise ValueError.
- Configurable similarity (cosine/euclidean/dotProduct), vector_field, text_field, index_name.
- Lazy import of `pymongo` (optional dependency).
- Connection URL from `MONGODB_ATLAS_URI` env var.

## Tests

26 unit tests (mock pymongo client): config validation, insert + dim mismatch, query with score, delete, count, get_by_id, list_ids.

`python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_mongodb_atlas_store` — 26 passed.