### PR TITLE
feat(llm): add 01.AI Yi series LLM component (#250)

### DIFF
--- a/agentuniverse/llm/default/yi_llm.py
+++ b/agentuniverse/llm/default/yi_llm.py
@@ -1,0 +1,156 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: yi_llm.py
+
+"""
+01.AI (零一万物) Yi series LLM.
+
+01.AI (https://www.01.ai) is the artificial intelligence company founded by
+Kai-Fu Lee whose flagship product line is the **Yi** family of foundation
+large language models (Yi-Large, Yi-Medium, Yi-Small, Yi-Vision, ...).
+
+The Yi models are exposed through a fully **OpenAI-compatible** Chat
+Completions API at ``https://api.01.ai/v1``. Because of that compatibility
+this component only needs to extend :class:`OpenAIStyleLLM` and wire up the
+correct default environment variables, the 01.AI API base URL and the
+per-model maximum context length table. Streaming, tool calling, the async
+interface and the LangChain bridge all work out of the box.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Optional, Union
+
+import tiktoken
+from pydantic import Field
+
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+# The maximum context length (input + output tokens) supported by the Yi
+# models currently available on the 01.AI platform. Values are taken from
+# the official 01.AI documentation (https://platform.lingyiwanhu.com).
+# When 01.AI releases a new model it is sufficient to add an entry here,
+# the rest of the component keeps working unchanged.
+YI_MAX_CONTEXT_LENGTH = {
+    # ---- Flagship large model ----
+    "yi-large": 32768,
+    "yi-large-turbo": 32768,
+    "yi-large-rag": 32768,
+    # ---- Mid-size model ----
+    "yi-medium": 16384,
+    "yi-medium-200k": 204800,
+    # ---- Small / fast model ----
+    "yi-small": 16384,
+    "yi-spark": 16384,
+    # ---- Vision model ----
+    "yi-vision": 16384,
+    "yi-vision-plus": 16384,
+}
+
+# Sensible default context length returned for models that are not yet listed
+# in the table above. The Yi family commonly exposes a 16k window, so 16384
+# is a safe conservative fallback.
+YI_DEFAULT_CONTEXT_LENGTH = 16384
+
+
+class YiLLM(OpenAIStyleLLM):
+    """01.AI Yi series LLM, an OpenAI-compatible wrapper around the Yi API.
+
+    01.AI runs the Yi family of foundation models behind an
+    OpenAI-compatible endpoint. Because the wire protocol is identical to
+    OpenAI's, this class only customises the credential/base-url plumbing
+    and the model context-length lookup table while inheriting the complete
+    request, streaming and langchain-bridge implementation from
+    :class:`OpenAIStyleLLM`.
+
+    Attributes:
+        api_key: 01.AI API key. Loaded from the ``YI_API_KEY`` environment
+            variable when not provided explicitly. Create one at
+            https://platform.lingyiwanhu.com.
+        api_base: 01.AI OpenAI-compatible API base URL. Defaults to
+            ``https://api.01.ai/v1`` unless overridden through the
+            ``YI_API_BASE`` environment variable.
+        proxy: Optional HTTP(S) proxy used for outbound requests.
+        organization: Optional organization id forwarded to the client.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("YI_API_KEY"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("YI_API_BASE") or
+                                    "https://api.01.ai/v1")
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("YI_PROXY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("YI_ORGANIZATION"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call to the 01.AI chat completions endpoint.
+
+        Users may override this method to customise the interaction, the
+        default implementation simply delegates to the OpenAI-style parent
+        which constructs and dispatches the request against the 01.AI API
+        base URL.
+
+        Args:
+            messages (list): The chat messages to send to the Yi model.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                client, e.g. ``temperature``, ``top_p``, ``max_tokens`` ...
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an iterator of
+            :class:`LLMOutput` chunks when ``stream=True`` is supplied.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call to the 01.AI chat completions endpoint.
+
+        Args:
+            messages (list): The chat messages to send to the Yi model.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                async client.
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an async
+            iterator of :class:`LLMOutput` chunks when ``stream=True``.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Yi model.
+
+        The combined length of the input prompt and the generated completion
+        must fit within this window. The value is resolved in the following
+        order:
+
+        1. If a context length was explicitly injected through the YAML
+           configuration (``max_context_length`` field) that value wins.
+        2. Otherwise the model name is looked up in
+           :data:`YI_MAX_CONTEXT_LENGTH`.
+        3. As a last resort :data:`YI_DEFAULT_CONTEXT_LENGTH` is returned.
+        """
+        if super().max_context_length():
+            return super().max_context_length()
+        return YI_MAX_CONTEXT_LENGTH.get(self.model_name, YI_DEFAULT_CONTEXT_LENGTH)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate the number of tokens that ``text`` will consume.
+
+        The Yi model family does not ship a public tokenizer registered in
+        ``tiktoken`` by name, so we fall back to the widely used
+        ``cl100k_base`` encoding which gives a good approximation suitable
+        for budget / prompt-window checks.
+
+        Args:
+            text: The raw string to tokenize.
+
+        Returns:
+            The integer number of tokens the text would be encoded into.
+        """
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            # Yi models are not registered in tiktoken by name; cl100k_base
+            # is a robust generic fallback for modern LLM tokenizers.
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))

