### PR TITLE
feat(tool): add QRCodeTool component (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/qrcode_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/qrcode_tool.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+
+"""Bounded QR code generation and decoding tool."""
+
+# Validation failures are converted to structured tool responses at the public
+# execute boundary, so bespoke exception subclasses would add no useful signal.
+# ruff: noqa: TRY003, TRY004
+
+import base64
+import os
+import tempfile
+from typing import Any, ClassVar, cast
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import (
+    resolve_safe_path,
+)
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class QRCodeTool(Tool):
+    """Generate and decode QR codes within ``base_dir``.
+
+    ``qrcode`` and ``Pillow`` are loaded lazily so importing this tool never
+    fails on environments without the optional imaging stack. Every file path
+    is confined to ``base_dir`` (including resolved symlinks) and writes use a
+    temporary file followed by ``os.replace`` so a failed save cannot corrupt
+    an existing image.
+
+    Supported modes:
+
+    * ``generate`` — encode text into a PNG (or another Pillow format) file.
+    * ``decode`` — read a QR code from an existing image file.
+    * ``generate_base64`` — encode text and return the image as a base64 string.
+    """
+
+    base_dir: str = "."
+    max_input_chars: int = 2_000
+    default_size: int = 10
+    default_border: int = 4
+    error_correction: str = "M"
+    box_size_min: int = 1
+    box_size_max: int = 100
+    border_min: int = 0
+    border_max: int = 20
+    max_read_bytes: int = 20 * 1024 * 1024
+    max_write_bytes: int = 20 * 1024 * 1024
+
+    _ERROR_LEVELS: ClassVar[dict[str, str]] = {
+        "L": "ERROR_CORRECT_L",
+        "M": "ERROR_CORRECT_M",
+        "Q": "ERROR_CORRECT_Q",
+        "H": "ERROR_CORRECT_H",
+    }
+    _IMAGE_EXTENSIONS: ClassVar[set[str]] = {
+        ".png",
+        ".bmp",
+        ".gif",
+        ".tiff",
+        ".tif",
+        ".jpeg",
+        ".jpg",
+    }
+
+    def execute(
+        self,
+        mode: str,
+        data: str | None = None,
+        file_path: str | None = None,
+        box_size: int | None = None,
+        border: int | None = None,
+        size: int | None = None,
+        error_correction: str | None = None,
+        output_format: str | None = None,
+        overwrite: bool = False,
+        fill_color: str = "black",
+        back_color: str = "white",
+    ) -> dict[str, Any]:
+        """Run a QR code operation.
+
+        Args:
+            mode: One of ``generate``, ``decode``, or ``generate_base64``.
+            data: Text to encode. Required for the generate modes.
+            file_path: Image path underneath ``base_dir``. Required for
+                ``generate`` (destination) and ``decode`` (source).
+            box_size: Pixels per QR module. Defaults to ``default_size``.
+            border: Quiet-zone width in modules. Defaults to ``default_border``.
+            size: Alias for ``box_size`` kept for convenience.
+            error_correction: Error correction level (L/M/Q/H).
+            output_format: Pillow image format for ``generate_base64``
+                (e.g. ``PNG``). Defaults to ``PNG``.
+            overwrite: Allow ``generate`` to replace an existing image.
+            fill_color: Foreground (module) color.
+            back_color: Background color.
+
+        Returns:
+            A structured success or error dictionary.
+        """
+        try:
+            self._validate_configuration()
+            normalized_mode = self._normalize_mode(mode)
+
+            if normalized_mode == "generate":
+                if file_path is None:
+                    raise ValueError("file_path is required for generate mode")
+                return self._generate(
+                    data,
+                    file_path,
+                    box_size,
+                    border,
+                    size,
+                    error_correction,
+                    overwrite,
+                    fill_color,
+                    back_color,
+                )
+            if normalized_mode == "decode":
+                if file_path is None:
+                    raise ValueError("file_path is required for decode mode")
+                return self._decode(file_path)
+            return self._generate_base64(
+                data,
+                box_size,
+                border,
+                size,
+                error_correction,
+                output_format,
+                fill_color,
+                back_color,
+            )
+        except ImportError as exc:
+            message = str(exc)
+            if "pyzbar" in message or "decoding requires" in message:
+                hint = (
+                    "QR code decoding requires the optional pyzbar package and "
+                    "the zbar native library. Install with: pip install pyzbar"
+                )
+            else:
+                hint = (
+                    "qrcode and Pillow are required for QR code operations. "
+                    "Install them with: pip install qrcode[pil]"
+                )
+            return self._error(
+                file_path,
+                "dependency_error",
+                hint,
+                detail=message,
+            )
+        except (TypeError, ValueError) as exc:
+            return self._error(file_path, "validation_error", str(exc))
+        except Exception as exc:  # library-specific parse/write failures
+            return self._error(
+                file_path,
+                "operation_error",
+                f"QR code operation failed: {exc}",
+            )
+
+    # ------------------------------------------------------------------ public
+
+    @staticmethod
+    def _error(path: Any, kind: str, message: str, detail: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status": "error",
+            "error_type": kind,
+            "error": message,
+        }
+        if detail:
+            payload["detail"] = detail
+        if path is not None:
+            payload["file_path"] = path
+        return payload
+
+    def _validate_configuration(self) -> None:
+        for name in ("max_input_chars", "max_read_bytes", "max_write_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        for name in ("box_size_min", "box_size_max", "border_min", "border_max"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if self.box_size_min > self.box_size_max:
+            raise ValueError("box_size_min cannot exceed box_size_max")
+        if self.border_min > self.border_max:
+            raise ValueError("border_min cannot exceed border_max")
+        for name in ("default_size", "default_border"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{name} must be an integer")
+        if self.error_correction not in self._ERROR_LEVELS:
+            allowed = ", ".join(sorted(self._ERROR_LEVELS))
+            raise ValueError(
+                f"error_correction must be one of {allowed}, got {self.error_correction!r}"
+            )
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+
+    @staticmethod
+    def _normalize_mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"generate", "decode", "generate_base64"}:
+            raise ValueError("mode must be generate, decode, or generate_base64")
+        return mode
+
+    def _resolve_image_path(self, file_path: str) -> str:
+        if not isinstance(file_path, str) or not file_path:
+            raise ValueError("file_path must be a non-empty string")
+        _, ext = os.path.splitext(file_path)
+        if ext.lower() not in self._IMAGE_EXTENSIONS:
+            raise ValueError(
+                "file_path must end with a supported image extension "
+                f"({', '.join(sorted(self._IMAGE_EXTENSIONS))})"
+            )
+        return cast(str, resolve_safe_path(file_path, self.base_dir))
+
+    # ------------------------------------------------------------ generation
+
+    def _build_qr(
+        self,
+        data: Any,
+        box_size: int | None,
+        border: int | None,
+        size: int | None,
+        error_correction: str | None,
+    ) -> Any:
+        if not isinstance(data, str):
+            raise TypeError("data must be a string")
+        if not data:
+            raise ValueError("data must be a non-empty string")
+        if len(data) > self.max_input_chars:
+            raise ValueError(
+                f"data length ({len(data)}) exceeds max_input_chars "
+                f"({self.max_input_chars})"
+            )
+
+        resolved_box = self._resolve_box_size(box_size, size)
+        resolved_border = self._resolve_border(border)
+        resolved_correction = self._resolve_correction(error_correction)
+
+        qrcode = self._load_qrcode()
+        constants = self._load_qrcode_constants()
+        correction_constant = getattr(constants, self._ERROR_LEVELS[resolved_correction])
+        qr = qrcode.QRCode(
+            version=None,
+            error_correction=correction_constant,
+            box_size=resolved_box,
+            border=resolved_border,
+        )
+        qr.add_data(data)
+        qr.make(fit=True)
+        return qr
+
+    def _resolve_box_size(self, box_size: int | None, size: int | None) -> int:
+        candidate = box_size if box_size is not None else size
+        if candidate is None:
+            candidate = self.default_size
+        if isinstance(candidate, bool) or not isinstance(candidate, int):
+            raise TypeError("box_size must be an integer")
+        if candidate < self.box_size_min or candidate > self.box_size_max:
+            raise ValueError(
+                f"box_size must be between {self.box_size_min} and {self.box_size_max}"
+            )
+        return candidate
+
+    def _resolve_border(self, border: int | None) -> int:
+        if border is None:
+            border = self.default_border
+        if isinstance(border, bool) or not isinstance(border, int):
+            raise TypeError("border must be an integer")
+        if border < self.border_min or border > self.border_max:
+            raise ValueError(
+                f"border must be between {self.border_min} and {self.border_max}"
+            )
+        return border
+
+    def _resolve_correction(self, error_correction: str | None) -> str:
+        if error_correction is None:
+            error_correction = self.error_correction
+        if not isinstance(error_correction, str):
+            raise TypeError("error_correction must be a string")
+        normalized = error_correction.strip().upper()
+        if normalized not in self._ERROR_LEVELS:
+            allowed = ", ".join(sorted(self._ERROR_LEVELS))
+            raise ValueError(
+                f"error_correction must be one of {allowed}, got {error_correction!r}"
+            )
+        return normalized
+
+    def _generate(
+        self,
+        data: str | None,
+        file_path: str,
+        box_size: int | None,
+        border: int | None,
+        size: int | None,
+        error_correction: str | None,
+        overwrite: bool,
+        fill_color: str,
+        back_color: str,
+    ) -> dict[str, Any]:
+        qr = self._build_qr(data, box_size, border, size, error_correction)
+        destination = self._resolve_image_path(file_path)
+        if os.path.exists(destination) and not overwrite:
+            raise ValueError(
+                f"file_path already exists: {destination} (set overwrite=true to replace)"
+            )
+        image = self._render_image(qr, fill_color, back_color)
+        self._atomic_save(image, destination)
+        return {
+            "status": "success",
+            "file_path": destination,
+            "data_length": len(data) if isinstance(data, str) else 0,
+            "box_size": qr.box_size,
+            "border": qr.border,
+            "error_correction": self._correction_label(qr.error_correction),
+        }
+
+    def _generate_base64(
+        self,
+        data: str | None,
+        box_size: int | None,
+        border: int | None,
+        size: int | None,
+        error_correction: str | None,
+        output_format: str | None,
+        fill_color: str,
+        back_color: str,
+    ) -> dict[str, Any]:
+        qr = self._build_qr(data, box_size, border, size, error_correction)
+        image = self._render_image(qr, fill_color, back_color)
+        image_format = self._normalize_image_format(output_format)
+        encoded = self._encode_image(image, image_format)
+        if len(encoded) > self.max_write_bytes:
+            raise ValueError(
+                f"encoded image length ({len(encoded)}) exceeds max_write_bytes "
+                f"({self.max_write_bytes})"
+            )
+        return {
+            "status": "success",
+            "image_base64": encoded,
+            "image_format": image_format,
+            "data_length": len(data) if isinstance(data, str) else 0,
+            "box_size": qr.box_size,
+            "border": qr.border,
+            "error_correction": self._correction_label(qr.error_correction),
+        }
+
+    # --------------------------------------------------------------- decoding
+
+    def _decode(self, file_path: str) -> dict[str, Any]:
+        source = self._resolve_image_path(file_path)
+        if not os.path.isfile(source):
+            raise ValueError(f"file_path does not exist: {source}")
+        if os.path.getsize(source) > self.max_read_bytes:
+            raise ValueError(
+                f"file_path exceeds max_read_bytes ({self.max_read_bytes})"
+            )
+        texts = self._read_qr(source)
+        if not texts:
+            return {
+                "status": "success",
+                "file_path": source,
+                "decoded": [],
+                "text": None,
+                "found": False,
+            }
+        return {
+            "status": "success",
+            "file_path": source,
+            "decoded": texts,
+            "text": texts[0],
+            "found": True,
+        }
+
+    # ------------------------------------------------------------- dependency
+
+    def _load_qrcode(self):
+        try:
+            import qrcode  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised via patch
+            raise ImportError("qrcode library is not installed") from exc
+        return qrcode
+
+    def _load_qrcode_constants(self):
+        return self._load_qrcode().constants
+
+    def _load_image(self):
+        try:
+            from PIL import Image  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised via patch
+            raise ImportError("Pillow is not installed") from exc
+        return Image
+
+    def _render_image(self, qr: Any, fill_color: str, back_color: str) -> Any:
+        if not isinstance(fill_color, str) or not fill_color:
+            raise ValueError("fill_color must be a non-empty string")
+        if not isinstance(back_color, str) or not back_color:
+            raise ValueError("back_color must be a non-empty string")
+        return qr.make_image(fill_color=fill_color, back_color=back_color)
+
+    @staticmethod
+    def _normalize_image_format(output_format: str | None) -> str:
+        if output_format is None or output_format == "":
+            return "PNG"
+        if not isinstance(output_format, str):
+            raise TypeError("output_format must be a string")
+        normalized = output_format.strip().upper()
+        if not normalized:
+            return "PNG"
+        if normalized == "JPG":
+            return "JPEG"
+        return normalized
+
+    def _encode_image(self, image: Any, image_format: str) -> str:
+        Image = self._load_image()
+        buffer = self._io_bytes()
+        image.save(buffer, format=image_format)
+        encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+        if not encoded:
+            raise ValueError("failed to encode image to base64")
+        return encoded
+
+    def _read_qr(self, source: str) -> list[str]:
+        try:
+            from pyzbar import pyzbar  # type: ignore[import-not-found]
+        except ImportError:
+            return self._read_qr_pillow(source)
+        image = self._load_image().open(source)
+        try:
+            decoded = pyzbar.decode(image)
+        finally:
+            try:
+                image.close()
+            except Exception:  # pragma: no cover - defensive close
+                pass
+        texts: list[str] = []
+        for item in decoded:
+            value = item.data.decode("utf-8", errors="replace") if item.data else ""
+            if value:
+                texts.append(value)
+        return texts
+
+    def _read_qr_pillow(self, source: str) -> list[str]:
+        # Pillow alone cannot decode QR codes, but the qrcode library cannot
+        # decode images either. Surface a helpful error so callers install the
+        # optional decoder instead of silently receiving an empty result.
+        raise ImportError(
+            "decoding requires the pyzbar package (pip install pyzbar) and the "
+            "zbar native library"
+        )
+
+    @staticmethod
+    def _io_bytes():
+        import io
+
+        return io.BytesIO()
+
+    def _atomic_save(self, image: Any, destination: str) -> None:
+        directory = os.path.dirname(destination) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, temp_name = tempfile.mkstemp(
+            prefix=".qrcode-",
+            suffix=os.path.splitext(destination)[1] or ".png",
+            dir=directory,
+        )
+        os.close(fd)
+        try:
+            image.save(temp_name)
+            if os.path.getsize(temp_name) > self.max_write_bytes:
+                raise ValueError(
+                    f"generated image exceeds max_write_bytes ({self.max_write_bytes})"
+                )
+            os.replace(temp_name, destination)
+        except BaseException:
+            if os.path.exists(temp_name):
+                try:
+                    os.remove(temp_name)
+                except OSError:  # pragma: no cover - best-effort cleanup
+                    pass
+            raise
+
+    @staticmethod
+    def _correction_label(constant: int) -> str:
+        # qrcode exposes the correction levels as module-level integers.
+        try:
+            from qrcode.constants import (  # type: ignore[import-not-found]
+                ERROR_CORRECT_H,
+                ERROR_CORRECT_L,
+                ERROR_CORRECT_M,
+                ERROR_CORRECT_Q,
+            )
+        except ImportError:  # pragma: no cover - exercised via patch
+            return "M"
+        mapping = {
+            ERROR_CORRECT_L: "L",
+            ERROR_CORRECT_M: "M",
+            ERROR_CORRECT_Q: "Q",
+            ERROR_CORRECT_H: "H",
+        }
+        return mapping.get(constant, "M")

--- a/agentuniverse/agent/action/tool/common_tool/qrcode_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/qrcode_tool.yaml
@@ -1,0 +1,114 @@
+name: qrcode_tool
+description: Generate QR code images and decode existing QR codes from image files. Requires the optional qrcode and Pillow packages.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.qrcode_tool
+  class: QRCodeTool
+input_keys:
+  - mode
+base_dir: .
+max_input_chars: 2000
+default_size: 10
+default_border: 4
+error_correction: M
+box_size_min: 1
+box_size_max: 100
+border_min: 0
+border_max: 20
+max_read_bytes: 20971520
+max_write_bytes: 20971520
+args_model:
+  mode:
+    type: string
+    description: Operation mode — generate, decode, or generate_base64.
+    required: true
+  data:
+    type: string
+    description: Text to encode. Required for generate and generate_base64 modes.
+    required: false
+  file_path:
+    type: string
+    description: Image path underneath the configured base_dir. Required for generate (destination) and decode (source).
+    required: false
+  box_size:
+    type: integer
+    description: Pixels per QR module. Falls back to default_size when omitted.
+    required: false
+  size:
+    type: integer
+    description: Alias for box_size.
+    required: false
+  border:
+    type: integer
+    description: Quiet-zone width in modules. Falls back to default_border when omitted.
+    required: false
+  error_correction:
+    type: string
+    description: Error correction level — L, M, Q, or H. Falls back to the tool-level error_correction.
+    required: false
+  output_format:
+    type: string
+    description: Pillow image format for generate_base64 (e.g. PNG). Defaults to PNG.
+    required: false
+  overwrite:
+    type: boolean
+    description: Allow generate mode to replace an existing image.
+    required: false
+    default: false
+  fill_color:
+    type: string
+    description: Foreground (module) color.
+    required: false
+    default: black
+  back_color:
+    type: string
+    description: Background color.
+    required: false
+    default: white
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: ["generate", "decode", "generate_base64"]
+      description: QR code operation mode.
+    data:
+      type: string
+      description: Text to encode for generate modes.
+    file_path:
+      type: string
+      description: Image path underneath base_dir.
+    box_size:
+      type: integer
+      minimum: 1
+      maximum: 100
+      description: Pixels per QR module.
+    size:
+      type: integer
+      minimum: 1
+      maximum: 100
+      description: Alias for box_size.
+    border:
+      type: integer
+      minimum: 0
+      maximum: 20
+      description: Quiet-zone width in modules.
+    error_correction:
+      type: string
+      enum: ["L", "M", "Q", "H"]
+      description: Error correction level.
+    output_format:
+      type: string
+      description: Pillow image format for generate_base64.
+    overwrite:
+      type: boolean
+      default: false
+    fill_color:
+      type: string
+      default: black
+    back_color:
+      type: string
+      default: white
+  required: ["mode"]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,76 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+
+## QRCodeTool
+
+`QRCodeTool` provides bounded QR code generation and decoding for agent workflows with three modes: `generate`, `decode`, and `generate_base64`. Install the optional dependencies:
+
+```bash
+pip install "qrcode[pil]"
+# decoding additionally needs pyzbar and the native zbar library: pip install pyzbar
+```
+
+The built-in component configuration is
+[`qrcode_tool.yaml`](../../../../../../agentuniverse/agent/action/tool/common_tool/qrcode_tool.yaml):
+
+```yaml
+name: qrcode_tool
+description: Generate QR code images and decode existing QR codes from image files.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.qrcode_tool
+  class: QRCodeTool
+input_keys: [mode]
+base_dir: .
+max_input_chars: 2000
+default_size: 10
+default_border: 4
+error_correction: M
+```
+
+Generate a QR code to a file:
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("qrcode_tool")
+result = tool.run(
+    mode="generate",
+    data="https://antgroup.com",
+    file_path="qrcodes/site.png",
+    box_size=10,
+    border=4,
+    error_correction="H",
+)
+```
+
+Generate a base64 string (handy when returning the image inline without writing a file):
+
+```python
+result = tool.run(mode="generate_base64", data="hello", output_format="PNG")
+print(result["image_base64"])
+```
+
+Decode an existing QR code image:
+
+```python
+result = tool.run(mode="decode", file_path="qrcodes/site.png")
+print(result["decoded"])
+```
+
+Parameters:
+
+- `mode`: required — `generate`, `decode`, or `generate_base64`.
+- `data`: required for `generate` and `generate_base64`; the text to encode, capped by `max_input_chars`.
+- `file_path`: required for `generate` (destination) and `decode` (source); confined to `base_dir` and must use a supported image extension (`.png`, `.bmp`, `.gif`, `.tiff`/`.tif`, `.jpeg`/`.jpg`).
+- `box_size` / `size`: pixels per QR module; `size` is an alias for `box_size`; defaults to `default_size`.
+- `border`: quiet-zone width in modules; defaults to `default_border`.
+- `error_correction`: correction level `L`/`M`/`Q`/`H`; defaults to the tool-level value.
+- `output_format`: `generate_base64` only; a Pillow image format, default `PNG`.
+- `overwrite`: `generate` only; allow replacing an existing image, default `false`.
+- `fill_color` / `back_color`: foreground and background colors, default `black` / `white`.
+
+`qrcode` and `Pillow` are loaded lazily, so importing the tool never fails. Every path is confined to `base_dir` after resolving symlinks; generation uses a same-directory temporary file followed by `os.replace`, so a failed write cannot corrupt an existing image. File size, input length, and module/border ranges are bounded. Decoding relies on the optional `pyzbar` package; when it is absent the tool returns a structured `dependency_error` with an install hint instead of silently returning an empty result.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,76 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+
+## QRCodeTool
+
+`QRCodeTool` 为智能体工作流提供受边界限制的二维码生成与解析，支持 `generate`、`decode` 和 `generate_base64` 三种模式。安装可选依赖即可使用：
+
+```bash
+pip install "qrcode[pil]"
+# 解析二维码还需要 pyzbar 及其底层 zbar 原生库：pip install pyzbar
+```
+
+内置组件配置位于
+[`qrcode_tool.yaml`](../../../../../../agentuniverse/agent/action/tool/common_tool/qrcode_tool.yaml)：
+
+```yaml
+name: qrcode_tool
+description: Generate QR code images and decode existing QR codes from image files.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.qrcode_tool
+  class: QRCodeTool
+input_keys: [mode]
+base_dir: .
+max_input_chars: 2000
+default_size: 10
+default_border: 4
+error_correction: M
+```
+
+生成二维码到文件：
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("qrcode_tool")
+result = tool.run(
+    mode="generate",
+    data="https://antgroup.com",
+    file_path="qrcodes/site.png",
+    box_size=10,
+    border=4,
+    error_correction="H",
+)
+```
+
+生成 base64（适合在对话或 JSON 中直接返回图片，不落盘）：
+
+```python
+result = tool.run(mode="generate_base64", data="hello", output_format="PNG")
+print(result["image_base64"])
+```
+
+从已有图片解析二维码：
+
+```python
+result = tool.run(mode="decode", file_path="qrcodes/site.png")
+print(result["decoded"])
+```
+
+参数说明：
+
+- `mode`：必填，可选 `generate`、`decode` 或 `generate_base64`。
+- `data`：`generate` 与 `generate_base64` 必填，要编码的文本，长度不超过 `max_input_chars`。
+- `file_path`：`generate`（目标文件）和 `decode`（源文件）必填，限制在 `base_dir` 内，必须为支持的图片扩展名（`.png`、`.bmp`、`.gif`、`.tiff`/`.tif`、`.jpeg`/`.jpg`）。
+- `box_size` / `size`：每个二维码模块的像素数，`size` 是 `box_size` 的别名，默认为 `default_size`。
+- `border`：静默区模块数，默认为 `default_border`。
+- `error_correction`：纠错等级 `L`/`M`/`Q`/`H`，默认取工具级配置。
+- `output_format`：仅 `generate_base64` 使用，Pillow 图片格式，默认 `PNG`。
+- `overwrite`：仅 `generate` 使用，是否允许覆盖已有文件，默认 `false`。
+- `fill_color` / `back_color`：前景色与背景色，默认 `black` / `white`。
+
+`qrcode` 与 `Pillow` 仅在真正执行操作时才懒加载，因此导入工具本身不会失败。所有路径都会在解析符号链接后限制在 `base_dir` 内，生成采用同目录临时文件 + `os.replace` 的原子写入，写入失败不会破坏已有图片；文件大小、输入长度、模块与边框取值均设有边界。解析依赖可选的 `pyzbar`，未安装时会返回结构化的 `dependency_error` 提示安装命令，而不是静默返回空结果。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_qrcode_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_qrcode_tool.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+
+"""Tests for the built-in QRCodeTool."""
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.agent.action.tool.common_tool import qrcode_tool as qrcode_module
+from agentuniverse.agent.action.tool.common_tool.qrcode_tool import QRCodeTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import (
+    ApplicationConfigManager,
+)
+from agentuniverse.base.config.component_configer.component_configer import (
+    ComponentConfiger,
+)
+from agentuniverse.base.config.component_configer.configers.tool_configer import (
+    ToolConfiger,
+)
+from agentuniverse.base.config.configer import Configer
+
+QRCODE_AVAILABLE = importlib.util.find_spec("qrcode") is not None
+PIL_AVAILABLE = importlib.util.find_spec("PIL") is not None
+PYZBAR_AVAILABLE = importlib.util.find_spec("pyzbar") is not None
+YAML_PATH = os.path.join(os.path.dirname(qrcode_module.__file__), "qrcode_tool.yaml")
+
+
+@unittest.skipUnless(QRCODE_AVAILABLE and PIL_AVAILABLE, "qrcode and Pillow required")
+class TestQRCodeValidation(unittest.TestCase):
+    """Input, configuration, and path boundaries."""
+
+    def setUp(self) -> None:
+        self.temp_dir_context = tempfile.TemporaryDirectory()
+        self.base_dir = self.temp_dir_context.name
+        self.tool = QRCodeTool(base_dir=self.base_dir)
+
+    def tearDown(self) -> None:
+        self.temp_dir_context.cleanup()
+
+    def test_invalid_mode_is_structured_error(self) -> None:
+        result = self.tool.execute(mode="delete", data="x", file_path="a.png")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("mode must be", result["error"])
+
+    def test_generate_requires_data(self) -> None:
+        result = self.tool.execute(mode="generate", file_path="a.png")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("data", result["error"])
+
+    def test_generate_requires_file_path(self) -> None:
+        result = self.tool.execute(mode="generate", data="hello")
+        self.assertIn("file_path is required", result["error"])
+
+    def test_decode_requires_file_path(self) -> None:
+        result = self.tool.execute(mode="decode")
+        self.assertIn("file_path is required", result["error"])
+
+    def test_rejects_non_image_extension(self) -> None:
+        result = self.tool.execute(mode="decode", file_path="notes.txt")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("supported image extension", result["error"])
+
+    def test_rejects_parent_path_escape(self) -> None:
+        result = self.tool.execute(mode="generate", data="x", file_path="../escape.png")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("escapes the allowed directory", result["error"])
+
+    def test_rejects_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as outside:
+            outside_file = os.path.join(outside, "outside.png")
+            with open(outside_file, "wb") as output:
+                output.write(b"not a qr code")
+            os.symlink(outside, os.path.join(self.base_dir, "linked"))
+            result = self.tool.execute(mode="decode", file_path="linked/outside.png")
+        self.assertIn("escapes the allowed directory", result["error"])
+
+    def test_rejects_input_over_budget(self) -> None:
+        self.tool.max_input_chars = 4
+        result = self.tool.execute(mode="generate", data="abcdef", file_path="a.png")
+        self.assertIn("max_input_chars", result["error"])
+
+    def test_rejects_invalid_error_correction(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            data="x",
+            file_path="a.png",
+            error_correction="Z",
+        )
+        self.assertIn("error_correction must be one of", result["error"])
+
+    def test_rejects_out_of_range_box_size(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            data="x",
+            file_path="a.png",
+            box_size=0,
+        )
+        self.assertIn("box_size must be between", result["error"])
+        result = self.tool.execute(
+            mode="generate",
+            data="x",
+            file_path="a.png",
+            box_size=10_000,
+        )
+        self.assertIn("box_size must be between", result["error"])
+
+    def test_rejects_out_of_range_border(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            data="x",
+            file_path="a.png",
+            border=99,
+        )
+        self.assertIn("border must be between", result["error"])
+
+    def test_rejects_boolean_numeric_config(self) -> None:
+        self.tool.max_input_chars = True
+        result = self.tool.execute(mode="generate", data="x", file_path="a.png")
+        self.assertIn("max_input_chars must be a positive integer", result["error"])
+
+    def test_missing_dependency_has_install_hint(self) -> None:
+        with patch.object(
+            self.tool,
+            "_load_qrcode",
+            side_effect=ImportError("missing"),
+        ):
+            result = self.tool.execute(mode="generate", data="x", file_path="a.png")
+        self.assertEqual(result["error_type"], "dependency_error")
+        self.assertIn("pip install qrcode[pil]", result["error"])
+
+
+@unittest.skipUnless(QRCODE_AVAILABLE and PIL_AVAILABLE, "qrcode and Pillow required")
+class TestQRCodeOperations(unittest.TestCase):
+    """Deterministic QR code generation round trips."""
+
+    def setUp(self) -> None:
+        self.temp_dir_context = tempfile.TemporaryDirectory()
+        self.base_dir = self.temp_dir_context.name
+        self.tool = QRCodeTool(base_dir=self.base_dir)
+
+    def tearDown(self) -> None:
+        self.temp_dir_context.cleanup()
+
+    def test_generate_creates_png_file(self) -> None:
+        result = self.tool.execute(mode="generate", data="hello world", file_path="qr.png")
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(os.path.isfile(result["file_path"]))
+        self.assertGreater(os.path.getsize(result["file_path"]), 0)
+        self.assertEqual(result["data_length"], len("hello world"))
+        self.assertEqual(result["error_correction"], "M")
+
+    def test_generate_in_subdirectory(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            data="nested",
+            file_path="output/qr.png",
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(os.path.isfile(os.path.join(self.base_dir, "output/qr.png")))
+
+    def test_generate_respects_custom_geometry(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            data="config",
+            file_path="qr.png",
+            box_size=5,
+            border=2,
+            error_correction="H",
+        )
+        self.assertEqual(result["box_size"], 5)
+        self.assertEqual(result["border"], 2)
+        self.assertEqual(result["error_correction"], "H")
+
+    def test_size_is_alias_for_box_size(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            data="config",
+            file_path="qr.png",
+            size=7,
+        )
+        self.assertEqual(result["box_size"], 7)
+
+    def test_generate_refuses_overwrite_and_preserves_file(self) -> None:
+        first = self.tool.execute(mode="generate", data="one", file_path="qr.png")
+        self.assertEqual(first["status"], "success")
+        original = os.path.getsize(first["file_path"])
+        result = self.tool.execute(mode="generate", data="two", file_path="qr.png")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("set overwrite=true", result["error"])
+        self.assertEqual(os.path.getsize(first["file_path"]), original)
+
+    def test_generate_overwrite_replaces_file(self) -> None:
+        self.tool.execute(mode="generate", data="one", file_path="qr.png")
+        result = self.tool.execute(
+            mode="generate",
+            data="two",
+            file_path="qr.png",
+            overwrite=True,
+        )
+        self.assertEqual(result["status"], "success")
+
+    def test_generate_base64_returns_encoded_png(self) -> None:
+        result = self.tool.execute(mode="generate_base64", data="encoded")
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(result["image_base64"])
+        self.assertEqual(result["image_format"], "PNG")
+
+    def test_generate_base64_respects_output_format(self) -> None:
+        result = self.tool.execute(
+            mode="generate_base64",
+            data="encoded",
+            output_format="bmp",
+        )
+        self.assertEqual(result["image_format"], "BMP")
+
+    def test_decode_missing_file(self) -> None:
+        result = self.tool.execute(mode="decode", file_path="missing.png")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("does not exist", result["error"])
+
+    def test_decode_oversized_file_rejected(self) -> None:
+        path = os.path.join(self.base_dir, "big.png")
+        with open(path, "wb") as output:
+            output.write(b"\x00" * 64)
+        self.tool.max_read_bytes = 8
+        result = self.tool.execute(mode="decode", file_path="big.png")
+        self.assertIn("max_read_bytes", result["error"])
+
+    def test_decode_without_decoder_reports_dependency(self) -> None:
+        if PYZBAR_AVAILABLE:
+            self.skipTest("pyzbar is installed, skipping dependency-error path")
+        self.tool.execute(mode="generate", data="hello", file_path="qr.png")
+        result = self.tool.execute(mode="decode", file_path="qr.png")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "dependency_error")
+        self.assertIn("pyzbar", result["error"])
+
+
+class TestQRCodeRegistration(unittest.TestCase):
+    """Component registration through the YAML configuration."""
+
+    def setUp(self) -> None:
+        self.config = Configer(path=os.path.abspath(YAML_PATH)).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self) -> None:
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self) -> None:
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "QRCodeTool")
+
+    def test_manager(self) -> None:
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, QRCodeTool)
+        self.assertEqual(tool.input_keys, ["mode"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new built-in `QRCodeTool` component for bounded QR code generation and decoding.

## Why

Closes #252. Agent workflows frequently need to mint a scannable QR code (links, payment strings, shareable IDs) or read one back from an uploaded image. This tool provides that capability with the same path/size boundaries and atomic-write guarantees as the other built-in file tools.

## Changes

- `agentuniverse/agent/action/tool/common_tool/qrcode_tool.py` — `QRCodeTool` with three modes:
  - `generate` — encode text into a PNG (or other Pillow format) file
  - `decode` — read QR codes from an existing image (requires optional `pyzbar`)
  - `generate_base64` — encode text and return the image as a base64 string
- `agentuniverse/agent/action/tool/common_tool/qrcode_tool.yaml` — built-in component configuration + args model schema
- `tests/test_agentuniverse/unit/agent/action/tool/test_qrcode_tool.py` — 26 tests (validation, operations, registration)
- `docs/.../集成的工具.md` and `docs/.../Integrated_Tools.md` — bilingual usage docs

## Design notes

- `qrcode` and `Pillow` are loaded lazily so importing the tool never fails on environments without the optional imaging stack.
- `file_path` is confined to `base_dir` via `resolve_safe_path` (including resolved symlinks); supported image extensions are enforced.
- Writes use a same-directory temporary file followed by `os.replace` (atomic), with `max_write_bytes` validation before the replace — a failed write cannot corrupt an existing image.
- Input length (`max_input_chars`), box size, and border ranges are bounded; booleans are rejected where integers are expected.
- `decode` depends on the optional `pyzbar` package; when it is absent the tool returns a structured `dependency_error` with an install hint instead of silently returning an empty result.
- Follows the existing built-in tool convention (`.yaml`, not `.yaml.example`) so it registers as a keyless built-in component like `secure_archive_tool` / `powerpoint_tool`.

## Install

```bash
pip install "qrcode[pil]"
# decoding additionally needs: pip install pyzbar   (+ native zbar library)
```

## Tests

```
26 passed
```
