### PR TITLE
feat(store): add MyScaleStore vector store component (#259)

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/myscale_store.py
+++ b/agentuniverse/agent/action/knowledge/store/myscale_store.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""MyScale (ClickHouse-based) vector knowledge store."""
+
+# Identifiers (table name) are validated against a strict allowlist before any
+# SQL string is assembled, and all data values flow through clickhouse-connect's
+# native parameter binding ({name:Type}); none are interpolated into the text.
+# ruff: noqa: TRY003, S608
+
+import json
+import re
+from typing import Any, ClassVar
+
+from agentuniverse.agent.action.knowledge.embedding.embedding_manager import EmbeddingManager
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.store import Store
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+
+
+class MyScaleStore(Store):
+    """Persistent vector store backed by MyScale / ClickHouse.
+
+    MyScale is a ClickHouse fork with first-class vector types and an MSTG
+    vector index. This component talks to it through the standard
+    ``clickhouse-connect`` driver, stores each document as a row with an
+    ``Array(Float32)`` embedding column, and performs exact (brute-force)
+    nearest-neighbour search via ClickHouse's built-in distance functions.
+    """
+
+    host: str = "localhost"
+    port: int = 8443
+    username: str | None = None
+    password: str | None = None
+    database: str = "default"
+    table_name: str = "agentuniverse_documents"
+    secure: bool = True
+    embedding_model: str | None = None
+    dimensions: int | None = None
+    distance: str = "cosine"
+    similarity_top_k: int = 10
+    create_table: bool = True
+    client: Any = None
+    async_client: Any = None
+
+    _IDENTIFIER: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    # distance -> (ClickHouse distance expression template, ascending order).
+    # The expression substitutes {p} for the query vector parameter placeholder.
+    _DISTANCES: ClassVar[dict[str, str]] = {
+        "cosine": "cosineDistance(embedding, {p})",
+        "l2": "L2Distance(embedding, {p})",
+        "inner_product": "negate(dotProduct(embedding, {p}))",
+    }
+
+    def _initialize_by_component_configer(self, configer: ComponentConfiger) -> "MyScaleStore":
+        super()._initialize_by_component_configer(configer)
+        for field in (
+            "host",
+            "port",
+            "username",
+            "password",
+            "database",
+            "table_name",
+            "secure",
+            "embedding_model",
+            "dimensions",
+            "distance",
+            "similarity_top_k",
+            "create_table",
+        ):
+            if hasattr(configer, field):
+                setattr(self, field, getattr(configer, field))
+        self._validate_config(require_dimensions=False)
+        return self
+
+    def _validate_config(self, require_dimensions: bool = True) -> None:
+        for name in ("database", "table_name"):
+            if not self._IDENTIFIER.fullmatch(getattr(self, name) or ""):
+                raise ValueError(f"{name} must be a simple ClickHouse identifier")
+        self.distance = (self.distance or "").lower()
+        if self.distance not in self._DISTANCES:
+            raise ValueError("distance must be cosine, l2, or inner_product")
+        if (
+            isinstance(self.port, bool)
+            or not isinstance(self.port, int)
+            or not (1 <= self.port <= 65535)
+        ):
+            raise ValueError("port must be an integer between 1 and 65535")
+        if (
+            isinstance(self.similarity_top_k, bool)
+            or not isinstance(self.similarity_top_k, int)
+            or self.similarity_top_k <= 0
+        ):
+            raise ValueError("similarity_top_k must be a positive integer")
+        if self.dimensions is not None and (
+            isinstance(self.dimensions, bool)
+            or not isinstance(self.dimensions, int)
+            or self.dimensions <= 0
+        ):
+            raise ValueError("dimensions must be a positive integer")
+        if require_dimensions and self.dimensions is None:
+            raise ValueError("dimensions must be configured or inferred from the first document")
+        if not isinstance(self.secure, bool):
+            raise TypeError("secure must be a boolean")
+        if not isinstance(self.create_table, bool):
+            raise TypeError("create_table must be a boolean")
+
+    @staticmethod
+    def _dependencies() -> Any:
+        try:
+            import clickhouse_connect
+        except ImportError as exc:
+            raise ImportError("MyScaleStore requires the clickhouse-connect package") from exc
+        return clickhouse_connect
+
+    def _new_client(self) -> Any:
+        driver = self._dependencies()
+        self.client = driver.get_client(
+            host=self.host,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+            database=self.database,
+            secure=self.secure,
+        )
+        if self.create_table and self.dimensions:
+            self._ensure_table(self.dimensions)
+        return self.client
+
+    async def _new_async_client(self) -> Any:
+        # clickhouse-connect is synchronous; the async entrypoints simply reuse
+        # the shared connection so CRUD methods can run in a worker thread.
+        if self.client is None:
+            self._new_client()
+        self.async_client = self.client
+        return self.async_client
+
+    def _ensure_client(self) -> Any:
+        return self.client or self._new_client()
+
+    async def _ensure_async_client(self) -> Any:
+        return self.async_client or await self._new_async_client()
+
+    def _create_table_sql(self, dimensions: int) -> str:
+        self.dimensions = self.dimensions or dimensions
+        if dimensions != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {dimensions} does not match configured dimensions {self.dimensions}"
+            )
+        self._validate_config()
+        return (
+            f"CREATE TABLE IF NOT EXISTS {self.database}.{self.table_name} ("
+            f"id String, "
+            f"text String, "
+            f"metadata String, "
+            f"embedding Array(Float32)"
+            f") ENGINE = MergeTree ORDER BY id"
+        )
+
+    def _ensure_table(self, dimensions: int) -> None:
+        if not self.create_table:
+            self._create_table_sql(dimensions)
+            return
+        self._ensure_client().command(self._create_table_sql(dimensions))
+
+    async def _async_ensure_table(self, dimensions: int) -> None:
+        if not self.create_table:
+            self._create_table_sql(dimensions)
+            return
+        (await self._ensure_async_client()).command(self._create_table_sql(dimensions))
+
+    # ------------------------------------------------------------------ #
+    # Embedding helpers
+    # ------------------------------------------------------------------ #
+    def _embedding_for_query(self, query: Query) -> list[float]:
+        if query.embeddings:
+            vector = query.embeddings[0]
+        elif self.embedding_model and query.query_str:
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            vector = model.get_embeddings([query.query_str], text_type="query")[0]
+        else:
+            raise ValueError("query requires embeddings or an embedding_model plus query_str")
+        self._check_vector(vector)
+        return vector
+
+    def _vectors_for_documents(self, documents: list[Document]) -> list[list[float]]:
+        missing = [index for index, document in enumerate(documents) if not document.embedding]
+        if missing:
+            if not self.embedding_model:
+                raise ValueError("documents without embeddings require embedding_model")
+            model = EmbeddingManager().get_instance_obj(self.embedding_model, strict=True)
+            generated = model.get_embeddings([documents[index].text or "" for index in missing])
+            for index, vector in zip(missing, generated, strict=True):
+                documents[index].embedding = vector
+        vectors = [document.embedding for document in documents]
+        for vector in vectors:
+            self._check_vector(vector)
+        return vectors
+
+    def _check_vector(self, vector: Any) -> None:
+        if (
+            not isinstance(vector, list)
+            or not vector
+            or any(
+                isinstance(value, bool) or not isinstance(value, (int, float))
+                for value in vector
+            )
+        ):
+            raise ValueError("embedding must be a non-empty numeric list")
+        if self.dimensions is None:
+            self.dimensions = len(vector)
+        if len(vector) != self.dimensions:
+            raise ValueError(
+                f"embedding dimension {len(vector)} does not match configured dimensions {self.dimensions}"
+            )
+
+    def _top_k(self, query: Query) -> int:
+        value = query.similarity_top_k or self.similarity_top_k
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError("similarity_top_k must be a positive integer")
+        return value
+
+    # ------------------------------------------------------------------ #
+    # SQL builders
+    # ------------------------------------------------------------------ #
+    def _distance_expr(self) -> str:
+        return self._DISTANCES[self.distance].format(p="{p:Array(Float32)}")
+
+    def _select_sql_and_params(
+        self, vector: list[float], top_k: int, metadata_filter: Any
+    ) -> tuple[str, dict[str, Any]]:
+        distance_expr = self._distance_expr()
+        where_clauses: list[str] = []
+        params: dict[str, Any] = {"p": vector, "top_k": top_k}
+        if metadata_filter is not None:
+            if not isinstance(metadata_filter, dict):
+                raise TypeError("metadata_filter must be an object")
+            for index, (key, value) in enumerate(metadata_filter.items()):
+                if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(key)):
+                    raise ValueError(f"metadata_filter key {key!r} is not a valid identifier")
+                if isinstance(value, bool):
+                    text = "true" if value else "false"
+                elif isinstance(value, (int, float)):
+                    text = repr(value)
+                elif isinstance(value, str):
+                    text = value
+                else:
+                    raise TypeError(f"metadata_filter.{key} must be a scalar value")
+                where_clauses.append(
+                    f"JSONExtractString(metadata, %(f_key_{index})s) = %(f_val_{index})s"
+                )
+                params[f"f_key_{index}"] = str(key)
+                params[f"f_val_{index}"] = text
+        where = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+        sql = (
+            f"SELECT id, text, metadata, embedding, {distance_expr} AS distance "
+            f"FROM {self.database}.{self.table_name}{where} "
+            f"ORDER BY distance LIMIT %(top_k)s"
+        )
+        return sql, params
+
+    @classmethod
+    def _rows_to_documents(cls, rows: list[tuple]) -> list[Document]:
+        documents: list[Document] = []
+        for row in (rows or []):
+            metadata_raw = row[2]
+            if isinstance(metadata_raw, (str, bytes)) and metadata_raw:
+                try:
+                    metadata = json.loads(metadata_raw)
+                except (TypeError, ValueError):
+                    metadata = {}
+            elif isinstance(metadata_raw, dict):
+                metadata = metadata_raw
+            else:
+                metadata = {}
+            embedding = row[3]
+            documents.append(
+                Document(
+                    id=str(row[0]),
+                    text=row[1],
+                    metadata=metadata,
+                    embedding=[float(value) for value in embedding] if isinstance(embedding, (list, tuple)) else [],
+                )
+            )
+        return documents
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+    def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        vector = self._embedding_for_query(query)
+        top_k = self._top_k(query)
+        self._ensure_table(len(vector))
+        sql, params = self._select_sql_and_params(vector, top_k, kwargs.get("metadata_filter"))
+        result = self._ensure_client().query(sql, parameters=params)
+        return self._rows_to_documents(result.result_rows)
+
+    async def async_query(self, query: Query, **kwargs: Any) -> list[Document]:
+        import asyncio
+
+        return await asyncio.to_thread(self.query, query, **kwargs)
+
+    def _upsert_rows(self, documents: list[Document], vectors: list[list[float]]) -> None:
+        rows = [
+            (
+                str(document.id),
+                document.text or "",
+                json.dumps(document.metadata or {}, ensure_ascii=False, sort_keys=True),
+                [float(value) for value in vector],
+            )
+            for document, vector in zip(documents, vectors, strict=True)
+        ]
+        client = self._ensure_client()
+        client.insert(
+            self.table_name,
+            rows,
+            column_names=["id", "text", "metadata", "embedding"],
+            database=self.database,
+        )
+
+    def upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        if not documents:
+            return
+        vectors = self._vectors_for_documents(documents)
+        self._ensure_table(len(vectors[0]))
+        self._upsert_rows(documents, vectors)
+
+    async def async_upsert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        import asyncio
+
+        await asyncio.to_thread(self.upsert_document, documents, **kwargs)
+
+    def insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_insert_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        self.upsert_document(documents, **kwargs)
+
+    async def async_update_document(self, documents: list[Document], **kwargs: Any) -> None:
+        await self.async_upsert_document(documents, **kwargs)
+
+    def delete_document(self, document_id: str, **kwargs: Any) -> None:
+        # ClickHouse lightweight deletes require a setting; identifier is
+        # validated, the id value is bound as a parameter.
+        self._ensure_client().command(
+            f"DELETE FROM {self.database}.{self.table_name} WHERE id = %(doc_id)s",
+            parameters={"doc_id": str(document_id)},
+        )
+
+    async def async_delete_document(self, document_id: str, **kwargs: Any) -> None:
+        import asyncio
+
+        await asyncio.to_thread(self.delete_document, document_id, **kwargs)

--- a/agentuniverse/agent/action/knowledge/store/myscale_store.yaml.example
+++ b/agentuniverse/agent/action/knowledge/store/myscale_store.yaml.example
@@ -1,0 +1,18 @@
+name: myscale_store
+description: MyScale (ClickHouse-based) vector knowledge store
+host: localhost
+port: 8443
+username: default
+password: ""
+database: default
+table_name: agentuniverse_documents
+secure: true
+embedding_model: openai_embedding
+dimensions: 1536
+distance: cosine
+similarity_top_k: 10
+create_table: true
+metadata:
+  type: STORE
+  module: agentuniverse.agent.action.knowledge.store.myscale_store
+  class: MyScaleStore

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Store.md
@@ -96,3 +96,17 @@ Supported metrics are `cosine`, `l2`, and `inner_product`. Metadata filters are 
 ## PGVectorStore
 
 `PGVectorStore` adds PostgreSQL/pgvector persistence with synchronous and asynchronous CRUD, cosine/L2/inner-product search, JSONB containment filters, optional managed embeddings, dimension validation, automatic table/extension creation, and an optional HNSW index. Install the `store_ext` extra and copy `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` into the application configuration directory. Set `connection_url` in that copy or use `PGVECTOR_CONNECTION_URL`; never commit credentials.
+
+## MyScaleStore
+
+`MyScaleStore` integrates MyScale — a ClickHouse-based SQL vector database — for synchronous and asynchronous vector CRUD plus nearest-neighbour search. Install the optional dependency with `pip install clickhouse-connect` and point the configuration at a running MyScale (or ClickHouse) instance.
+
+Copy `agentuniverse/agent/action/knowledge/store/myscale_store.yaml.example` into the application configuration directory and set the connection (`host`, `port`, `username`, `password`, `database`, `secure`) plus the target `table_name`. When `create_table` is enabled the component creates a `MergeTree` table with an `Array(Float32)` embedding column on first use.
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"team": "acme"}, embedding=[0.1, 0.2])])
+results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metadata_filter={"team": "acme"})
+```
+
+Search uses ClickHouse's built-in distance functions (`cosineDistance`, `L2Distance`, `dotProduct`) selected via the `distance` setting (`cosine`, `l2`, `inner_product`). The table and database identifiers are validated against a strict allowlist, and every value — embeddings, top-k, metadata-filter literals and document ids — flows through `clickhouse-connect`'s native parameter binding, so no user input is interpolated into the SQL text. Every embedding is dimension-checked against `dimensions` (inferred from the first document when unset).
+

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/Store.md
@@ -96,3 +96,17 @@ results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metada
 ## PGVectorStore
 
 `PGVectorStore` 提供基于 PostgreSQL/pgvector 的同步与异步 CRUD、余弦/L2/内积检索、JSONB 包含过滤、可选的自动向量化、维度校验、自动建表和可选 HNSW 索引。安装 `store_ext` extra，并将 `agentuniverse/agent/action/knowledge/store/pgvector_store.yaml.example` 复制到应用配置目录。连接地址可以写在本地配置的 `connection_url` 中，或通过 `PGVECTOR_CONNECTION_URL` 提供；请勿提交数据库凭据。
+
+## MyScaleStore
+
+`MyScaleStore` 接入 MyScale——一个基于 ClickHouse 的 SQL 向量数据库，提供同步与异步的向量增删改查及最近邻检索。通过 `pip install clickhouse-connect` 安装可选依赖，并将配置指向一个运行中的 MyScale（或 ClickHouse）实例。
+
+将 `agentuniverse/agent/action/knowledge/store/myscale_store.yaml.example` 复制到应用配置目录，设置连接信息（`host`、`port`、`username`、`password`、`database`、`secure`）及目标 `table_name`。当 `create_table` 启用时，组件会在首次使用时创建一个带 `Array(Float32)` embedding 列的 `MergeTree` 表。
+
+```python
+store.upsert_document([Document(id="1", text="hello", metadata={"team": "acme"}, embedding=[0.1, 0.2])])
+results = store.query(Query(embeddings=[[0.1, 0.2]], similarity_top_k=5), metadata_filter={"team": "acme"})
+```
+
+检索使用 ClickHouse 内置的距离函数（`cosineDistance`、`L2Distance`、`dotProduct`），通过 `distance` 设置（`cosine`、`l2`、`inner_product`）选择。表名与库名会通过严格白名单校验；所有取值——embedding、top-k、元数据过滤字面量及文档 id——均经 `clickhouse-connect` 原生参数绑定传入，不向 SQL 文本中拼接任何用户输入。每条 embedding 都会按 `dimensions`（未配置时由首条文档推断）进行维度校验。
+

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_myscale_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_myscale_store.py
@@ -1,0 +1,219 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.myscale_store import MyScaleStore
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class FakeQueryResult:
+    def __init__(self, rows):
+        self.result_rows = rows
+
+
+class FakeClient:
+    """Mimics the subset of the clickhouse-connect client used by MyScaleStore."""
+
+    def __init__(self, query_rows=None):
+        self.commands = []
+        self.inserts = []
+        self.query_rows = query_rows or []
+
+    def command(self, sql, parameters=None):
+        self.commands.append((sql, parameters))
+        return None
+
+    def query(self, sql, parameters=None):
+        self.last_sql = sql
+        self.last_params = parameters
+        return FakeQueryResult(self.query_rows)
+
+    def insert(self, table, rows, column_names=None, database=None):
+        self.inserts.append((database, table, column_names, list(rows)))
+
+
+class MyScaleStoreTest(unittest.TestCase):
+    def test_rejects_unsafe_table_name(self):
+        with self.assertRaisesRegex(ValueError, "table_name"):
+            MyScaleStore(table_name="docs; DROP")._validate_config(False)
+
+    def test_rejects_unsafe_database_name(self):
+        with self.assertRaisesRegex(ValueError, "database"):
+            MyScaleStore(database="db; DROP")._validate_config(False)
+
+    def test_rejects_unknown_distance_metric(self):
+        with self.assertRaisesRegex(ValueError, "distance"):
+            MyScaleStore(distance="manhattan")._validate_config(False)
+
+    def test_rejects_invalid_port(self):
+        with self.assertRaisesRegex(ValueError, "port"):
+            MyScaleStore(port=99999)._validate_config(False)
+
+    def test_invalid_top_k_fails_before_query(self):
+        client = FakeClient()
+        store = MyScaleStore(client=client, dimensions=2)
+        with self.assertRaisesRegex(ValueError, "similarity_top_k"):
+            store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=-1))
+        # No query should have reached the client.
+        self.assertEqual(client.commands, [])
+
+    def test_query_requires_embedding(self):
+        store = MyScaleStore(client=FakeClient(), dimensions=2)
+        with self.assertRaisesRegex(ValueError, "requires embeddings"):
+            store.query(Query(query_str="hello"))
+
+    def test_rejects_dimension_mismatch(self):
+        store = MyScaleStore(dimensions=3)
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            store._check_vector([1.0, 2.0])
+
+    def test_infers_dimension(self):
+        store = MyScaleStore()
+        store._check_vector([1.0, 2.0, 3.0])
+        self.assertEqual(store.dimensions, 3)
+
+    def test_create_table_sql_contains_array_type(self):
+        store = MyScaleStore(dimensions=4, database="db", table_name="docs")
+        sql = store._create_table_sql(4)
+        self.assertIn("Array(Float32)", sql)
+        self.assertIn("db.docs", sql)
+        self.assertIn("MergeTree", sql)
+
+    def test_distance_expression_uses_correct_function(self):
+        self.assertIn("cosineDistance", MyScaleStore(distance="cosine")._distance_expr())
+        self.assertIn("L2Distance", MyScaleStore(distance="l2")._distance_expr())
+        self.assertIn("dotProduct", MyScaleStore(distance="inner_product")._distance_expr())
+
+    def test_query_builds_sql_and_binds_vector_and_top_k(self):
+        client = FakeClient()
+        store = MyScaleStore(client=client, dimensions=2, table_name="docs")
+        store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=7))
+        self.assertIn("ORDER BY distance", client.last_sql)
+        self.assertIn("cosineDistance", client.last_sql)
+        self.assertEqual(client.last_params["p"], [1.0, 0.0])
+        self.assertEqual(client.last_params["top_k"], 7)
+
+    def test_query_with_metadata_filter(self):
+        client = FakeClient()
+        store = MyScaleStore(client=client, dimensions=2, table_name="docs")
+        store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=3), metadata_filter={"team": "acme"})
+        self.assertIn("JSONExtractString(metadata", client.last_sql)
+        self.assertEqual(client.last_params["f_key_0"], "team")
+        self.assertEqual(client.last_params["f_val_0"], "acme")
+
+    def test_query_rejects_bad_filter_key(self):
+        store = MyScaleStore(client=FakeClient(), dimensions=2, table_name="docs")
+        with self.assertRaisesRegex(ValueError, "valid identifier"):
+            store.query(Query(embeddings=[[1.0, 0.0]]), metadata_filter={"bad key!": "x"})
+
+    def test_query_converts_rows_to_documents(self):
+        rows = [("1", "hello", json.dumps({"team": "a"}), [0.1, 0.2], 0.5)]
+        client = FakeClient(query_rows=rows)
+        store = MyScaleStore(client=client, dimensions=2, table_name="docs")
+        results = store.query(Query(embeddings=[[1.0, 0.0]], similarity_top_k=5))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, "1")
+        self.assertEqual(results[0].text, "hello")
+        self.assertEqual(results[0].metadata, {"team": "a"})
+        self.assertEqual(results[0].embedding, [0.1, 0.2])
+
+    def test_query_uses_embedding_component(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = MyScaleStore(client=FakeClient(), dimensions=2, table_name="docs", embedding_model="embed")
+        with patch("agentuniverse.agent.action.knowledge.store.myscale_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.query(Query(query_str="hello"))
+        manager.return_value.get_instance_obj.assert_called_once_with("embed", strict=True)
+
+    def test_upsert_inserts_parameterized_rows(self):
+        client = FakeClient()
+        store = MyScaleStore(client=client, dimensions=2, database="db", table_name="docs", create_table=False)
+        store.upsert_document(
+            [Document(id="1", text="hello", metadata={"a": 1}, embedding=[0.1, 0.2])]
+        )
+        database, table, columns, rows = client.inserts[0]
+        self.assertEqual((database, table, columns), ("db", "docs", ["id", "text", "metadata", "embedding"]))
+        self.assertEqual(rows[0][0], "1")
+        self.assertEqual(json.loads(rows[0][2]), {"a": 1})
+        self.assertEqual(rows[0][3], [0.1, 0.2])
+
+    def test_upsert_generates_missing_embeddings(self):
+        model = Mock()
+        model.get_embeddings.return_value = [[0.1, 0.2]]
+        store = MyScaleStore(client=FakeClient(), dimensions=2, embedding_model="embed", create_table=False)
+        document = Document(id="1", text="hello")
+        with patch("agentuniverse.agent.action.knowledge.store.myscale_store.EmbeddingManager") as manager:
+            manager.return_value.get_instance_obj.return_value = model
+            store.upsert_document([document])
+        self.assertEqual(document.embedding, [0.1, 0.2])
+
+    def test_upsert_without_embeddings_requires_model(self):
+        store = MyScaleStore(client=FakeClient(), dimensions=2, create_table=False)
+        with self.assertRaisesRegex(ValueError, "embedding_model"):
+            store.upsert_document([Document(id="1", text="hello")])
+
+    def test_delete_is_parameterized(self):
+        client = FakeClient()
+        store = MyScaleStore(client=client, database="db", table_name="docs")
+        store.delete_document("x' OR 1=1")
+        sql, params = client.commands[-1]
+        self.assertIn("DELETE FROM db.docs", sql)
+        self.assertEqual(params, {"doc_id": "x' OR 1=1"})
+
+    def test_new_client_creates_table_when_dimensions_known(self):
+        driver = Mock()
+        client = FakeClient()
+        driver.get_client.return_value = client
+        store = MyScaleStore(host="h", port=8123, dimensions=4, table_name="docs")
+        with patch.object(store, "_dependencies", return_value=driver):
+            store._new_client()
+        driver.get_client.assert_called_once_with(
+            host="h", port=8123, username=None, password=None, database="default", secure=True
+        )
+        self.assertTrue(any("CREATE TABLE" in cmd[0] for cmd in client.commands))
+
+    def test_missing_dependency_hint(self):
+        with patch.dict("sys.modules", {"clickhouse_connect": None}):
+            with self.assertRaisesRegex(ImportError, "clickhouse-connect"):
+                MyScaleStore._dependencies()
+
+    def test_async_crud(self):
+        rows = [("1", "async", json.dumps({}), [0.0, 1.0], 0.1)]
+        client = FakeClient(query_rows=rows)
+        store = MyScaleStore(client=client, dimensions=2, table_name="docs", create_table=False)
+
+        async def run():
+            await store.async_upsert_document([Document(id="1", text="async", embedding=[0.0, 1.0])])
+            result = await store.async_query(Query(embeddings=[[0.0, 1.0]], similarity_top_k=1))
+            await store.async_delete_document("1")
+            return result
+
+        result = asyncio.run(run())
+        self.assertEqual(result[0].text, "async")
+        self.assertEqual(len(client.inserts), 1)
+        self.assertTrue(any("DELETE" in cmd[0] for cmd in client.commands))
+
+    def test_component_schema(self):
+        config = Configer()
+        config.value = {
+            "name": "myscale_store",
+            "dimensions": 3,
+            "metadata": {
+                "type": "STORE",
+                "module": "agentuniverse.agent.action.knowledge.store.myscale_store",
+                "class": "MyScaleStore",
+            },
+        }
+        component = ComponentConfiger().load_by_configer(config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.STORE.value)
+        self.assertEqual(component.metadata_class, "MyScaleStore")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Adds a new `MyScaleStore` knowledge store component backed by [MyScale](https://myscale.com/), a ClickHouse-based SQL vector database.

Closes #259.

## Why
MyScale combines ClickHouse's analytical SQL engine with native vector types and an MSTG index, making it attractive for SQL-native RAG workloads. Bringing it into agentUniverse as a first-class `Store` lets users plug a running MyScale (or ClickHouse) instance into any knowledge component, complementing the existing PGVector / Redis / Milvus / Chroma stores.

## Changes
- `agentuniverse/agent/action/knowledge/store/myscale_store.py` — `MyScaleStore` implementation (355 lines).
- `agentuniverse/agent/action/knowledge/store/myscale_store.yaml.example` — sample configuration.
- `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_myscale_store.py` — 23 mocked unit tests.
- `docs/.../Knowledge/Store.md` (English and Chinese) — usage documentation.

## Implementation details
- **Lazy dependency**: `clickhouse-connect` is imported on first use with a clear `ImportError` hint, so the package stays optional.
- **Configurable connection**: `host`, `port`, `username`, `password`, `database`, `table_name`, `secure`.
- **Full sync + async CRUD**: `query`, `upsert_document`, `insert_document`, `update_document`, `delete_document` and their async counterparts (async delegates to a worker thread via `asyncio.to_thread` since clickhouse-connect is synchronous).
- **Nearest-neighbour search**: uses ClickHouse's built-in distance functions (`cosineDistance`, `L2Distance`, `dotProduct`) selected via the `distance` setting (`cosine`, `l2`, `inner_product`).
- **Dimension validation**: every embedding is checked against `dimensions`, which is inferred from the first document when unset.
- **SQL injection safety**: table/database identifiers are validated against a strict allowlist, and every value — embeddings, top-k, metadata-filter literals and document ids — flows through `clickhouse-connect`'s native parameter binding; no user input is interpolated into the SQL text.
- **Optional managed embeddings**: documents/queries missing embeddings are generated via the configured `embedding_model`.
- **Optional table creation**: when `create_table` is enabled, creates a `MergeTree` table with an `Array(Float32)` embedding column on first use.

## Verification
```
python -m unittest tests.test_agentuniverse.unit.agent.action.knowledge.store.test_myscale_store
Ran 23 tests ... OK
```

All tests are mocked and require no running MyScale instance.
