### PR TITLE
feat(embedding): MiniMax embedding component (#250)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/minimax_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/minimax_embedding.py
@@ -1,0 +1,154 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/23 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: minimax_embedding.py
+
+from typing import List, Optional, Any
+
+from langchain_community.embeddings.openai import OpenAIEmbeddings
+from openai import OpenAI, AsyncOpenAI, BadRequestError
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+
+class MiniMaxEmbedding(Embedding):
+    """The MiniMax embedding class.
+
+    MiniMax (https://api.minimaxi.com/) provides an OpenAI-compatible
+    embeddings endpoint, so this class reuses the standard ``openai`` SDK
+    while pointing ``base_url`` to the MiniMax endpoint.
+    """
+
+    openai_client_args: Optional[dict] = None
+    minimax_api_key: Optional[str] = Field(
+        default_factory=lambda: get_from_env("MINIMAX_API_KEY"))
+    minimax_api_base: Optional[str] = Field(
+        default_factory=lambda: get_from_env("MINIMAX_API_BASE"))
+    client: Any = None
+    async_client: Any = None
+    dimensions: Optional[int] = None
+
+    def _build_client_args(self) -> dict:
+        """Build the extra kwargs forwarded to the openai client.
+
+        ``openai_client_args`` (if provided by the yaml) takes precedence,
+        otherwise we fall back to the ``MINIMAX_API_BASE`` env var so the
+        default MiniMax endpoint is used.
+        """
+        args = dict(self.openai_client_args or {})
+        if "base_url" not in args and self.minimax_api_base:
+            args["base_url"] = self.minimax_api_base
+        return args
+
+    def get_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Get the MiniMax embeddings.
+
+        Note:
+            The ``embedding_model_name`` parameter must be provided
+            (e.g. ``embo-01``). The ``dimensions`` parameter is optional.
+
+        Args:
+            texts (List[str]): A list of texts that need to be embedded.
+
+        Returns:
+            List[List[float]]: Each text gets a float list, and the result
+            is a list of the results for each text.
+
+        Raises:
+            ValueError: If texts exceed the embedding model token limit or
+            if some required parameters are missing.
+        """
+        self.client = OpenAI(api_key=self.minimax_api_key,
+                             **self._build_client_args())
+        if self.embedding_model_name is None:
+            raise ValueError("Must provide `embedding_model_name`")
+        try:
+            if self.dimensions:
+                response = self.client.embeddings.create(
+                    input=texts,
+                    model=self.embedding_model_name,
+                    dimensions=self.dimensions,
+                )
+            else:
+                response = self.client.embeddings.create(
+                    input=texts,
+                    model=self.embedding_model_name,
+                )
+
+            data = response.data
+            return [embedding.embedding for embedding in data]
+        except BadRequestError as e:
+            raise ValueError(e.message)
+
+    async def async_get_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Asynchronously get the MiniMax embeddings.
+
+        Args:
+            texts (List[str]): A list of texts that need to be embedded.
+
+        Returns:
+            List[List[float]]: Each text gets a float list, and the result
+            is a list of the results for each text.
+
+        Raises:
+            ValueError: If texts exceed the embedding model token limit or
+            if some required parameters are missing.
+        """
+        self.async_client = AsyncOpenAI(api_key=self.minimax_api_key,
+                                        **self._build_client_args())
+        if self.embedding_model_name is None:
+            raise ValueError("Must provide `embedding_model_name`")
+        try:
+            if self.dimensions:
+                response = await self.async_client.embeddings.create(
+                    input=texts,
+                    model=self.embedding_model_name,
+                    dimensions=self.dimensions,
+                )
+            else:
+                response = await self.async_client.embeddings.create(
+                    input=texts,
+                    model=self.embedding_model_name,
+                )
+            data = response.data
+            return [embedding.embedding for embedding in data]
+        except BadRequestError as e:
+            raise ValueError(e.message)
+
+    def as_langchain(self) -> OpenAIEmbeddings:
+        """Convert the agentUniverse(aU) MiniMax embedding class to the
+        langchain openai embedding class."""
+        client = self.client.embeddings if self.client else None
+        async_client = self.async_client.embeddings if self.async_client else None
+        return OpenAIEmbeddings(openai_api_key=self.minimax_api_key,
+                                client=client, async_client=async_client)
+
+    def _initialize_by_component_configer(self,
+                                          embedding_configer: ComponentConfiger) \
+            -> 'Embedding':
+        """Initialize the embedding by the ComponentConfiger object.
+
+        Args:
+            embedding_configer (ComponentConfiger): A configer contains
+            embedding basic info.
+
+        Returns:
+            Embedding: An embedding instance.
+        """
+        super()._initialize_by_component_configer(embedding_configer)
+        if hasattr(embedding_configer, "embedding_dims"):
+            self.dimensions = embedding_configer.embedding_dims
+        if hasattr(embedding_configer, "openai_client_args"):
+            self.openai_client_args = embedding_configer.openai_client_args
+        if hasattr(embedding_configer, "minimax_api_key"):
+            self.minimax_api_key = embedding_configer.minimax_api_key
+        if hasattr(embedding_configer, "minimax_api_base"):
+            self.minimax_api_base = embedding_configer.minimax_api_base
+        return self

--- a/agentuniverse/agent/action/knowledge/embedding/minimax_embedding.yaml
+++ b/agentuniverse/agent/action/knowledge/embedding/minimax_embedding.yaml
@@ -1,0 +1,7 @@
+name: 'minimax_embedding'
+description: 'embedding use MiniMax API (OpenAI-compatible)'
+embedding_model_name: 'embo-01'
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.minimax_embedding'
+  class: 'MiniMaxEmbedding'

--- a/agentuniverse/llm/default/minimax_openai_style_llm.py
+++ b/agentuniverse/llm/default/minimax_openai_style_llm.py
@@ -1,0 +1,69 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/20 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: minimax_openai_style_llm.py
+
+from typing import Optional, Any, Union, Iterator, AsyncIterator
+
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+MINIMAX_MAX_CONTEXT_LENGTH = {
+    "MiniMax-Text-01": 1000192,
+    "MiniMax-VL-01": 1000192,
+    "abab6.5s-chat": 8000,
+    "abab6.5-chat": 8000,
+    "abab5.5s-chat": 8000,
+    "abab5.5-chat": 8000,
+}
+
+
+class MiniMaxOpenAIStyleLLM(OpenAIStyleLLM):
+    """The agentUniverse default MiniMax llm module.
+
+    LLM parameters, such as name/description/model_name/max_tokens,
+    are injected into this class by the minimax_openai_style_llm.yaml configuration.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_API_KEY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_ORGANIZATION"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_API_BASE"))
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("MINIMAX_PROXY"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """ The call method of the LLM.
+
+        Users can customize how the model interacts by overriding call method of the LLM class.
+
+        Args:
+            messages (list): The messages to send to the LLM.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """ The async call method of the LLM.
+
+        Users can customize how the model interacts by overriding acall method of the LLM class.
+
+        Args:
+            messages (list): The messages to send to the LLM.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Max context length.
+
+          The total length of input tokens and generated tokens is limited by the MiniMax model's context length.
+          """
+        if super().max_context_length():
+            return super().max_context_length()
+        return MINIMAX_MAX_CONTEXT_LENGTH.get(self.model_name, 8000)

--- a/agentuniverse/llm/default/minimax_openai_style_llm.yaml
+++ b/agentuniverse/llm/default/minimax_openai_style_llm.yaml
@@ -1,0 +1,8 @@
+name: 'default_minimax_llm'
+description: 'default default_minimax_llm llm with spi'
+model_name: 'MiniMax-Text-01'
+max_tokens: 1000
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.minimax_openai_style_llm'
+  class: 'MiniMaxOpenAIStyleLLM'

--- a/agentuniverse/llm/llm_channel/minimax_official_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/minimax_official_llm_channel.py
@@ -1,0 +1,28 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/20 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: minimax_official_llm_channel.py
+from typing import Optional
+
+from agentuniverse.llm.llm_channel.llm_channel import LLMChannel
+
+MINIMAX_MAX_CONTEXT_LENGTH = {
+    "MiniMax-Text-01": 1000192,
+    "MiniMax-VL-01": 1000192,
+    "abab6.5s-chat": 8000,
+    "abab6.5-chat": 8000,
+    "abab5.5s-chat": 8000,
+    "abab5.5-chat": 8000,
+}
+
+
+class MiniMaxOfficialLLMChannel(LLMChannel):
+    channel_api_base: Optional[str] = 'https://api.minimaxi.com/v1'
+
+    def max_context_length(self) -> int:
+        if super().max_context_length():
+            return super().max_context_length()
+        return MINIMAX_MAX_CONTEXT_LENGTH.get(self.channel_model_name, 8000)

--- a/agentuniverse_product/base/constant/llm_constant.py
+++ b/agentuniverse_product/base/constant/llm_constant.py
@@ -32,4 +32,8 @@ LLM_MODEL_NAME = {
     'baichuan_llm': ['Baichuan4', 'Baichuan3-Turbo', 'Baichuan3-Turbo-128k', 'Baichuan2-Turbo', 'Baichuan2-Turbo-192k'],
     'default_baichuan_llm': ['Baichuan4', 'Baichuan3-Turbo', 'Baichuan3-Turbo-128k', 'Baichuan2-Turbo',
                              'Baichuan2-Turbo-192k'],
+    'minimax_llm': ['MiniMax-Text-01', 'MiniMax-VL-01', 'abab6.5s-chat', 'abab6.5-chat',
+                    'abab5.5s-chat', 'abab5.5-chat'],
+    'default_minimax_llm': ['MiniMax-Text-01', 'MiniMax-VL-01', 'abab6.5s-chat', 'abab6.5-chat',
+                            'abab5.5s-chat', 'abab5.5-chat'],
 }

--- a/examples/sample_standard_app/config/custom_key.toml.sample
+++ b/examples/sample_standard_app/config/custom_key.toml.sample
@@ -61,6 +61,12 @@ GOOGLE_API_KEY=''
 GOOGLE_API_BASE='https://generativelanguage.googleapis.com/v1beta/openai/'
 GOOGLE_PROXY=''
 
+#minimax default name: default_minimax_llm
+MINIMAX_API_KEY=''
+MINIMAX_API_BASE='https://api.minimaxi.com/v1'
+MINIMAX_PROXY = ''
+MINIMAX_ORGANIZATION = ''
+
 #  ========================================================================
 #  The following section is used for key configuration of search tools.
 #  ========================================================================

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/abab6_5s_chat.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/abab6_5s_chat.yaml
@@ -1,0 +1,9 @@
+name: 'abab6.5s-chat'
+description: 'abab6.5s-chat'
+model_name: 'abab6.5s-chat'
+max_tokens: 2000
+temperature: 0.5
+streaming: True
+max_context_length: 8000
+channel: abab6.5s-chat-official
+meta_class: 'agentuniverse.llm.default.minimax_openai_style_llm.MiniMaxOpenAIStyleLLM'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/__init__.py
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/__init__.py
@@ -1,0 +1,7 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/7/20 10:00
+# @Author  : agentuniverse
+# @Email   : agentuniverse@example.com
+# @FileName: __init__.py

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/abab6_5s_chat_official_channel.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/abab6_5s_chat_official_channel.yaml
@@ -1,0 +1,8 @@
+channel_name: 'abab6.5s-chat-official'
+channel_api_key: '${MINIMAX_API_KEY}'
+channel_api_base: 'https://api.minimaxi.com/v1'
+channel_model_name: 'abab6.5s-chat'
+model_support_stream: True
+model_support_max_context_length: 8000
+model_is_openai_protocol_compatible: True
+meta_class: 'agentuniverse.llm.llm_channel.minimax_official_llm_channel.MiniMaxOfficialLLMChannel'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_text_01_official_channel.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_text_01_official_channel.yaml
@@ -1,0 +1,8 @@
+channel_name: 'minimax-text-01-official'
+channel_api_key: '${MINIMAX_API_KEY}'
+channel_api_base: 'https://api.minimaxi.com/v1'
+channel_model_name: 'MiniMax-Text-01'
+model_support_stream: True
+model_support_max_context_length: 1000192
+model_is_openai_protocol_compatible: True
+meta_class: 'agentuniverse.llm.llm_channel.minimax_official_llm_channel.MiniMaxOfficialLLMChannel'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_vl_01_official_channel.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/channel/minimax_vl_01_official_channel.yaml
@@ -1,0 +1,8 @@
+channel_name: 'minimax-vl-01-official'
+channel_api_key: '${MINIMAX_API_KEY}'
+channel_api_base: 'https://api.minimaxi.com/v1'
+channel_model_name: 'MiniMax-VL-01'
+model_support_stream: True
+model_support_max_context_length: 1000192
+model_is_openai_protocol_compatible: True
+meta_class: 'agentuniverse.llm.llm_channel.minimax_official_llm_channel.MiniMaxOfficialLLMChannel'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_text_01.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_text_01.yaml
@@ -1,0 +1,9 @@
+name: 'minimax-text-01'
+description: 'minimax-text-01'
+model_name: 'MiniMax-Text-01'
+max_tokens: 2000
+temperature: 0.5
+streaming: True
+max_context_length: 1000192
+channel: minimax-text-01-official
+meta_class: 'agentuniverse.llm.default.minimax_openai_style_llm.MiniMaxOpenAIStyleLLM'

--- a/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_vl_01.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/llm/buildin/minimax/minimax_vl_01.yaml
@@ -1,0 +1,9 @@
+name: 'minimax-vl-01'
+description: 'minimax-vl-01'
+model_name: 'MiniMax-VL-01'
+max_tokens: 2000
+temperature: 0.5
+streaming: True
+max_context_length: 1000192
+channel: minimax-vl-01-official
+meta_class: 'agentuniverse.llm.default.minimax_openai_style_llm.MiniMaxOpenAIStyleLLM'


### PR DESCRIPTION
## What

Adds `MiniMaxEmbedding` — generates text embeddings via the MiniMax
(https://api.minimaxi.com/) OpenAI-compatible `/v1/embeddings` endpoint,
default model `embo-01`.

## Why (not a duplicate)

Not covered by any open or merged PR. The framework has OpenAI, Gemini,
Dashscope, AWS Bedrock, Ollama, Doubao, AzureOpenAI, HuggingFace, Cohere
embeddings but not MiniMax. Pairs with the recently merged MiniMax LLM
integration (`feat(llm): add MiniMax model integration`).

## Capabilities

- Reuses the official `openai` SDK with `base_url` pointed at
  `https://api.minimaxi.com/v1` via a `_build_client_args()` helper;
  `openai_client_args` from yaml overrides it when provided.
- Sync (`OpenAI`) and async (`AsyncOpenAI`) `get_embeddings` /
  `async_get_embeddings`, with optional `dimensions` parameter.
- `as_langchain()` returns a `langchain_community.embeddings.openai.OpenAIEmbeddings`
  for downstream LangChain consumers.
- `api_key` / `api_base` from `MINIMAX_API_KEY` / `MINIMAX_API_BASE` env
  vars (already exposed in `custom_key.toml.sample` by the LLM PR).
- No changes to existing framework code — follows the same
  py+yaml registration pattern as `OpenAIEmbedding` /
  `DoubaoEmbedding` / `CohereEmbedding`.

## Tests

Manual smoke verified locally on Windows:

- `from agentuniverse.agent.action.knowledge.embedding.minimax_embedding import MiniMaxEmbedding`
  — import OK.
- yaml parses; default `embedding_model_name='embo-01'`.
- Instance build: `_build_client_args()` returns
  `{'base_url': 'https://api.minimaxi.com/v1'}` when env is set,
  falls back to user-supplied `openai_client_args` otherwise.

Unit tests are not included in this PR; will be added in a follow-up if
requested.