### PR TITLE
feat(embedding): add Jina AI Embedding component (#250)

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/jina_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/jina_embedding.py
@@ -1,0 +1,249 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: jina_embedding.py
+
+"""
+Jina AI Embedding component.
+
+[Jina AI](https://jina.ai) provides state-of-the-art multilingual
+embeddings through the ``jina-embeddings-v3`` model family, exposed via a
+simple HTTP API at ``https://api.jina.ai/v1/embeddings``.
+
+Unlike the OpenAI / DashScope embeddings which are consumed through a
+dedicated SDK, the Jina Embeddings API is a plain JSON-over-HTTPS endpoint
+with no first-party Python client, so this component calls it directly with
+``requests`` (synchronous) and ``asyncio + requests`` (asynchronous). The
+response shape is compatible with the OpenAI embeddings response, so the
+component only needs to read ``data[*].embedding``.
+
+The component implements the agentUniverse :class:`Embedding` interface, so
+it can be referenced from any store / reader that consumes an embedding
+component.
+"""
+
+import asyncio
+from typing import Any, List, Optional
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.util.env_util import get_from_env
+
+# Default Jina Embeddings API endpoint. It can be overridden through the
+# ``JINA_API_BASE`` environment variable or the ``api_base`` YAML field.
+JINA_EMBEDDING_API_BASE = "https://api.jina.ai/v1/embeddings"
+
+# Default embedding model. jina-embeddings-v3 is the current flagship; it
+# supports configurable output dimensions (default 1024) and multilingual
+# text.
+JINA_DEFAULT_EMBEDDING_MODEL = "jina-embeddings-v3"
+
+# Default output dimensionality. jina-embeddings-v3 supports 32, 64, 128,
+# 256, 512, 768, 1024; 1024 is the recommended default.
+JINA_DEFAULT_DIMENSIONS = 1024
+
+
+class JinaEmbedding(Embedding):
+    """Jina AI Embedding class.
+
+    Calls the Jina Embeddings HTTP API to turn a list of texts into vectors.
+    Because the API has no first-party Python client this component uses
+    ``requests`` directly and exposes the :meth:`get_embeddings` /
+    :meth:`async_get_embeddings` methods required by the agentUniverse
+    :class:`Embedding` base class.
+
+    Attributes:
+        api_key: Jina AI API key. Falls back to the ``JINA_API_KEY``
+            environment variable when not provided explicitly.
+        api_base: Jina Embeddings endpoint URL. Defaults to
+            ``https://api.jina.ai/v1/embeddings``.
+        embedding_model_name: The embedding model id, defaults to
+            ``jina-embeddings-v3``.
+        dimensions: Output vector dimensionality, defaults to ``1024``.
+        request_timeout: Timeout in seconds for the HTTP call. ``requests``
+            defaults to no timeout, so without this a stalled Jina API would
+            hang the whole embedding step indefinitely.
+        batch_size: Maximum number of texts sent in a single API call.
+            Jina accepts batched inputs; larger batches reduce round-trips
+            but increase per-request payload size.
+    """
+
+    # Override the base-class attribute so the Jina flagship model is the
+    # default; users can still pass a different model name in YAML / code.
+    embedding_model_name: Optional[str] = Field(default=JINA_DEFAULT_EMBEDDING_MODEL)
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("JINA_API_KEY"))
+    api_base: str = JINA_EMBEDDING_API_BASE
+    dimensions: Optional[int] = JINA_DEFAULT_DIMENSIONS
+    request_timeout: int = 30
+    batch_size: int = 32
+
+    def get_embeddings(self, texts: List[str], **kwargs: Any) -> List[List[float]]:
+        """Get the Jina embeddings for a list of texts (synchronous).
+
+        Note:
+            The ``embedding_model_name`` attribute must be provided (it
+            defaults to ``jina-embeddings-v3``). The ``dimensions`` attribute
+            is optional and defaults to ``1024``.
+
+        Args:
+            texts: A list of texts that need to be embedded.
+            **kwargs: Reserved for future use / overrides.
+
+        Returns:
+            A list of embedding vectors, one per input text, in the same
+            order as the input.
+
+        Raises:
+            ValueError: If ``texts`` is empty or ``embedding_model_name``
+                is missing.
+            Exception: If the API key is missing or the HTTP call fails.
+        """
+        if not texts:
+            raise ValueError("Jina embedding received an empty text list.")
+        if self.embedding_model_name is None:
+            raise ValueError("Must provide `embedding_model_name`")
+        self._ensure_api_key()
+
+        all_embeddings: List[List[float]] = []
+        for start in range(0, len(texts), self.batch_size):
+            batch = texts[start:start + self.batch_size]
+            payload = self._build_payload(batch)
+            response_json = self._post(payload)
+            for item in sorted(response_json.get("data", []),
+                               key=lambda d: d.get("index", 0)):
+                all_embeddings.append(item.get("embedding", []))
+        return all_embeddings
+
+    async def async_get_embeddings(self, texts: List[str], **kwargs: Any) -> \
+            List[List[float]]:
+        """Asynchronously get the Jina embeddings for a list of texts.
+
+        The Jina API has no native async client, so this method runs the
+        blocking :meth:`get_embeddings` in a thread executor via
+        :func:`asyncio.to_thread`, allowing it to be ``await``ed without
+        blocking the event loop.
+
+        Args:
+            texts: A list of texts that need to be embedded.
+            **kwargs: Reserved for future use / overrides.
+
+        Returns:
+            A list of embedding vectors, one per input text, in the same
+            order as the input.
+        """
+        return await asyncio.to_thread(self.get_embeddings, texts, **kwargs)
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _ensure_api_key(self) -> None:
+        """Validate that an API key is configured before calling the API."""
+        if not self.api_key:
+            raise Exception(
+                "Jina AI API key is not set. Please configure it in the "
+                "component or set the JINA_API_KEY environment variable.")
+
+    def _build_payload(self, batch: List[str]) -> dict:
+        """Build the JSON request body for the Jina Embeddings API.
+
+        Args:
+            batch: The slice of texts to embed in a single request.
+
+        Returns:
+            A dict payload suitable for ``requests.post(json=...)``.
+        """
+        payload: dict = {
+            "model": self.embedding_model_name,
+            "input": batch,
+        }
+        if self.dimensions is not None:
+            payload["dimensions"] = self.dimensions
+        return payload
+
+    def _post(self, payload: dict) -> dict:
+        """Send a POST request to the Jina Embeddings API and decode JSON.
+
+        The HTTP send and the JSON decode are isolated: a non-JSON body
+        (e.g. an upstream HTML error page) is surfaced as a non-JSON
+        response rather than misreported as an API-call error.
+
+        Args:
+            payload: The request body.
+
+        Returns:
+            The decoded JSON response dict.
+
+        Raises:
+            Exception: If the HTTP call fails or the body is not valid JSON.
+        """
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        try:
+            response = requests.post(self.api_base, headers=headers,
+                                     json=payload, timeout=self.request_timeout)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Jina AI embedding API call error: {e}")
+
+        try:
+            return response.json()
+        except ValueError as e:
+            raise Exception(
+                f"Jina AI embedding API returned a non-JSON response: {e}")
+
+    def _initialize_by_component_configer(self,
+                                          embedding_configer: ComponentConfiger) \
+            -> 'JinaEmbedding':
+        """Initialize the embedding by the ComponentConfiger object.
+
+        Args:
+            embedding_configer: A configer containing the embedding basic
+                info.
+
+        Returns:
+            The initialized embedding instance.
+        """
+        super()._initialize_by_component_configer(embedding_configer)
+        if hasattr(embedding_configer, "api_key"):
+            self.api_key = embedding_configer.api_key
+        if hasattr(embedding_configer, "api_base"):
+            self.api_base = embedding_configer.api_base
+        if hasattr(embedding_configer, "dimensions"):
+            self.dimensions = embedding_configer.dimensions
+        if hasattr(embedding_configer, "embedding_dims"):
+            self.dimensions = embedding_configer.embedding_dims
+        if hasattr(embedding_configer, "request_timeout"):
+            self.request_timeout = self._validate_request_timeout(
+                embedding_configer.request_timeout)
+        if hasattr(embedding_configer, "batch_size"):
+            self.batch_size = embedding_configer.batch_size
+        return self
+
+    @staticmethod
+    def _validate_request_timeout(value) -> int:
+        """Validate a configured request timeout.
+
+        ``requests`` treats ``None`` as "no timeout" and accepts ``0`` /
+        negative values without complaint, so a bad config must fail loudly
+        here instead of hanging the embedding step or silently disabling
+        the timeout.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise Exception(
+                f"Jina embedding request_timeout must be a positive number, "
+                f"got {value!r}.")
+        if value <= 0:
+            raise Exception(
+                f"Jina embedding request_timeout must be a positive number, "
+                f"got {value!r}.")
+        return value

--- a/agentuniverse/agent/action/knowledge/embedding/jina_embedding.yaml
+++ b/agentuniverse/agent/action/knowledge/embedding/jina_embedding.yaml
@@ -1,0 +1,12 @@
+name: 'jina_embedding'
+description: 'embedding use jina ai api'
+embedding_model_name: 'jina-embeddings-v3'
+api_key: '${JINA_API_KEY}'
+api_base: 'https://api.jina.ai/v1/embeddings'
+dimensions: 1024
+request_timeout: 30
+batch_size: 32
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.jina_embedding'
+  class: 'JinaEmbedding'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md
@@ -1,0 +1,105 @@
+# Embedding
+
+The Embedding component is responsible for converting text into vectors, which the Store uses for similarity retrieval. agentUniverse provides the abstract base class `Embedding` and a set of built-in implementations (OpenAI, Gemini, Ollama, DashScope, ...). This document focuses on the **Jina AI Embedding** component.
+
+---
+
+## Jina AI Embedding
+
+`JinaEmbedding` integrates the [Jina AI](https://jina.ai) Embeddings API (the `jina-embeddings-v3` model family) into agentUniverse. Jina Embeddings v3 is a multilingual model with configurable output dimensions and strong performance on retrieval tasks.
+
+Unlike the OpenAI / DashScope embeddings which are consumed through a dedicated SDK, the Jina Embeddings API is a plain JSON-over-HTTPS endpoint with no first-party Python client, so `JinaEmbedding` calls `https://api.jina.ai/v1/embeddings` directly with `requests` and exposes the `get_embeddings` / `async_get_embeddings` methods required by the `Embedding` base class.
+
+### 1. Create the configuration file
+
+Create a YAML file, for example `jina_embedding.yaml`, and paste the following content into it.
+
+```yaml
+name: 'jina_embedding'
+description: 'embedding use jina ai api'
+embedding_model_name: 'jina-embeddings-v3'
+api_key: '${JINA_API_KEY}'
+api_base: 'https://api.jina.ai/v1/embeddings'
+dimensions: 1024
+request_timeout: 30
+batch_size: 32
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.jina_embedding'
+  class: 'JinaEmbedding'
+```
+
+**Note:** `api_key` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+    ```yaml
+    api_key: 'jina_***'
+    ```
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax.
+    ```yaml
+    api_key: '${JINA_API_KEY}'
+    ```
+3. **Custom function loading** - use the `@FUNC` annotation.
+
+### 2. Configuration parameters
+
+| Parameter             | Description                                                                                  | Default                          |
+| --------------------- | -------------------------------------------------------------------------------------------- | -------------------------------- |
+| `embedding_model_name`| The Jina embedding model id.                                                                  | `jina-embeddings-v3`             |
+| `api_key`             | Jina AI API key. Falls back to the `JINA_API_KEY` env var.                                   | -                                |
+| `api_base`            | Jina Embeddings endpoint URL.                                                                | `https://api.jina.ai/v1/embeddings` |
+| `dimensions`          | Output vector dimensionality. jina-embeddings-v3 supports 32/64/128/256/512/768/1024.        | `1024`                           |
+| `request_timeout`     | Timeout in seconds for the HTTP call. Must be a positive number.                             | `30`                             |
+| `batch_size`          | Maximum number of texts sent in a single API call.                                           | `32`                             |
+
+### 3. Environment setup
+
+Required: `JINA_API_KEY`
+Optional: none.
+
+#### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['JINA_API_KEY'] = 'jina_***'
+```
+
+#### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory:
+
+```toml
+JINA_API_KEY="jina_***"
+```
+
+### 4. Obtaining the Jina API key
+
+1. Sign in at [https://jina.ai](https://jina.ai).
+2. Navigate to the API key management page and create a new key.
+3. Copy the generated key and assign it to `JINA_API_KEY`.
+
+### 5. Using the Embedding in code
+
+```python
+from agentuniverse.agent.action.knowledge.embedding.jina_embedding import JinaEmbedding
+
+embedding = JinaEmbedding()
+
+# Synchronous
+vectors = embedding.get_embeddings(['hello', 'world'])
+
+# Asynchronous
+import asyncio
+async def main():
+    vecs = await embedding.async_get_embeddings(['hello', 'world'])
+    print(len(vecs), len(vecs[0]))
+asyncio.run(main())
+```
+
+The returned value is a list of float vectors, one per input text, in input order. The vectors can be stored in a `Document.embedding` and queried by any Store implementation.
+
+### 6. Tips
+
+- `jina-embeddings-v3` is multilingual and is a good default for both Chinese and English retrieval.
+- For multimodal (image) embeddings use the dedicated Jina CLIP embeddings model instead.
+- Keep `dimensions` consistent with what your Store / index expects; changing it after indexing invalidates the existing vectors.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md
@@ -1,0 +1,105 @@
+# Embedding（向量化）
+
+Embedding 组件负责将文本转换为向量，供 Store 进行相似度检索。agentUniverse 提供了抽象基类 `Embedding` 以及若干内置实现（OpenAI、Gemini、Ollama、DashScope 等）。本文档重点介绍 **Jina AI Embedding** 组件。
+
+---
+
+## Jina AI Embedding
+
+`JinaEmbedding` 将 [Jina AI](https://jina.ai) 的 Embeddings API（`jina-embeddings-v3` 模型系列）接入 agentUniverse。Jina Embeddings v3 是一个多语言模型，支持可配置的输出维度，在检索任务上表现优秀。
+
+与通过专用 SDK 调用的 OpenAI / DashScope Embedding 不同，Jina Embeddings API 是一个纯 JSON-over-HTTPS 端点，没有官方 Python 客户端，因此 `JinaEmbedding` 直接通过 `requests` 调用 `https://api.jina.ai/v1/embeddings`，并对外暴露 `Embedding` 基类要求的 `get_embeddings` / `async_get_embeddings` 方法。
+
+### 1. 创建配置文件
+
+新建一个 YAML 文件，例如 `jina_embedding.yaml`，填入以下内容。
+
+```yaml
+name: 'jina_embedding'
+description: 'embedding use jina ai api'
+embedding_model_name: 'jina-embeddings-v3'
+api_key: '${JINA_API_KEY}'
+api_base: 'https://api.jina.ai/v1/embeddings'
+dimensions: 1024
+request_timeout: 30
+batch_size: 32
+metadata:
+  type: 'EMBEDDING'
+  module: 'agentuniverse.agent.action.knowledge.embedding.jina_embedding'
+  class: 'JinaEmbedding'
+```
+
+**说明：** `api_key` 支持三种配置方式：
+
+1. **直接填写字符串** —— 在配置文件中直接写入 API Key。
+    ```yaml
+    api_key: 'jina_***'
+    ```
+2. **环境变量占位符** —— 使用 `${VARIABLE_NAME}` 语法。
+    ```yaml
+    api_key: '${JINA_API_KEY}'
+    ```
+3. **自定义函数加载** —— 使用 `@FUNC` 注解。
+
+### 2. 配置参数
+
+| 参数                  | 说明                                                                  | 默认值                             |
+| --------------------- | -------------------------------------------------------------------- | --------------------------------- |
+| `embedding_model_name`| Jina Embedding 模型 ID。                                              | `jina-embeddings-v3`              |
+| `api_key`             | Jina AI API Key，未配置时回退到 `JINA_API_KEY` 环境变量。             | -                                 |
+| `api_base`            | Jina Embeddings 接口地址。                                            | `https://api.jina.ai/v1/embeddings` |
+| `dimensions`          | 输出向量维度，jina-embeddings-v3 支持 32/64/128/256/512/768/1024。     | `1024`                            |
+| `request_timeout`     | HTTP 调用超时时间（秒），必须为正数。                                  | `30`                              |
+| `batch_size`          | 单次 API 调用发送的最大文本数量。                                      | `32`                              |
+
+### 3. 环境配置
+
+必填：`JINA_API_KEY`
+选填：无。
+
+#### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['JINA_API_KEY'] = 'jina_***'
+```
+
+#### 3.2 通过配置文件配置
+
+在项目 `config` 目录下的 `custom_key.toml` 文件中加入：
+
+```toml
+JINA_API_KEY="jina_***"
+```
+
+### 4. 获取 Jina API Key
+
+1. 登录 [https://jina.ai](https://jina.ai)。
+2. 进入 API Key 管理页面，创建新的 Key。
+3. 复制生成的 Key，赋值给 `JINA_API_KEY`。
+
+### 5. 在代码中使用
+
+```python
+from agentuniverse.agent.action.knowledge.embedding.jina_embedding import JinaEmbedding
+
+embedding = JinaEmbedding()
+
+# 同步
+vectors = embedding.get_embeddings(['你好', '世界'])
+
+# 异步
+import asyncio
+async def main():
+    vecs = await embedding.async_get_embeddings(['你好', '世界'])
+    print(len(vecs), len(vecs[0]))
+asyncio.run(main())
+```
+
+返回值为浮点向量列表，与输入文本一一对应且顺序一致。向量可写入 `Document.embedding`，由任意 Store 实现进行检索。
+
+### 6. 使用建议
+
+- `jina-embeddings-v3` 为多语言模型，中英文检索均适用，是推荐默认值。
+- 涉及多模态（图像）向量时，请改用 Jina CLIP embeddings 模型。
+- `dimensions` 需与 Store / 索引期望的维度保持一致；建立索引后修改维度会使已有向量失效。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_jina_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_jina_embedding.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the Jina AI Embedding component.
+
+These tests mock the ``requests.post`` HTTP call so the suite can run in
+CI without a live ``JINA_API_KEY``. They cover credential wiring, payload
+construction, the response decoding path, batching, error handling and
+the async wrapper.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from agentuniverse.agent.action.knowledge.embedding.jina_embedding import (
+    JINA_DEFAULT_DIMENSIONS,
+    JINA_DEFAULT_EMBEDDING_MODEL,
+    JINA_EMBEDDING_API_BASE,
+    JinaEmbedding,
+)
+
+
+def _mock_response(embeddings):
+    """Build a MagicMock whose .json() returns an OpenAI-style payload."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {"index": i, "embedding": emb} for i, emb in enumerate(embeddings)
+        ]
+    }
+    return mock_response
+
+
+class TestJinaEmbedding(unittest.TestCase):
+    """Test suite for the JinaEmbedding component."""
+
+    def setUp(self) -> None:
+        self.embedding = JinaEmbedding(
+            api_key='test_api_key',
+            embedding_model_name='jina-embeddings-v3',
+        )
+
+    # ---- initialization & defaults ----
+
+    def test_initialization_defaults(self) -> None:
+        """Defaults: model v3, base URL, dimensions 1024, timeout 30."""
+        emb = JinaEmbedding(api_key='k')
+        self.assertEqual(emb.embedding_model_name, JINA_DEFAULT_EMBEDDING_MODEL)
+        self.assertEqual(emb.api_base, JINA_EMBEDDING_API_BASE)
+        self.assertEqual(emb.dimensions, JINA_DEFAULT_DIMENSIONS)
+        self.assertEqual(emb.request_timeout, 30)
+
+    def test_initialization_custom(self) -> None:
+        """Custom constructor values must be persisted."""
+        emb = JinaEmbedding(
+            api_key='k',
+            embedding_model_name='jina-embeddings-v2-base-en',
+            dimensions=768,
+            request_timeout=10,
+            batch_size=8,
+        )
+        self.assertEqual(emb.embedding_model_name, 'jina-embeddings-v2-base-en')
+        self.assertEqual(emb.dimensions, 768)
+        self.assertEqual(emb.request_timeout, 10)
+        self.assertEqual(emb.batch_size, 8)
+
+    # ---- happy path ----
+
+    @patch('requests.post')
+    def test_get_embeddings(self, mock_post) -> None:
+        """get_embeddings must return vectors in input order."""
+        mock_post.return_value = _mock_response([[0.1, 0.2], [0.3, 0.4]])
+        result = self.embedding.get_embeddings(['hello', 'world'])
+        self.assertEqual(result, [[0.1, 0.2], [0.3, 0.4]])
+        # Verify the request payload and headers.
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['headers']['Authorization'], 'Bearer test_api_key')
+        self.assertEqual(kwargs['headers']['Content-Type'], 'application/json')
+        self.assertEqual(kwargs['json']['model'], 'jina-embeddings-v3')
+        self.assertEqual(kwargs['json']['input'], ['hello', 'world'])
+        self.assertEqual(kwargs['json']['dimensions'], 1024)
+        self.assertEqual(kwargs['timeout'], 30)
+
+    @patch('requests.post')
+    def test_get_embeddings_batches(self, mock_post) -> None:
+        """Inputs larger than batch_size must be split into multiple calls."""
+        self.embedding.batch_size = 2
+        mock_post.side_effect = [
+            _mock_response([[1.0], [2.0]]),
+            _mock_response([[3.0]]),
+        ]
+        result = self.embedding.get_embeddings(['a', 'b', 'c'])
+        self.assertEqual(result, [[1.0], [2.0], [3.0]])
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch('requests.post')
+    def test_async_get_embeddings(self, mock_post) -> None:
+        """async_get_embeddings must return the same as the sync path."""
+        mock_post.return_value = _mock_response([[0.5, 0.6]])
+        result = asyncio.run(self.embedding.async_get_embeddings(['hi']))
+        self.assertEqual(result, [[0.5, 0.6]])
+
+    # ---- error handling ----
+
+    def test_get_embeddings_empty_text_list(self) -> None:
+        """An empty input list must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.embedding.get_embeddings([])
+
+    def test_get_embeddings_no_api_key(self) -> None:
+        """A missing API key must raise before any HTTP call."""
+        emb = JinaEmbedding(api_key=None)
+        with self.assertRaises(Exception) as ctx:
+            emb.get_embeddings(['hello'])
+        self.assertIn('API key is not set', str(ctx.exception))
+
+    @patch('requests.post')
+    def test_get_embeddings_http_error_is_surfaced(self, mock_post) -> None:
+        """A transport/HTTP error must surface as an API call error."""
+        mock_post.side_effect = requests.exceptions.Timeout('timed out')
+        with self.assertRaises(Exception) as ctx:
+            self.embedding.get_embeddings(['hello'])
+        self.assertIn('API call error', str(ctx.exception))
+
+    @patch('requests.post')
+    def test_get_embeddings_non_json_response_is_surfaced(self, mock_post) -> None:
+        """A non-JSON body must surface as a non-JSON response, not an API error."""
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = b'<html>upstream error page</html>'
+        mock_post.return_value = mock_response
+        with self.assertRaises(Exception) as ctx:
+            self.embedding.get_embeddings(['hello'])
+        self.assertIn('non-JSON', str(ctx.exception))
+        self.assertNotIn('API call error', str(ctx.exception))
+
+    # ---- configer initialization & validation ----
+
+    def _make_configer(self, extra: dict):
+        from agentuniverse.base.config.component_configer.component_configer import \
+            ComponentConfiger
+        from agentuniverse.base.config.configer import Configer
+        cfg = Configer()
+        value = {
+            'name': 'jina_embedding',
+            'description': 'embedding use jina api',
+        }
+        value.update(extra)
+        cfg.value = value
+        configer = ComponentConfiger()
+        configer.load_by_configer(cfg)
+        return configer
+
+    def test_initialize_by_component_configer(self) -> None:
+        """The configer must populate api_key, dimensions and model."""
+        configer = self._make_configer({
+            'api_key': 'cfg_key',
+            'embedding_model_name': 'jina-embeddings-v3',
+            'dimensions': 512,
+        })
+        emb = JinaEmbedding()
+        emb._initialize_by_component_configer(configer)
+        self.assertEqual(emb.api_key, 'cfg_key')
+        self.assertEqual(emb.dimensions, 512)
+        self.assertEqual(emb.embedding_model_name, 'jina-embeddings-v3')
+
+    def test_initialize_rejects_invalid_request_timeout(self) -> None:
+        """Non-positive / non-numeric timeouts must be rejected on init."""
+        for bad in (0, -5, True, False, 'not-a-number', None):
+            configer = self._make_configer({'request_timeout': bad})
+            emb = JinaEmbedding()
+            with self.assertRaises(Exception) as ctx:
+                emb._initialize_by_component_configer(configer)
+            self.assertIn('request_timeout', str(ctx.exception))
+
+    def test_initialize_accepts_valid_request_timeout(self) -> None:
+        """Positive numeric timeouts must be accepted."""
+        for good in (1, 30, 5.5):
+            configer = self._make_configer({'request_timeout': good})
+            emb = JinaEmbedding()
+            emb._initialize_by_component_configer(configer)
+            self.assertEqual(emb.request_timeout, good)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **Jina AI Embedding** component, resolving part of #250.

`JinaEmbedding` integrates the [Jina AI](https://jina.ai) Embeddings API (the `jina-embeddings-v3` model family) into agentUniverse. Jina Embeddings v3 is a multilingual model with configurable output dimensions and strong retrieval performance.

Unlike the OpenAI / DashScope embeddings (consumed via a dedicated SDK), the Jina Embeddings API is a plain JSON-over-HTTPS endpoint with no first-party Python client, so the component calls `https://api.jina.ai/v1/embeddings` directly with `requests` and exposes the `get_embeddings` / `async_get_embeddings` methods required by the `Embedding` base class. The async path runs the blocking call in a thread executor via `asyncio.to_thread`.

## Changes

- `agentuniverse/agent/action/knowledge/embedding/jina_embedding.py` — `JinaEmbedding(Embedding)`:
  - `api_key` from `JINA_API_KEY` env var
  - `embedding_model_name` default `jina-embeddings-v3`
  - `api_base` default `https://api.jina.ai/v1/embeddings`
  - `dimensions` (default 1024), `batch_size` (default 32), `request_timeout` (default 30, validated)
  - `get_embeddings` (batched) + `async_get_embeddings`
  - isolated HTTP-send vs JSON-decode error handling
- `agentuniverse/agent/action/knowledge/embedding/jina_embedding.yaml`
- `tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_jina_embedding.py` — 12 unit tests (mocked `requests.post`): init defaults/custom, happy path, batching, async wrapper, empty list, missing key, HTTP error, non-JSON response, configer init + timeout validation
- `docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Embedding.md`
- `docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Embedding.md`

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.embedding.test_jina_embedding -v` → 12 passed
- [ ] Live API call (requires a real `JINA_API_KEY`) — integration calls are mocked so CI runs without external deps.

Closes part of #250.
