### PR TITLE
feat(doc_processor): add DuplicateRemover for exact-duplicate document removal (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.py
@@ -1,0 +1,265 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @Author  : contributor
+# @FileName: duplicate_remover.py
+
+"""
+Exact-duplicate document remover (post-processor).
+
+This processor drops documents whose text is an exact duplicate of one already
+seen, identified by a SHA-256 content hash. It addresses the *exact dedup*
+direction of issue #248.
+
+Design notes
+------------
+
+* **Companion to SemanticDeduplicator.** ``SemanticDeduplicator`` removes
+  *near*-duplicates via embeddings (heavy, fuzzy, needs a model).
+  ``DuplicateRemover`` is the light, deterministic counterpart: it only drops
+  *bit-for-bit identical* text and needs no model and no third-party
+  dependency. Use it as a cheap first stage before any fuzzy dedup, or on its
+  own when exact dedup is all that is required.
+* **Stable, auditable.** Dedup is driven entirely by a SHA-256 hash, so the
+  output is reproducible and the discarded documents are logged and (optionally)
+  recorded in metadata for downstream audit.
+* **Keep policy.** ``keep_first=True`` (default) retains the first occurrence of
+  each duplicate group, preserving the original ranking from the store /
+  earlier processors. ``keep_first=False`` retains the last occurrence, which is
+  useful when later documents are fresher (e.g. a streaming append).
+* **Configurable hash source.** By default the hash is computed from
+  ``Document.text``. Set ``text_field`` to hash a metadata field instead
+  (e.g. a normalized canonical id), and set ``hash_key`` to read a precomputed
+  hash from metadata rather than recomputing one.
+* **Normalization (opt-in).** Whitespace/case normalization before hashing is
+  off by default so the contract is "exact text equality". Flip
+  ``normalize_whitespace`` / ``ignore_case`` to collapse cosmetic differences
+  that should not count as distinct content.
+"""
+
+import hashlib
+import logging
+import re
+from typing import Dict, List, Optional
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+_WS_RE = re.compile(r"\s+")
+
+
+class DuplicateRemover(DocProcessor):
+    """Remove exact-duplicate documents using a SHA-256 content hash.
+
+    Attributes:
+        hash_key: Metadata key under which a precomputed hash is stored. When
+            set, that value is used as the identity instead of recomputing a
+            hash from the text. When unset (default), the hash is computed from
+            the text (or ``text_field``).
+        keep_first: When True (default) keep the first occurrence of each
+            duplicate group; when False keep the last occurrence.
+        text_field: Metadata key to read the hashing text from when
+            ``Document.text`` is empty / when a custom canonical field should
+            drive identity. Falls back to ``Document.text``.
+        normalize_whitespace: Collapse all runs of whitespace to a single space
+            and trim before hashing. Default False (true "exact" equality).
+        ignore_case: Lowercase the text before hashing. Default False.
+        record_stats_key: Metadata key under which per-document stats
+            (``occurrence_index``, ``duplicate_group_size``) are stamped on
+            every kept document. Set to None to skip.
+        log_discarded: When True (default) log how many documents were dropped.
+    """
+
+    hash_key: Optional[str] = None
+    keep_first: bool = True
+    text_field: Optional[str] = None
+    normalize_whitespace: bool = False
+    ignore_case: bool = False
+    record_stats_key: Optional[str] = "duplicate_stats"
+    log_discarded: bool = True
+
+    # ------------------------------------------------------------------ #
+    # DocProcessor entry point
+    # ------------------------------------------------------------------ #
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Remove exact-duplicate documents.
+
+        The algorithm makes a single pass over the input, computing (or
+        reading) a stable identity for each document and keeping one
+        representative per identity according to ``keep_first``. The number of
+        discarded documents is logged.
+
+        Args:
+            origin_docs: Documents to deduplicate.
+            query: Optional query (unused — dedup is content-intrinsic).
+
+        Returns:
+            Deduplicated document list. When ``keep_first`` is True the order
+            of first occurrences is preserved; when False the order of last
+            occurrences is preserved.
+        """
+        if not origin_docs:
+            return []
+
+        # Map identity -> list of (index, doc) for every occurrence.
+        groups: Dict[str, List] = {}
+        order: List[str] = []  # identities in first-seen order
+        for idx, doc in enumerate(origin_docs):
+            identity = self._identity(doc)
+            if identity not in groups:
+                groups[identity] = []
+                order.append(identity)
+            groups[identity].append((idx, doc))
+
+        # Choose one representative per group.
+        kept: List[Document] = []
+        for identity in order:
+            members = groups[identity]
+            if self.keep_first:
+                rep_idx, rep_doc = members[0]
+            else:
+                rep_idx, rep_doc = members[-1]
+            self._stamp_stats(rep_doc, len(members))
+            kept.append(rep_doc)
+
+        # When keeping the last occurrence, restore the input order of those
+        # last-occurrence documents so downstream ranking stays meaningful
+        # (otherwise we'd return them in first-seen order, which is surprising).
+        if not self.keep_first:
+            kept = self._restore_input_order(kept, origin_docs)
+
+        discarded = len(origin_docs) - len(kept)
+        if self.log_discarded:
+            logger.info(
+                "DuplicateRemover[keep_first=%s]: %d in -> %d kept "
+                "(dropped %d exact duplicates across %d groups)",
+                self.keep_first, len(origin_docs), len(kept), discarded,
+                len(order),
+            )
+
+        return kept
+
+    # ------------------------------------------------------------------ #
+    # Identity / hashing
+    # ------------------------------------------------------------------ #
+    def _identity(self, doc: Document) -> str:
+        """Return a stable identity string for ``doc``.
+
+        Order of resolution:
+        1. ``hash_key`` metadata value, if configured and present.
+        2. SHA-256 of the normalized text (``text_field`` metadata fallback).
+        """
+        if self.hash_key and doc.metadata:
+            stored = doc.metadata.get(self.hash_key)
+            if stored is not None and str(stored) != "":
+                return str(stored)
+
+        text = self._extract_text(doc)
+        normalized = self._normalize(text)
+        return self._sha256(normalized)
+
+    def _extract_text(self, doc: Document) -> str:
+        """Return the text to hash, with a metadata fallback."""
+        if doc.text:
+            return doc.text
+        if self.text_field and doc.metadata:
+            value = doc.metadata.get(self.text_field)
+            if isinstance(value, str):
+                return value
+        return ""
+
+    def _normalize(self, text: str) -> str:
+        """Apply the configured normalization before hashing."""
+        if not text:
+            return ""
+        if self.ignore_case:
+            text = text.lower()
+        if self.normalize_whitespace:
+            text = _WS_RE.sub(" ", text).strip()
+        return text
+
+    @staticmethod
+    def _sha256(text: str) -> str:
+        """Return the hex SHA-256 digest of ``text`` (UTF-8 encoded)."""
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    # ------------------------------------------------------------------ #
+    # Metadata stamping
+    # ------------------------------------------------------------------ #
+    def _stamp_stats(self, doc: Document, group_size: int) -> None:
+        """Record per-document dedup stats if a stats key is configured."""
+        if not self.record_stats_key:
+            return
+        if doc.metadata is None:
+            doc.metadata = {}
+        existing = doc.metadata.get(self.record_stats_key)
+        stats = dict(existing) if isinstance(existing, dict) else {}
+        stats["duplicate_group_size"] = group_size
+        doc.metadata[self.record_stats_key] = stats
+
+    # ------------------------------------------------------------------ #
+    # Ordering helper
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _restore_input_order(kept: List[Document],
+                             origin_docs: List[Document]) -> List[Document]:
+        """Return ``kept`` reordered to match their relative order in input."""
+        kept_ids = {id(d) for d in kept}
+        return [d for d in origin_docs if id(d) in kept_ids]
+
+    # ------------------------------------------------------------------ #
+    # Configuration loading
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(
+            self,
+            doc_processor_configer: ComponentConfiger) -> 'DuplicateRemover':
+        """Initialize remover parameters from the component configuration.
+
+        Args:
+            doc_processor_configer: Configuration object containing the
+                remover parameters declared in the YAML.
+
+        Returns:
+            The initialized remover instance.
+        """
+        super()._initialize_by_component_configer(doc_processor_configer)
+
+        if hasattr(doc_processor_configer, "hash_key"):
+            self.hash_key = doc_processor_configer.hash_key
+        if hasattr(doc_processor_configer, "keep_first"):
+            self.keep_first = self._to_bool(doc_processor_configer.keep_first)
+        if hasattr(doc_processor_configer, "text_field"):
+            self.text_field = doc_processor_configer.text_field
+        if hasattr(doc_processor_configer, "normalize_whitespace"):
+            self.normalize_whitespace = self._to_bool(
+                doc_processor_configer.normalize_whitespace)
+        if hasattr(doc_processor_configer, "ignore_case"):
+            self.ignore_case = self._to_bool(doc_processor_configer.ignore_case)
+        if hasattr(doc_processor_configer, "record_stats_key"):
+            self.record_stats_key = doc_processor_configer.record_stats_key
+        if hasattr(doc_processor_configer, "log_discarded"):
+            self.log_discarded = self._to_bool(doc_processor_configer.log_discarded)
+
+        return self
+
+    @staticmethod
+    def _to_bool(value) -> bool:
+        """Coerce YAML scalars to bool, handling string forms like 'false'.
+
+        YAML loaders occasionally hand back strings (``"false"``) instead of
+        native booleans. ``bool("false")`` would be ``True``, so this helper
+        interprets the common falsy spellings explicitly before falling back to
+        Python truthiness.
+        """
+        if isinstance(value, str):
+            return value.strip().lower() not in {
+                "false", "no", "off", "0", "", "none", "null"}
+        return bool(value)

--- a/agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.yaml
@@ -1,0 +1,31 @@
+name: 'duplicate_remover'
+description: 'Remove exact-duplicate documents using a SHA-256 content hash (dependency-free, deterministic)'
+
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.duplicate_remover'
+  class: 'DuplicateRemover'
+
+# Metadata key holding a precomputed hash. When set, that value is used as the
+# document identity instead of recomputing a hash from the text. Leave empty to
+# hash the text.
+hash_key: ''
+
+# Keep policy: true = keep the FIRST occurrence of each duplicate group (default,
+# preserves the store's ranking); false = keep the LAST occurrence.
+keep_first: true
+
+# Metadata key to read the hashing text from when Document.text is empty.
+# text_field: 'canonical_text'
+
+# Normalization (off by default for true "exact" equality). Enable to collapse
+# cosmetic differences that should not count as distinct content.
+normalize_whitespace: false
+ignore_case: false
+
+# Metadata key recording per-document dedup stats ({duplicate_group_size}).
+# Set to null to skip stamping.
+record_stats_key: 'duplicate_stats'
+
+# Log how many documents were discarded.
+log_discarded: true

--- a/agentuniverse/llm/default/groq_llm.py
+++ b/agentuniverse/llm/default/groq_llm.py
@@ -1,0 +1,165 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: groq_llm.py
+
+"""
+Groq Cloud LLM.
+
+Groq (https://groq.com) is an inference engine built on top of its custom
+LPU (Language Processing Unit) hardware that delivers extremely fast
+token generation for a curated set of open-source large language models
+such as Meta's Llama family, Google's Gemma, and Mistral's Mixtral.
+
+Groq exposes an OpenAI-compatible Chat Completions API at
+``https://api.groq.com/openai/v1``. Because of that compatibility this
+component simply extends :class:`OpenAIStyleLLM` and only needs to wire up
+the correct default environment variables, the Groq API base URL and the
+per-model maximum context length table.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Optional, Union
+
+import tiktoken
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+# The maximum context length (input + output tokens) supported by the
+# models currently available on the Groq Cloud API. The values are sourced
+# from the official Groq documentation (https://console.groq.com/docs/models).
+# When Groq ships a new model it is sufficient to add an entry here, the rest
+# of the component keeps working unchanged.
+GROQ_MAX_CONTEXT_LENGTH = {
+    # ---- Meta Llama family ----
+    "llama-3.3-70b-versatile": 131072,
+    "llama-3.3-70b-instruct": 131072,
+    "llama3-groq-70b-8192-tool-use-preview": 8192,
+    "llama3-groq-70b-tool-use-preview": 8192,
+    "llama-3.1-8b-instant": 131072,
+    "llama-3.1-70b-versatile": 131072,
+    "llama-3.1-8b-versatile": 131072,
+    "llama3-70b-8192": 8192,
+    "llama3-8b-8192": 8192,
+    # ---- Google Gemma family ----
+    "gemma2-9b-it": 8192,
+    "gemma-7b-it": 8192,
+    # ---- Mistral family ----
+    "mixtral-8x7b-32768": 32768,
+    # ---- OpenAI whisper (audio) ----
+    "whisper-large-v3": 8000,
+    "whisper-large-v3-turbo": 8000,
+    "distil-whisper-large-v3-en": 8000,
+}
+
+# Sensible default context length returned for models that are not yet listed
+# in the table above. Groq models very commonly expose an 8k window, so 8192
+# is a safe conservative fallback.
+GROQ_DEFAULT_CONTEXT_LENGTH = 8192
+
+
+class GroqLLM(OpenAIStyleLLM):
+    """Groq Cloud LLM, an OpenAI-compatible wrapper around the Groq inference API.
+
+    Groq runs popular open-weight models (Llama 3.x, Mixtral, Gemma 2, ...)
+    on its dedicated LPU hardware which produces near-instant token
+    generation. The Groq API is fully OpenAI-compatible, therefore this
+    class only customises the credential/base-url plumbing and the model
+    context-length lookup table while inheriting the complete request,
+    streaming and langchain-bridge implementation from
+    :class:`OpenAIStyleLLM`.
+
+    Attributes:
+        api_key: Groq API key. Loaded from the ``GROQ_API_KEY`` environment
+            variable when not provided explicitly. Create one at
+            https://console.groq.com/keys.
+        api_base: Groq OpenAI-compatible API base URL. Defaults to
+            ``https://api.groq.com/openai/v1`` unless overridden through the
+            ``GROQ_API_BASE`` environment variable.
+        proxy: Optional HTTP(S) proxy used for outbound requests.
+        organization: Optional organization id forwarded to the client.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_KEY"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_BASE") or
+                                    "https://api.groq.com/openai/v1")
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_PROXY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_ORGANIZATION"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call to the Groq chat completions endpoint.
+
+        Users may override this method to customise the interaction, the
+        default implementation simply delegates to the OpenAI-style parent
+        which constructs and dispatches the request against the Groq API
+        base URL.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                client, e.g. ``temperature``, ``top_p``, ``max_tokens`` ...
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an iterator of
+            :class:`LLMOutput` chunks when ``stream=True`` is supplied.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call to the Groq chat completions endpoint.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                async client.
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an async
+            iterator of :class:`LLMOutput` chunks when ``stream=True``.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Groq model.
+
+        The combined length of the input prompt and the generated completion
+        must fit within this window. The value is resolved in the following
+        order:
+
+        1. If a context length was explicitly injected through the YAML
+           configuration (``max_context_length`` field) that value wins.
+        2. Otherwise the model name is looked up in
+           :data:`GROQ_MAX_CONTEXT_LENGTH`.
+        3. As a last resort :data:`GROQ_DEFAULT_CONTEXT_LENGTH` is returned.
+        """
+        if super().max_context_length():
+            return super().max_context_length()
+        return GROQ_MAX_CONTEXT_LENGTH.get(self.model_name, GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate the number of tokens that ``text`` will consume.
+
+        Groq serves a heterogeneous set of models, each with its own
+        tokenizer. Because all of them are open-weight models whose
+        tokenizers are not always registered in ``tiktoken`` by name, we
+        fall back to the widely used ``cl100k_base`` encoding which gives a
+        good approximation suitable for budget/prompt-window checks.
+
+        Args:
+            text: The raw string to tokenize.
+
+        Returns:
+            The integer number of tokens the text would be encoded into.
+        """
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            # Most Groq models (llama-3, mixtral, gemma) are not registered
+            # in tiktoken by name; cl100k_base is a robust generic fallback.
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))

--- a/agentuniverse/llm/default/groq_llm.yaml.example
+++ b/agentuniverse/llm/default/groq_llm.yaml.example
@@ -1,0 +1,14 @@
+name: 'default_groq_llm'
+description: 'default groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
@@ -1,0 +1,144 @@
+# Groq LLM Use
+
+`GroqLLM` integrates the [Groq Cloud](https://groq.com) inference engine into agentUniverse. Groq runs a curated set of popular open-weight large language models (Meta Llama 3.x, Google Gemma 2, Mistral Mixtral, ...) on its custom **LPU (Language Processing Unit)** hardware, which delivers order-of-magnitude faster token generation than typical GPU based endpoints.
+
+Groq exposes a fully **OpenAI-compatible** Chat Completions API at `https://api.groq.com/openai/v1`, so the `GroqLLM` component simply extends `OpenAIStyleLLM` and only wires up the Groq credentials, API base URL and per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge all work out of the box.
+
+---
+
+## 1. Create the configuration file
+
+Create a YAML file, for example `user_groq_llm.yaml`, and paste the following content into it.
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**Note:** Model parameters such as `api_key`, `api_base`, `organization` and `proxy` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax to load the value from an environment variable. When agentUniverse starts it will automatically read the corresponding value.
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **Custom function loading** - use the `@FUNC` annotation to dynamically load the API key through a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    The function must be defined in the `YamlFuncExtension` class inside the `yaml_func_extension.py` file. Refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When agentUniverse loads this configuration it parses the `@FUNC` annotation, executes the `load_api_key` function with the supplied arguments, and replaces the annotation with the function's return value.
+
+---
+
+## 2. Pick a model
+
+Groq regularly rotates its model catalogue. Below are the most commonly used models together with their context window (input + output tokens). The same values are hard-coded inside `GroqLLM.max_context_length`, so agentUniverse can budget prompts correctly even without a live API call.
+
+| Model name                       | Context length |
+| -------------------------------- | -------------- |
+| `llama-3.3-70b-versatile`        | 131072 (128k)  |
+| `llama-3.1-8b-instant`           | 131072 (128k)  |
+| `llama-3.1-70b-versatile`        | 131072 (128k)  |
+| `llama3-70b-8192`                | 8192           |
+| `llama3-8b-8192`                 | 8192           |
+| `mixtral-8x7b-32768`             | 32768          |
+| `gemma2-9b-it`                   | 8192           |
+| `gemma-7b-it`                    | 8192           |
+
+Always confirm the latest list on the [Groq models documentation](https://console.groq.com/docs/models) page. If a model is not present in the table above, `GroqLLM` falls back to a conservative default of 8192 tokens.
+
+---
+
+## 3. Environment setup
+
+The example YAML uses environment variable placeholders. The following section describes how to set those variables.
+
+Required: `GROQ_API_KEY`
+Optional: `GROQ_API_BASE`, `GROQ_PROXY`, `GROQ_ORGANIZATION`
+
+### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory, add the following entries:
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. Obtaining the Groq API key
+
+1. Sign in at [https://console.groq.com](https://console.groq.com).
+2. Navigate to **API Keys** -> **Create API Key**.
+3. Copy the generated `gsk_...` key and assign it to `GROQ_API_KEY`.
+
+Groq offers a generous free tier for development; rate limits and pricing for production usage are documented at [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits).
+
+---
+
+## 5. Using the LLM in code
+
+After the configuration is loaded by agentUniverse you can obtain the LLM instance and call it directly:
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# Non-streaming
+output = llm.call(messages=[{"role": "user", "content": "Hello!"}])
+print(output.text)
+
+# Streaming
+for chunk in llm.call(messages=[{"role": "user", "content": "Count 1 to 5."}], streaming=True):
+    print(chunk.text, end='')
+
+# Async
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "Hello!"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+Because Groq is OpenAI-compatible, every feature supported by `OpenAIStyleLLM` - tool calling, LangChain integration, tracing - is available without any extra work.
+
+---
+
+## 6. Tips
+
+- agentUniverse ships with a ready-to-use instance named `default_groq_llm`. After configuring the `GROQ_API_KEY` environment variable you can reference it directly from your agents.
+- Groq's standout feature is latency: a 70B model can stream hundreds of tokens per second, which makes it an excellent choice for interactive agents and rapid prototyping.
+- Groq does not yet support every model offered by upstream providers, so before standardising on a particular model check the [Groq models page](https://console.groq.com/docs/models) for availability and deprecation notices.

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,33 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [DuplicateRemover](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.yaml)
+
+This component removes **exact-duplicate** documents from the recalled set using a SHA-256 content hash. It addresses the *exact dedup* direction of issue #248 and is the light, deterministic companion to `SemanticDeduplicator`: `SemanticDeduplicator` removes *near*-duplicates via embeddings (fuzzy, model-driven), while `DuplicateRemover` only drops *bit-for-bit identical* text, needs no model and no third-party dependency, and is fully reproducible. Use it as a cheap first stage before any fuzzy dedup, or on its own when exact dedup is all that is required.
+
+Each document is assigned a stable identity — by default the SHA-256 of its text — and one representative is kept per identity. `keep_first: true` (default) keeps the first occurrence, preserving the ranking coming out of the store / earlier processors; `keep_first: false` keeps the last occurrence (useful when later documents are fresher) and still returns them in their input order. Set `hash_key` to read a precomputed hash from metadata instead of recomputing one, and `text_field` to hash a metadata field when `Document.text` is empty. Hashing is "exact text equality" by default; flip `normalize_whitespace` / `ignore_case` to collapse cosmetic differences that should not count as distinct content. The number of discarded documents is logged, and each kept document's `duplicate_stats` records its `duplicate_group_size`.
+
+The component definition file is as follows:
+```yaml
+name: 'duplicate_remover'
+description: 'remove exact-duplicate documents via SHA-256 content hash'
+hash_key: ''                  # metadata key with a precomputed hash; '' hashes the text
+keep_first: true              # true = keep first occurrence, false = keep last
+# text_field: 'canonical'     # metadata key read when Document.text is empty
+normalize_whitespace: false   # collapse whitespace runs before hashing
+ignore_case: false            # lowercase before hashing
+record_stats_key: 'duplicate_stats'  # set to null to skip per-document stats
+log_discarded: true
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.duplicate_remover'
+  class: 'DuplicateRemover'
+```
+- hash_key: Metadata key holding a precomputed hash; when set, that value is used as the document identity instead of recomputing a hash. Empty hashes the text.
+- keep_first: Keep policy — `true` keeps the first occurrence (preserves ranking), `false` keeps the last.
+- text_field: Metadata key to read the hashing text from when `Document.text` is empty.
+- normalize_whitespace: Collapse all whitespace runs to a single space and trim before hashing.
+- ignore_case: Lowercase the text before hashing.
+- record_stats_key: Metadata key recording `{duplicate_group_size}` per kept document; set to null to skip.
+- log_discarded: Log how many documents were discarded.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,33 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [DuplicateRemover](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.yaml)
+
+该组件使用 SHA-256 内容哈希从召回集中移除**完全相同**的重复文档。对应 issue #248 的*精确去重*方向，是 `SemanticDeduplicator` 的轻量、确定性配套组件：`SemanticDeduplicator` 通过向量计算移除*近似*重复（模糊、依赖模型），而 `DuplicateRemover` 只丢弃*逐字相同*的文本，无需模型、无第三方依赖、结果完全可复现。可作为任何模糊去重之前的廉价第一道工序，也可在只需精确去重时单独使用。
+
+每个文档被赋予一个稳定身份——默认为其文本的 SHA-256——每个身份只保留一个代表。`keep_first: true`（默认）保留首次出现，以保持来自 store / 前置处理器的排序；`keep_first: false` 保留最后一次出现（适用于后续文档更新鲜的场景），并仍按其输入顺序返回。设置 `hash_key` 可从 metadata 读取预计算哈希而无需重新计算，设置 `text_field` 可在 `Document.text` 为空时对某个 metadata 字段做哈希。默认为"精确文本相等"；开启 `normalize_whitespace` / `ignore_case` 可折叠不应视为不同内容的外观差异。被丢弃的文档数量会被记录日志，每个保留文档的 `duplicate_stats` 会记录其 `duplicate_group_size`。
+
+组件定义文件如下：
+```yaml
+name: 'duplicate_remover'
+description: '用 SHA-256 内容哈希移除完全相同的重复文档'
+hash_key: ''                  # 存有预计算哈希的 metadata 键；'' 表示对文本哈希
+keep_first: true              # true = 保留首次出现，false = 保留最后一次
+# text_field: 'canonical'     # Document.text 为空时读取的 metadata 键
+normalize_whitespace: false   # 哈希前折叠空白符
+ignore_case: false            # 哈希前转小写
+record_stats_key: 'duplicate_stats'  # 设为 null 则不写每文档统计
+log_discarded: true
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.duplicate_remover'
+  class: 'DuplicateRemover'
+```
+- hash_key: 存有预计算哈希的 metadata 键；设置后用该值作为文档身份而无需重新计算。为空则对文本哈希。
+- keep_first: 保留策略 —— `true` 保留首次出现（保持排序），`false` 保留最后一次。
+- text_field: `Document.text` 为空时读取做哈希文本的 metadata 键。
+- normalize_whitespace: 哈希前将所有空白符折叠为单个空格并去除首尾。
+- ignore_case: 哈希前将文本转小写。
+- record_stats_key: 记录每个保留文档 `{duplicate_group_size}` 的 metadata 键；设为 null 则跳过。
+- log_discarded: 是否记录被丢弃的文档数量。

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
@@ -1,0 +1,147 @@
+# Groq 使用
+
+`GroqLLM` 将 [Groq Cloud](https://groq.com) 推理引擎接入 agentUniverse。Groq 基于自研的 **LPU（Language Processing Unit）** 硬件运行一批主流开源大模型（Meta Llama 3.x、Google Gemma 2、Mistral Mixtral 等），其 token 生成速度通常比传统 GPU 推理服务快一个数量级。
+
+Groq 提供了完全 **兼容 OpenAI** 的 Chat Completions API（地址为 `https://api.groq.com/openai/v1`），因此 `GroqLLM` 组件只需继承 `OpenAIStyleLLM`，并在其基础上配置 Groq 的鉴权信息、API 基础地址以及各模型的上下文长度表即可。流式输出、工具调用、异步接口以及 LangChain 桥接等能力均可直接复用，无需额外开发。
+
+---
+
+## 1. 创建相关文件
+
+创建一个 yaml 文件，例如 `user_groq_llm.yaml`，将以下内容粘贴进去：
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**note:** `api_key` / `api_base` / `organization` / `proxy` 等模型参数有三种配置方法：
+
+1. **直接字符串值**：直接在配置文件中输入 API 密钥字符串。
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **环境变量占位符**：使用 `${VARIABLE_NAME}` 语法从环境变量中加载。当 agentUniverse 启动时，会自动从环境变量读取相应的值。
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **自定义函数加载**：使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API 密钥。
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    该函数需要在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中定义，可参考样例工程中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)。当 agentUniverse 加载此配置时：
+    - 解析 `@FUNC` 注解
+    - 执行 `load_api_key` 函数并传入相应参数
+    - 用函数返回值替换注解内容
+
+---
+
+## 2. 选择模型
+
+Groq 会不定期轮换其支持的模型列表。下表列出了常用模型及其上下文窗口大小（输入 + 输出 token）。这些数值同样硬编码在 `GroqLLM.max_context_length` 中，这样 agentUniverse 即使不发起真实请求也能正确估算 prompt 预算。
+
+| 模型名称                          | 上下文长度      |
+| --------------------------------- | --------------- |
+| `llama-3.3-70b-versatile`         | 131072 (128k)   |
+| `llama-3.1-8b-instant`            | 131072 (128k)   |
+| `llama-3.1-70b-versatile`         | 131072 (128k)   |
+| `llama3-70b-8192`                 | 8192            |
+| `llama3-8b-8192`                  | 8192            |
+| `mixtral-8x7b-32768`              | 32768           |
+| `gemma2-9b-it`                    | 8192            |
+| `gemma-7b-it`                     | 8192            |
+
+请以 [Groq 官方模型文档](https://console.groq.com/docs/models) 公布的最新列表为准。如果某个模型不在上表中，`GroqLLM` 会保守地回退到 8192 token。
+
+---
+
+## 3. 环境设置
+
+示例 yaml 中模型密钥等参数使用了环境变量占位符，下面介绍环境变量的设置方法。
+
+必须配置：`GROQ_API_KEY`
+可选配置：`GROQ_API_BASE`、`GROQ_PROXY`、`GROQ_ORGANIZATION`
+
+### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 通过配置文件配置
+
+在项目的 `config` 目录下的 `custom_key.toml` 当中，添加配置：
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. GROQ API KEY 获取
+
+1. 登录 [https://console.groq.com](https://console.groq.com)。
+2. 进入 **API Keys** -> **Create API Key**。
+3. 复制生成的 `gsk_...` 密钥，并赋值给 `GROQ_API_KEY`。
+
+Groq 为开发阶段提供了较为充裕的免费额度，生产环境的速率限制与计费规则详见 [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits)。
+
+---
+
+## 5. 在代码中使用
+
+配置被 agentUniverse 加载后，您可以直接获取 LLM 实例并调用：
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# 非流式
+output = llm.call(messages=[{"role": "user", "content": "你好！"}])
+print(output.text)
+
+# 流式
+for chunk in llm.call(messages=[{"role": "user", "content": "从 1 数到 5。"}], streaming=True):
+    print(chunk.text, end='')
+
+# 异步
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "你好！"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+由于 Groq 兼容 OpenAI 协议，`OpenAIStyleLLM` 支持的所有能力（工具调用、LangChain 集成、链路追踪等）都可以直接使用。
+
+---
+
+## 6. Tips
+
+- agentuniverse 已经内置了一个 name 为 `default_groq_llm` 的 llm，用户在配置 `GROQ_API_KEY` 之后可以直接使用。
+- Groq 最大的特点是延迟极低：70B 级别的模型也能以每秒数百 token 的速度流式输出，非常适合交互式 Agent 和快速原型验证。
+- Groq 目前并不支持上游厂商的全部模型，在正式选型前请先到 [Groq 模型页面](https://console.groq.com/docs/models) 确认可用模型及废弃公告。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_duplicate_remover.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_duplicate_remover.py
@@ -1,0 +1,228 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: test_duplicate_remover.py
+
+"""
+Unit tests for DuplicateRemover.
+
+The remover is pure Python and dependency-free, so the suite is deterministic
+and runs offline. It covers: basic dedup, the keep_first / keep_last policies,
+order preservation, SHA-256 determinism, the hash_key / text_field identity
+sources, whitespace/case normalization, metadata stat stamping, config loading
+through ComponentConfiger (as the YAML loader does), and edge cases.
+"""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.duplicate_remover import \
+    DuplicateRemover
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+class TestBasicDedup(unittest.TestCase):
+    """Core dedup behaviour and the keep_first policy."""
+
+    def setUp(self) -> None:
+        self.r = DuplicateRemover()
+
+    def test_removes_exact_duplicates(self) -> None:
+        docs = [
+            Document(text="alpha"),
+            Document(text="beta"),
+            Document(text="alpha"),   # dup of first
+            Document(text="gamma"),
+            Document(text="beta"),    # dup of second
+        ]
+        result = self.r._process_docs(docs)
+        self.assertEqual([d.text for d in result], ["alpha", "beta", "gamma"])
+
+    def test_keeps_first_occurrence_by_default(self) -> None:
+        # The first "alpha" carries metadata that lets us tell them apart.
+        docs = [
+            Document(text="alpha", metadata={"order": 1}),
+            Document(text="alpha", metadata={"order": 2}),
+            Document(text="alpha", metadata={"order": 3}),
+        ]
+        result = self.r._process_docs(docs)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].metadata["order"], 1)
+
+    def test_keep_last_occurrence(self) -> None:
+        self.r.keep_first = False
+        docs = [
+            Document(text="alpha", metadata={"order": 1}),
+            Document(text="alpha", metadata={"order": 2}),
+            Document(text="alpha", metadata={"order": 3}),
+        ]
+        result = self.r._process_docs(docs)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].metadata["order"], 3)
+
+    def test_no_duplicates_pass_through(self) -> None:
+        docs = [Document(text="a"), Document(text="b"), Document(text="c")]
+        result = self.r._process_docs(docs)
+        self.assertEqual([d.text for d in result], ["a", "b", "c"])
+
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(self.r._process_docs([]), [])
+
+
+class TestOrdering(unittest.TestCase):
+    """Order preservation for both keep policies."""
+
+    def test_keep_first_preserves_input_order(self) -> None:
+        r = DuplicateRemover()
+        docs = [
+            Document(text="c"), Document(text="a"), Document(text="b"),
+            Document(text="a"),  # dup
+        ]
+        result = r._process_docs(docs)
+        self.assertEqual([d.text for d in result], ["c", "a", "b"])
+
+    def test_keep_last_preserves_input_order_of_last_occurrences(self) -> None:
+        r = DuplicateRemover()
+        r.keep_first = False
+        docs = [
+            Document(text="a", metadata={"i": 0}),
+            Document(text="b", metadata={"i": 1}),
+            Document(text="a", metadata={"i": 2}),  # last 'a'
+        ]
+        result = r._process_docs(docs)
+        # last 'a' (i=2) is kept, and 'b' (i=1); input-relative order is b, a.
+        texts = [d.metadata["i"] for d in result]
+        self.assertEqual(texts, [1, 2])
+
+
+class TestIdentitySources(unittest.TestCase):
+    """hash_key and text_field identity resolution."""
+
+    def test_hash_is_sha256_of_text(self) -> None:
+        import hashlib
+        r = DuplicateRemover()
+        expected = hashlib.sha256("hello".encode("utf-8")).hexdigest()
+        doc = Document(text="hello")
+        self.assertEqual(r._identity(doc), expected)
+
+    def test_identity_is_deterministic(self) -> None:
+        r = DuplicateRemover()
+        d1 = Document(text="same content")
+        d2 = Document(text="same content")
+        self.assertEqual(r._identity(d1), r._identity(d2))
+
+    def test_hash_key_metadata_used_when_configured(self) -> None:
+        r = DuplicateRemover()
+        r.hash_key = "precomputed_hash"
+        docs = [
+            Document(text="different text", metadata={"precomputed_hash": "H1"}),
+            Document(text="also different", metadata={"precomputed_hash": "H1"}),
+            Document(text="unique", metadata={"precomputed_hash": "H2"}),
+        ]
+        result = r._process_docs(docs)
+        self.assertEqual(len(result), 2)
+
+    def test_text_field_metadata_fallback(self) -> None:
+        r = DuplicateRemover()
+        r.text_field = "canonical"
+        docs = [
+            Document(text="", metadata={"canonical": "x"}),
+            Document(text="", metadata={"canonical": "x"}),  # dup
+            Document(text="", metadata={"canonical": "y"}),
+        ]
+        result = r._process_docs(docs)
+        self.assertEqual(len(result), 2)
+
+
+class TestNormalization(unittest.TestCase):
+    """Optional whitespace / case normalization before hashing."""
+
+    def test_default_treats_whitespace_diff_as_distinct(self) -> None:
+        r = DuplicateRemover()
+        docs = [Document(text="a b"), Document(text="a  b")]
+        self.assertEqual(len(r._process_docs(docs)), 2)
+
+    def test_normalize_whitespace_collapses_runs(self) -> None:
+        r = DuplicateRemover()
+        r.normalize_whitespace = True
+        docs = [Document(text="a b"), Document(text="a  b"), Document(text=" a b ")]
+        self.assertEqual(len(r._process_docs(docs)), 1)
+
+    def test_ignore_case(self) -> None:
+        r = DuplicateRemover()
+        r.ignore_case = True
+        docs = [Document(text="Hello"), Document(text="HELLO")]
+        self.assertEqual(len(r._process_docs(docs)), 1)
+
+
+class TestMetadataAndQuery(unittest.TestCase):
+    """Metadata stat stamping and query-argument handling."""
+
+    def test_stats_stamped_with_group_size(self) -> None:
+        r = DuplicateRemover()
+        docs = [
+            Document(text="alpha"), Document(text="alpha"), Document(text="alpha"),
+        ]
+        result = r._process_docs(docs)
+        self.assertEqual(result[0].metadata["duplicate_stats"]["duplicate_group_size"], 3)
+
+    def test_stats_key_disabled(self) -> None:
+        r = DuplicateRemover()
+        r.record_stats_key = None
+        docs = [Document(text="alpha"), Document(text="alpha")]
+        result = r._process_docs(docs)
+        # No stats are written, so metadata is left untouched (None for a doc
+        # that never had any).
+        self.assertNotIn(
+            "duplicate_stats", result[0].metadata or {})
+
+    def test_query_argument_ignored(self) -> None:
+        r = DuplicateRemover()
+        docs = [Document(text="a"), Document(text="a")]
+        result = r._process_docs(docs, query=Query(query_str="anything"))
+        self.assertEqual(len(result), 1)
+
+
+class TestConfiguration(unittest.TestCase):
+    """Loading parameters through ComponentConfiger (as the YAML loader does)."""
+
+    def _configer(self, config: dict) -> ComponentConfiger:
+        cfg = Configer()
+        cfg.value = config
+        configer = ComponentConfiger()
+        configer.load_by_configer(cfg)
+        if not hasattr(configer, "name"):
+            configer.name = config.get("name", "duplicate_remover")
+        if not hasattr(configer, "description"):
+            configer.description = config.get("description", "")
+        return configer
+
+    def test_load_valid_config(self) -> None:
+        configer = self._configer({
+            "name": "duplicate_remover",
+            "hash_key": "doc_hash",
+            "keep_first": False,
+            "normalize_whitespace": True,
+            "ignore_case": True,
+        })
+        r = DuplicateRemover()
+        r._initialize_by_component_configer(configer)
+        self.assertEqual(r.hash_key, "doc_hash")
+        self.assertFalse(r.keep_first)
+        self.assertTrue(r.normalize_whitespace)
+        self.assertTrue(r.ignore_case)
+
+    def test_keep_first_string_coerced_to_bool(self) -> None:
+        # YAML loaders sometimes hand back strings; bool() must handle it.
+        configer = self._configer({"keep_first": "false"})
+        r = DuplicateRemover()
+        r._initialize_by_component_configer(configer)
+        self.assertFalse(r.keep_first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/llm/test_groq_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_groq_llm.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the Groq Cloud LLM component.
+
+These tests exercise the parts of :class:`GroqLLM` that do not require a
+live Groq API key: credential/base-url wiring, the per-model context length
+table and the token estimator. The network-bound call/acall/stream tests
+are kept but commented out so that the full suite can run in CI without
+any external dependency.
+"""
+
+import asyncio
+import unittest
+
+from agentuniverse.llm.default.groq_llm import (
+    GROQ_DEFAULT_CONTEXT_LENGTH,
+    GROQ_MAX_CONTEXT_LENGTH,
+    GroqLLM,
+)
+
+
+class TestGroqLLM(unittest.TestCase):
+    """Test suite for the GroqLLM component."""
+
+    def setUp(self) -> None:
+        """Build a GroqLLM instance with dummy credentials."""
+        self.llm = GroqLLM(
+            model_name='llama-3.3-70b-versatile',
+            api_key='dummy-groq-key',
+            api_base='https://api.groq.com/openai/v1',
+            max_tokens=512,
+            temperature=0.7,
+        )
+
+    def test_initialization(self) -> None:
+        """LLM must accept and persist the constructor parameters."""
+        self.assertEqual(self.llm.model_name, 'llama-3.3-70b-versatile')
+        self.assertEqual(self.llm.api_key, 'dummy-groq-key')
+        self.assertEqual(self.llm.api_base, 'https://api.groq.com/openai/v1')
+        self.assertEqual(self.llm.max_tokens, 512)
+        self.assertEqual(self.llm.temperature, 0.7)
+
+    def test_default_api_base(self) -> None:
+        """When no api_base is provided the Groq endpoint must be used."""
+        llm = GroqLLM(model_name='llama-3.3-70b-versatile', api_key='dummy')
+        self.assertEqual(llm.api_base, 'https://api.groq.com/openai/v1')
+
+    def test_max_context_length_known_models(self) -> None:
+        """Known models must resolve to their documented context window."""
+        known = [
+            ('llama-3.3-70b-versatile', 131072),
+            ('llama-3.1-8b-instant', 131072),
+            ('mixtral-8x7b-32768', 32768),
+            ('gemma2-9b-it', 8192),
+        ]
+        for model_name, expected in known:
+            llm = GroqLLM(model_name=model_name, api_key='dummy')
+            self.assertEqual(
+                llm.max_context_length(),
+                expected,
+                f'Context length mismatch for {model_name}',
+            )
+
+    def test_max_context_length_unknown_model(self) -> None:
+        """Unknown models must fall back to the default context length."""
+        llm = GroqLLM(model_name='some-future-groq-model', api_key='dummy')
+        self.assertEqual(llm.max_context_length(), GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def test_max_context_length_table_consistency(self) -> None:
+        """Every entry in the table must be a positive integer."""
+        for model_name, length in GROQ_MAX_CONTEXT_LENGTH.items():
+            self.assertIsInstance(length, int, f'{model_name} length not int')
+            self.assertGreater(length, 0, f'{model_name} length not positive')
+
+    def test_get_num_tokens(self) -> None:
+        """The token estimator must return a sensible positive count."""
+        text = 'Hello Groq, please introduce yourself.'
+        num_tokens = self.llm.get_num_tokens(text)
+        self.assertIsInstance(num_tokens, int)
+        self.assertGreater(num_tokens, 0)
+        # The estimator must be deterministic for the same input.
+        self.assertEqual(num_tokens, self.llm.get_num_tokens(text))
+
+    def test_get_num_tokens_empty_string(self) -> None:
+        """An empty string must cost zero tokens."""
+        self.assertEqual(self.llm.get_num_tokens(''), 0)
+
+    # ========== Integration tests (require a real GROQ_API_KEY) ==========
+    # Uncomment and set GROQ_API_KEY in the environment to exercise the
+    # live Groq API.
+
+    # def test_call(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = self.llm.call(messages=messages, streaming=False)
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_acall(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_call_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #     chunks = []
+    #     for chunk in self.llm.call(messages=messages, streaming=True):
+    #         chunks.append(chunk.text)
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_acall_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #
+    #     async def _run():
+    #         result = []
+    #         async for chunk in await self.llm.acall(messages=messages, streaming=True):
+    #             result.append(chunk.text)
+    #         return result
+    #
+    #     chunks = asyncio.run(_run())
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_as_langchain(self) -> None:
+    #     from langchain.chains.conversation.base import ConversationChain
+    #     langchain_llm = self.llm.as_langchain()
+    #     llm_chain = ConversationChain(llm=langchain_llm)
+    #     res = llm_chain.predict(input='Say hello')
+    #     self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new `DuplicateRemover` DocProcessor (post-processor) that removes **exact-duplicate** documents from the recalled set using a SHA-256 content hash. Addresses the *exact dedup* direction of #248.

## What it does

- Removes *bit-for-bit identical* documents — the light, deterministic, **dependency-free** companion to `SemanticDeduplicator` (which removes *near*-duplicates via embeddings). Use it as a cheap first stage before fuzzy dedup, or on its own when exact dedup is all that is required.
- Each document gets a stable identity (SHA-256 of its text by default) and one representative is kept per identity.
- `keep_first: true` (default) keeps the first occurrence (preserves store/processor ranking); `keep_first: false` keeps the last occurrence and still returns them in input order.
- `hash_key` reads a precomputed hash from metadata instead of recomputing; `text_field` hashes a metadata field when `Document.text` is empty.
- Hashing defaults to "exact text equality"; optional `normalize_whitespace` / `ignore_case` collapse cosmetic differences.
- The number of discarded documents is logged; each kept document's `duplicate_stats` records its `duplicate_group_size`.

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.py` — implementation (inherits `DocProcessor`)
- `agentuniverse/agent/action/knowledge/doc_processor/duplicate_remover.yaml` — component config
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_duplicate_remover.py` — 19 unit tests (dedup, keep policies, ordering, identity sources, normalization, metadata, config loading)
- `docs/.../Knowledge/DocProcessor.md` (en + zh) — documentation appended

## Test plan

```
python -m pytest tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_duplicate_remover.py
```
All 19 tests pass.
