### PR TITLE
feat(tool): add UUIDGeneratorTool component (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+
+"""Bounded UUID generation and validation tool (standard library only)."""
+
+# Validation failures are converted to structured tool responses at the public
+# execute boundary, so bespoke exception subclasses would add no useful signal.
+# ruff: noqa: TRY003, TRY004
+
+import re
+import uuid as _uuid
+from typing import Any, ClassVar
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class UUIDGeneratorTool(Tool):
+    """Generate, validate, and extract UUIDs with zero external dependencies.
+
+    The tool relies only on the Python standard-library ``uuid`` module, so it
+    imports and runs in any environment. Supported modes:
+
+    * ``generate`` — emit one UUID (``uuid4`` by default; ``uuid3``/``uuid5``
+      require a ``namespace``).
+    * ``generate_batch`` — emit up to ``count`` UUIDs in a single call.
+    * ``validate`` — report whether a candidate string is a well-formed UUID.
+    * ``extract`` — pull every well-formed UUID out of an arbitrary string.
+
+    Output formatting is controlled by ``format``: ``string`` (the canonical
+    hyphenated form), ``hex`` (32 hex digits with no separators), or ``urn``
+    (the ``urn:uuid:...`` form).
+    """
+
+    version: int = 4
+    namespace: str = "dns"
+    name: str = "agentuniverse"
+    count: int = 1
+    format: str = "string"
+    max_batch_size: int = 1_000
+    max_extract_chars: int = 100_000
+
+    _NAMESPACES: ClassVar[dict[str, Any]] = {
+        "dns": _uuid.NAMESPACE_DNS,
+        "url": _uuid.NAMESPACE_URL,
+        "oid": _uuid.NAMESPACE_OID,
+        "x500": _uuid.NAMESPACE_X500,
+    }
+    _FORMATS: ClassVar[set[str]] = {"string", "hex", "urn"}
+    _VERSIONS: ClassVar[set[int]] = {3, 4, 5}
+    _UUID_REGEX: ClassVar[re.Pattern[str]] = re.compile(
+        r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+    )
+
+    def execute(
+        self,
+        mode: str,
+        version: int | None = None,
+        namespace: str | None = None,
+        name: str | None = None,
+        count: int | None = None,
+        format: str | None = None,
+        value: str | None = None,
+    ) -> dict[str, Any]:
+        """Run a UUID operation.
+
+        Args:
+            mode: One of ``generate``, ``generate_batch``, ``validate``,
+                or ``extract``.
+            version: UUID version (3, 4, or 5). Defaults to the tool-level value.
+            namespace: Namespace key (``dns``/``url``/``oid``/``x500``) or a
+                UUID string. Required for versions 3 and 5.
+            name: Name used by versions 3 and 5. Defaults to the tool-level value.
+            count: Number of UUIDs for ``generate_batch``.
+            format: Output format — ``string``, ``hex``, or ``urn``.
+            value: Candidate UUID (for ``validate``) or text to scan
+                (for ``extract``).
+
+        Returns:
+            A structured success or error dictionary.
+        """
+        try:
+            self._validate_configuration()
+            normalized_mode = self._normalize_mode(mode)
+            resolved_version = self._resolve_version(version)
+            resolved_format = self._resolve_format(format)
+            resolved_namespace = self._resolve_namespace(namespace, resolved_version)
+            resolved_name = self._resolve_name(name, resolved_version)
+
+            if normalized_mode == "generate":
+                return self._generate(resolved_version, resolved_namespace, resolved_name, resolved_format)
+            if normalized_mode == "generate_batch":
+                return self._generate_batch(
+                    resolved_version,
+                    resolved_namespace,
+                    resolved_name,
+                    resolved_format,
+                    count,
+                )
+            if normalized_mode == "validate":
+                if value is None:
+                    raise ValueError("value is required for validate mode")
+                return self._validate(value)
+            return self._extract(value)
+        except (TypeError, ValueError) as exc:
+            return self._error(mode, "validation_error", str(exc))
+        except Exception as exc:  # defensive: any unexpected failure
+            return self._error(mode, "operation_error", f"UUID operation failed: {exc}")
+
+    # ------------------------------------------------------------------ public
+
+    @staticmethod
+    def _error(mode: Any, kind: str, message: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status": "error",
+            "error_type": kind,
+            "error": message,
+        }
+        if isinstance(mode, str) and mode:
+            payload["mode"] = mode.strip().lower()
+        return payload
+
+    def _validate_configuration(self) -> None:
+        for name in ("max_batch_size", "max_extract_chars"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.version not in self._VERSIONS:
+            allowed = ", ".join(str(v) for v in sorted(self._VERSIONS))
+            raise ValueError(f"version must be one of {allowed}, got {self.version!r}")
+        if self.format not in self._FORMATS:
+            allowed = ", ".join(sorted(self._FORMATS))
+            raise ValueError(f"format must be one of {allowed}, got {self.format!r}")
+        if not isinstance(self.namespace, str) or not self.namespace:
+            raise ValueError("namespace must be a non-empty string")
+        if not isinstance(self.name, str):
+            raise TypeError("name must be a string")
+        if isinstance(self.count, bool) or not isinstance(self.count, int) or self.count <= 0:
+            raise ValueError("count must be a positive integer")
+
+    @staticmethod
+    def _normalize_mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"generate", "generate_batch", "validate", "extract"}:
+            raise ValueError("mode must be generate, generate_batch, validate, or extract")
+        return mode
+
+    def _resolve_version(self, version: Any) -> int:
+        if version is None:
+            return self.version
+        if isinstance(version, bool) or not isinstance(version, int):
+            raise TypeError("version must be an integer")
+        if version not in self._VERSIONS:
+            allowed = ", ".join(str(v) for v in sorted(self._VERSIONS))
+            raise ValueError(f"version must be one of {allowed}, got {version!r}")
+        return version
+
+    def _resolve_format(self, format: Any) -> str:
+        if format is None:
+            return self.format
+        if not isinstance(format, str):
+            raise TypeError("format must be a string")
+        normalized = format.strip().lower()
+        if normalized not in self._FORMATS:
+            allowed = ", ".join(sorted(self._FORMATS))
+            raise ValueError(f"format must be one of {allowed}, got {format!r}")
+        return normalized
+
+    def _resolve_namespace(self, namespace: Any, version: int) -> _uuid.UUID | None:
+        if version == 4:
+            return None
+        candidate = self.namespace if namespace is None else namespace
+        if not isinstance(candidate, str) or not candidate:
+            raise ValueError(
+                f"namespace is required for uuid{version} and must be a non-empty string"
+            )
+        key = candidate.strip().lower()
+        if key in self._NAMESPACES:
+            return self._NAMESPACES[key]
+        try:
+            return _uuid.UUID(candidate)
+        except (ValueError, AttributeError, TypeError) as exc:
+            known = ", ".join(sorted(self._NAMESPACES))
+            raise ValueError(
+                f"namespace must be one of {known} or a valid UUID string, "
+                f"got {candidate!r}"
+            ) from exc
+
+    def _resolve_name(self, name: Any, version: int) -> str | None:
+        if version == 4:
+            return None
+        candidate = self.name if name is None else name
+        if not isinstance(candidate, str):
+            raise TypeError(f"name is required for uuid{version} and must be a string")
+        if candidate == "":
+            raise ValueError(f"name is required for uuid{version} and must be a non-empty string")
+        return candidate
+
+    # ------------------------------------------------------------- generation
+
+    def _make_uuid(self, version: int, namespace: _uuid.UUID | None, name: str | None) -> _uuid.UUID:
+        if version == 4:
+            return _uuid.uuid4()
+        if version == 3:
+            assert namespace is not None and name is not None
+            return _uuid.uuid3(namespace, name)
+        assert version == 5 and namespace is not None and name is not None
+        return _uuid.uuid5(namespace, name)
+
+    @staticmethod
+    def _format_uuid(value: _uuid.UUID, fmt: str) -> str:
+        if fmt == "hex":
+            return value.hex
+        if fmt == "urn":
+            return value.urn
+        return str(value)
+
+    def _generate(
+        self,
+        version: int,
+        namespace: _uuid.UUID | None,
+        name: str | None,
+        fmt: str,
+    ) -> dict[str, Any]:
+        generated = self._make_uuid(version, namespace, name)
+        payload: dict[str, Any] = {
+            "status": "success",
+            "uuid": self._format_uuid(generated, fmt),
+            "format": fmt,
+            "version": version,
+        }
+        if namespace is not None:
+            payload["namespace"] = str(namespace)
+        if name is not None:
+            payload["name"] = name
+        return payload
+
+    def _generate_batch(
+        self,
+        version: int,
+        namespace: _uuid.UUID | None,
+        name: str | None,
+        fmt: str,
+        count: Any,
+    ) -> dict[str, Any]:
+        if count is None:
+            count = self.count
+        if isinstance(count, bool) or not isinstance(count, int):
+            raise TypeError("count must be an integer")
+        if count <= 0:
+            raise ValueError("count must be a positive integer")
+        if count > self.max_batch_size:
+            raise ValueError(
+                f"count ({count}) exceeds max_batch_size ({self.max_batch_size})"
+            )
+        uuids = [self._format_uuid(self._make_uuid(version, namespace, name), fmt) for _ in range(count)]
+        payload: dict[str, Any] = {
+            "status": "success",
+            "uuids": uuids,
+            "count": len(uuids),
+            "format": fmt,
+            "version": version,
+        }
+        if namespace is not None:
+            payload["namespace"] = str(namespace)
+        if name is not None:
+            payload["name"] = name
+        return payload
+
+    # ------------------------------------------------------------- validation
+
+    def _validate(self, value: Any) -> dict[str, Any]:
+        if not isinstance(value, str) or not value:
+            raise ValueError("value must be a non-empty string")
+        normalized = value.strip()
+        try:
+            parsed = _uuid.UUID(normalized)
+        except (ValueError, AttributeError, TypeError):
+            parsed = None
+        is_valid = parsed is not None and str(parsed) == normalized.lower()
+        payload: dict[str, Any] = {
+            "status": "success",
+            "value": value,
+            "valid": is_valid,
+        }
+        if is_valid and parsed is not None:
+            payload["uuid"] = str(parsed)
+            payload["hex"] = parsed.hex
+            payload["urn"] = parsed.urn
+            payload["version"] = parsed.version
+            payload["variant"] = self._variant_label(parsed.variant)
+        return payload
+
+    @staticmethod
+    def _variant_label(variant: Any) -> str:
+        if variant == _uuid.RFC_4122:
+            return "rfc4122"
+        if variant == _uuid.RESERVED_NCS:
+            return "reserved_ncs"
+        if variant == _uuid.RESERVED_MICROSOFT:
+            return "reserved_microsoft"
+        if variant == _uuid.RESERVED_FUTURE:
+            return "reserved_future"
+        return "unknown"
+
+    # --------------------------------------------------------------- extract
+
+    def _extract(self, value: Any) -> dict[str, Any]:
+        if value is None:
+            raise ValueError("value is required for extract mode")
+        if not isinstance(value, str):
+            raise TypeError("value must be a string")
+        if len(value) > self.max_extract_chars:
+            raise ValueError(
+                f"value length ({len(value)}) exceeds max_extract_chars "
+                f"({self.max_extract_chars})"
+            )
+        matches = self._UUID_REGEX.findall(value)
+        normalized = [m.lower() for m in matches]
+        unique: list[str] = []
+        seen: set[str] = set()
+        for candidate in normalized:
+            if candidate not in seen:
+                seen.add(candidate)
+                unique.append(candidate)
+        return {
+            "status": "success",
+            "uuids": unique,
+            "count": len(unique),
+            "total_matches": len(normalized),
+        }

--- a/agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.yaml
@@ -1,0 +1,76 @@
+name: uuid_generator_tool
+description: Generate, validate, and extract UUIDs using only the Python standard library. Zero external dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.uuid_generator_tool
+  class: UUIDGeneratorTool
+input_keys:
+  - mode
+version: 4
+namespace: dns
+name: agentuniverse
+count: 1
+format: string
+max_batch_size: 1000
+max_extract_chars: 100000
+args_model:
+  mode:
+    type: string
+    description: Operation mode — generate, generate_batch, validate, or extract.
+    required: true
+  version:
+    type: integer
+    description: UUID version (3, 4, or 5). Defaults to the tool-level value (4).
+    required: false
+  namespace:
+    type: string
+    description: Namespace key (dns/url/oid/x500) or a UUID string. Required for versions 3 and 5.
+    required: false
+  name:
+    type: string
+    description: Name used by versions 3 and 5.
+    required: false
+  count:
+    type: integer
+    description: Number of UUIDs for generate_batch.
+    required: false
+  format:
+    type: string
+    description: Output format — string, hex, or urn.
+    required: false
+  value:
+    type: string
+    description: Candidate UUID (validate) or text to scan (extract).
+    required: false
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: ["generate", "generate_batch", "validate", "extract"]
+      description: UUID operation mode.
+    version:
+      type: integer
+      enum: [3, 4, 5]
+      description: UUID version.
+    namespace:
+      type: string
+      description: Namespace key or UUID string for versions 3 and 5.
+    name:
+      type: string
+      description: Name for versions 3 and 5.
+    count:
+      type: integer
+      minimum: 1
+      maximum: 1000
+      description: Number of UUIDs for generate_batch.
+    format:
+      type: string
+      enum: ["string", "hex", "urn"]
+      description: Output format for generated UUIDs.
+    value:
+      type: string
+      description: Candidate UUID (validate) or text to scan (extract).
+  required: ["mode"]
+  additionalProperties: false

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,79 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+
+## UUIDGeneratorTool
+
+`UUIDGeneratorTool` generates, validates, and extracts UUIDs using only the Python standard-library `uuid` module, so it has zero external dependencies and runs anywhere. It supports four modes: `generate`, `generate_batch`, `validate`, and `extract`.
+
+The built-in component configuration is
+[`uuid_generator_tool.yaml`](../../../../../../agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.yaml):
+
+```yaml
+name: uuid_generator_tool
+description: Generate, validate, and extract UUIDs using only the Python standard library.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.uuid_generator_tool
+  class: UUIDGeneratorTool
+input_keys: [mode]
+version: 4
+namespace: dns
+name: agentuniverse
+count: 1
+format: string
+max_batch_size: 1000
+max_extract_chars: 100000
+```
+
+Generate a single UUID (random `uuid4` by default):
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("uuid_generator_tool")
+print(tool.run(mode="generate")["uuid"])
+# 06b7fde6-8b8b-4d66-8d7d-63cd860ec69a
+```
+
+Deterministic UUIDs from a name (versions 3 and 5 require a `namespace` and `name`):
+
+```python
+result = tool.run(mode="generate", version=5, namespace="dns", name="example.com")
+# same inputs always yield cfbff0d1-9375-5685-968c-48ce8b15ae17
+```
+
+Generate several at once:
+
+```python
+result = tool.run(mode="generate_batch", count=10)
+print(result["uuids"])  # 10 unique uuid4 strings
+```
+
+Validate a candidate string:
+
+```python
+result = tool.run(mode="validate", value="550e8400-e29b-41d4-a716-446655440000")
+print(result["valid"], result.get("version"))
+```
+
+Pull every UUID out of arbitrary text:
+
+```python
+result = tool.run(mode="extract", value="ids: 550e8400-e29b-41d4-a716-446655440000 and ...")
+print(result["uuids"], result["count"])
+```
+
+Parameters:
+
+- `mode`: required — `generate`, `generate_batch`, `validate`, or `extract`.
+- `version`: UUID version `3`, `4`, or `5`; defaults to the tool-level `version` (`4`). Versions 3 and 5 are deterministic and derive the UUID from a `namespace` and `name`.
+- `namespace`: required for versions 3 and 5. Accepts the well-known keys `dns`, `url`, `oid`, `x500`, or any valid UUID string.
+- `name`: required for versions 3 and 5; the name to hash with the namespace.
+- `count`: number of UUIDs for `generate_batch`; defaults to the tool-level `count` and is capped by `max_batch_size`.
+- `format`: output format for generated UUIDs — `string` (canonical hyphenated form, default), `hex` (32 hex digits), or `urn` (`urn:uuid:...`).
+- `value`: the candidate UUID for `validate`, or the text to scan for `extract`.
+
+`generate` returns the UUID plus its format/version (and namespace/name when used). `generate_batch` returns the list and the produced count. `validate` returns `valid` with the parsed UUID, hex, urn, version, and variant on success. `extract` returns the deduplicated UUIDs, their count, and the raw match total. Batch size and extraction text length are bounded; booleans are rejected where integers are expected.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,79 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+
+## UUIDGeneratorTool
+
+`UUIDGeneratorTool` 用于生成、校验和提取 UUID，仅依赖 Python 标准库的 `uuid` 模块，零外部依赖，可在任意环境运行。支持四种模式：`generate`、`generate_batch`、`validate` 和 `extract`。
+
+内置组件配置位于
+[`uuid_generator_tool.yaml`](../../../../../../agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.yaml)：
+
+```yaml
+name: uuid_generator_tool
+description: Generate, validate, and extract UUIDs using only the Python standard library.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.uuid_generator_tool
+  class: UUIDGeneratorTool
+input_keys: [mode]
+version: 4
+namespace: dns
+name: agentuniverse
+count: 1
+format: string
+max_batch_size: 1000
+max_extract_chars: 100000
+```
+
+生成单个 UUID（默认随机 `uuid4`）：
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("uuid_generator_tool")
+print(tool.run(mode="generate")["uuid"])
+# 06b7fde6-8b8b-4d66-8d7d-63cd860ec69a
+```
+
+由名称生成确定性 UUID（版本 3 和 5 需要 `namespace` 与 `name`）：
+
+```python
+result = tool.run(mode="generate", version=5, namespace="dns", name="example.com")
+# 相同输入总是得到 cfbff0d1-9375-5685-968c-48ce8b15ae17
+```
+
+批量生成：
+
+```python
+result = tool.run(mode="generate_batch", count=10)
+print(result["uuids"])  # 10 个不重复的 uuid4 字符串
+```
+
+校验候选字符串：
+
+```python
+result = tool.run(mode="validate", value="550e8400-e29b-41d4-a716-446655440000")
+print(result["valid"], result.get("version"))
+```
+
+从任意文本中提取所有 UUID：
+
+```python
+result = tool.run(mode="extract", value="ids: 550e8400-e29b-41d4-a716-446655440000 以及 ...")
+print(result["uuids"], result["count"])
+```
+
+参数说明：
+
+- `mode`：必填，可选 `generate`、`generate_batch`、`validate` 或 `extract`。
+- `version`：UUID 版本 `3`、`4` 或 `5`，默认取工具级 `version`（`4`）。版本 3 和 5 为确定性 UUID，由 `namespace` 与 `name` 推导。
+- `namespace`：版本 3 和 5 必填，支持内置键 `dns`、`url`、`oid`、`x500`，或任意合法 UUID 字符串。
+- `name`：版本 3 和 5 必填，与命名空间一起参与哈希的名称。
+- `count`：`generate_batch` 生成的 UUID 数量，默认取工具级 `count`，上限为 `max_batch_size`。
+- `format`：生成 UUID 的输出格式——`string`（标准连字符格式，默认）、`hex`（32 位十六进制）或 `urn`（`urn:uuid:...`）。
+- `value`：`validate` 的候选 UUID，或 `extract` 要扫描的文本。
+
+`generate` 返回 UUID 及其格式/版本（使用时附带 namespace/name）；`generate_batch` 返回列表与生成数量；`validate` 在成功时返回 `valid` 及解析后的 UUID、hex、urn、版本与变体；`extract` 返回去重后的 UUID、数量与原始匹配总数。批量大小与提取文本长度均设有边界；需要整数处会拒绝布尔值。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_uuid_generator_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_uuid_generator_tool.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+"""Tests for the built-in UUIDGeneratorTool."""
+
+import os
+import unittest
+
+from agentuniverse.agent.action.tool.common_tool import uuid_generator_tool as uuid_module
+from agentuniverse.agent.action.tool.common_tool.uuid_generator_tool import UUIDGeneratorTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import (
+    ApplicationConfigManager,
+)
+from agentuniverse.base.config.component_configer.component_configer import (
+    ComponentConfiger,
+)
+from agentuniverse.base.config.component_configer.configers.tool_configer import (
+    ToolConfiger,
+)
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = os.path.join(os.path.dirname(uuid_module.__file__), "uuid_generator_tool.yaml")
+CANONICAL = "550e8400-e29b-41d4-a716-446655440000"
+
+
+class TestUUIDGeneratorValidation(unittest.TestCase):
+    """Input and configuration boundaries."""
+
+    def setUp(self) -> None:
+        self.tool = UUIDGeneratorTool()
+
+    def test_invalid_mode_is_structured_error(self) -> None:
+        result = self.tool.execute(mode="delete")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("mode must be", result["error"])
+
+    def test_validate_requires_value(self) -> None:
+        result = self.tool.execute(mode="validate")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("value is required", result["error"])
+
+    def test_extract_requires_value(self) -> None:
+        result = self.tool.execute(mode="extract")
+        self.assertIn("value is required", result["error"])
+
+    def test_rejects_unsupported_version(self) -> None:
+        result = self.tool.execute(mode="generate", version=2)
+        self.assertIn("version must be one of", result["error"])
+
+    def test_rejects_unsupported_format(self) -> None:
+        result = self.tool.execute(mode="generate", format="base64")
+        self.assertIn("format must be one of", result["error"])
+
+    def test_rejects_invalid_count(self) -> None:
+        result = self.tool.execute(mode="generate_batch", count=0)
+        self.assertIn("count must be a positive integer", result["error"])
+
+    def test_rejects_batch_over_limit(self) -> None:
+        result = self.tool.execute(mode="generate_batch", count=10_000)
+        self.assertIn("max_batch_size", result["error"])
+
+    def test_v5_requires_namespace(self) -> None:
+        result = self.tool.execute(mode="generate", version=5, name="example.com", namespace="")
+        self.assertIn("namespace is required for uuid5", result["error"])
+
+    def test_v5_rejects_unknown_namespace(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            version=5,
+            namespace="not-a-namespace",
+            name="example.com",
+        )
+        self.assertIn("namespace must be one of", result["error"])
+
+    def test_v5_requires_name(self) -> None:
+        result = self.tool.execute(mode="generate", version=5, namespace="dns", name="")
+        self.assertIn("name is required for uuid5", result["error"])
+
+    def test_extract_rejects_oversized_text(self) -> None:
+        self.tool.max_extract_chars = 4
+        result = self.tool.execute(mode="extract", value="abcdefgh")
+        self.assertIn("max_extract_chars", result["error"])
+
+    def test_rejects_boolean_count_config(self) -> None:
+        self.tool.count = True
+        result = self.tool.execute(mode="generate_batch")
+        self.assertIn("count must be a positive integer", result["error"])
+
+    def test_rejects_invalid_tool_level_config(self) -> None:
+        self.tool.version = 2
+        result = self.tool.execute(mode="generate")
+        self.assertIn("version must be one of", result["error"])
+
+
+class TestUUIDGeneratorOperations(unittest.TestCase):
+    """Deterministic UUID operations."""
+
+    def setUp(self) -> None:
+        self.tool = UUIDGeneratorTool()
+
+    def test_generate_uuid4_default(self) -> None:
+        result = self.tool.execute(mode="generate")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["version"], 4)
+        self.assertEqual(result["format"], "string")
+        self.assertEqual(len(result["uuid"]), 36)
+        self.assertNotIn("namespace", result)
+
+    def test_generate_hex_format(self) -> None:
+        result = self.tool.execute(mode="generate", format="hex")
+        self.assertEqual(len(result["uuid"]), 32)
+        self.assertEqual(result["format"], "hex")
+        self.assertNotIn("-", result["uuid"])
+
+    def test_generate_urn_format(self) -> None:
+        result = self.tool.execute(mode="generate", format="urn")
+        self.assertTrue(result["uuid"].startswith("urn:uuid:"))
+        self.assertEqual(result["format"], "urn")
+
+    def test_v5_is_deterministic(self) -> None:
+        first = self.tool.execute(mode="generate", version=5, namespace="dns", name="example.com")
+        second = self.tool.execute(mode="generate", version=5, namespace="dns", name="example.com")
+        self.assertEqual(first["uuid"], second["uuid"])
+        self.assertEqual(first["version"], 5)
+        self.assertEqual(first["namespace"], "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        self.assertEqual(first["name"], "example.com")
+
+    def test_v5_uuid_string_namespace(self) -> None:
+        ns_uuid = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        result = self.tool.execute(mode="generate", version=5, namespace=ns_uuid, name="example.com")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["namespace"], ns_uuid)
+
+    def test_v3_is_deterministic(self) -> None:
+        first = self.tool.execute(mode="generate", version=3, namespace="url", name="hello")
+        second = self.tool.execute(mode="generate", version=3, namespace="url", name="hello")
+        self.assertEqual(first["uuid"], second["uuid"])
+        self.assertEqual(first["version"], 3)
+
+    def test_generate_batch_returns_unique_uuids(self) -> None:
+        result = self.tool.execute(mode="generate_batch", count=10)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 10)
+        self.assertEqual(len(result["uuids"]), 10)
+        self.assertEqual(len(set(result["uuids"])), 10)
+
+    def test_generate_batch_uses_tool_level_count(self) -> None:
+        self.tool.count = 4
+        result = self.tool.execute(mode="generate_batch")
+        self.assertEqual(result["count"], 4)
+
+    def test_generate_batch_v5_is_deterministic(self) -> None:
+        result = self.tool.execute(mode="generate_batch", version=5, namespace="dns", name="example.com", count=2)
+        self.assertEqual(len(set(result["uuids"])), 1)
+
+    def test_validate_accepts_canonical_uuid(self) -> None:
+        result = self.tool.execute(mode="validate", value=CANONICAL)
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["uuid"], CANONICAL)
+        self.assertEqual(result["version"], 4)
+
+    def test_validate_rejects_non_uuid(self) -> None:
+        result = self.tool.execute(mode="validate", value="not-a-uuid")
+        self.assertFalse(result["valid"])
+        self.assertNotIn("uuid", result)
+
+    def test_validate_rejects_hex_only_string(self) -> None:
+        result = self.tool.execute(mode="validate", value="550e8400e29b41d4a716446655440000")
+        self.assertFalse(result["valid"])
+
+    def test_extract_finds_all_uuids(self) -> None:
+        text = f"first {CANONICAL} then 123e4567-e89b-12d3-a456-426614174000 done"
+        result = self.tool.execute(mode="extract", value=text)
+        self.assertEqual(result["count"], 2)
+        self.assertIn(CANONICAL, result["uuids"])
+
+    def test_extract_deduplicates(self) -> None:
+        text = f"{CANONICAL} and again {CANONICAL}"
+        result = self.tool.execute(mode="extract", value=text)
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["total_matches"], 2)
+
+    def test_extract_returns_empty_when_none_found(self) -> None:
+        result = self.tool.execute(mode="extract", value="no uuids here at all")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 0)
+        self.assertEqual(result["uuids"], [])
+
+
+class TestUUIDGeneratorRegistration(unittest.TestCase):
+    """Component registration through the YAML configuration."""
+
+    def setUp(self) -> None:
+        self.config = Configer(path=os.path.abspath(YAML_PATH)).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self) -> None:
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self) -> None:
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "UUIDGeneratorTool")
+
+    def test_manager(self) -> None:
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, UUIDGeneratorTool)
+        self.assertEqual(tool.input_keys, ["mode"])
+        self.assertEqual(tool.version, 4)
+        self.assertEqual(tool.format, "string")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new built-in `UUIDGeneratorTool` component for bounded UUID generation, validation, and extraction.

