### PR TITLE
fix(reader): avoid image OCR debug prints

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.util.logging.logging_util import LOGGER
 
 
 class ImageOCRReader(Reader):
@@ -21,14 +22,13 @@ class ImageOCRReader(Reader):
     """
 
     def _load_data(self, file: Union[str, Path], ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: ImageOCRReader start load file={file}")
         if isinstance(file, str):
             file = Path(file)
         if not isinstance(file, Path) or not file.exists():
             raise FileNotFoundError(f"ImageOCRReader file not found: {file}")
 
         text, engine = self._ocr(file)
-        print(f"debugging: ImageOCRReader extracted by {engine}, length={len(text)}")
+        LOGGER.debug(f"ImageOCRReader extracted text by {engine}.")
 
         metadata: Dict = {"source": "image", "file_name": file.name, "engine": engine}
         if ext_info:
@@ -39,7 +39,7 @@ class ImageOCRReader(Reader):
         # Try PaddleOCR
         try:
             from paddleocr import PaddleOCR  # type: ignore
-            print("debugging: ImageOCRReader using PaddleOCR")
+            LOGGER.debug("ImageOCRReader using PaddleOCR.")
             ocr = PaddleOCR(use_angle_cls=True, lang='ch')
             result = ocr.ocr(str(file), cls=True)
             lines: List[str] = []
@@ -50,23 +50,23 @@ class ImageOCRReader(Reader):
                         lines.append(txt)
             return "\n".join(lines), "paddleocr"
         except Exception as e_paddle:
-            print(f"debugging: ImageOCRReader PaddleOCR failed: {e_paddle}")
+            LOGGER.debug(f"ImageOCRReader PaddleOCR failed: {e_paddle}")
 
         # Fallback to pytesseract
         try:
             from PIL import Image  # type: ignore
             import pytesseract  # type: ignore
-            print("debugging: ImageOCRReader using pytesseract")
+            LOGGER.debug("ImageOCRReader using pytesseract.")
             img = Image.open(file)
             text = pytesseract.image_to_string(img, lang='chi_sim+eng')
             return text, "pytesseract"
         except Exception as e_tess:
-            print(f"debugging: ImageOCRReader pytesseract failed: {e_tess}")
+            LOGGER.debug(f"ImageOCRReader pytesseract failed: {e_tess}")
 
         # Fallback to easyocr
         try:
             import easyocr  # type: ignore
-            print("debugging: ImageOCRReader using easyocr")
+            LOGGER.debug("ImageOCRReader using easyocr.")
             reader = easyocr.Reader(['ch_sim', 'en'])
             result = reader.readtext(str(file), detail=0)
             return "\n".join(result), "easyocr"

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_reader.py
@@ -1,0 +1,27 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.image.image_ocr_reader import ImageOCRReader
+
+
+class ImageOCRReaderTest(unittest.TestCase):
+
+    def test_load_data_does_not_print_file_path(self):
+        reader = ImageOCRReader()
+        stdout = io.StringIO()
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as temp_file, \
+                patch.object(reader, "_ocr", return_value=("text", "mock")), \
+                redirect_stdout(stdout):
+            documents = reader._load_data(Path(temp_file.name))
+
+        self.assertEqual("text", documents[0].text)
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace `ImageOCRReader` debug `print` calls with project logger debug output.
- Avoid printing local image paths and OCR fallback errors to caller stdout.
- Add regression coverage that loads a mocked image OCR result and verifies stdout remains clean.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_image_ocr_reader.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.