### PR TITLE
fix(tool): preserve falsey API values

### DIFF
--- a/agentuniverse/agent/action/tool/api_tool.py
+++ b/agentuniverse/agent/action/tool/api_tool.py
@@ -51,7 +51,7 @@ class APITool(Tool):
                         return str(value)
                     elif option['type'] == 'boolean':
                         return self._convert_boolean(value)
-                    elif option['type'] == 'null' and not value:
+                    elif option['type'] == 'null' and value is None:
                         return None
                     else:
                         # Unsupported type, try next option

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_anyof_null.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_anyof_null.py
@@ -1,0 +1,18 @@
+import unittest
+
+from agentuniverse.agent.action.tool.api_tool import APITool
+
+
+class APIToolAnyOfNullTest(unittest.TestCase):
+
+    def test_any_of_null_does_not_convert_falsey_values(self):
+        tool = APITool()
+        schema = [{"type": "null"}, {"type": "integer"}]
+
+        self.assertEqual(0, tool.convert_body_property_any_of({}, 0, schema))
+        self.assertEqual("", tool.convert_body_property_any_of({}, "", schema))
+        self.assertIsNone(tool.convert_body_property_any_of({}, None, schema))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Change `APITool.convert_body_property_any_of` so `null` conversion only matches actual `None`.
- Preserve valid falsey values such as `0` and empty strings instead of converting them to `None`.
- Add regression coverage for `0`, empty string, and `None` with an `anyOf` schema.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_anyof_null.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/tool/api_tool.py tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_anyof_null.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.