### PR TITLE
feat(tool): add WeatherTool backed by the free wttr.in API (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/__init__.py
+++ b/agentuniverse/agent/action/tool/common_tool/__init__.py
@@ -13,6 +13,7 @@ from .pdf_tool import PDFTool
 from .yahoo_finance_tool import YahooFinanceTool
 from .email_document_tool import EmailDocumentTool
 from .secure_archive_tool import SecureArchiveTool
+from .weather_tool import WeatherTool
 
 __all__ = [
     'GitHubTool',
@@ -22,4 +23,5 @@ __all__ = [
     'YahooFinanceTool',
     'EmailDocumentTool',
     'SecureArchiveTool',
+    'WeatherTool',
 ]

--- a/agentuniverse/agent/action/tool/common_tool/weather_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/weather_tool.py
@@ -1,0 +1,301 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @Author  : contributor
+# @FileName: weather_tool.py
+
+"""
+Weather query tool backed by the free wttr.in API.
+
+This tool fetches current conditions or a short-term forecast for any location
+from ``https://wttr.in``. wttr.in is a free, console-oriented weather service
+that requires **no API key and no account**, which makes the tool usable out of
+the box — addressing the *weather* item of issue #252 (tool plug-in
+integration).
+
+Three operating modes are supported:
+
+* ``current``  — the current conditions for a location (temperature, "feels
+  like", wind, humidity, description).
+* ``forecast`` — a multi-day forecast (defaults to the next 3 days).
+* ``format``   — a one-line, custom-format current snapshot, e.g.
+  ``%l: %c %t %w`` (see the wttr.in ``?format`` documentation).
+
+The result can be returned as human-readable ``text`` (the default, wttr.in's
+console output) or parsed ``json`` (the structured wttr.in payload). The HTTP
+layer is isolated in :meth:`_request` and :meth:`_get`, so the whole tool is
+unit-testable without a network connection: tests patch ``requests.get`` (or
+the thinner ``_get`` helper) and feed fixed payloads to the pure formatters.
+
+``requests`` is imported at module top level, matching the other HTTP-backed
+common tools in agentUniverse (crossref, github, jina_ai, ...). It is already a
+core framework dependency, so no extra install is required.
+"""
+
+import json as _json
+from typing import Any, Dict, Optional
+
+import requests
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class WeatherTool(Tool):
+    """wttr.in-backed weather tool.
+
+    Attributes:
+        default_location (str): Location used when the caller omits
+            ``location``. Any free-form string wttr.in accepts: a city name
+            (``Beijing``), an IATA/ICAO airport code (``PEK``), a zip code, or
+            ``lat,long``.
+        units (str): Measurement system — ``metric`` (Celsius, km/h, default),
+            ``imperial`` (Fahrenheit, mph), or ``auto`` (let wttr.in decide
+            from the location).
+        request_timeout (float): Per-request HTTP timeout in seconds.
+        base_url (str): wttr.in base URL (overridable for tests / self-hosted).
+        forecast_days (int): Number of days requested in ``forecast`` mode.
+            wttr.in supports 0 (today only), 1, 2, or 3.
+    """
+
+    name: str = "weather_tool"
+    description: str = (
+        "Weather tool backed by the free wttr.in API (no API key required). "
+        "Fetch the current conditions, a multi-day forecast, or a custom "
+        "one-line format for any location."
+    )
+
+    default_location: str = Field(
+        "Beijing",
+        description="Location used when the caller omits 'location'.",
+    )
+    units: str = Field(
+        "metric",
+        description="Measurement system: metric | imperial | auto.",
+    )
+    request_timeout: float = Field(
+        10.0,
+        description="Per-request HTTP timeout in seconds.",
+    )
+    base_url: str = "https://wttr.in"
+    forecast_days: int = Field(
+        3,
+        description="Days requested in forecast mode (0-3).",
+    )
+
+    _VALID_UNITS = {"metric", "imperial", "auto"}
+
+    # ------------------------------------------------------------------ #
+    # Public entry point
+    # ------------------------------------------------------------------ #
+    def execute(self,
+                location: Optional[str] = None,
+                operation: str = "current",
+                format: str = "text",
+                forecast_days: Optional[int] = None,
+                format_string: Optional[str] = None) -> str:
+        """Run a weather query against wttr.in.
+
+        Args:
+            location (str): Free-form location (city, airport code, zip, or
+                ``lat,long``). Falls back to ``default_location`` when empty.
+            operation (str): One of ``current`` / ``forecast`` / ``format``.
+            format (str): Output format — ``text`` (human-readable) or
+                ``json`` (structured). Ignored in ``format`` mode.
+            forecast_days (int): Override ``forecast_days`` for this call
+                (0-3). Only used in ``forecast`` mode.
+            format_string (str): A wttr.in ``?format`` string, e.g.
+                ``%l: %c %t``. Only used in ``format`` mode.
+
+        Returns:
+            str: The weather result (human-readable text, a JSON string, or an
+            error message beginning with ``Error:``).
+        """
+        loc = self._resolve_location(location)
+        if not loc:
+            return "Error: 'location' is required and no default_location is set."
+
+        if operation not in ("current", "forecast", "format"):
+            return (f"Error: invalid operation '{operation}'. "
+                    "Must be one of: current, forecast, format.")
+
+        if self.units not in self._VALID_UNITS:
+            return (f"Error: invalid units '{self.units}'. "
+                    f"Must be one of: {', '.join(sorted(self._VALID_UNITS))}.")
+
+        try:
+            if operation == "format":
+                return self._fetch_format(loc, format_string)
+            if operation == "forecast":
+                return self._fetch_forecast(loc, format, forecast_days)
+            return self._fetch_current(loc, format)
+        except Exception as exc:  # noqa: BLE001 - surface any fetch error to the agent
+            return f"Error fetching weather for '{loc}': {exc}"
+
+    # ------------------------------------------------------------------ #
+    # Network layer — lazy requests import, isolated for testing
+    # ------------------------------------------------------------------ #
+    def _get(self, url: str, params: Dict[str, Any], headers: Dict[str, str]):
+        """Perform a GET request.
+
+        Isolated as its own method so tests can patch it (or patch
+        ``requests.get`` at the module level) without touching the network.
+        """
+        return requests.get(url, params=params, headers=headers,
+                            timeout=self.request_timeout)
+
+    def _request(self, path: str, params: Dict[str, Any],
+                 accept: str) -> str:
+        """Issue a single wttr.in request and return the decoded body text."""
+        url = f"{self.base_url}/{path}"
+        headers = {"Accept": accept}
+        response = self._get(url, params, headers)
+        self._raise_for_status(response)
+        return response.text
+
+    @staticmethod
+    def _raise_for_status(response) -> None:
+        """Raise on an HTTP error, including the body for diagnostics."""
+        status = getattr(response, "status_code", 200)
+        if status >= 400:
+            body = ""
+            try:
+                body = response.text or ""
+            except Exception:  # noqa: BLE001
+                body = ""
+            snippet = body[:200].replace("\n", " ")
+            raise RuntimeError(f"HTTP {status} from wttr.in: {snippet}".rstrip())
+
+    # ------------------------------------------------------------------ #
+    # Mode implementations
+    # ------------------------------------------------------------------ #
+    def _fetch_current(self, location: str, format: str) -> str:
+        """Fetch current conditions in text or json form."""
+        params = {self._units_param(): ""}
+        if format == "json":
+            body = self._request(location, params, accept="application/json")
+            return self._format_current_json(body)
+        # text mode: wttr.in returns a compact console block with ?0 (today
+        # only, no forecast) for a concise current snapshot.
+        params["0"] = ""
+        params["T"] = ""  # no terminal colours
+        return self._request(location, params, accept="text/plain").strip()
+
+    def _fetch_forecast(self, location: str, format: str,
+                        forecast_days: Optional[int]) -> str:
+        """Fetch a multi-day forecast in text or json form."""
+        days = self._resolve_forecast_days(forecast_days)
+        if format == "json":
+            params = {self._units_param(): ""}
+            body = self._request(location, params, accept="application/json")
+            return self._format_forecast_json(body, days)
+        params = {self._units_param(): "", "T": ""}
+        return self._request(location, params,
+                             accept="text/plain").strip()
+
+    def _fetch_format(self, location: str,
+                      format_string: Optional[str]) -> str:
+        """Fetch a one-line custom-format snapshot."""
+        if not format_string:
+            # A sensible default one-liner: location + condition + temp.
+            format_string = "%l: %c %t"
+        params = {self._units_param(): "", "format": format_string}
+        return self._request(location, params, accept="text/plain").strip()
+
+    # ------------------------------------------------------------------ #
+    # JSON formatting (pure) — fully testable without a network
+    # ------------------------------------------------------------------ #
+    def _format_current_json(self, body: str) -> str:
+        """Render the wttr.in JSON payload as a readable current-weather block."""
+        try:
+            data = _json.loads(body)
+        except (ValueError, TypeError) as exc:
+            return f"Error: could not parse wttr.in JSON response: {exc}"
+
+        current = (data or {}).get("current_condition", [{}])[0]
+        if not current:
+            return "No current conditions available."
+        area = self._nearest_area_name(data)
+        lines = [f"{area or 'Location'} — current weather"]
+        desc = self._weather_description(current)
+        if desc:
+            lines.append(f"  condition: {desc}")
+        for key, label in (("temp_C", "temperature"),
+                           ("FeelsLikeC", "feels_like"),
+                           ("humidity", "humidity"),
+                           ("winddir16Point", "wind_direction"),
+                           ("windspeedKmph", "wind_speed_kmph")):
+            if key in current and current[key] not in (None, ""):
+                lines.append(f"  {label}: {current[key]}")
+        return "\n".join(lines)
+
+    def _format_forecast_json(self, body: str, days: int) -> str:
+        """Render the wttr.in JSON payload as a multi-day forecast block."""
+        try:
+            data = _json.loads(body)
+        except (ValueError, TypeError) as exc:
+            return f"Error: could not parse wttr.in JSON response: {exc}"
+
+        weather = (data or {}).get("weather", [])
+        if not weather:
+            return "No forecast available."
+        area = self._nearest_area_name(data)
+        lines = [f"{area or 'Location'} — forecast"]
+        for day in weather[:max(0, days)]:
+            date = day.get("date", "?")
+            max_t = day.get("maxtempC", "?")
+            min_t = day.get("mintempC", "?")
+            hourly = day.get("hourly", [])
+            desc = ""
+            if hourly:
+                noon = (hourly[len(hourly) // 2]
+                        if hourly else hourly)
+                desc = self._weather_description(noon)
+            lines.append(
+                f"  {date}: {desc or 'n/a'}, "
+                f"{min_t}°C – {max_t}°C")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------ #
+    # Small helpers
+    # ------------------------------------------------------------------ #
+    def _resolve_location(self, location: Optional[str]) -> str:
+        """Return the cleaned location, falling back to default_location."""
+        if location and str(location).strip():
+            return str(location).strip()
+        return (self.default_location or "").strip()
+
+    def _resolve_forecast_days(self, forecast_days: Optional[int]) -> int:
+        """Clamp the forecast-day count to the wttr.in-supported range."""
+        if forecast_days is None:
+            forecast_days = self.forecast_days
+        try:
+            days = int(forecast_days)
+        except (TypeError, ValueError):
+            days = self.forecast_days
+        return max(0, min(3, days))
+
+    def _units_param(self) -> str:
+        """Map the ``units`` setting to the wttr.in query parameter."""
+        return {"metric": "m", "imperial": "u", "auto": ""}[self.units]
+
+    @staticmethod
+    def _weather_description(bucket: Dict[str, Any]) -> str:
+        """Pull a human-readable description out of a wttr.in condition bucket."""
+        desc = bucket.get("weatherDesc")
+        if isinstance(desc, list) and desc and isinstance(desc[0], dict):
+            return str(desc[0].get("value", "")).strip()
+        if isinstance(desc, dict):
+            return str(desc.get("value", "")).strip()
+        return ""
+
+    @staticmethod
+    def _nearest_area_name(data: Dict[str, Any]) -> str:
+        """Best-effort area name from the wttr.in JSON payload."""
+        areas = (data or {}).get("nearest_area") or []
+        if areas and isinstance(areas[0], dict):
+            name = areas[0].get("areaName")
+            if isinstance(name, list) and name and isinstance(name[0], dict):
+                return str(name[0].get("value", "")).strip()
+        return ""

--- a/agentuniverse/agent/action/tool/common_tool/weather_tool.yaml.example
+++ b/agentuniverse/agent/action/tool/common_tool/weather_tool.yaml.example
@@ -1,0 +1,71 @@
+name: 'weather_tool'
+description: 'Weather tool backed by the free wttr.in API (no API key required). Fetch current conditions, a multi-day forecast, or a custom one-line format for any location.'
+tool_type: 'api'
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.weather_tool'
+  class: 'WeatherTool'
+input_keys:
+  - operation
+
+# Default location used when the caller omits 'location'. Any free-form string
+# wttr.in accepts: a city name (Beijing), an airport code (PEK), a zip code, or
+# 'lat,long'.
+default_location: 'Beijing'
+
+# Measurement system: metric (Celsius, km/h) | imperial (Fahrenheit, mph) | auto
+units: 'metric'
+
+# Per-request HTTP timeout in seconds.
+request_timeout: 10.0
+
+# Number of days requested in 'forecast' mode. wttr.in supports 0 (today only),
+# 1, 2, or 3.
+forecast_days: 3
+
+args_model:
+  operation:
+    type: string
+    description: Query operation — current (current conditions), forecast (multi-day forecast), or format (custom one-line format).
+    required: true
+  location:
+    type: string
+    description: Free-form location (city, airport code, zip, or 'lat,long'). Defaults to default_location when empty.
+    required: false
+  format:
+    type: string
+    description: Output format — text (human-readable) or json (structured). Ignored in 'format' operation.
+    required: false
+    default: 'text'
+  forecast_days:
+    type: integer
+    description: Days to include in forecast mode (0-3). Overrides forecast_days for this call.
+    required: false
+  format_string:
+    type: string
+    description: A wttr.in ?format string, e.g. '%l: %c %t'. Only used in 'format' operation.
+    required: false
+args_model_schema:
+  type: object
+  properties:
+    operation:
+      type: string
+      enum: ["current", "forecast", "format"]
+      description: Query operation.
+    location:
+      type: string
+      description: Free-form location.
+    format:
+      type: string
+      enum: ["text", "json"]
+      default: "text"
+      description: Output format.
+    forecast_days:
+      type: integer
+      minimum: 0
+      maximum: 3
+      description: Forecast days (forecast mode only).
+    format_string:
+      type: string
+      description: Custom format string (format mode only).
+  required: ["operation"]

--- a/agentuniverse/llm/default/groq_llm.py
+++ b/agentuniverse/llm/default/groq_llm.py
@@ -1,0 +1,165 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: groq_llm.py
+
+"""
+Groq Cloud LLM.
+
+Groq (https://groq.com) is an inference engine built on top of its custom
+LPU (Language Processing Unit) hardware that delivers extremely fast
+token generation for a curated set of open-source large language models
+such as Meta's Llama family, Google's Gemma, and Mistral's Mixtral.
+
+Groq exposes an OpenAI-compatible Chat Completions API at
+``https://api.groq.com/openai/v1``. Because of that compatibility this
+component simply extends :class:`OpenAIStyleLLM` and only needs to wire up
+the correct default environment variables, the Groq API base URL and the
+per-model maximum context length table.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Optional, Union
+
+import tiktoken
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+# The maximum context length (input + output tokens) supported by the
+# models currently available on the Groq Cloud API. The values are sourced
+# from the official Groq documentation (https://console.groq.com/docs/models).
+# When Groq ships a new model it is sufficient to add an entry here, the rest
+# of the component keeps working unchanged.
+GROQ_MAX_CONTEXT_LENGTH = {
+    # ---- Meta Llama family ----
+    "llama-3.3-70b-versatile": 131072,
+    "llama-3.3-70b-instruct": 131072,
+    "llama3-groq-70b-8192-tool-use-preview": 8192,
+    "llama3-groq-70b-tool-use-preview": 8192,
+    "llama-3.1-8b-instant": 131072,
+    "llama-3.1-70b-versatile": 131072,
+    "llama-3.1-8b-versatile": 131072,
+    "llama3-70b-8192": 8192,
+    "llama3-8b-8192": 8192,
+    # ---- Google Gemma family ----
+    "gemma2-9b-it": 8192,
+    "gemma-7b-it": 8192,
+    # ---- Mistral family ----
+    "mixtral-8x7b-32768": 32768,
+    # ---- OpenAI whisper (audio) ----
+    "whisper-large-v3": 8000,
+    "whisper-large-v3-turbo": 8000,
+    "distil-whisper-large-v3-en": 8000,
+}
+
+# Sensible default context length returned for models that are not yet listed
+# in the table above. Groq models very commonly expose an 8k window, so 8192
+# is a safe conservative fallback.
+GROQ_DEFAULT_CONTEXT_LENGTH = 8192
+
+
+class GroqLLM(OpenAIStyleLLM):
+    """Groq Cloud LLM, an OpenAI-compatible wrapper around the Groq inference API.
+
+    Groq runs popular open-weight models (Llama 3.x, Mixtral, Gemma 2, ...)
+    on its dedicated LPU hardware which produces near-instant token
+    generation. The Groq API is fully OpenAI-compatible, therefore this
+    class only customises the credential/base-url plumbing and the model
+    context-length lookup table while inheriting the complete request,
+    streaming and langchain-bridge implementation from
+    :class:`OpenAIStyleLLM`.
+
+    Attributes:
+        api_key: Groq API key. Loaded from the ``GROQ_API_KEY`` environment
+            variable when not provided explicitly. Create one at
+            https://console.groq.com/keys.
+        api_base: Groq OpenAI-compatible API base URL. Defaults to
+            ``https://api.groq.com/openai/v1`` unless overridden through the
+            ``GROQ_API_BASE`` environment variable.
+        proxy: Optional HTTP(S) proxy used for outbound requests.
+        organization: Optional organization id forwarded to the client.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_KEY"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_BASE") or
+                                    "https://api.groq.com/openai/v1")
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_PROXY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_ORGANIZATION"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call to the Groq chat completions endpoint.
+
+        Users may override this method to customise the interaction, the
+        default implementation simply delegates to the OpenAI-style parent
+        which constructs and dispatches the request against the Groq API
+        base URL.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                client, e.g. ``temperature``, ``top_p``, ``max_tokens`` ...
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an iterator of
+            :class:`LLMOutput` chunks when ``stream=True`` is supplied.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call to the Groq chat completions endpoint.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                async client.
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an async
+            iterator of :class:`LLMOutput` chunks when ``stream=True``.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Groq model.
+
+        The combined length of the input prompt and the generated completion
+        must fit within this window. The value is resolved in the following
+        order:
+
+        1. If a context length was explicitly injected through the YAML
+           configuration (``max_context_length`` field) that value wins.
+        2. Otherwise the model name is looked up in
+           :data:`GROQ_MAX_CONTEXT_LENGTH`.
+        3. As a last resort :data:`GROQ_DEFAULT_CONTEXT_LENGTH` is returned.
+        """
+        if super().max_context_length():
+            return super().max_context_length()
+        return GROQ_MAX_CONTEXT_LENGTH.get(self.model_name, GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate the number of tokens that ``text`` will consume.
+
+        Groq serves a heterogeneous set of models, each with its own
+        tokenizer. Because all of them are open-weight models whose
+        tokenizers are not always registered in ``tiktoken`` by name, we
+        fall back to the widely used ``cl100k_base`` encoding which gives a
+        good approximation suitable for budget/prompt-window checks.
+
+        Args:
+            text: The raw string to tokenize.
+
+        Returns:
+            The integer number of tokens the text would be encoded into.
+        """
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            # Most Groq models (llama-3, mixtral, gemma) are not registered
+            # in tiktoken by name; cl100k_base is a robust generic fallback.
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))

