### PR TITLE
fix(llm): avoid Claude async stream prints

### DIFF
--- a/agentuniverse/llm/default/claude_llm.py
+++ b/agentuniverse/llm/default/claude_llm.py
@@ -14,6 +14,7 @@ from pydantic import Field
 
 from agentuniverse.base.config.component_configer.configers.llm_configer import LLMConfiger
 from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.base.util.logging.logging_util import LOGGER
 from agentuniverse.base.util.system_util import process_yaml_func
 from agentuniverse.llm.claude_langchain_instance import ClaudeLangChainInstance
 from agentuniverse.llm.llm import LLM
@@ -120,7 +121,7 @@ class ClaudeLLM(LLM):
 
     async def agenerate_stream_result(self, chat_completion: AsyncIterator):
         async for chunk in chat_completion:
-            print(chunk)
+            LOGGER.debug(f"ClaudeLLM received async stream chunk: {chunk.type}")
             if chunk.type != 'content_block_delta':
                 continue
             yield LLMOutput(text=chunk.delta.text, raw=chunk.model_dump())

--- a/tests/test_agentuniverse/unit/llm/test_claude_llm_stream.py
+++ b/tests/test_agentuniverse/unit/llm/test_claude_llm_stream.py
@@ -1,0 +1,52 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+from agentuniverse.llm.default.claude_llm import ClaudeLLM
+
+
+class _AsyncChunks:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        self._iter = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _Chunk:
+    type = "content_block_delta"
+    delta = SimpleNamespace(text="hello")
+
+    def model_dump(self):
+        return {"type": self.type, "text": self.delta.text}
+
+
+class ClaudeLLMStreamTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_async_stream_does_not_print_chunks(self):
+        llm = ClaudeLLM()
+        stdout = io.StringIO()
+
+        async def collect():
+            return [
+                output
+                async for output in llm.agenerate_stream_result(_AsyncChunks([_Chunk()]))
+            ]
+
+        with redirect_stdout(stdout):
+            outputs = await collect()
+
+        self.assertEqual("hello", outputs[0].text)
+        self.assertEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one. | 在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Replace the direct chunk `print` in Claude async streaming with project logger debug output.
- Keep async stream output behavior unchanged for `content_block_delta` chunks.
- Add regression coverage that consumes a mocked async stream and verifies stdout remains clean.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** | **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/llm/test_claude_llm_stream.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/llm/default/claude_llm.py tests/test_agentuniverse/unit/llm/test_claude_llm_stream.py`: passed.
- Full unit test was not run to completion locally because this environment is missing project runtime dependencies.

**Please list the names of the docs that were added or modified in this PR (fill in as needed):** | **请列出本次PR新增或修改的文档名称(按需填写):**

- None.