### PR TITLE
feat(knowledge): add LengthFilter doc processor (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/length_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/length_filter.py
@@ -1,0 +1,228 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: length_filter.py
+
+"""
+Length-filter document pre-processor.
+
+Filters the documents recalled by a RAG pipeline by their **length**, so
+documents that are too short to be informative (fragments, boilerplate,
+single-word hits) or too long to be useful (dumped whole pages) can be
+dropped *before* they reach the LLM.
+
+It is a focused, per-document predicate processor — the *length-only*
+direction of issue #258. It is distinct from:
+
+* ``ThresholdFilter`` — a general filter combinator that supports score /
+  length / top-k / percentile filters with AND/OR logic. ``LengthFilter``
+  is a single-purpose, configuration-light component for users who only
+  need length filtering, with an explicit length-unit selector
+  (``counter``) and an explicit ``drop_mode``.
+* ``ContextBudgetCompressor`` — manages the **cumulative** size of the
+  kept set and can split the boundary document. ``LengthFilter`` only
+  applies a per-document length range and never truncates.
+
+Length is measured explicitly and honestly via ``counter``:
+
+* ``"char"`` — exact character count (default).
+* ``"word"`` — exact whitespace word count.
+* ``"token"`` — BPE token count via ``tiktoken`` (encoding configurable);
+  falls back to the chars/4 estimate with a warning if tiktoken is not
+  installed.
+
+``drop_mode`` controls which side of the range is removed:
+
+* ``"drop_short"`` — remove documents whose length is below ``min_length``.
+* ``"drop_long"``  — remove documents whose length is above ``max_length``.
+* ``"both"``       — remove documents outside ``[min_length, max_length]``.
+"""
+
+import logging
+from typing import List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_VALID_COUNTERS = {"char", "word", "token"}
+_VALID_DROP_MODES = {"drop_short", "drop_long", "both"}
+
+# Cache of tiktoken encoders keyed by encoding name. Keying by name means
+# multiple filter instances can use different encodings, and a failed lookup
+# for one encoding never poisons another. A value of None means "tiktoken not
+# installed" for that name.
+_TIKTOKEN_ENCODERS: dict = {}
+
+
+class LengthFilter(DocProcessor):
+    """Filter documents by their text length.
+
+    Attributes:
+        min_length: Minimum inclusive length; documents shorter than this are
+            dropped when ``drop_mode`` includes the short side. ``0`` disables
+            the lower bound.
+        max_length: Maximum inclusive length; documents longer than this are
+            dropped when ``drop_mode`` includes the long side. ``0`` (the
+            default) disables the upper bound.
+        counter: How each document's length is measured: ``"char"`` (default),
+            ``"word"``, or ``"token"`` (BPE tokens via tiktoken).
+        drop_mode: Which side of the range is removed: ``"drop_short"``,
+            ``"drop_long"``, or ``"both"``.
+        tiktoken_encoding: Encoding passed to ``tiktoken`` when
+            ``counter == "token"``.
+    """
+
+    min_length: int = 0
+    max_length: int = 0
+    counter: str = "char"
+    drop_mode: str = "drop_short"
+    tiktoken_encoding: str = "cl100k_base"
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Filter documents by their length according to ``drop_mode``.
+
+        Args:
+            origin_docs: Documents to be filtered.
+            query: Unused; kept for interface compatibility.
+
+        Returns:
+            Documents whose length satisfies the configured bounds and drop
+            mode. Original order is preserved.
+        """
+        if not origin_docs:
+            return []
+
+        kept: List[Document] = []
+        for doc in origin_docs:
+            length = self._count(doc.text or "")
+            if self._keep(length):
+                kept.append(doc)
+        return kept
+
+    # ------------------------------------------------------------------ #
+    # Length measurement & decision
+    # ------------------------------------------------------------------ #
+
+    def _keep(self, length: int) -> bool:
+        """Decide whether a document of the given length is kept.
+
+        Args:
+            length: The document length in the unit of ``counter``.
+
+        Returns:
+            True if the document passes the filter, False otherwise.
+        """
+        drop_short = self.drop_mode in ("drop_short", "both")
+        drop_long = self.drop_mode in ("drop_long", "both")
+
+        if drop_short and self.min_length > 0 and length < self.min_length:
+            return False
+        if drop_long and self.max_length > 0 and length > self.max_length:
+            return False
+        return True
+
+    def _count(self, text: str) -> int:
+        """Measure the length of ``text`` in the unit of ``counter``.
+
+        Args:
+            text: The raw document text.
+
+        Returns:
+            The length as a non-negative integer.
+        """
+        if self.counter == "char":
+            return len(text)
+        if self.counter == "word":
+            return len(text.split())
+        if self.counter == "token":
+            encoder = _tiktoken_encoder(self.tiktoken_encoding)
+            if encoder is not None:
+                return len(encoder.encode(text))
+            logger.warning(
+                "tiktoken is not available; counting with the chars/4 estimate "
+                "instead. Install tiktoken or set counter to 'char'/'word' to "
+                "silence this.")
+        # Fallback when counter is unknown or tiktoken is unavailable.
+        return max(1, len(text) // 4) if text else 0
+
+    def _initialize_by_component_configer(self,
+                                          doc_processor_configer: ComponentConfiger) \
+            -> 'LengthFilter':
+        """Initialize the filter from its component config.
+
+        Validates ``counter`` and ``drop_mode`` eagerly so a bad config fails
+        at component initialization rather than silently disabling filtering.
+
+        Args:
+            doc_processor_configer: Configuration object for the doc processor.
+
+        Returns:
+            The initialized filter instance.
+
+        Raises:
+            ValueError: If ``counter`` or ``drop_mode`` is invalid.
+        """
+        super()._initialize_by_component_configer(doc_processor_configer)
+        if hasattr(doc_processor_configer, "min_length"):
+            self.min_length = doc_processor_configer.min_length
+        if hasattr(doc_processor_configer, "max_length"):
+            self.max_length = doc_processor_configer.max_length
+        if hasattr(doc_processor_configer, "counter"):
+            self.counter = doc_processor_configer.counter
+        if hasattr(doc_processor_configer, "drop_mode"):
+            self.drop_mode = doc_processor_configer.drop_mode
+        if hasattr(doc_processor_configer, "tiktoken_encoding"):
+            self.tiktoken_encoding = doc_processor_configer.tiktoken_encoding
+
+        if self.counter not in _VALID_COUNTERS:
+            raise ValueError(
+                f"counter must be one of {sorted(_VALID_COUNTERS)}, "
+                f"got '{self.counter}'.")
+        if self.drop_mode not in _VALID_DROP_MODES:
+            raise ValueError(
+                f"drop_mode must be one of {sorted(_VALID_DROP_MODES)}, "
+                f"got '{self.drop_mode}'.")
+        return self
+
+
+def _tiktoken_encoder(encoding: str):
+    """Return a cached tiktoken encoder for ``encoding``.
+
+    Two distinct failure modes are handled differently:
+
+    * tiktoken is not installed (an optional dependency) -> return None so the
+      caller degrades to the estimate counter with a warning. This is a
+      legitimate graceful fallback for a missing dependency.
+    * tiktoken is installed but ``encoding`` is not a known encoding name ->
+      raise ValueError. A bad configuration must fail loudly rather than
+      silently switching the counting unit from tokens to the chars/4 estimate.
+
+    Results are cached per encoding name, so one instance's encoder is never
+    handed to another instance that configured a different encoding, and an
+    invalid name does not poison subsequent lookups.
+    """
+    if encoding in _TIKTOKEN_ENCODERS:
+        return _TIKTOKEN_ENCODERS[encoding]
+
+    try:
+        import tiktoken
+    except ImportError as exc:
+        logger.debug("tiktoken is not installed; degrading to the estimate counter: %s", exc)
+        _TIKTOKEN_ENCODERS[encoding] = None
+        return None
+
+    try:
+        encoder = tiktoken.get_encoding(encoding)
+    except Exception as exc:
+        raise ValueError(f"Invalid tiktoken encoding {encoding!r}: {exc}") from exc
+
+    _TIKTOKEN_ENCODERS[encoding] = encoder
+    return encoder

--- a/agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml
@@ -1,0 +1,11 @@
+name: 'length_filter'
+description: 'filter recalled documents by text length'
+min_length: 10           # drop documents shorter than this (0 disables)
+max_length: 0            # drop documents longer than this (0 disables)
+counter: 'char'          # char | word | token
+drop_mode: 'drop_short'  # drop_short | drop_long | both
+tiktoken_encoding: 'cl100k_base'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.length_filter'
+  class: 'LengthFilter'

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,31 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [LengthFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml)
+
+This component filters the recalled documents by their **length**, so documents that are too short to be informative (fragments, boilerplate, single-word hits) or too long to be useful (dumped whole pages) can be dropped before they reach the LLM. It addresses the *length filtering* direction of issue #258.
+
+It is a focused, per-document predicate processor. It is distinct from `ThresholdFilter` (a general filter combinator with score / length / top-k / percentile filters and AND/OR logic) and from `ContextBudgetCompressor` (which manages the **cumulative** size of the kept set and can split the boundary document). `LengthFilter` only applies a per-document length range and never truncates.
+
+Length is measured explicitly via `counter`: `char` (exact character count, default), `word` (whitespace word count), or `token` (BPE tokens via tiktoken, falling back to a chars/4 estimate with a warning when tiktoken is not installed). `drop_mode` controls which side of the range is removed: `drop_short` (below `min_length`), `drop_long` (above `max_length`), or `both` (outside `[min_length, max_length]`). Bounds are inclusive; a bound of `0` disables that side.
+
+The component definition file is as follows:
+```yaml
+name: 'length_filter'
+description: 'filter recalled documents by text length'
+min_length: 10           # drop documents shorter than this (0 disables)
+max_length: 0            # drop documents longer than this (0 disables)
+counter: 'char'          # char | word | token
+drop_mode: 'drop_short'  # drop_short | drop_long | both
+tiktoken_encoding: 'cl100k_base'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.length_filter'
+  class: 'LengthFilter'
+```
+- min_length: Minimum inclusive length; documents shorter than this are dropped when `drop_mode` includes the short side. `0` disables the lower bound.
+- max_length: Maximum inclusive length; documents longer than this are dropped when `drop_mode` includes the long side. `0` disables the upper bound.
+- counter: How each document's length is measured: `char` (default), `word`, or `token`.
+- drop_mode: Which side of the range is removed: `drop_short`, `drop_long`, or `both`.
+- tiktoken_encoding: Encoding passed to tiktoken when `counter` is `token`.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,31 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [LengthFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml)
+
+该组件按**长度**过滤召回文档，从而在到达 LLM 之前丢弃过短（无信息量的片段、样板文本、单词命中）或过长（整页搬运）的文档。对应 issue #258 的*长度过滤*方向。
+
+它是一个聚焦的单文档断言处理器。与 `ThresholdFilter`（支持得分/长度/top-k/百分位过滤并支持 AND/OR 组合的通用过滤组合器）以及 `ContextBudgetCompressor`（管理保留集合的**累计**大小，可切分边界文档）不同，`LengthFilter` 只对每个文档应用一个长度区间，且不会截断。
+
+长度通过 `counter` 显式计量：`char`（精确字符数，默认）、`word`（按空白符切分的词数）或 `token`（经 tiktoken 计算的 BPE token 数；未安装 tiktoken 时回退为字符数/4 的估算值并给出告警）。`drop_mode` 控制移除哪一侧：`drop_short`（低于 `min_length`）、`drop_long`（高于 `max_length`）或 `both`（落在 `[min_length, max_length]` 区间外）。边界为闭区间；某侧设为 `0` 表示关闭该侧过滤。
+
+组件定义文件如下：
+```yaml
+name: 'length_filter'
+description: '按长度过滤召回文档'
+min_length: 10           # 丢弃短于此长度的文档（0 表示关闭）
+max_length: 0            # 丢弃长于此长度的文档（0 表示关闭）
+counter: 'char'          # char | word | token
+drop_mode: 'drop_short'  # drop_short | drop_long | both
+tiktoken_encoding: 'cl100k_base'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.length_filter'
+  class: 'LengthFilter'
+```
+- min_length: 最小长度（闭区间）；当 `drop_mode` 包含短侧时，短于此值的文档被丢弃。`0` 表示关闭下界。
+- max_length: 最大长度（闭区间）；当 `drop_mode` 包含长侧时，长于此值的文档被丢弃。`0` 表示关闭上界。
+- counter: 计量每个文档长度的方式：`char`（默认）、`word` 或 `token`。
+- drop_mode: 移除区间哪一侧：`drop_short`、`drop_long` 或 `both`。
+- tiktoken_encoding: 当 `counter` 为 `token` 时传给 tiktoken 的编码。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_length_filter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_length_filter.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: test_length_filter.py
+
+"""
+Unit tests for the LengthFilter document processor.
+
+These tests cover length measurement (char/word/token), the three drop
+modes, bounds handling, order preservation, configer initialization and
+validation.
+"""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.length_filter import (
+    LengthFilter,
+)
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class TestLengthFilter(unittest.TestCase):
+    """Test suite for the LengthFilter component."""
+
+    def setUp(self) -> None:
+        self.filter = LengthFilter()
+        # Documents with known character lengths: 5, 10, 20.
+        self.docs = [
+            Document(text='short'),                 # 5 chars
+            Document(text='medium-len'),            # 10 chars
+            Document(text='this-is-twenty-chars'),  # 20 chars
+        ]
+
+    # ---- length measurement ----
+
+    def test_count_char(self) -> None:
+        """counter='char' must return the exact character count."""
+        f = LengthFilter(counter='char')
+        self.assertEqual(f._count('hello'), 5)
+        self.assertEqual(f._count(''), 0)
+
+    def test_count_word(self) -> None:
+        """counter='word' must return the whitespace word count."""
+        f = LengthFilter(counter='word')
+        self.assertEqual(f._count('hello world'), 2)
+        self.assertEqual(f._count('one'), 1)
+        self.assertEqual(f._count(''), 0)
+
+    def test_count_token(self) -> None:
+        """counter='token' must return a positive integer for non-empty text."""
+        f = LengthFilter(counter='token')
+        n = f._count('hello world')
+        self.assertIsInstance(n, int)
+        self.assertGreater(n, 0)
+
+    # ---- drop modes ----
+
+    def test_drop_short(self) -> None:
+        """drop_short removes documents below min_length."""
+        f = LengthFilter(min_length=10, counter='char', drop_mode='drop_short')
+        result = f._process_docs(self.docs, None)
+        # 'short' (5) is dropped; the rest (10, 20) are kept.
+        self.assertEqual([d.text for d in result], ['medium-len', 'this-is-twenty-chars'])
+
+    def test_drop_long(self) -> None:
+        """drop_long removes documents above max_length."""
+        f = LengthFilter(max_length=10, counter='char', drop_mode='drop_long')
+        result = f._process_docs(self.docs, None)
+        # 'this-is-twenty-chars' (20) is dropped; the rest (5, 10) are kept.
+        self.assertEqual([d.text for d in result], ['short', 'medium-len'])
+
+    def test_drop_both(self) -> None:
+        """both removes documents outside [min_length, max_length]."""
+        f = LengthFilter(min_length=6, max_length=15, counter='char',
+                         drop_mode='both')
+        result = f._process_docs(self.docs, None)
+        # Only 'medium-len' (10) is within [6, 15].
+        self.assertEqual([d.text for d in result], ['medium-len'])
+
+    def test_drop_both_inclusive_bounds(self) -> None:
+        """Bounds must be inclusive (== min/max length is kept)."""
+        f = LengthFilter(min_length=10, max_length=10, counter='char',
+                         drop_mode='both')
+        result = f._process_docs(self.docs, None)
+        self.assertEqual([d.text for d in result], ['medium-len'])
+
+    # ---- order preservation & edge cases ----
+
+    def test_preserves_order(self) -> None:
+        """The relative order of the kept documents must be unchanged."""
+        docs = [
+            Document(text='x' * 100),
+            Document(text='y' * 5),
+            Document(text='z' * 100),
+        ]
+        f = LengthFilter(min_length=10, counter='char', drop_mode='drop_short')
+        result = f._process_docs(docs, None)
+        self.assertEqual([d.text for d in result], ['x' * 100, 'z' * 100])
+
+    def test_empty_input(self) -> None:
+        """An empty document list must return an empty list."""
+        f = LengthFilter(min_length=10, counter='char')
+        self.assertEqual(f._process_docs([], None), [])
+
+    def test_no_filtering_when_bounds_disabled(self) -> None:
+        """With min_length=0 and max_length=0 all documents are kept."""
+        f = LengthFilter(min_length=0, max_length=0, counter='char',
+                         drop_mode='both')
+        result = f._process_docs(self.docs, None)
+        self.assertEqual(len(result), 3)
+
+    def test_empty_text_treated_as_zero(self) -> None:
+        """Documents whose text is empty must be treated as length 0."""
+        docs = [Document(text=''), Document(text='keepme')]
+        f = LengthFilter(min_length=5, counter='char', drop_mode='drop_short')
+        result = f._process_docs(docs, None)
+        self.assertEqual([d.text for d in result], ['keepme'])
+
+    def test_process_docs_public_interface(self) -> None:
+        """The public process_docs wrapper must behave like _process_docs."""
+        f = LengthFilter(min_length=10, counter='char')
+        result = f.process_docs(self.docs, Query(query_str='ignored'))
+        self.assertEqual([d.text for d in result], ['medium-len', 'this-is-twenty-chars'])
+
+    # ---- configer initialization & validation ----
+
+    def _make_configer(self, extra: dict) -> ComponentConfiger:
+        cfg = Configer()
+        value = {
+            'name': 'length_filter',
+            'description': 'filter by length',
+        }
+        value.update(extra)
+        cfg.value = value
+        configer = ComponentConfiger()
+        configer.load_by_configer(cfg)
+        return configer
+
+    def test_initialize_by_component_configer(self) -> None:
+        """The configer must populate min/max length, counter and drop_mode."""
+        configer = self._make_configer({
+            'min_length': 8,
+            'max_length': 100,
+            'counter': 'word',
+            'drop_mode': 'both',
+        })
+        f = LengthFilter()
+        f._initialize_by_component_configer(configer)
+        self.assertEqual(f.min_length, 8)
+        self.assertEqual(f.max_length, 100)
+        self.assertEqual(f.counter, 'word')
+        self.assertEqual(f.drop_mode, 'both')
+
+    def test_initialize_rejects_invalid_counter(self) -> None:
+        """An unknown counter value must raise ValueError on init."""
+        configer = self._make_configer({'counter': 'bytes'})
+        f = LengthFilter()
+        with self.assertRaises(ValueError) as ctx:
+            f._initialize_by_component_configer(configer)
+        self.assertIn('counter', str(ctx.exception))
+
+    def test_initialize_rejects_invalid_drop_mode(self) -> None:
+        """An unknown drop_mode value must raise ValueError on init."""
+        configer = self._make_configer({'drop_mode': 'drop_all'})
+        f = LengthFilter()
+        with self.assertRaises(ValueError) as ctx:
+            f._initialize_by_component_configer(configer)
+        self.assertIn('drop_mode', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **LengthFilter** document pre-processor, resolving part of #258.

`LengthFilter` filters the documents recalled by a RAG pipeline by their **length**, so documents that are too short to be informative (fragments, boilerplate, single-word hits) or too long to be useful (dumped whole pages) can be dropped *before* they reach the LLM.

It is a focused, per-document predicate processor — distinct from:
- `ThresholdFilter` — a general filter combinator (score / length / top-k / percentile with AND/OR logic).
- `ContextBudgetCompressor` — manages the **cumulative** size of the kept set and can split the boundary document.

`LengthFilter` only applies a per-document length range and never truncates.

## Changes

- `agentuniverse/agent/action/knowledge/doc_processor/length_filter.py` — `LengthFilter(DocProcessor)`:
  - `min_length`, `max_length` (0 disables a bound; bounds are inclusive)
  - `counter`: `char` (default) | `word` | `token` (BPE tokens via tiktoken, with a chars/4 fallback when tiktoken is missing)
  - `drop_mode`: `drop_short` | `drop_long` | `both`
  - eager validation of `counter` and `drop_mode`
- `agentuniverse/agent/action/knowledge/doc_processor/length_filter.yaml`
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_length_filter.py` — 15 unit tests: char/word/token counting, all three drop modes, inclusive bounds, order preservation, empty input, disabled bounds, empty text, public interface, configer init + validation
- docs appended to `docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md` and `docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md`

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.doc_processor.test_length_filter` → 15 passed

Closes part of #258.