--- a/agentuniverse/llm/default/yi_llm.yaml.example
+++ b/agentuniverse/llm/default/yi_llm.yaml.example
@@ -1,0 +1,14 @@
+name: 'default_yi_llm'
+description: 'default yi llm powered by 01.AI (零一万物) Yi series models'
+model_name: 'yi-large'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${YI_API_KEY}'
+api_base: 'https://api.01.ai/v1'
+organization: '${YI_ORGANIZATION}'
+proxy: '${YI_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.yi_llm'
+  class: 'YiLLM'

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Yi_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Yi_LLM_Use.md
@@ -1,0 +1,145 @@
+# Yi LLM Use
+
+`YiLLM` integrates the [01.AI (零一万物)](https://www.01.ai) **Yi** family of foundation large language models into agentUniverse. The Yi series — Yi-Large, Yi-Medium, Yi-Small, Yi-Vision and friends — is developed by 01.AI, the AI company founded by Kai-Fu Lee.
+
+01.AI exposes a fully **OpenAI-compatible** Chat Completions API at `https://api.01.ai/v1`, so the `YiLLM` component simply extends `OpenAIStyleLLM` and only wires up the 01.AI credentials, API base URL and per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge all work out of the box.
+
+---
+
+## 1. Create the configuration file
+
+Create a YAML file, for example `user_yi_llm.yaml`, and paste the following content into it.
+
+```yaml
+name: 'user_yi_llm'
+description: 'user yi llm powered by 01.AI Yi series models'
+model_name: 'yi-large'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${YI_API_KEY}'
+api_base: 'https://api.01.ai/v1'
+organization: '${YI_ORGANIZATION}'
+proxy: '${YI_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.yi_llm'
+  class: 'YiLLM'
+```
+
+**Note:** Model parameters such as `api_key`, `api_base`, `organization` and `proxy` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+
+    ```yaml
+    api_key: 'your-yi-key'
+    ```
+
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax to load the value from an environment variable. When agentUniverse starts it will automatically read the corresponding value.
+
+    ```yaml
+    api_key: '${YI_API_KEY}'
+    ```
+
+3. **Custom function loading** - use the `@FUNC` annotation to dynamically load the API key through a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="yi"))'
+    ```
+
+    The function must be defined in the `YamlFuncExtension` class inside the `yaml_func_extension.py` file. Refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When agentUniverse loads this configuration it parses the `@FUNC` annotation, executes the `load_api_key` function with the supplied arguments, and replaces the annotation with the function's return value.
+
+---
+
+## 2. Pick a model
+
+01.AI offers several Yi models. Below are the most commonly used models together with their context window (input + output tokens). The same values are hard-coded inside `YiLLM.max_context_length`, so agentUniverse can budget prompts correctly even without a live API call.
+
+| Model name            | Context length |
+| --------------------- | -------------- |
+| `yi-large`            | 32768 (32k)    |
+| `yi-large-turbo`      | 32768 (32k)    |
+| `yi-large-rag`        | 32768 (32k)    |
+| `yi-medium`           | 16384 (16k)    |
+| `yi-medium-200k`      | 204800 (200k)  |
+| `yi-small`            | 16384 (16k)    |
+| `yi-spark`            | 16384 (16k)    |
+| `yi-vision`           | 16384 (16k)    |
+| `yi-vision-plus`      | 16384 (16k)    |
+
+Always confirm the latest list on the [01.AI platform documentation](https://platform.lingyiwanhu.com). If a model is not present in the table above, `YiLLM` falls back to a conservative default of 16384 tokens.
+
+---
+
+## 3. Environment setup
+
+The example YAML uses environment variable placeholders. The following section describes how to set those variables.
+
+Required: `YI_API_KEY`
+Optional: `YI_API_BASE`, `YI_PROXY`, `YI_ORGANIZATION`
+
+### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['YI_API_KEY'] = 'your-yi-key'
+os.environ['YI_API_BASE'] = 'https://api.01.ai/v1'
+```
+
+### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory, add the following entries:
+
+```toml
+YI_API_KEY="your-yi-key"
+YI_API_BASE="https://api.01.ai/v1"
+YI_ORGANIZATION=""
+YI_PROXY=""
+```
+
+---
+
+## 4. Obtaining the 01.AI API key
+
+1. Sign in at [https://platform.lingyiwanhu.com](https://platform.lingyiwanhu.com).
+2. Navigate to **API Key** management and create a new key.
+3. Copy the generated key and assign it to `YI_API_KEY`.
+
+Pricing, rate limits and free-tier quotas are documented on the 01.AI platform.
+
+---
+
+## 5. Using the LLM in code
+
+After the configuration is loaded by agentUniverse you can obtain the LLM instance and call it directly:
+
+```python
+from agentuniverse.llm.default.yi_llm import YiLLM
+
+llm = YiLLM(model_name='yi-large')
+
+# Non-streaming
+output = llm.call(messages=[{"role": "user", "content": "Hello!"}])
+print(output.text)
+
+# Streaming
+for chunk in llm.call(messages=[{"role": "user", "content": "Count 1 to 5."}], streaming=True):
+    print(chunk.text, end='')
+
+# Async
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "Hello!"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+Because 01.AI is OpenAI-compatible, every feature supported by `OpenAIStyleLLM` - tool calling, LangChain integration, tracing - is available without any extra work.
+
+---
+
+## 6. Tips
+
+- agentUniverse ships with a ready-to-use instance template named `default_yi_llm` (see `yi_llm.yaml.example`). After configuring the `YI_API_KEY` environment variable you can reference it directly from your agents.
+- `yi-large` is the flagship model and is recommended for complex reasoning; `yi-medium`/`yi-small` are faster and cheaper for simpler tasks.
+- For multimodal (image + text) inputs use `yi-vision` or `yi-vision-plus`.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Yi使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Yi使用.md
@@ -1,0 +1,145 @@
+# Yi（零一万物）模型使用
+
+`YiLLM` 将 [01.AI（零一万物）](https://www.01.ai) 的 **Yi** 系列基础大语言模型接入 agentUniverse。Yi 系列（Yi-Large、Yi-Medium、Yi-Small、Yi-Vision 等）由李开复创办的 01.AI 公司研发。
+
+01.AI 提供完全 **OpenAI 兼容** 的 Chat Completions API，地址为 `https://api.01.ai/v1`，因此 `YiLLM` 组件只需继承 `OpenAIStyleLLM`，配置好 01.AI 的凭证、API 地址以及各模型的上下文长度表即可。流式输出、工具调用、异步接口以及 LangChain 桥接均可直接使用。
+
+---
+
+## 1. 创建配置文件
+
+新建一个 YAML 文件，例如 `user_yi_llm.yaml`，填入以下内容。
+
+```yaml
+name: 'user_yi_llm'
+description: 'user yi llm powered by 01.AI Yi series models'
+model_name: 'yi-large'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${YI_API_KEY}'
+api_base: 'https://api.01.ai/v1'
+organization: '${YI_ORGANIZATION}'
+proxy: '${YI_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.yi_llm'
+  class: 'YiLLM'
+```
+
+**说明：** `api_key`、`api_base`、`organization`、`proxy` 等模型参数支持三种配置方式：
+
+1. **直接填写字符串** —— 在配置文件中直接写入 API Key。
+
+    ```yaml
+    api_key: 'your-yi-key'
+    ```
+
+2. **环境变量占位符** —— 使用 `${VARIABLE_NAME}` 语法从环境变量读取，agentUniverse 启动时会自动读取对应值。
+
+    ```yaml
+    api_key: '${YI_API_KEY}'
+    ```
+
+3. **自定义函数加载** —— 使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API Key。
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="yi"))'
+    ```
+
+    该函数需定义在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中，可参考示例项目中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)。agentUniverse 加载配置时会解析 `@FUNC` 注解，使用传入参数执行 `load_api_key` 函数，并用返回值替换注解。
+
+---
+
+## 2. 选择模型
+
+01.AI 提供多个 Yi 模型。下表列出常用模型及其上下文窗口（输入 + 输出 token）。相同的值已硬编码在 `YiLLM.max_context_length` 中，因此 agentUniverse 即使不发起真实 API 调用也能正确预估 prompt 预算。
+
+| 模型名称              | 上下文长度     |
+| --------------------- | -------------- |
+| `yi-large`            | 32768 (32k)    |
+| `yi-large-turbo`      | 32768 (32k)    |
+| `yi-large-rag`        | 32768 (32k)    |
+| `yi-medium`           | 16384 (16k)    |
+| `yi-medium-200k`      | 204800 (200k)  |
+| `yi-small`            | 16384 (16k)    |
+| `yi-spark`            | 16384 (16k)    |
+| `yi-vision`           | 16384 (16k)    |
+| `yi-vision-plus`      | 16384 (16k)    |
+
+请以 [01.AI 平台文档](https://platform.lingyiwanhu.com) 上的最新列表为准。若使用的模型不在上表中，`YiLLM` 会回退到默认的 16384 token。
+
+---
+
+## 3. 环境配置
+
+示例 YAML 使用了环境变量占位符，以下说明如何设置这些变量。
+
+必填：`YI_API_KEY`
+选填：`YI_API_BASE`、`YI_PROXY`、`YI_ORGANIZATION`
+
+### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['YI_API_KEY'] = 'your-yi-key'
+os.environ['YI_API_BASE'] = 'https://api.01.ai/v1'
+```
+
+### 3.2 通过配置文件配置
+
+在项目 `config` 目录下的 `custom_key.toml` 文件中加入以下内容：
+
+```toml
+YI_API_KEY="your-yi-key"
+YI_API_BASE="https://api.01.ai/v1"
+YI_ORGANIZATION=""
+YI_PROXY=""
+```
+
+---
+
+## 4. 获取 01.AI API Key
+
+1. 登录 [https://platform.lingyiwanhu.com](https://platform.lingyiwanhu.com)。
+2. 进入 **API Key** 管理页面，创建新的 Key。
+3. 复制生成的 Key，赋值给 `YI_API_KEY`。
+
+计费、限流及免费额度说明请参见 01.AI 平台。
+
+---
+
+## 5. 在代码中使用
+
+配置被 agentUniverse 加载后，即可获取 LLM 实例并直接调用：
+
+```python
+from agentuniverse.llm.default.yi_llm import YiLLM
+
+llm = YiLLM(model_name='yi-large')
+
+# 非流式
+output = llm.call(messages=[{"role": "user", "content": "你好！"}])
+print(output.text)
+
+# 流式
+for chunk in llm.call(messages=[{"role": "user", "content": "从 1 数到 5。"}], streaming=True):
+    print(chunk.text, end='')
+
+# 异步
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "你好！"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+由于 01.AI 与 OpenAI 完全兼容，`OpenAIStyleLLM` 支持的所有特性（工具调用、LangChain 集成、链路追踪）均可直接使用，无需额外开发。
+
+---
+
+## 6. 使用建议
+
+- agentUniverse 内置了名为 `default_yi_llm` 的实例模板（见 `yi_llm.yaml.example`），配置好 `YI_API_KEY` 环境变量后即可在 Agent 中直接引用。
+- `yi-large` 为旗舰模型，适合复杂推理；`yi-medium`/`yi-small` 速度更快、成本更低，适合简单任务。
+- 涉及多模态（图文）输入时，请使用 `yi-vision` 或 `yi-vision-plus`。

--- a/tests/test_agentuniverse/unit/llm/test_yi_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_yi_llm.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the 01.AI Yi series LLM component.
+
+These tests exercise the parts of :class:`YiLLM` that do not require a
+live 01.AI API key: credential/base-url wiring, the per-model context
+length table and the token estimator. The network-bound call/acall/stream
+tests are kept but commented out so that the full suite can run in CI
+without any external dependency.
+"""
+
+import asyncio
+import unittest
+
+from agentuniverse.llm.default.yi_llm import (
+    YI_DEFAULT_CONTEXT_LENGTH,
+    YI_MAX_CONTEXT_LENGTH,
+    YiLLM,
+)
+
+
+class TestYiLLM(unittest.TestCase):
+    """Test suite for the YiLLM component."""
+
+    def setUp(self) -> None:
+        """Build a YiLLM instance with dummy credentials."""
+        self.llm = YiLLM(
+            model_name='yi-large',
+            api_key='dummy-yi-key',
+            api_base='https://api.01.ai/v1',
+            max_tokens=512,
+            temperature=0.7,
+        )
+
+    def test_initialization(self) -> None:
+        """LLM must accept and persist the constructor parameters."""
+        self.assertEqual(self.llm.model_name, 'yi-large')
+        self.assertEqual(self.llm.api_key, 'dummy-yi-key')
+        self.assertEqual(self.llm.api_base, 'https://api.01.ai/v1')
+        self.assertEqual(self.llm.max_tokens, 512)
+        self.assertEqual(self.llm.temperature, 0.7)
+
+    def test_default_api_base(self) -> None:
+        """When no api_base is provided the 01.AI endpoint must be used."""
+        llm = YiLLM(model_name='yi-large', api_key='dummy')
+        self.assertEqual(llm.api_base, 'https://api.01.ai/v1')
+
+    def test_max_context_length_known_models(self) -> None:
+        """Known models must resolve to their documented context window."""
+        known = [
+            ('yi-large', 32768),
+            ('yi-medium', 16384),
+            ('yi-small', 16384),
+            ('yi-vision', 16384),
+            ('yi-medium-200k', 204800),
+        ]
+        for model_name, expected in known:
+            llm = YiLLM(model_name=model_name, api_key='dummy')
+            self.assertEqual(
+                llm.max_context_length(),
+                expected,
+                f'Context length mismatch for {model_name}',
+            )
+
+    def test_max_context_length_unknown_model(self) -> None:
+        """Unknown models must fall back to the default context length."""
+        llm = YiLLM(model_name='some-future-yi-model', api_key='dummy')
+        self.assertEqual(llm.max_context_length(), YI_DEFAULT_CONTEXT_LENGTH)
+
+    def test_max_context_length_table_consistency(self) -> None:
+        """Every entry in the table must be a positive integer."""
+        for model_name, length in YI_MAX_CONTEXT_LENGTH.items():
+            self.assertIsInstance(length, int, f'{model_name} length not int')
+            self.assertGreater(length, 0, f'{model_name} length not positive')
+
+    def test_get_num_tokens(self) -> None:
+        """The token estimator must return a sensible positive count."""
+        text = 'Hello Yi, please introduce yourself.'
+        num_tokens = self.llm.get_num_tokens(text)
+        self.assertIsInstance(num_tokens, int)
+        self.assertGreater(num_tokens, 0)
+        # The estimator must be deterministic for the same input.
+        self.assertEqual(num_tokens, self.llm.get_num_tokens(text))
+
+    def test_get_num_tokens_empty_string(self) -> None:
+        """An empty string must cost zero tokens."""
+        self.assertEqual(self.llm.get_num_tokens(''), 0)
+
+    # ========== Integration tests (require a real YI_API_KEY) ==========
+    # Uncomment and set YI_API_KEY in the environment to exercise the
+    # live 01.AI API.
+
+    # def test_call(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = self.llm.call(messages=messages, streaming=False)
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_acall(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_call_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #     chunks = []
+    #     for chunk in self.llm.call(messages=messages, streaming=True):
+    #         chunks.append(chunk.text)
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_acall_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #
+    #     async def _run():
+    #         result = []
+    #         async for chunk in await self.llm.acall(messages=messages, streaming=True):
+    #             result.append(chunk.text)
+    #         return result
+    #
+    #     chunks = asyncio.run(_run())
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_as_langchain(self) -> None:
+    #     from langchain.chains.conversation.base import ConversationChain
+    #     langchain_llm = self.llm.as_langchain()
+    #     llm_chain = ConversationChain(llm=langchain_llm)
+    #     res = llm_chain.predict(input='Say hello')
+    #     self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **01.AI (零一万物) Yi series LLM** component, resolving part of #250.

`YiLLM` integrates the [01.AI](https://www.01.ai) Yi family of foundation large language models (Yi-Large, Yi-Medium, Yi-Small, Yi-Vision, ...). 01.AI exposes a fully **OpenAI-compatible** Chat Completions API at `https://api.01.ai/v1`, so the component simply extends `OpenAIStyleLLM` and only wires up the credentials, API base URL and per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge all work out of the box.

## Changes

- `agentuniverse/llm/default/yi_llm.py` — `YiLLM(OpenAIStyleLLM)` with:
  - `api_key` from `YI_API_KEY` env var
  - `api_base` default `https://api.01.ai/v1`
  - `YI_MAX_CONTEXT_LENGTH` table (yi-large: 32k, yi-medium: 16k, yi-small: 16k, yi-vision: 16k, ...) with a 16k fallback
  - `get_num_tokens` using tiktoken `cl100k_base` fallback
- `agentuniverse/llm/default/yi_llm.yaml.example` — ready-to-use instance template
- `tests/test_agentuniverse/unit/llm/test_yi_llm.py` — 7 unit tests (init, default api_base, known/unknown context-length lookup, table consistency, token counting)
- `docs/guidebook/en/In-Depth_Guides/Components/LLMs/Yi_LLM_Use.md`
- `docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Yi使用.md`

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.llm.test_yi_llm -v` → 7 passed
- [ ] Live API call (requires a real `YI_API_KEY`) — integration calls are stubbed/commented out so CI runs without external deps.

Closes part of #250.
