### PR TITLE
feat(knowledge): add ProfanityFilter post-processor (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.py
@@ -1,0 +1,344 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: profanity_filter.py
+
+"""
+Profanity filter — a knowledge post-processing DocProcessor.
+
+Filters, masks, or flags recalled documents that contain profanity based on a
+built-in English word list. Useful for knowledge bases that serve end-user
+facing agents where offensive language should be blocked, redacted, or at
+least surfaced for review before the content reaches the model or the user.
+
+Three actions are supported:
+
+- **drop**   — discard any document whose profanity ratio meets ``threshold``;
+- **mask**   — replace every matched profane word with ``replacement`` (e.g.
+               ``***``) and keep the document;
+- **redact** — leave the text untouched but stamp a ``profanity_summary`` into
+               the document metadata so downstream stages can decide.
+
+The detector is deterministic, case-insensitive, and dependency-free. It
+matches whole words only (so "class" never matches "ass") and tolerates a few
+common leet/obfuscation substitutions (``@`` -> ``a``, ``$`` -> ``s``,
+``0`` -> ``o``, ``1``/``!`` -> ``i``) so trivial evasions such as ``b@dword``
+are still caught. Custom terms can be added via ``extra_words``.
+
+Addresses #248 (knowledge post-processing components). Structurally it mirrors
+``LanguageFilter`` (a filter-style post-processor with a conservative keep
+policy for borderline input) and is distinct from
+``SensitiveDataRedactor``, which targets structured PII rather than offensive
+vocabulary.
+"""
+
+import logging
+import re
+from typing import Dict, List, Optional, Set
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# A compact built-in list of common English profanity / slurs. It is not
+# exhaustive by design — operators who need broader coverage can extend it via
+# ``extra_words``. Kept lowercase; matching is case-insensitive.
+_DEFAULT_PROFANITY_WORDS: Set[str] = {
+    # generic strong profanity
+    "ass", "asshole", "bastard", "bitch", "crap", "damn", "dick",
+    "fuck", "fucker", "fucking", "goddamn", "hell", "jackass",
+    "piss", "shit", "bullshit", "prick", "bollocks", "wanker",
+    "arse", "arsehole", "twat", "cunt", "cock", "dickhead",
+    # hateful / slur terms (kept so they are caught and reported)
+    "nigger", "nigga", "faggot", "fag", "retard", "dyke", "tranny",
+    "chink", "spic", "kike", "paki", "wetback",
+}
+
+# Leet-speak normalisation table used before matching. Keys are the obfuscated
+# characters, values are the plain characters they commonly stand in for.
+_LEET_MAP = {
+    "@": "a", "4": "a",
+    "$": "s", "5": "s",
+    "0": "o",
+    "1": "i", "!": "i",
+    "3": "e",
+    "7": "t",
+    "+": "t",
+}
+
+# Pre-compiled character class of all leet substitutes for fast normalisation.
+_LEET_CHARS = "".join(re.escape(ch) for ch in _LEET_MAP)
+
+
+def _normalise_token(token: str) -> str:
+    """Normalise a token by collapsing common leet substitutions to lowercase.
+
+    For example ``b@dw0rd`` -> ``badword``. Non-substituted characters are
+    lowercased and any character outside ``[a-z]`` after normalisation is
+    dropped, which lets the whole-word match ignore punctuation that the
+    tokenizer has already split on.
+    """
+    out_chars = []
+    for ch in token:
+        lower = ch.lower()
+        if lower in _LEET_MAP:
+            out_chars.append(_LEET_MAP[lower])
+        elif "a" <= lower <= "z":
+            out_chars.append(lower)
+        # anything else is dropped
+    return "".join(out_chars)
+
+
+class ProfanityFilter(DocProcessor):
+    """Filter, mask, or flag documents containing profanity.
+
+    Attributes:
+        action: How to handle profane content. One of:
+            - ``"drop"``   — remove documents whose profanity ratio is at
+                             least ``threshold``;
+            - ``"mask"``   — replace each matched profane word with
+                             ``replacement`` (document is kept);
+            - ``"redact"`` — keep the text unchanged but write a
+                             ``profanity_summary`` into metadata.
+            Default ``"mask"``.
+        replacement: Text substituted for each profane match when
+            ``action == "mask"``. Default ``"***"``.
+        threshold: Profanity ratio in ``[0.0, 1.0]`` above which a document is
+            considered offensive. The ratio is ``profane_word_count /
+            total_word_count``. Only consulted by the ``drop`` action (and is
+            recorded in the summary for the other actions). Default ``0.05``
+            — a document is dropped once 5% of its tokens are profane.
+        extra_words: Additional profane terms to merge with the built-in list.
+            Matching is case-insensitive and whole-word.
+        whole_word_only: When ``True`` (default) only whole tokens are matched,
+            so "class" never triggers on the substring "ass". Set ``False`` to
+            fall back to naive substring matching (faster but produces false
+            positives — rarely what you want).
+        summary_key: Metadata key under which a per-document
+            ``{words: [...], count: int, ratio: float}`` summary is written.
+            Set to ``None`` / empty to omit the summary.
+    """
+
+    action: str = "mask"
+    replacement: str = "***"
+    threshold: float = 0.05
+    extra_words: Set[str] = set()
+    whole_word_only: bool = True
+    summary_key: str = "profanity_summary"
+
+    # The effective word set, built lazily from the default list + extra_words.
+    _word_set: Set[str] = set()
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Process documents according to the configured ``action``."""
+        if not origin_docs:
+            return []
+
+        words = self._effective_words()
+
+        result: List[Document] = []
+        dropped = 0
+        masked = 0
+        for doc in origin_docs:
+            text = doc.text or ""
+
+            if self.whole_word_only:
+                matches = self._find_whole_word_matches(text, words)
+            else:
+                matches = self._find_substring_matches(text, words)
+
+            ratio, count = self._compute_ratio(text, matches)
+
+            summary = {
+                "words": sorted({m["matched"] for m in matches}),
+                "count": count,
+                "ratio": round(ratio, 6),
+                "action": self.action,
+            }
+
+            if self.action == "drop":
+                if ratio >= self.threshold:
+                    dropped += 1
+                    # Document is discarded — do not stamp summary.
+                    continue
+                # Kept: optionally stamp summary for downstream visibility.
+                result.append(self._stamp(doc, summary))
+            elif self.action == "mask":
+                if count > 0:
+                    new_text = self._apply_mask(text, matches)
+                    masked += 1
+                    result.append(self._with_text(doc, new_text, summary))
+                else:
+                    result.append(self._stamp(doc, summary))
+            elif self.action == "redact":
+                result.append(self._stamp(doc, summary))
+            else:
+                raise ValueError(
+                    f"Invalid action: {self.action!r}. "
+                    f"Must be one of 'drop', 'mask', 'redact'."
+                )
+
+        if dropped or masked:
+            logger.debug(
+                "ProfanityFilter: action=%s dropped=%d masked=%d of %d docs",
+                self.action, dropped, masked, len(origin_docs),
+            )
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Matching helpers
+    # ------------------------------------------------------------------ #
+    def _effective_words(self) -> Set[str]:
+        """Return the active profanity word set (built-in + extra)."""
+        return _DEFAULT_PROFANITY_WORDS | {w.lower() for w in self.extra_words}
+
+    def _find_whole_word_matches(self, text: str,
+                                 words: Set[str]) -> List[Dict[str, object]]:
+        """Find whole-word profanity matches, tolerating leet substitutions.
+
+        Returns a list of ``{"start", "end", "matched"}`` dicts. ``start``/
+        ``end`` are indices into the *original* ``text`` so masking can replace
+        the exact span the user saw. ``matched`` is the normalised profane
+        word found.
+        """
+        matches: List[Dict[str, object]] = []
+        # Tokenize on word boundaries while keeping original spans.
+        for m in re.finditer(r"[A-Za-z0-9@$_!3+7]+", text):
+            token = m.group(0)
+            normalised = _normalise_token(token)
+            if normalised and normalised in words:
+                matches.append({
+                    "start": m.start(),
+                    "end": m.end(),
+                    "matched": normalised,
+                })
+        return matches
+
+    def _find_substring_matches(self, text: str,
+                                words: Set[str]) -> List[Dict[str, object]]:
+        """Naive case-insensitive substring matching (whole_word_only=False).
+
+        Matches may overlap; earlier matches win to avoid double-counting.
+        """
+        matches: List[Dict[str, object]] = []
+        lower = text.lower()
+        occupied = [False] * len(text)
+        # Search longer words first so "asshole" is found before "ass".
+        for word in sorted(words, key=len, reverse=True):
+            if not word:
+                continue
+            start = lower.find(word)
+            while start != -1:
+                end = start + len(word)
+                if not any(occupied[start:end]):
+                    matches.append({
+                        "start": start,
+                        "end": end,
+                        "matched": word,
+                    })
+                    for i in range(start, end):
+                        occupied[i] = True
+                start = lower.find(word, start + 1)
+        # Restore original (left-to-right) order regardless of search order.
+        matches.sort(key=lambda d: d["start"])
+        return matches
+
+    def _compute_ratio(self, text: str,
+                       matches: List[Dict[str, object]]) -> tuple:
+        """Return ``(ratio, count)`` for ``text`` given ``matches``.
+
+        ``ratio = count / total_word_count`` and is clamped to ``[0.0, 1.0]``.
+        A "word" here is any maximal run of alphanumerics; empty text has a
+        ratio of ``0.0``.
+        """
+        if not text:
+            return 0.0, 0
+        total = len(re.findall(r"\w+", text))
+        if total == 0:
+            return 0.0, 0
+        count = len(matches)
+        ratio = count / total
+        return max(0.0, min(1.0, ratio)), count
+
+    def _apply_mask(self, text: str,
+                    matches: List[Dict[str, object]]) -> str:
+        """Replace each matched span in ``text`` with ``self.replacement``.
+
+        Iterates from the end backwards so earlier indices stay valid.
+        """
+        out = text
+        for m in sorted(matches, key=lambda d: d["start"], reverse=True):
+            out = out[:m["start"]] + self.replacement + out[m["end"]:]
+        return out
+
+    # ------------------------------------------------------------------ #
+    # Document mutation helpers
+    # ------------------------------------------------------------------ #
+    def _stamp(self, doc: Document, summary: Dict[str, object]) -> Document:
+        """Return ``doc`` with the profanity summary stamped into metadata."""
+        if not self.summary_key:
+            return doc
+        meta = dict(doc.metadata or {})
+        meta[self.summary_key] = summary
+        return Document(text=doc.text, metadata=meta)
+
+    def _with_text(self, doc: Document, new_text: str,
+                   summary: Dict[str, object]) -> Document:
+        """Return a copy of ``doc`` with replaced text and stamped summary."""
+        meta = dict(doc.metadata or {})
+        if self.summary_key:
+            meta[self.summary_key] = summary
+        return Document(text=new_text, metadata=meta)
+
+    # ------------------------------------------------------------------ #
+    # Config initialisation
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(
+            self, doc_processor_configer: ComponentConfiger) -> "ProfanityFilter":
+        """Initialise the filter from its component configuration.
+
+        Validates ``action`` and clamps ``threshold`` to ``[0.0, 1.0]``.
+        """
+        super()._initialize_by_component_configer(doc_processor_configer)
+
+        if hasattr(doc_processor_configer, "action"):
+            self.action = doc_processor_configer.action
+            if self.action not in {"drop", "mask", "redact"}:
+                raise ValueError(
+                    f"Invalid action: {self.action!r}. "
+                    f"Must be one of 'drop', 'mask', 'redact'."
+                )
+
+        if hasattr(doc_processor_configer, "replacement"):
+            self.replacement = doc_processor_configer.replacement
+
+        if hasattr(doc_processor_configer, "threshold"):
+            self.threshold = doc_processor_configer.threshold
+            if not 0.0 <= float(self.threshold) <= 1.0:
+                raise ValueError(
+                    f"threshold must be in [0.0, 1.0], got {self.threshold}."
+                )
+
+        if hasattr(doc_processor_configer, "extra_words"):
+            extra = doc_processor_configer.extra_words
+            if isinstance(extra, (list, tuple, set)):
+                self.extra_words = {str(w).lower() for w in extra}
+            else:
+                raise ValueError(
+                    "extra_words must be a list/tuple/set of strings."
+                )
+
+        if hasattr(doc_processor_configer, "whole_word_only"):
+            self.whole_word_only = bool(doc_processor_configer.whole_word_only)
+
+        if hasattr(doc_processor_configer, "summary_key"):
+            self.summary_key = doc_processor_configer.summary_key
+
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.yaml
@@ -1,0 +1,12 @@
+name: 'profanity_filter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.profanity_filter'
+  class: 'ProfanityFilter'
+description: 'Filters, masks, or flags recalled documents containing profanity based on a built-in English word list.'
+action: 'mask'            # drop | mask | redact
+replacement: '***'        # text substituted for each match when action == mask
+threshold: 0.05           # profanity ratio at/above which a document is dropped (drop action)
+extra_words: []           # extra profane terms merged with the built-in list
+whole_word_only: true     # match whole tokens only (avoid 'ass' in 'class')
+summary_key: 'profanity_summary'   # metadata key for the per-document summary; '' to omit

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,33 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [ProfanityFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.yaml)
+
+This component filters, masks, or flags profanity in recalled documents based on a built-in English word list. It suits end-user-facing agents where offensive content should be blocked, redacted, or at least surfaced for review before it reaches the model or the user. It addresses the *content compliance / post-processing* direction of issue #248.
+
+Three actions are supported: `drop` (discard documents whose profanity ratio meets `threshold`), `mask` (replace every matched profane word with `replacement`, e.g. `***`, keeping the document), and `redact` (leave the text untouched but write a `profanity_summary` into metadata for downstream decisions). Detection is deterministic, case-insensitive, and dependency-free; by default it matches whole words only (so "class" never trips on "ass") and tolerates common leet/obfuscation substitutions (`@`→`a`, `$`/`5`→`s`, `0`→`o`, `1`/`!`→`i`), so trivial evasions such as `sh1t` are still caught. Domain-specific terms can be added via `extra_words`.
+
+It mirrors `LanguageFilter` structurally (a filter-style post-processor with a conservative keep policy) and complements `SensitiveDataRedactor`: the latter redacts structured PII, while this component targets offensive vocabulary.
+
+The component definition file is as follows:
+```yaml
+name: 'profanity_filter'
+description: 'filter/mask/flag recalled documents containing profanity'
+action: 'mask'            # drop | mask | redact
+replacement: '***'        # text substituted for each match when action == mask
+threshold: 0.05           # profanity ratio at/above which a document is dropped (drop action)
+extra_words: []           # extra profane terms merged with the built-in list
+whole_word_only: true     # match whole tokens only (avoid 'ass' in 'class')
+summary_key: 'profanity_summary'   # metadata key for the per-document summary; '' to omit
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.profanity_filter'
+  class: 'ProfanityFilter'
+```
+- action: How profanity is handled. `drop` discards, `mask` masks/replaces, `redact` flags without changing text.
+- replacement: Text substituted for each match under the `mask` action, default `***`.
+- threshold: Profanity ratio (profane word count / total word count, in [0.0, 1.0]); only the `drop` action uses it to decide whether to discard a document.
+- extra_words: Extra profane terms merged with the built-in list; matching is case-insensitive and whole-word.
+- whole_word_only: When true, only whole tokens are matched; when false, matching degrades to substring (faster but prone to false positives — rarely recommended).
+- summary_key: Metadata key recording a `{words, count, ratio, action}` summary per document; set to empty to omit.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,33 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [ProfanityFilter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.yaml)
+
+该组件基于内置的英文脏话词表，对召回文档中的脏话进行过滤、遮蔽或标记。适用于面向终端用户的智能体场景——在这些场景下，冒犯性内容应在进入模型上下文或展示给用户之前被拦截、脱敏或至少被标注出来以供审核。对应 issue #248 的*内容合规 / 后处理*方向。
+
+支持三种动作：`drop`（丢弃脏话比例达到 `threshold` 的文档）、`mask`（把每个命中的脏话词替换为 `replacement`，如 `***`，保留文档）、`redact`（不改文本，仅在 metadata 中写入 `profanity_summary`，交由下游决策）。检测过程确定性、大小写不敏感、无第三方依赖；默认只匹配整词（因此 "class" 不会因包含 "ass" 而误判），并能容忍常见的 leet 混淆替换（`@`→`a`、`$`/`5`→`s`、`0`→`o`、`1`/`!`→`i`），从而能识破 `sh1t` 这类简单伪装。可通过 `extra_words` 追加领域专属词。
+
+它在结构上参照 `LanguageFilter`（同为保守保留的过滤型后处理器），与针对结构化 PII 的 `SensitiveDataRedactor` 互补：后者脱敏的是个人敏感信息，本组件针对的是冒犯性词汇。
+
+组件定义文件如下：
+```yaml
+name: 'profanity_filter'
+description: '基于内置英文脏话词表过滤/遮蔽/标记召回文档'
+action: 'mask'            # drop | mask | redact
+replacement: '***'        # action == mask 时替换每个命中的文本
+threshold: 0.05           # 脏话比例达到该值即丢弃文档（drop 动作生效）
+extra_words: []           # 追加到内置词表的额外脏话词
+whole_word_only: true     # 仅匹配整词（避免 "class" 命中 "ass"）
+summary_key: 'profanity_summary'   # 每篇文档汇总的 metadata 键；'' 表示不写入
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.profanity_filter'
+  class: 'ProfanityFilter'
+```
+- action: 处理脏话的方式。`drop` 丢弃、`mask` 遮蔽替换、`redact` 仅标记不改文本。
+- replacement: `mask` 动作下替换每个命中文本的字符串，默认 `***`。
+- threshold: 脏话比例（脏话词数 / 总词数，取值 [0.0, 1.0]），仅 `drop` 动作据此判定是否丢弃文档。
+- extra_words: 与内置词表合并的额外脏话词，匹配大小写不敏感且按整词。
+- whole_word_only: 为真时只匹配整词；为假时退化为子串匹配（更快但易误判，通常不建议）。
+- summary_key: 每篇文档 `{words, count, ratio, action}` 汇总的 metadata 键；设为空则不写入。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_profanity_filter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_profanity_filter.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for ProfanityFilter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.profanity_filter \
+    import ProfanityFilter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestProfanityFilter(unittest.TestCase):
+
+    def _filter(self, docs, **kwargs):
+        proc = ProfanityFilter(**kwargs)
+        return proc.process_docs(docs, None)
+
+    # ------------------------------------------------------------------ #
+    # drop action
+    # ------------------------------------------------------------------ #
+    def test_drop_removes_profane_document(self):
+        # "shit" is 1 of 2 words -> ratio 0.5 >= 0.05 -> dropped.
+        docs = [Document(text="this shit")]
+        result = self._filter(docs, action="drop")
+        self.assertEqual(len(result), 0)
+
+    def test_drop_keeps_clean_document(self):
+        docs = [Document(text="a clean sentence about programming")]
+        result = self._filter(docs, action="drop")
+        self.assertEqual(len(result), 1)
+
+    def test_drop_threshold_respected(self):
+        # 1 profane word of 20 total -> ratio 0.05. threshold 0.5 keeps it.
+        text = "damn " + "word " * 19
+        docs = [Document(text=text.strip())]
+        result = self._filter(docs, action="drop", threshold=0.5)
+        self.assertEqual(len(result), 1)
+        # Same text with a low threshold drops it.
+        result2 = self._filter(docs, action="drop", threshold=0.01)
+        self.assertEqual(len(result2), 0)
+
+    # ------------------------------------------------------------------ #
+    # mask action
+    # ------------------------------------------------------------------ #
+    def test_mask_replaces_profane_word(self):
+        docs = [Document(text="what the fuck")]
+        result = self._filter(docs, action="mask", replacement="***")
+        self.assertEqual(len(result), 1)
+        self.assertNotIn("fuck", result[0].text)
+        self.assertIn("***", result[0].text)
+        self.assertIn("what the", result[0].text)
+
+    def test_mask_custom_replacement(self):
+        docs = [Document(text="you bastard")]
+        result = self._filter(docs, action="mask", replacement="[BLEEP]")
+        self.assertIn("[BLEEP]", result[0].text)
+        self.assertNotIn("bastard", result[0].text)
+
+    def test_mask_preserves_clean_text(self):
+        original = "a perfectly clean sentence"
+        docs = [Document(text=original)]
+        result = self._filter(docs, action="mask")
+        self.assertEqual(result[0].text, original)
+
+    # ------------------------------------------------------------------ #
+    # redact action
+    # ------------------------------------------------------------------ #
+    def test_redact_keeps_text_but_stamps_summary(self):
+        original = "this is bullshit"
+        docs = [Document(text=original)]
+        result = self._filter(docs, action="redact")
+        self.assertEqual(len(result), 1)
+        # Text unchanged.
+        self.assertEqual(result[0].text, original)
+        # Summary stamped.
+        summary = result[0].metadata["profanity_summary"]
+        self.assertIn("bullshit", summary["words"])
+        self.assertGreater(summary["count"], 0)
+
+    # ------------------------------------------------------------------ #
+    # matching behaviour
+    # ------------------------------------------------------------------ #
+    def test_whole_word_only_avoids_substring_false_positive(self):
+        # "class" and "glass" contain "ass" but must NOT match.
+        docs = [Document(text="the glass and class are clean")]
+        result = self._filter(docs, action="mask")
+        self.assertEqual(result[0].text, "the glass and class are clean")
+
+    def test_case_insensitive_matching(self):
+        docs = [Document(text="WHAT THE FUCK")]
+        result = self._filter(docs, action="mask")
+        self.assertNotIn("FUCK", result[0].text)
+        self.assertIn("***", result[0].text)
+
+    def test_leet_substitution_matched(self):
+        # "sh1t" style obfuscation -> "1" normalises to "i" -> "shit".
+        docs = [Document(text="you sh1t")]
+        result = self._filter(docs, action="mask")
+        self.assertNotIn("sh1t", result[0].text)
+        self.assertIn("***", result[0].text)
+
+    def test_substring_mode_matches_inside_words(self):
+        # With whole_word_only off, "ass" matches inside "class".
+        docs = [Document(text="the class is nice")]
+        result = self._filter(docs, action="mask", whole_word_only=False,
+                              extra_words=["ass"])
+        self.assertIn("***", result[0].text)
+
+    def test_extra_words_merged(self):
+        docs = [Document(text="you are a zorbot")]
+        result = self._filter(docs, action="mask",
+                              extra_words=["zorbot"])
+        self.assertNotIn("zorbot", result[0].text)
+
+    # ------------------------------------------------------------------ #
+    # edge cases / metadata
+    # ------------------------------------------------------------------ #
+    def test_empty_input(self):
+        proc = ProfanityFilter(action="mask")
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_empty_text_kept(self):
+        docs = [Document(text="")]
+        result = self._filter(docs, action="drop")
+        self.assertEqual(len(result), 1)
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="clean text", metadata={"source": "wiki"})
+        result = self._filter([doc], action="mask")
+        self.assertEqual(result[0].metadata["source"], "wiki")
+
+    def test_summary_ratio_and_count(self):
+        docs = [Document(text="fuck shit damn")]  # 3 profane of 3 -> ratio 1.0
+        result = self._filter(docs, action="redact")
+        summary = result[0].metadata["profanity_summary"]
+        self.assertEqual(summary["count"], 3)
+        self.assertAlmostEqual(summary["ratio"], 1.0)
+
+    def test_summary_key_omitted_when_empty(self):
+        docs = [Document(text="clean text")]
+        result = self._filter(docs, action="redact", summary_key="")
+        self.assertNotIn("profanity_summary", result[0].metadata or {})
+
+    def test_invalid_action_raises(self):
+        proc = ProfanityFilter(action="nonsense")
+        with self.assertRaises(ValueError):
+            proc.process_docs([Document(text="hi")], None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds a new knowledge post-processing component **ProfanityFilter** (#248, content-compliance direction).

A dependency-free `DocProcessor` that filters, masks, or flags recalled documents containing profanity based on a built-in English word list — useful for end-user-facing agents where offensive content should be blocked, redacted, or surfaced for review before it reaches the model or the user.

## Behaviour

Three actions (`action`):
- **drop** — discard documents whose profanity ratio meets `threshold`;
- **mask** — replace every matched profane word with `replacement` (e.g. `***`) and keep the document;
- **redact** — leave the text untouched but stamp a `profanity_summary` into metadata so downstream stages can decide.

Detection is deterministic, case-insensitive, and dependency-free:
- whole-word matching only by default (so `class` never trips on `ass`), via `whole_word_only`;
- tolerates common leet/obfuscation substitutions (`@`→`a`, `$`/`5`→`s`, `0`→`o`, `1`/`!`→`i`), so `sh1t` is still caught;
- configurable via `threshold` (profanity ratio), `extra_words` (merge with built-in list), `replacement`, and `summary_key`.

It mirrors `LanguageFilter` structurally and complements `SensitiveDataRedactor` (which targets structured PII rather than offensive vocabulary).

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.py` (~330 lines)
- `agentuniverse/agent/action/knowledge/doc_processor/profanity_filter.yaml`
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_profanity_filter.py` (18 tests)
- `docs/.../DocProcessor.md` (zh + en, new section appended)

## Test plan

All 18 unit tests pass (`python .../test_profanity_filter.py`), covering: drop/mask/redact actions, threshold behaviour, whole-word vs substring matching, leet substitution, case-insensitivity, custom replacement, `extra_words`, metadata preservation, summary contents/omission, empty input, and invalid-action validation.

Closes #248.
