### PR TITLE
fix(config): avoid custom key config prints

### DIFF
--- a/agentuniverse/base/config/custom_configer/custom_key_configer.py
+++ b/agentuniverse/base/config/custom_configer/custom_key_configer.py
@@ -9,6 +9,7 @@
 import os
 
 from agentuniverse.base.annotation.singleton import singleton
+from agentuniverse.base.util.logging.logging_util import LOGGER
 from ..configer import Configer
 
 
@@ -22,8 +23,9 @@ class CustomKeyConfiger(Configer):
             try:
                 self.load()
             except FileNotFoundError as e:
-                print(f"Custom key file {config_path} read error, "
-                      f"skip load custom key.")
+                LOGGER.warning(
+                    f"Custom key file {config_path} read error, skip load custom key."
+                )
         if self._Configer__value.get("KEY_LIST"):
             for key, value in self._Configer__value.get("KEY_LIST").items():
                 os.environ[key] = str(value)

--- a/tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py
@@ -1,0 +1,21 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from agentuniverse.base.config.custom_configer.custom_key_configer import CustomKeyConfiger
+
+
+class CustomKeyConfigerTest(unittest.TestCase):
+
+    def test_missing_config_does_not_print_to_stdout(self):
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            configer = CustomKeyConfiger("missing_custom_key.toml")
+
+        self.assertEqual({}, configer.value)
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace the direct `print` in `CustomKeyConfiger` missing-file handling with project logger warning output.
- Keep the existing behavior of skipping custom key loading when the file is absent.
- Add regression coverage that verifies missing custom key config does not write to stdout.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/base/config/custom_configer/custom_key_configer.py tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.