### PR TITLE
feat(store): add VespaStore vector store component (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/vespa_store.py
+++ b/agentuniverse/agent/action/knowledge/store/vespa_store.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Vespa open-source search and vector engine knowledge store."""
+
+# The pyvespa client exposes dict payloads to Vespa over HTTP; we validate
+# every identifier used in the YQL body against strict allowlists first.
+# ruff: noqa: TRY003
+
+import json
+import re
+from typing import Any, ClassVar
+from urllib.parse import urlparse
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class VespaStore(Store):
+    """Persistent vector store backed by a running Vespa application.
+
+    Vespa combines inverted-index text search with approximate nearest
+    neighbour (ANN) vector search. This component assumes the target schema
+    already exists on the application (it is not responsible for deploying a
+    package) and only performs data-plane CRUD plus ANN query operations via
+    the optional ``pyvespa`` dependency.
+    """
+
+    application_url: str | None = None
+    cert_path: str | None = None
+    key_path: str | None = None
+    schema_name: str = "agentuniverse_document"
+    namespace: str = "agentuniverse"
+    cluster_name: str = "agentuniverse_cluster"
+    embedding_model: str | None = None
+    dimensions: int | None = None
+    embedding_field: str = "embedding"
+    id_field: str = "id"
+    text_field: str = "text"
+    metadata_field: str = "metadata"
+    similarity_top_k: int = 10
+    client: Any = None
+    async_client: Any = None
+
+    _DISTANCES: ClassVar[set[str]] = {"euclidean", "angular", "innerproduct", "geodegrees", "hamming"}
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "VespaStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "application_url",
+            "cert_path",
+            "key_path",
+            "schema_name",
+            "namespace",
+            "cluster_name",
+            "embedding_model",
+            "dimensions",
+            "embedding_field",
+            "id_field",
+            "text_field",
+            "metadata_field",
+            "similarity_top_k",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config(require_dimensions=False)
+        return self
+
+    def _validate_config(self, require_dimensions: bool = True) -> None:
+        identifier = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+        for name in ("schema_name", "namespace", "cluster_name",
+                     "embedding_field", "id_field", "text_field", "metadata_field"):
+            value = getattr(self, name)
+            if not identifier.fullmatch(value or ""):
+                raise ValueError(f"{name} must be a simple Vespa identifier")
+        if (
+            isinstance(self.similarity_top_k, bool)
+            or not isinstance(self.similarity_top_k, int)
+            or self.similarity_top_k <= 0
+        ):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if self.dimensions is not None and (
+            isinstance(self.dimensions, bool)
+            or not isinstance(self.dimensions, int)
+            or self.dimensions <= 0
+        ):
+            raise ValueError("dimensions must be a positive integer")
+        if require_dimensions and self.dimensions is None:
+            raise ValueError("dimensions must be configured or inferred from the first document")
+
+    @staticmethod
+    def _dependencies() -> Any:
+        try:
+            from vespa.application import Vespa
+        except ImportError as exc:
+            raise ImportError("VespaStore requires the pyvespa package") from exc
+        return Vespa
+
+    def _url(self) -> str:
+        value = self.application_url
+        if not value:
+            raise ValueError("application_url is required; set it in the YAML configuration")
+        parsed = urlparse(value)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("application_url must be an absolute http(s) URL")
+        return value
+
+    def _new_client(self) -> Any:
+        Vespa = self._dependencies()
+        kwargs: dict[str, Any] = {"url": self._url()}
+        if self.cert_path:
+            kwargs["cert"] = self.cert_path
+        if self.key_path:
+            kwargs["key"] = self.key_path
+        self.client = Vespa(**kwargs)
+        return self.client
+
+    async def _new_async_client(self) -> Any:
+        Vespa = self._dependencies()
+        kwargs: dict[str, Any] = {"url": self._url()}
+        if self.cert_path:
+            kwargs["cert"] = self.cert_path
+        if self.key_path:
+            kwargs["key"] = self.key_path
+        self.async_client = Vespa(**kwargs)
+        return self.async_client
+
+    def _ensure_client(self) -> Any:
+        return self.client or self._new_client()
+
+    async def _ensure_async_client(self) -> Any:
+        return self.async_client or await self._new_async_client()
+
+    # ------------------------------------------------------------------ #
+    # Embedding helpers
+    # ------------------------------------------------------------------ #
+    def _embedding_for_query(self, query: Query) -> list[float]:
+        if query.embeddings:
+            vector = query.embeddings[0]
+        elif self.embedding_model and query.query_str:
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            vector = model.get_embeddings([query.query_str], text_type="query")[0]
+        else:
+            raise ValueError("query requires embeddings or an embedding_model plus query_str")
+        self._check_vector(vector)
+        return vector
+
+    def _vectors_for_documents(self, documents: list[Document]) -> list[list[float]]:
+        missing = [index for index, document in enumerate(documents) if not document.embedding]
+        if missing:
+            if not self.embedding_model:
+                raise ValueError("documents without embeddings require embedding_model")
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            generated = model.get_embeddings([documents[index].text or "" for index in missing])
+            for index, vector in zip(missing, generated, strict=True):
+                documents[index].embedding = vector
+        vectors = [document.embedding for document in documents]
+        for vector in vectors:
+            self._check_vector(vector)
+        return vectors
+
+    def _check_vector(self, vector: Any) -> None:
+        if (
+            not isinstance(vector, list)
+            or not vector
+            or any(
+                isinstance(value, bool) or not isinstance(value, (int, float))
+                for value in vector
+            )
+        ):
+            raise ValueError("embedding must be a non-empty numeric list")
+        if self.dimensions is None:
+            self.dimensions = len(vector)
+        if len(vector) != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {len(vector)} does not match configured dimensions {self.dimensions}"
+            )
+
+    def _top_k(self, query: Query) -> int:
+        value = query.similarity_top_k or self.similarity_top_k
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError("similarity_top_k must be a positive integer")
+        return value
+
+    # ------------------------------------------------------------------ #
+    # Vespa payload helpers
+    # ------------------------------------------------------------------ #
+    def _fields_for_document(self, document: Document, vector: list[float]) -> dict[str, Any]:
+        metadata = document.metadata or {}
+        return {
+            self.id_field: str(document.id),
+            self.text_field: document.text or "",
+            self.metadata_field: json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+            self.embedding_field: [float(value) for value in vector],
+        }
+
+    def _yql(self, vector: list[float], top_k: int, metadata_filter: Any) -> dict[str, Any]:
+        nearest = (
+            f"({{targetHits:{top_k}}})nearestNeighbor({self.embedding_field}, query_embedding)"
+        )
+        where = nearest
+        if metadata_filter is not None:
+            if not isinstance(metadata_filter, dict):
+                raise TypeError("metadata_filter must be an object")
+            clauses = [nearest]
+            for key, value in metadata_filter.items():
+                if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(key)):
+                    raise ValueError(f"metadata_filter key {key!r} is not a valid identifier")
+                if isinstance(value, bool):
+                    literal = "true" if value else "false"
+                elif isinstance(value, (int, float)):
+                    literal = repr(value)
+                elif isinstance(value, str):
+                    literal = ", ".join(json.dumps(part) for part in value.split(","))
+                    literal = f"[{literal}]"
+                else:
+                    raise TypeError(f"metadata_filter.{key} must be a scalar value")
+                clauses.append(f"{self.metadata_field}.contains({{key:{json.dumps(str(key))}, value:{literal}}})")
+            where = " AND ".join(clauses)
+        yql = (
+            f"select * from {self.schema_name} "
+            f"where {where}"
+        )
+        body: dict[str, Any] = {
+            "yql": yql,
+            "input.query(query_embedding)": [float(value) for value in vector],
+            "hits": top_k,
+        }
+        return body
+
+    def _hit_to_document(self, hit: Any) -> Document | None:
+        if not isinstance(hit, dict):
+            return None
+        fields = hit.get("fields", {})
+        if not fields:
+            return None
+        metadata_raw = fields.get(self.metadata_field)
+        if isinstance(metadata_raw, (str, bytes)) and metadata_raw:
+            try:
+                metadata = json.loads(metadata_raw)
+            except (TypeError, ValueError):
+                metadata = {}
+        elif isinstance(metadata_raw, dict):
+            metadata = metadata_raw
+        else:
+            metadata = {}
+        embedding = fields.get(self.embedding_field)
+        if isinstance(embedding, dict):
+            embedding = embedding.get("values", embedding)
+        return Document(
+            id=str(fields.get(self.id_field, hit.get("id", ""))),
+            text=fields.get(self.text_field, ""),
+            metadata=metadata,
+            embedding=[float(value) for value in embedding] if isinstance(embedding, list) else [],
+        )
+
+    @classmethod
+    def _hits(cls, response: Any) -> list[Any]:
+        payload = cls._response_payload(response)
+        if not payload:
+            return []
+        if isinstance(payload, dict):
+            root = payload.get("root", {}) or {}
+            children = root.get("children", []) if isinstance(root, dict) else []
+            if children:
+                return children
+            return payload.get("hits", []) or []
+        return []
+
+    @staticmethod
+    def _response_payload(response: Any) -> Any:
+        if response is None:
+            return {}
+        if isinstance(response, dict):
+            return response
+        # pyvespa response objects expose the decoded JSON via `.json` (attribute)
+        # or via the ``get_json()`` / ``json`` helpers depending on the version.
+        payload = getattr(response, "json", None)
+        if isinstance(payload, dict):
+            return payload
+        if callable(payload):
+            try:
+                return payload()
+            except TypeError:
+                pass
+        get_json = getattr(response, "get_json", None)
+        if callable(get_json):
+            try:
+                return get_json()
+            except TypeError:
+                pass
+        return {}
+
+    @staticmethod
+    def _ensure_successful(response: Any, operation: str) -> None:
+        status = getattr(response, "status_code", None)
+        if status is not None and status >= 400:
+            raise RuntimeError(f"Vespa {operation} failed with status {status}")
+        is_success = getattr(response, "is_successful", None)
+        if callable(is_success):
+            is_success = is_success()
+        if is_success is False:
+            raise RuntimeError(f"Vespa {operation} was not successful")
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+    def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        body = self._yql(vector, top_k, kwargs.get("metadata_filter"))
+        response = self._ensure_client().query(body=body)
+        return [doc for doc in (self._hit_to_document(hit) for hit in self._hits(response)) if doc]
+
+    async def async_query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        body = self._yql(vector, top_k, kwargs.get("metadata_filter"))
+        response = await (await self._ensure_async_client()).query(body=body)
+        return [doc for doc in (self._hit_to_document(hit) for hit in self._hits(response)) if doc]
+
+    def upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        client = self._ensure_client()
+        for document, vector in zip(documents, vectors, strict=True):
+            response = client.feed_data_point(
+                schema=self.schema_name,
+                data_id=str(document.id),
+                fields=self._fields_for_document(document, vector),
+                namespace=self.namespace,
+            )
+            self._ensure_successful(response, "upsert")
+
+    async def async_upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        client = await self._ensure_async_client()
+        for document, vector in zip(documents, vectors, strict=True):
+            response = await client.feed_data_point(
+                schema=self.schema_name,
+                data_id=str(document.id),
+                fields=self._fields_for_document(document, vector),
+                namespace=self.namespace,
+            )
+            self._ensure_successful(response, "upsert")
+
+    def insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs: Any) -> None:
+        response = self._ensure_client().delete_data(
+            schema=self.schema_name,
+            data_id=str(document_id),
+            namespace=self.namespace,
+        )
+        self._ensure_successful(response, "delete")
+
+    async def async_delete_document(self, document_id: str, **kwargs: Any) -> None:
+        response = await (await self._ensure_async_client()).delete_data(
+            schema=self.schema_name,
+            data_id=str(document_id),
+            namespace=self.namespace,
+        )
+        self._ensure_successful(response, "delete")

--- a/agentuniverse/agent/action/knowledge/store/vespa_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/vespa_store.yaml.example
@@ -1,0 +1,20 @@
+name: vespa_store
+description: Vespa open-source search and vector engine knowledge store
+application_url: http://localhost:8080
+# mTLS data-plane credentials for Vespa Cloud / secured endpoints.
+cert_path: /path/to/data-plane-public-cert.pem
+key_path: /path/to/data-plane-private-key.pem
+schema_name: agentuniverse_document
+namespace: agentuniverse
+cluster_name: agentuniverse_cluster
+embedding_model: openai_embedding
+dimensions: 1536
+embedding_field: embedding
+id_field: id
+text_field: text
+metadata_field: metadata
+similarity_top_k: 10
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.vespa_store
+  class: VespaStore

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -96,3 +96,17 @@ Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are 
 ## PGVectorStore
 
 `PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.
+
+## VespaStore
+
+`VespaStore` integrates the open-source Vespa search and vector engine for synchronous and asynchronous vector CRUD plus approximate nearest neighbour (ANN) search. Install the optional dependency with `pip install pyvespa` and deploy a Vespa application whose schema exposes `embedding` (tensor), `id`, `text`, and `metadata` fields — the component only performs data-plane operations and does not deploy or alter the application package.
+
+Copy `agentuniverse/agent/action/knowledge/store/vespa_store.yaml.example` into the application configuration directory, set `application_url` to the application container endpoint, and (for mTLS-secured endpoints such as Vespa Cloud) provide `cert_path` and `key_path`. Field names (`schema_name`, `namespace`, `embedding_field`, `id_field`, `text_field`, `metadata_field`) are configurable so the component can target an existing schema.
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"team": "acme"}, embedding=[0.1, 0.2])])
+results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metadata_filter={"team": "acme"})
+```
+
+Query combines YQL `nearestNeighbor` with optional metadata clauses; all identifiers are validated against a strict allowlist before the request body is constructed, and every embedding is dimension-checked against `dimensions` (inferred from the first document when not set).
+

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -96,3 +96,17 @@ results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metada
 ## PGVectorStore
 
 `PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。
+
+## VespaStore
+
+`VespaStore` 接入开源的 Vespa 搜索与向量引擎，提供同步与异步的向量增删改查及近似最近邻（ANN）检索。通过 `pip install pyvespa` 安装可选依赖，并部署一个 Vespa 应用，其 schema 需暴露 `embedding`（tensor）、`id`、`text`、`metadata` 字段——本组件只负责数据面操作，不会部署或修改应用包。
+
+将 `agentuniverse/agent/action/knowledge/store/vespa_store.yaml.example` 复制到应用配置目录，把 `application_url` 指向应用容器端点；若端点启用了 mTLS（如 Vespa Cloud），请同时提供 `cert_path` 与 `key_path`。字段名（`schema_name`、`namespace`、`embedding_field`、`id_field`、`text_field`、`metadata_field`）均可配置，以便对接已有 schema。
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"team": "acme"}, embedding=[0.1, 0.2])])
+results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metadata_filter={"team": "acme"})
+```
+
+检索逻辑将 YQL 的 `nearestNeighbor` 与可选的元数据过滤条件组合；所有标识符在构造请求体前都会通过严格白名单校验，每条 embedding 都会按 `dimensions`（未配置时由首条文档推断）进行维度校验。
+

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_vespa_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_vespa_store.py
@@ -1,0 +1,234 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.vespa_store import VespaStore
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class FakeResponse:
+    """Stand-in for pyvespa VespaResponse / VespaQueryResponse objects."""
+
+    def __init__(self, status_code=200, successful=True, payload=None):
+        self.status_code = status_code
+        self._successful = successful
+        self._payload = payload or {}
+
+    def is_successful(self):
+        return self._successful
+
+    def get_json(self):
+        return self._payload
+
+
+class FakeVespaClient:
+    """Mimics the subset of the pyvespa sync client used by VespaStore."""
+
+    def __init__(self, query_response=None):
+        self.fed = []
+        self.deleted = []
+        self.query_response = query_response or FakeResponse(payload={"root": {"children": []}})
+
+    def feed_data_point(self, schema, data_id, fields, namespace=None, **kwargs):
+        self.fed.append((schema, namespace, data_id, fields))
+        return FakeResponse()
+
+    def delete_data(self, schema, data_id, namespace=None, **kwargs):
+        self.deleted.append((schema, namespace, str(data_id)))
+        return FakeResponse()
+
+    def query(self, body=None, **kwargs):
+        self.last_body = body
+        return self.query_response
+
+
+class FakeAsyncVespaClient(FakeVespaClient):
+    async def feed_data_point(self, schema, data_id, fields, namespace=None, **kwargs):
+        self.fed.append((schema, namespace, data_id, fields))
+        return FakeResponse()
+
+    async def delete_data(self, schema, data_id, namespace=None, **kwargs):
+        self.deleted.append((schema, namespace, str(data_id)))
+        return FakeResponse()
+
+    async def query(self, body=None, **kwargs):
+        self.last_body = body
+        return self.query_response
+
+
+def _hit(document_id, text, metadata, embedding):
+    return {
+        "id": f"id:agentuniverse:agentuniverse_document::{document_id}",
+        "fields": {
+            "id": document_id,
+            "text": text,
+            "metadata": json.dumps(metadata),
+            "embedding": embedding,
+        },
+    }
+
+
+class VespaStoreTest(unittest.TestCase):
+    def test_rejects_unsafe_schema_name(self):
+        with self.assertRaisesRegex(ValueError, "schema_name"):
+            VespaStore(schema_name="bad name")._validate_config(False)
+
+    def test_rejects_invalid_application_url(self):
+        with self.assertRaisesRegex(ValueError, "application_url"):
+            VespaStore(application_url="not-a-url")._url()
+        with self.assertRaisesRegex(ValueError, "application_url is required"):
+            VespaStore()._url()
+
+    def test_invalid_top_k_fails_before_query(self):
+        store = VespaStore(client=FakeVespaClient(), dimensions=2)
+        with self.assertRaisesRegex(ValueError, "similarity_top_k"):
+            store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=-1))
+
+    def test_query_requires_embedding(self):
+        store = VespaStore(client=FakeVespaClient(), dimensions=2)
+        with self.assertRaisesRegex(ValueError, "requires embeddings"):
+            store.query(Query(query_str="hello"))
+
+    def test_rejects_dimension_mismatch(self):
+        store = VespaStore(dimensions=3)
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            store._check_vector([1.0, 2.0])
+
+    def test_infers_dimension(self):
+        store = VespaStore()
+        store._check_vector([1.0, 2.0, 3.0])
+        self.assertEqual(store.dimensions, 3)
+
+    def test_yql_contains_nearest_neighbor_and_top_k(self):
+        store = VespaStore(schema_name="docs", dimensions=2)
+        body = store._yql([1.0, 0.0], 4, None)
+        self.assertIn("nearestNeighbor(embedding, query_embedding)", body["yql"])
+        self.assertIn("targetHits:4", body["yql"])
+        self.assertIn("from docs", body["yql"])
+        self.assertEqual(body["hits"], 4)
+        self.assertEqual(body["input.query(query_embedding)"], [1.0, 0.0])
+
+    def test_yql_appends_metadata_filter(self):
+        store = VespaStore(dimensions=2)
+        body = store._yql([1.0, 0.0], 3, {"team": "acme"})
+        self.assertIn("AND", body["yql"])
+        self.assertIn('"team"', body["yql"])
+        self.assertIn('"acme"', body["yql"])
+
+    def test_yql_rejects_bad_filter_key(self):
+        store = VespaStore(dimensions=2)
+        with self.assertRaisesRegex(ValueError, "valid identifier"):
+            store._yql([1.0, 0.0], 3, {"bad key!": "x"})
+
+    def test_query_converts_hits_to_documents(self):
+        payload = {"root": {"children": [_hit("1", "hello", {"team": "a"}, [0.1, 0.2])]}}
+        client = FakeVespaClient(query_response=FakeResponse(payload=payload))
+        store = VespaStore(client=client, dimensions=2)
+        results = store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=5))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, "1")
+        self.assertEqual(results[0].text, "hello")
+        self.assertEqual(results[0].metadata, {"team": "a"})
+        self.assertEqual(results[0].embedding, [0.1, 0.2])
+
+    def test_query_uses_embedding_component(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = VespaStore(client=FakeVespaClient(), dimensions=2, embedding_model="embed")
+        with patch("agentuniverse.agent.action.knowledge.store.vespa_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.query(Query(query_str="hello"))
+        manager.return_value.get_instance_obj.assert_called_once_with("embed", strict=True)
+
+    def test_upsert_feeds_each_document(self):
+        client = FakeVespaClient()
+        store = VespaStore(client=client, dimensions=2, schema_name="docs", namespace="ns")
+        store.upsert_document(
+            [Document(id="1", text="hello", metadata={"a": 1}, embedding=[0.1, 0.2])]
+        )
+        schema, namespace, data_id, fields = client.fed[0]
+        self.assertEqual((schema, namespace, data_id), ("docs", "ns", "1"))
+        self.assertEqual(fields["text"], "hello")
+        self.assertEqual(json.loads(fields["metadata"]), {"a": 1})
+        self.assertEqual(fields["embedding"], [0.1, 0.2])
+
+    def test_upsert_generates_missing_embeddings(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = VespaStore(client=FakeVespaClient(), dimensions=2, embedding_model="embed")
+        document = Document(id="1", text="hello")
+        with patch("agentuniverse.agent.action.knowledge.store.vespa_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.upsert_document([document])
+        self.assertEqual(document.embedding, [0.1, 0.2])
+
+    def test_upsert_without_embeddings_requires_model(self):
+        store = VespaStore(client=FakeVespaClient(), dimensions=2)
+        with self.assertRaisesRegex(ValueError, "embedding_model"):
+            store.upsert_document([Document(id="1", text="hello")])
+
+    def test_delete_passes_schema_and_namespace(self):
+        client = FakeVespaClient()
+        VespaStore(client=client, schema_name="docs", namespace="ns").delete_document("abc")
+        self.assertEqual(client.deleted, [("docs", "ns", "abc")])
+
+    def test_upsert_raises_on_failure(self):
+        client = FakeVespaClient()
+        client.feed_data_point = Mock(return_value=FakeResponse(status_code=500, successful=False))
+        store = VespaStore(client=client, dimensions=2)
+        with self.assertRaisesRegex(RuntimeError, "upsert"):
+            store.upsert_document([Document(id="1", text="x", embedding=[0.1, 0.2])])
+
+    def test_new_client_passes_mtls_credentials(self):
+        vespa_cls = Mock()
+        store = VespaStore(application_url="http://localhost:8080", cert_path="c.pem", key_path="k.pem")
+        with patch.object(store, "_dependencies", return_value=vespa_cls):
+            store._new_client()
+        vespa_cls.assert_called_once_with(
+            url="http://localhost:8080", cert="c.pem", key="k.pem"
+        )
+
+    def test_missing_dependency_hint(self):
+        with patch.dict("sys.modules", {"vespa.application": None, "vespa": None}):
+            with self.assertRaisesRegex(ImportError, "pyvespa"):
+                VespaStore._dependencies()
+
+    def test_async_crud(self):
+        payload = {"root": {"children": [_hit("1", "async", {}, [0.0, 1.0])]}}
+        client = FakeAsyncVespaClient(query_response=FakeResponse(payload=payload))
+        store = VespaStore(async_client=client, dimensions=2)
+
+        async def run():
+            await store.async_upsert_document([Document(id="1", text="async", embedding=[0.0, 1.0])])
+            result = await store.async_query(Query(embeddings=[[0.0, 1.0]], similarity_top_k=1))
+            await store.async_delete_document("1")
+            return result
+
+        result = asyncio.run(run())
+        self.assertEqual(result[0].text, "async")
+        self.assertEqual(client.deleted, [("agentuniverse_document", "agentuniverse", "1")])
+        self.assertEqual(len(client.fed), 1)
+
+    def test_component_schema(self):
+        config = Configer()
+        config.value = {
+            "name": "vespa_store",
+            "dimensions": 3,
+            "metadata": {
+                "type": "STORE",
+                "module": "agentuniverse.agent.action.knowledge.store.vespa_store",
+                "class": "VespaStore",
+            },
+        }
+        component = ComponentConfiger().load_by_configer(config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.STORE.value)
+        self.assertEqual(component.metadata_class, "VespaStore")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Adds a new `VespaStore` knowledge store component backed by the open-source [Vespa](https://vespa.ai/) search and vector engine.

Closes #259.

## Why
Vespa combines inverted-index text search with approximate nearest neighbour (ANN) vector search and is a popular open-source option for production search/RAG workloads. Bringing it into agentUniverse as a first-class `Store` lets users plug a running Vespa application into any knowledge component, complementing the existing PGVector / Redis / Milvus / Chroma stores.

## Changes
- `agentuniverse/agent/action/knowledge/store/vespa_store.py` — `VespaStore` implementation (377 lines).
- `agentuniverse/agent/action/knowledge/store/vespa_store.yaml.example` — sample configuration.
- `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_vespa_store.py` — 20 mocked unit tests.
- `docs/.../Knowledge/Store.md` (English and Chinese) — usage documentation.

## Implementation details
- **Lazy dependency**: `pyvespa` is imported on first use with a clear `ImportError` hint, so the package stays optional.
- **Configurable mTLS**: `application_url`, `cert_path`, `key_path` (data-plane credentials for Vespa Cloud / secured endpoints).
- **Full sync + async CRUD**: `query`, `upsert_document`, `insert_document`, `update_document`, `delete_document` and their async counterparts.
- **ANN search**: builds a YQL `nearestNeighbor` query and maps the Vespa response hits back to `Document` objects.
- **Dimension validation**: every embedding is checked against `dimensions`, which is inferred from the first document when unset.
- **Identifier safety**: `schema_name`, `namespace`, `cluster_name` and field names are validated against a strict allowlist before any request body is constructed; metadata filter keys are validated too.
- **Optional managed embeddings**: documents/queries missing embeddings are generated via the configured `embedding_model`.

## Verification
```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_vespa_store
Ran 20 tests ... OK
```

All tests are mocked and require no running Vespa instance.