## Why

Contributes to #252. Agents frequently need to mint unique identifiers (request IDs, trace IDs, object keys), check whether a string is a valid UUID, or pull UUIDs out of free-form text. This tool covers all three with **zero external dependencies** — it relies only on the Python standard-library `uuid` module, so it imports and runs in every environment.

## Changes

- `agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.py` — `UUIDGeneratorTool` (331 lines) with four modes:
  - `generate` — emit one UUID (`uuid4` by default; `uuid3`/`uuid5` are deterministic given a `namespace` + `name`)
  - `generate_batch` — emit up to `count` UUIDs in one call
  - `validate` — report whether a candidate string is a well-formed UUID
  - `extract` — pull every well-formed UUID out of arbitrary text
- `agentuniverse/agent/action/tool/common_tool/uuid_generator_tool.yaml` — built-in component configuration + args model schema
- `tests/test_agentuniverse/unit/agent/action/tool/test_uuid_generator_tool.py` — 30 tests (validation, operations, registration)
- `docs/.../集成的工具.md` and `docs/.../Integrated_Tools.md` — bilingual usage docs

## Design notes

- Standard-library only (`import uuid`, `import re`) — no optional packages, no install step.
- Output formatting via `format`: `string` (canonical hyphenated form), `hex` (32 hex digits), or `urn` (`urn:uuid:...`).
- Versions 3/4/5 supported; 3 and 5 are deterministic from a `namespace` (well-known key `dns`/`url`/`oid`/`x500` or any UUID string) plus a `name`.
- `validate` round-trips through `uuid.UUID` and additionally checks the normalized string matches, so hex-only or otherwise mangled input is correctly reported invalid.
- `extract` deduplicates results while reporting both the unique count and raw match total.
- Batch size (`max_batch_size`) and extraction text length (`max_extract_chars`) are bounded; booleans are rejected where integers are expected; validation failures return structured `error` dictionaries consistent with the other built-in tools.
- Follows the existing built-in tool convention (`.yaml`, not `.yaml.example`) so it registers as a keyless built-in component.

## Tests

```
30 passed
```