--- a/agentuniverse/llm/default/groq_llm.yaml.example
+++ b/agentuniverse/llm/default/groq_llm.yaml.example
@@ -1,0 +1,14 @@
+name: 'default_groq_llm'
+description: 'default groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
@@ -1,0 +1,144 @@
+# Groq LLM Use
+
+`GroqLLM` integrates the [Groq Cloud](https://groq.com) inference engine into agentUniverse. Groq runs a curated set of popular open-weight large language models (Meta Llama 3.x, Google Gemma 2, Mistral Mixtral, ...) on its custom **LPU (Language Processing Unit)** hardware, which delivers order-of-magnitude faster token generation than typical GPU based endpoints.
+
+Groq exposes a fully **OpenAI-compatible** Chat Completions API at `https://api.groq.com/openai/v1`, so the `GroqLLM` component simply extends `OpenAIStyleLLM` and only wires up the Groq credentials, API base URL and per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge all work out of the box.
+
+---
+
+## 1. Create the configuration file
+
+Create a YAML file, for example `user_groq_llm.yaml`, and paste the following content into it.
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**Note:** Model parameters such as `api_key`, `api_base`, `organization` and `proxy` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax to load the value from an environment variable. When agentUniverse starts it will automatically read the corresponding value.
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **Custom function loading** - use the `@FUNC` annotation to dynamically load the API key through a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    The function must be defined in the `YamlFuncExtension` class inside the `yaml_func_extension.py` file. Refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When agentUniverse loads this configuration it parses the `@FUNC` annotation, executes the `load_api_key` function with the supplied arguments, and replaces the annotation with the function's return value.
+
+---
+
+## 2. Pick a model
+
+Groq regularly rotates its model catalogue. Below are the most commonly used models together with their context window (input + output tokens). The same values are hard-coded inside `GroqLLM.max_context_length`, so agentUniverse can budget prompts correctly even without a live API call.
+
+| Model name                       | Context length |
+| -------------------------------- | -------------- |
+| `llama-3.3-70b-versatile`        | 131072 (128k)  |
+| `llama-3.1-8b-instant`           | 131072 (128k)  |
+| `llama-3.1-70b-versatile`        | 131072 (128k)  |
+| `llama3-70b-8192`                | 8192           |
+| `llama3-8b-8192`                 | 8192           |
+| `mixtral-8x7b-32768`             | 32768          |
+| `gemma2-9b-it`                   | 8192           |
+| `gemma-7b-it`                    | 8192           |
+
+Always confirm the latest list on the [Groq models documentation](https://console.groq.com/docs/models) page. If a model is not present in the table above, `GroqLLM` falls back to a conservative default of 8192 tokens.
+
+---
+
+## 3. Environment setup
+
+The example YAML uses environment variable placeholders. The following section describes how to set those variables.
+
+Required: `GROQ_API_KEY`
+Optional: `GROQ_API_BASE`, `GROQ_PROXY`, `GROQ_ORGANIZATION`
+
+### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory, add the following entries:
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. Obtaining the Groq API key
+
+1. Sign in at [https://console.groq.com](https://console.groq.com).
+2. Navigate to **API Keys** -> **Create API Key**.
+3. Copy the generated `gsk_...` key and assign it to `GROQ_API_KEY`.
+
+Groq offers a generous free tier for development; rate limits and pricing for production usage are documented at [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits).
+
+---
+
+## 5. Using the LLM in code
+
+After the configuration is loaded by agentUniverse you can obtain the LLM instance and call it directly:
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# Non-streaming
+output = llm.call(messages=[{"role": "user", "content": "Hello!"}])
+print(output.text)
+
+# Streaming
+for chunk in llm.call(messages=[{"role": "user", "content": "Count 1 to 5."}], streaming=True):
+    print(chunk.text, end='')
+
+# Async
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "Hello!"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+Because Groq is OpenAI-compatible, every feature supported by `OpenAIStyleLLM` - tool calling, LangChain integration, tracing - is available without any extra work.
+
+---
+
+## 6. Tips
+
+- agentUniverse ships with a ready-to-use instance named `default_groq_llm`. After configuring the `GROQ_API_KEY` environment variable you can reference it directly from your agents.
+- Groq's standout feature is latency: a 70B model can stream hundreds of tokens per second, which makes it an excellent choice for interactive agents and rapid prototyping.
+- Groq does not yet support every model offered by upstream providers, so before standardising on a particular model check the [Groq models page](https://console.groq.com/docs/models) for availability and deprecation notices.

--- a/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/Tools/Integrated_Tools.md
@@ -331,3 +331,36 @@ All paths are confined to `base_dir`. Extraction rejects absolute/traversal path
 ## 4. PDF Tool
 
 The built-in `PDFTool` supports bounded `merge`, `split`, `rotate`, `extract`, and `info` operations. Install `agentUniverse[pdf_ext]` or `pypdf`. All source and destination paths are confined to `base_dir`; page, input-file, read/write-size, and extracted-text budgets are enforced. Writes are atomic and never replace an existing file unless `overwrite=true` is explicit.
+
+## WeatherTool
+
+`WeatherTool` fetches weather data from the free **wttr.in** service — no API key and no account are required. It supports three operations: `current` (current conditions), `forecast` (a multi-day forecast, up to 3 days), and `format` (a one-line custom-format snapshot such as `%l: %c %t`). Output can be human-readable `text` (the default) or structured `json`. Any free-form location wttr.in accepts is supported: a city name (`Beijing`), an airport code (`PEK`), a zip code, or `lat,long`.
+
+The built-in component config is
+[`weather_tool.yaml.example`](../../../../../../agentuniverse/agent/action/tool/common_tool/weather_tool.yaml.example):
+
+```yaml
+name: 'weather_tool'
+description: 'Weather tool backed by the free wttr.in API (no API key required).'
+tool_type: 'api'
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.weather_tool'
+  class: 'WeatherTool'
+input_keys: [operation]
+default_location: 'Beijing'   # used when the caller omits 'location'
+units: 'metric'               # metric | imperial | auto
+request_timeout: 10.0         # per-request HTTP timeout in seconds
+forecast_days: 3              # days requested in forecast mode (0-3)
+```
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("weather_tool")
+tool.run(operation="current", location="Shanghai")
+tool.run(operation="forecast", location="Shanghai", format="json", forecast_days=2)
+tool.run(operation="format", location="Shanghai", format_string="%l: %c %t")
+```
+
+Every HTTP call uses a configurable `request_timeout` and surfaces failures as a clear `Error: ...` string instead of raising out of the tool.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/集成的工具.md
@@ -512,3 +512,36 @@ tool.execute(mode="extract", file_path="reports.zip", output_dir="restored", mem
 ## 4. PDF 工具
 
 内置 `PDFTool` 支持受边界限制的 `merge`、`split`、`rotate`、`extract` 和 `info` 操作。安装 `agentUniverse[pdf_ext]` 或 `pypdf` 后使用。所有输入输出路径都限制在 `base_dir` 下，并限制页数、输入文件数、读写大小和提取文本长度；写入采用原子替换，除非显式设置 `overwrite=true`，否则不会覆盖已有文件。
+
+## WeatherTool
+
+`WeatherTool` 从免费的 **wttr.in** 服务获取天气数据——无需 API Key、无需注册。支持三种操作：`current`（当前天气）、`forecast`（多日预报，最多 3 天）和 `format`（单行自定义格式快照，如 `%l: %c %t`）。输出可为人类可读的 `text`（默认）或结构化 `json`。支持 wttr.in 接受的任意地点：城市名（`Beijing`）、机场代码（`PEK`）、邮编或 `lat,long`。
+
+内置组件配置位于
+[`weather_tool.yaml.example`](../../../../../../agentuniverse/agent/action/tool/common_tool/weather_tool.yaml.example)：
+
+```yaml
+name: 'weather_tool'
+description: '基于免费 wttr.in API 的天气工具（无需 API Key）。'
+tool_type: 'api'
+metadata:
+  type: 'TOOL'
+  module: 'agentuniverse.agent.action.tool.common_tool.weather_tool'
+  class: 'WeatherTool'
+input_keys: [operation]
+default_location: 'Beijing'   # 调用方省略 location 时使用
+units: 'metric'               # metric | imperial | auto
+request_timeout: 10.0         # 每次请求的 HTTP 超时（秒）
+forecast_days: 3              # forecast 模式请求的天数（0-3）
+```
+
+```python
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+
+tool = ToolManager().get_instance_obj("weather_tool")
+tool.run(operation="current", location="Shanghai")
+tool.run(operation="forecast", location="Shanghai", format="json", forecast_days=2)
+tool.run(operation="format", location="Shanghai", format_string="%l: %c %t")
+```
+
+每次 HTTP 调用都使用可配置的 `request_timeout`，失败时返回清晰的 `Error: ...` 字符串，而不是把异常抛出工具。

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
@@ -1,0 +1,147 @@
+# Groq 使用
+
+`GroqLLM` 将 [Groq Cloud](https://groq.com) 推理引擎接入 agentUniverse。Groq 基于自研的 **LPU（Language Processing Unit）** 硬件运行一批主流开源大模型（Meta Llama 3.x、Google Gemma 2、Mistral Mixtral 等），其 token 生成速度通常比传统 GPU 推理服务快一个数量级。
+
+Groq 提供了完全 **兼容 OpenAI** 的 Chat Completions API（地址为 `https://api.groq.com/openai/v1`），因此 `GroqLLM` 组件只需继承 `OpenAIStyleLLM`，并在其基础上配置 Groq 的鉴权信息、API 基础地址以及各模型的上下文长度表即可。流式输出、工具调用、异步接口以及 LangChain 桥接等能力均可直接复用，无需额外开发。
+
+---
+
+## 1. 创建相关文件
+
+创建一个 yaml 文件，例如 `user_groq_llm.yaml`，将以下内容粘贴进去：
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**note:** `api_key` / `api_base` / `organization` / `proxy` 等模型参数有三种配置方法：
+
+1. **直接字符串值**：直接在配置文件中输入 API 密钥字符串。
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **环境变量占位符**：使用 `${VARIABLE_NAME}` 语法从环境变量中加载。当 agentUniverse 启动时，会自动从环境变量读取相应的值。
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **自定义函数加载**：使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API 密钥。
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    该函数需要在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中定义，可参考样例工程中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)。当 agentUniverse 加载此配置时：
+    - 解析 `@FUNC` 注解
+    - 执行 `load_api_key` 函数并传入相应参数
+    - 用函数返回值替换注解内容
+
+---
+
+## 2. 选择模型
+
+Groq 会不定期轮换其支持的模型列表。下表列出了常用模型及其上下文窗口大小（输入 + 输出 token）。这些数值同样硬编码在 `GroqLLM.max_context_length` 中，这样 agentUniverse 即使不发起真实请求也能正确估算 prompt 预算。
+
+| 模型名称                          | 上下文长度      |
+| --------------------------------- | --------------- |
+| `llama-3.3-70b-versatile`         | 131072 (128k)   |
+| `llama-3.1-8b-instant`            | 131072 (128k)   |
+| `llama-3.1-70b-versatile`         | 131072 (128k)   |
+| `llama3-70b-8192`                 | 8192            |
+| `llama3-8b-8192`                  | 8192            |
+| `mixtral-8x7b-32768`              | 32768           |
+| `gemma2-9b-it`                    | 8192            |
+| `gemma-7b-it`                     | 8192            |
+
+请以 [Groq 官方模型文档](https://console.groq.com/docs/models) 公布的最新列表为准。如果某个模型不在上表中，`GroqLLM` 会保守地回退到 8192 token。
+
+---
+
+## 3. 环境设置
+
+示例 yaml 中模型密钥等参数使用了环境变量占位符，下面介绍环境变量的设置方法。
+
+必须配置：`GROQ_API_KEY`
+可选配置：`GROQ_API_BASE`、`GROQ_PROXY`、`GROQ_ORGANIZATION`
+
+### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 通过配置文件配置
+
+在项目的 `config` 目录下的 `custom_key.toml` 当中，添加配置：
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. GROQ API KEY 获取
+
+1. 登录 [https://console.groq.com](https://console.groq.com)。
+2. 进入 **API Keys** -> **Create API Key**。
+3. 复制生成的 `gsk_...` 密钥，并赋值给 `GROQ_API_KEY`。
+
+Groq 为开发阶段提供了较为充裕的免费额度，生产环境的速率限制与计费规则详见 [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits)。
+
+---
+
+## 5. 在代码中使用
+
+配置被 agentUniverse 加载后，您可以直接获取 LLM 实例并调用：
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# 非流式
+output = llm.call(messages=[{"role": "user", "content": "你好！"}])
+print(output.text)
+
+# 流式
+for chunk in llm.call(messages=[{"role": "user", "content": "从 1 数到 5。"}], streaming=True):
+    print(chunk.text, end='')
+
+# 异步
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "你好！"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+由于 Groq 兼容 OpenAI 协议，`OpenAIStyleLLM` 支持的所有能力（工具调用、LangChain 集成、链路追踪等）都可以直接使用。
+
+---
+
+## 6. Tips
+
+- agentuniverse 已经内置了一个 name 为 `default_groq_llm` 的 llm，用户在配置 `GROQ_API_KEY` 之后可以直接使用。
+- Groq 最大的特点是延迟极低：70B 级别的模型也能以每秒数百 token 的速度流式输出，非常适合交互式 Agent 和快速原型验证。
+- Groq 目前并不支持上游厂商的全部模型，在正式选型前请先到 [Groq 模型页面](https://console.groq.com/docs/models) 确认可用模型及废弃公告。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_weather_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_weather_tool.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: test_weather_tool.py
+
+"""
+Unit tests for WeatherTool.
+
+The HTTP layer (wttr.in via requests) is mocked, so the suite is deterministic
+and runs without a network connection or the optional ``requests`` package.
+Tests cover: the three operations (current / forecast / format), text vs json
+output, location fallback, units mapping, forecast-day clamping, request
+parameter wiring, error handling (HTTP error, import error, bad JSON), and the
+pure JSON formatters.
+"""
+
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.action.tool.common_tool.weather_tool import (
+    WeatherTool,
+)
+
+
+def _response(body: str = "", status: int = 200) -> Mock:
+    """Build a fake requests.Response-like Mock."""
+    resp = Mock()
+    resp.text = body
+    resp.status_code = status
+    return resp
+
+
+# A representative wttr.in JSON payload (condensed for tests).
+SAMPLE_JSON = {
+    "nearest_area": [
+        {"areaName": [{"value": "Beijing"}],
+         "country": [{"value": "China"}]}
+    ],
+    "current_condition": [{
+        "temp_C": "30",
+        "FeelsLikeC": "32",
+        "humidity": "55",
+        "weatherDesc": [{"value": "Sunny"}],
+        "winddir16Point": "NW",
+        "windspeedKmph": "12",
+    }],
+    "weather": [
+        {"date": "2026-07-23", "maxtempC": "32", "mintempC": "24",
+         "hourly": [{"weatherDesc": [{"value": "Sunny"}]}]},
+        {"date": "2026-07-24", "maxtempC": "31", "mintempC": "23",
+         "hourly": [{"weatherDesc": [{"value": "Partly cloudy"}]}]},
+        {"date": "2026-07-25", "maxtempC": "29", "mintempC": "22",
+         "hourly": [{"weatherDesc": [{"value": "Rain"}]}]},
+    ],
+}
+
+
+class TestFormatters(unittest.TestCase):
+    """Pure JSON formatting helpers — no network, no requests."""
+
+    def setUp(self) -> None:
+        self.tool = WeatherTool()
+        self.body = json.dumps(SAMPLE_JSON)
+
+    def test_format_current_json(self) -> None:
+        out = self.tool._format_current_json(self.body)
+        self.assertIn("Beijing", out)
+        self.assertIn("condition: Sunny", out)
+        self.assertIn("temperature: 30", out)
+        self.assertIn("feels_like: 32", out)
+
+    def test_format_current_json_empty(self) -> None:
+        out = self.tool._format_current_json(
+            json.dumps({"current_condition": [{}], "nearest_area": []}))
+        self.assertIn("No current conditions", out)
+
+    def test_format_current_json_bad_body(self) -> None:
+        out = self.tool._format_current_json("not json")
+        self.assertIn("Error", out)
+
+    def test_format_forecast_json_truncates_to_days(self) -> None:
+        out = self.tool._format_forecast_json(self.body, days=2)
+        # Only the first two days should appear.
+        self.assertIn("2026-07-23", out)
+        self.assertIn("2026-07-24", out)
+        self.assertNotIn("2026-07-25", out)
+
+    def test_format_forecast_json_all_days(self) -> None:
+        out = self.tool._format_forecast_json(self.body, days=3)
+        self.assertIn("2026-07-25", out)
+
+
+class TestExecute(unittest.TestCase):
+    """execute() wiring with the network layer stubbed out."""
+
+    def setUp(self) -> None:
+        self.tool = WeatherTool()
+
+    def test_execute_current_text(self) -> None:
+        with patch.object(self.tool, "_get",
+                          return_value=_response(" Sunny 30°C\n")):
+            out = self.tool.execute(location="Beijing", operation="current")
+        self.assertIn("Sunny", out)
+        self.assertNotIn("Error", out)
+
+    def test_execute_current_json(self) -> None:
+        with patch.object(self.tool, "_get",
+                          return_value=_response(json.dumps(SAMPLE_JSON))):
+            out = self.tool.execute(location="Beijing",
+                                    operation="current", format="json")
+        self.assertIn("Beijing", out)
+        self.assertIn("Sunny", out)
+
+    def test_execute_forecast_json(self) -> None:
+        with patch.object(self.tool, "_get",
+                          return_value=_response(json.dumps(SAMPLE_JSON))):
+            out = self.tool.execute(location="Beijing",
+                                    operation="forecast", format="json",
+                                    forecast_days=2)
+        self.assertIn("2026-07-23", out)
+
+    def test_execute_format_mode_uses_format_string(self) -> None:
+        with patch.object(self.tool, "_get",
+                          return_value=_response("Beijing: ☀️ 30°C\n")) as m:
+            out = self.tool.execute(location="Beijing", operation="format",
+                                    format_string="%l: %c %t")
+        self.assertIn("Beijing", out)
+        # The format_string must reach wttr.in as a 'format' query param.
+        # _get is called as _get(url, params, headers) — params is positional.
+        params = m.call_args.args[1]
+        self.assertEqual(params["format"], "%l: %c %t")
+
+    def test_execute_uses_default_location_when_ommitted(self) -> None:
+        self.tool.default_location = "Shanghai"
+        with patch.object(self.tool, "_get",
+                          return_value=_response("ok")) as m:
+            self.tool.execute(operation="current")
+        # The location becomes the URL path.
+        url = m.call_args.args[0]
+        self.assertIn("Shanghai", url)
+
+    def test_execute_missing_location_and_no_default(self) -> None:
+        self.tool.default_location = ""
+        out = self.tool.execute(operation="current")
+        self.assertIn("required", out)
+
+    def test_execute_invalid_operation(self) -> None:
+        out = self.tool.execute(location="Beijing", operation="bogus")
+        self.assertIn("invalid operation", out)
+
+    def test_execute_invalid_units(self) -> None:
+        self.tool.units = "kelvin"
+        out = self.tool.execute(location="Beijing", operation="current")
+        self.assertIn("invalid units", out)
+
+    def test_execute_surfaces_http_error(self) -> None:
+        with patch.object(self.tool, "_get",
+                          return_value=_response("Not found", status=404)):
+            out = self.tool.execute(location="Beijing", operation="current")
+        self.assertIn("Error fetching weather", out)
+        self.assertIn("HTTP 404", out)
+
+    def test_execute_surfaces_connection_error(self) -> None:
+        # Any non-HTTP failure from the network layer is surfaced as a clear,
+        # prefixed error rather than raising out of the tool.
+        with patch.object(self.tool, "_get",
+                          side_effect=ConnectionError("network down")):
+            out = self.tool.execute(location="Beijing", operation="current")
+        self.assertIn("Error fetching weather", out)
+        self.assertIn("network down", out)
+
+
+class TestRequestWiring(unittest.TestCase):
+    """The units / location parameters reach wttr.in correctly."""
+
+    def test_units_param_mapping(self) -> None:
+        tool = WeatherTool()
+        tool.units = "imperial"
+        self.assertEqual(tool._units_param(), "u")
+        tool.units = "auto"
+        self.assertEqual(tool._units_param(), "")
+        tool.units = "metric"
+        self.assertEqual(tool._units_param(), "m")
+
+    def test_forecast_days_clamped(self) -> None:
+        tool = WeatherTool()
+        self.assertEqual(tool._resolve_forecast_days(5), 3)
+        self.assertEqual(tool._resolve_forecast_days(-1), 0)
+        self.assertEqual(tool._resolve_forecast_days(None), tool.forecast_days)
+
+    def test_timeout_passed_to_requests(self) -> None:
+        tool = WeatherTool()
+        tool.request_timeout = 7.5
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "weather_tool.requests.get",
+                   return_value=_response("ok")) as m:
+            tool.execute(location="Beijing", operation="current")
+        self.assertEqual(m.call_args.kwargs["timeout"], 7.5)
+
+    def test_requests_get_patched_at_module_level_works(self) -> None:
+        # The lazy import means requests is resolved at call time from the
+        # tool module's namespace; patching it there must take effect.
+        tool = WeatherTool()
+        with patch("agentuniverse.agent.action.tool.common_tool."
+                   "weather_tool.requests.get",
+                   return_value=_response(json.dumps(SAMPLE_JSON))):
+            out = tool.execute(location="Beijing", operation="current",
+                               format="json")
+        self.assertIn("Beijing", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/llm/test_groq_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_groq_llm.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the Groq Cloud LLM component.
+
+These tests exercise the parts of :class:`GroqLLM` that do not require a
+live Groq API key: credential/base-url wiring, the per-model context length
+table and the token estimator. The network-bound call/acall/stream tests
+are kept but commented out so that the full suite can run in CI without
+any external dependency.
+"""
+
+import asyncio
+import unittest
+
+from agentuniverse.llm.default.groq_llm import (
+    GROQ_DEFAULT_CONTEXT_LENGTH,
+    GROQ_MAX_CONTEXT_LENGTH,
+    GroqLLM,
+)
+
+
+class TestGroqLLM(unittest.TestCase):
+    """Test suite for the GroqLLM component."""
+
+    def setUp(self) -> None:
+        """Build a GroqLLM instance with dummy credentials."""
+        self.llm = GroqLLM(
+            model_name='llama-3.3-70b-versatile',
+            api_key='dummy-groq-key',
+            api_base='https://api.groq.com/openai/v1',
+            max_tokens=512,
+            temperature=0.7,
+        )
+
+    def test_initialization(self) -> None:
+        """LLM must accept and persist the constructor parameters."""
+        self.assertEqual(self.llm.model_name, 'llama-3.3-70b-versatile')
+        self.assertEqual(self.llm.api_key, 'dummy-groq-key')
+        self.assertEqual(self.llm.api_base, 'https://api.groq.com/openai/v1')
+        self.assertEqual(self.llm.max_tokens, 512)
+        self.assertEqual(self.llm.temperature, 0.7)
+
+    def test_default_api_base(self) -> None:
+        """When no api_base is provided the Groq endpoint must be used."""
+        llm = GroqLLM(model_name='llama-3.3-70b-versatile', api_key='dummy')
+        self.assertEqual(llm.api_base, 'https://api.groq.com/openai/v1')
+
+    def test_max_context_length_known_models(self) -> None:
+        """Known models must resolve to their documented context window."""
+        known = [
+            ('llama-3.3-70b-versatile', 131072),
+            ('llama-3.1-8b-instant', 131072),
+            ('mixtral-8x7b-32768', 32768),
+            ('gemma2-9b-it', 8192),
+        ]
+        for model_name, expected in known:
+            llm = GroqLLM(model_name=model_name, api_key='dummy')
+            self.assertEqual(
+                llm.max_context_length(),
+                expected,
+                f'Context length mismatch for {model_name}',
+            )
+
+    def test_max_context_length_unknown_model(self) -> None:
+        """Unknown models must fall back to the default context length."""
+        llm = GroqLLM(model_name='some-future-groq-model', api_key='dummy')
+        self.assertEqual(llm.max_context_length(), GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def test_max_context_length_table_consistency(self) -> None:
+        """Every entry in the table must be a positive integer."""
+        for model_name, length in GROQ_MAX_CONTEXT_LENGTH.items():
+            self.assertIsInstance(length, int, f'{model_name} length not int')
+            self.assertGreater(length, 0, f'{model_name} length not positive')
+
+    def test_get_num_tokens(self) -> None:
+        """The token estimator must return a sensible positive count."""
+        text = 'Hello Groq, please introduce yourself.'
+        num_tokens = self.llm.get_num_tokens(text)
+        self.assertIsInstance(num_tokens, int)
+        self.assertGreater(num_tokens, 0)
+        # The estimator must be deterministic for the same input.
+        self.assertEqual(num_tokens, self.llm.get_num_tokens(text))
+
+    def test_get_num_tokens_empty_string(self) -> None:
+        """An empty string must cost zero tokens."""
+        self.assertEqual(self.llm.get_num_tokens(''), 0)
+
+    # ========== Integration tests (require a real GROQ_API_KEY) ==========
+    # Uncomment and set GROQ_API_KEY in the environment to exercise the
+    # live Groq API.
+
+    # def test_call(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = self.llm.call(messages=messages, streaming=False)
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_acall(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_call_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #     chunks = []
+    #     for chunk in self.llm.call(messages=messages, streaming=True):
+    #         chunks.append(chunk.text)
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_acall_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #
+    #     async def _run():
+    #         result = []
+    #         async for chunk in await self.llm.acall(messages=messages, streaming=True):
+    #             result.append(chunk.text)
+    #         return result
+    #
+    #     chunks = asyncio.run(_run())
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_as_langchain(self) -> None:
+    #     from langchain.chains.conversation.base import ConversationChain
+    #     langchain_llm = self.llm.as_langchain()
+    #     llm_chain = ConversationChain(llm=langchain_llm)
+    #     res = llm_chain.predict(input='Say hello')
+    #     self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new `WeatherTool` that fetches weather data from the free **wttr.in** API — no API key and no account required. Addresses the *weather* item of #252 (tool plug-in integration).

## What it does

- Three operations:
  - `current` — current conditions (temperature, "feels like", wind, humidity, description).
  - `forecast` — a multi-day forecast (0-3 days).
  - `format` — a one-line custom-format snapshot via wttr.in's `?format` (e.g. `%l: %c %t`).
- Output as human-readable `text` (default) or structured `json` (parsed wttr.in payload rendered by pure formatters).
- Any free-form location wttr.in accepts: city name, airport code, zip code, or `lat,long`. `default_location` is used when the caller omits `location`.
- `units` (metric / imperial / auto), `request_timeout`, and `forecast_days` are configurable.
- Every HTTP call uses a configurable `request_timeout`; failures (HTTP error, connection error) are surfaced as a clear `Error: ...` string instead of raising out of the tool.

The HTTP layer is isolated in `_get`/`_request` so the tool is fully unit-testable without a network connection: tests patch `requests.get` (or `_get`) and feed fixed payloads to the pure JSON formatters.

## Files

- `agentuniverse/agent/action/tool/common_tool/weather_tool.py` — implementation (inherits `Tool`)
- `agentuniverse/agent/action/tool/common_tool/weather_tool.yaml.example` — component config (example, like other keyless common tools)
- `agentuniverse/agent/action/tool/common_tool/__init__.py` — export `WeatherTool`
- `tests/test_agentuniverse/unit/agent/action/tool/test_weather_tool.py` — 19 unit tests (formatters, all operations, location fallback, units mapping, forecast-day clamping, request wiring, error handling)
- `docs/.../Tools/Integrated_Tools.md` (en) and `docs/.../工具列表/集成的工具.md` (zh) — documentation appended

## Test plan

```
python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_weather_tool.py
```
All 19 tests pass.
