### PR TITLE
feat(tool): add TranslatorTool for key-less Google Translate (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/translator_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/translator_tool.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Translation tool backed by the free Google Translate endpoint.
+
+The tool wraps the public, key-less ``translate.googleapis.com`` endpoint so
+that an agent can translate text between 100+ languages without registering an
+API key. Network access is required, but no credentials are needed.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+from typing import Any, ClassVar, Dict, Optional
+
+import httpx
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+GOOGLE_TRANSLATE_ENDPOINT = "https://translate.googleapis.com/translate_a/single"
+
+
+class TranslatorTool(Tool):
+    """Translate text between 100+ languages using the free Google endpoint.
+
+    The tool exposes a single ``translate`` operation. Source and target
+    languages follow the two/three-letter ISO 639 codes used by Google
+    Translate (for example ``en``, ``zh``, ``ja``, ``auto``). ``source`` may be
+    set to ``auto`` to let Google detect the source language automatically.
+    """
+
+    description: str = (
+        "Translate text between 100+ languages using the free Google "
+        "Translate endpoint (no API key required)."
+    )
+
+    # Configurable defaults.
+    default_source: str = Field(
+        default="auto",
+        description="Default source language code. Use 'auto' for detection.",
+    )
+    default_target: str = Field(
+        default="en",
+        description="Default target language code, e.g. 'en', 'zh', 'ja'.",
+    )
+    request_timeout: float = Field(
+        default=15.0,
+        description="HTTP request timeout in seconds.",
+    )
+
+    # Sampling of the supported languages; the upstream API accepts many more.
+    SUPPORTED_LANGUAGES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "auto", "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn",
+            "bs", "bg", "ca", "ceb", "ny", "zh", "zh-CN", "zh-TW", "co",
+            "hr", "cs", "da", "nl", "en", "eo", "et", "fi", "fr", "fy",
+            "gl", "ka", "de", "el", "gu", "ht", "ha", "haw", "he", "hi",
+            "hmn", "hu", "is", "ig", "id", "ga", "it", "ja", "jw", "kn",
+            "kk", "km", "rw", "ko", "ku", "ky", "lo", "la", "lv", "lt",
+            "lb", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mn", "my",
+            "ne", "no", "or", "ps", "fa", "pl", "pt", "pa", "ro", "ru",
+            "sm", "gd", "sr", "st", "sn", "sd", "si", "sk", "sl", "so",
+            "es", "su", "sw", "sv", "tl", "tg", "ta", "tt", "te", "th",
+            "tr", "tk", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi",
+            "yo", "zu",
+        }
+    )
+
+    MAX_TEXT_CHARS: ClassVar[int] = 50_000
+
+    def execute(
+        self,
+        text: str,
+        source: Optional[str] = None,
+        target: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Translate ``text`` and return a structured result.
+
+        Args:
+            text: The text to translate. Leading/trailing whitespace is
+                stripped and the length is capped by ``MAX_TEXT_CHARS``.
+            source: Source language code. Falls back to ``default_source``.
+            target: Target language code. Falls back to ``default_target``.
+
+        Returns:
+            A dictionary with ``status`` plus the translation result. Network
+            and validation failures are returned as ``error`` fields rather
+            than raised.
+        """
+        try:
+            normalized_text = self._validate_text(text)
+            source_lang = self._resolve_language(source, self.default_source)
+            target_lang = self._resolve_language(target, self.default_target)
+            self._check_language_pair(source_lang, target_lang)
+
+            translated, detected_source = self._request_translation(
+                normalized_text, source_lang, target_lang
+            )
+            return {
+                "status": "success",
+                "translated_text": translated,
+                "source_language": detected_source or source_lang,
+                "target_language": target_lang,
+                "original_text": normalized_text,
+                "engine": "google_translate",
+            }
+        except (TypeError, ValueError) as exc:
+            LOGGER.error(f"TranslatorTool validation error: {exc}")
+            return self._error("validation_error", str(exc))
+        except httpx.HTTPError as exc:
+            LOGGER.error(f"TranslatorTool network error: {exc}")
+            return self._error("network_error", str(exc))
+        except Exception as exc:
+            LOGGER.error(f"TranslatorTool operation failed: {exc}")
+            return self._error("operation_error", f"Translation failed: {exc}")
+
+    @staticmethod
+    def _error(kind: str, message: str) -> Dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message}
+
+    def _validate_text(self, value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("text must be a string")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("text must not be empty")
+        if len(normalized) > self.MAX_TEXT_CHARS:
+            raise ValueError(
+                f"text exceeds MAX_TEXT_CHARS ({self.MAX_TEXT_CHARS})"
+            )
+        return normalized
+
+    def _resolve_language(self, value: Any, fallback: str) -> str:
+        if value is None:
+            resolved = fallback
+        else:
+            if not isinstance(value, str):
+                raise TypeError("language must be a string")
+            resolved = value.strip()
+        if not resolved:
+            raise ValueError("language must not be empty")
+        return resolved
+
+    def _check_language_pair(self, source: str, target: str) -> None:
+        normalized_source = source.lower()
+        normalized_target = target.lower()
+        if normalized_source not in self.SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"unsupported source language: {source!r}. "
+                "See https://cloud.google.com/translate/docs/languages"
+            )
+        if normalized_target not in self.SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"unsupported target language: {target!r}. "
+                "See https://cloud.google.com/translate/docs/languages"
+            )
+        if (
+            normalized_source != "auto"
+            and normalized_source == normalized_target
+        ):
+            raise ValueError("source and target must be different languages")
+
+    def _request_translation(
+        self, text: str, source: str, target: str
+    ) -> tuple[str, str]:
+        """Call the Google Translate endpoint and parse the response.
+
+        Returns a ``(translated_text, detected_source_language)`` tuple. The
+        detected source language is only meaningful when ``source == 'auto'``.
+        """
+        params = {
+            "client": "gtx",
+            "sl": source,
+            "tl": target,
+            "dt": "t",
+            "q": text,
+        }
+        response = httpx.get(
+            GOOGLE_TRANSLATE_ENDPOINT,
+            params=params,
+            timeout=self.request_timeout,
+            headers={"User-Agent": "agentuniverse-translator-tool/1.0"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return self._parse_google_response(payload)
+
+    @staticmethod
+    def _parse_google_response(payload: Any) -> tuple[str, str]:
+        """Extract translation and detected source language from payload.
+
+        Google returns a nested list. ``payload[0]`` is a list of segments,
+        where each segment is ``[translated_chunk, original_chunk, ...]``.
+        ``payload[2]`` holds the detected source language when ``sl=auto``.
+        """
+        if not isinstance(payload, list) or not payload:
+            raise ValueError("unexpected Google Translate response: empty body")
+        segments = payload[0]
+        if not isinstance(segments, list) or not segments:
+            raise ValueError("unexpected Google Translate response: no segments")
+        translated_chunks: list[str] = []
+        for segment in segments:
+            if isinstance(segment, list) and segment and isinstance(segment[0], str):
+                translated_chunks.append(segment[0])
+        translated = "".join(translated_chunks)
+        detected_source = ""
+        if len(payload) > 2 and isinstance(payload[2], str):
+            detected_source = payload[2]
+        return translated, detected_source

--- a/agentuniverse/agent/action/tool/common_tool/translator_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/translator_tool.yaml
@@ -1,0 +1,22 @@
+name: translator_tool
+description: >-
+  Translate text between 100+ languages using the free Google Translate
+  endpoint (no API key required).
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.translator_tool
+  class: TranslatorTool
+input_keys:
+  - text
+default_source: auto
+default_target: en
+request_timeout: 15.0
+args_model_schema:
+  type: object
+  properties:
+    text: {type: string, description: "Text to translate."}
+    source: {type: string, description: "Source language code. Defaults to 'auto' for detection."}
+    target: {type: string, description: "Target language code, e.g. 'en', 'zh', 'ja'."}
+  required: [text]
+  additionalProperties: false

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TranslatorTool.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TranslatorTool.md
@@ -1,0 +1,71 @@
+# TranslatorTool
+
+`TranslatorTool` 使用 Google 翻译的免费公开端点（`translate.googleapis.com/translate_a/single`）在 100+ 种语言之间翻译文本，无需申请 API Key。适合智能体在不携带任何凭证的情况下完成跨语言文本转换。
+
+## 功能特性
+
+- 支持 100+ 种语言（英语 `en`、中文 `zh`、日语 `ja`、韩语 `ko` 等）
+- 支持自动检测源语言（`source='auto'`），并返回检测到的源语言
+- 无需 API Key，零配置即可使用
+- 基于 `httpx`，支持请求超时控制
+- 单次翻译默认上限 50,000 字符
+- 校验失败和网络异常均以结构化 `error` 返回，不会抛出未捕获异常
+
+## 使用方式
+
+```python
+from agentuniverse.agent.action.tool.common_tool.translator_tool import TranslatorTool
+
+tool = TranslatorTool()
+
+# 自动检测源语言并翻译成英语
+result = tool.execute(text="你好，世界", source="auto", target="en")
+print(result["translated_text"])   # "Hello, world"
+print(result["source_language"])   # "zh"
+print(result["target_language"])   # "en"
+
+# 使用默认源/目标语言
+tool = TranslatorTool(default_source="zh", default_target="en")
+print(tool.execute(text="你好")["translated_text"])
+```
+
+## YAML 配置
+
+```yaml
+name: translator_tool
+description: Translate text between 100+ languages using the free Google Translate endpoint (no API key required).
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.translator_tool
+  class: TranslatorTool
+input_keys:
+  - text
+default_source: auto
+default_target: en
+request_timeout: 15.0
+```
+
+## 参数说明
+
+`execute()` 方法接受以下参数：
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `text` | `str` | 是 | 待翻译文本，自动去除首尾空白，最长 50,000 字符 |
+| `source` | `str` | 否 | 源语言代码，缺省取 `default_source`；`auto` 表示自动检测 |
+| `target` | `str` | 否 | 目标语言代码，缺省取 `default_target` |
+
+工具字段：
+
+| 字段 | 默认值 | 说明 |
+| --- | --- | --- |
+| `default_source` | `auto` | 默认源语言，支持自动检测 |
+| `default_target` | `en` | 默认目标语言 |
+| `request_timeout` | `15.0` | HTTP 请求超时时间（秒） |
+
+返回值为字典，成功时包含 `status='success'`、`translated_text`、`source_language`、`target_language`、`original_text`、`engine`；失败时包含 `status='error'`、`error_type`（`validation_error` / `network_error` / `operation_error`）以及 `error` 详情。
+
+## 网络依赖
+
+该工具依赖公网访问 `https://translate.googleapis.com/translate_a/single`，无需任何环境变量或密钥配置。如运行环境无法访问 Google 服务，会返回 `network_error`。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_translator_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_translator_tool.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import Mock, patch
+
+import httpx
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool import translator_tool as translator_module
+from agentuniverse.agent.action.tool.common_tool.translator_tool import TranslatorTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = translator_module.__file__.replace(".py", ".yaml")
+
+
+def httpx_response_mock(*, json_data=None):
+    response = Mock()
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TranslatorToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = TranslatorTool()
+
+    def _google_payload(self, translated="Hello", detected="en"):
+        # Google's nested-list response format:
+        # payload[0] = list of [translated_chunk, original_chunk, ...] segments
+        # payload[2] = detected source language (when sl=auto)
+        return [[[translated, "你好", None, None, 1]], None, detected]
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_returns_translated_text(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("Hello", "zh"))
+        result = self.tool.execute(text="你好", source="auto", target="en")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["translated_text"], "Hello")
+        self.assertEqual(result["source_language"], "zh")
+        self.assertEqual(result["target_language"], "en")
+        self.assertEqual(result["engine"], "google_translate")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_uses_defaults_when_omitted(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("Bonjour", ""))
+        tool = TranslatorTool(default_source="fr", default_target="en")
+        result = tool.execute(text="bonjour")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["target_language"], "en")
+        call_params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(call_params["sl"], "fr")
+        self.assertEqual(call_params["tl"], "en")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_explicit_languages(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("Hallo", "de"))
+        result = self.tool.execute(text="hello", source="en", target="de")
+        self.assertEqual(result["translated_text"], "Hallo")
+        self.assertEqual(result["source_language"], "de")
+        self.assertEqual(result["target_language"], "de")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_passes_timeout_and_query(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("x", "en"))
+        self.tool.execute(text="hi", source="en", target="zh")
+        kwargs = mock_get.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], self.tool.request_timeout)
+        self.assertEqual(kwargs["params"]["q"], "hi")
+        self.assertEqual(kwargs["params"]["sl"], "en")
+        self.assertEqual(kwargs["params"]["tl"], "zh")
+        self.assertEqual(kwargs["params"]["client"], "gtx")
+
+    def test_translate_rejects_empty_text(self) -> None:
+        result = self.tool.execute(text="   ")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("empty", result["error"])
+
+    def test_translate_rejects_non_string_text(self) -> None:
+        result = self.tool.execute(text=123)
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_translate_rejects_unsupported_source(self) -> None:
+        result = self.tool.execute(text="hi", source="klingon", target="en")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unsupported source language", result["error"])
+
+    def test_translate_rejects_unsupported_target(self) -> None:
+        result = self.tool.execute(text="hi", source="en", target="klingon")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unsupported target language", result["error"])
+
+    def test_translate_rejects_same_source_and_target(self) -> None:
+        result = self.tool.execute(text="hi", source="en", target="en")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("different languages", result["error"])
+
+    def test_translate_rejects_oversized_text(self) -> None:
+        original = TranslatorTool.MAX_TEXT_CHARS
+        TranslatorTool.MAX_TEXT_CHARS = 5
+        try:
+            result = self.tool.execute(text="abcdefgh")
+        finally:
+            TranslatorTool.MAX_TEXT_CHARS = original
+        self.assertEqual(result["status"], "error")
+        self.assertIn("MAX_TEXT_CHARS", result["error"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_handles_network_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = httpx.ConnectError("boom")
+        result = self.tool.execute(text="hi", source="en", target="zh")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "network_error")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_handles_malformed_payload(self, mock_get: Mock) -> None:
+        # Non-empty payload whose segment list is empty raises ValueError in
+        # the response parser, surfaced as a validation_error.
+        mock_get.return_value = httpx_response_mock(json_data=[[]])
+        result = self.tool.execute(text="hi", source="en", target="zh")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("no segments", result["error"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_handles_unexpected_exception(self, mock_get: Mock) -> None:
+        # response.json() raising a non-(TypeError/ValueError) becomes operation_error.
+        mock_get.return_value = httpx_response_mock(json_data=None)
+        mock_get.return_value.json.side_effect = RuntimeError("decode failed")
+        result = self.tool.execute(text="hi", source="en", target="zh")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "operation_error")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_multi_segment_concatenation(self, mock_get: Mock) -> None:
+        payload = [[["Hello, ", "你好, ", None, None, 0], ["world", "世界", None, None, 0]], None, "zh"]
+        mock_get.return_value = httpx_response_mock(json_data=payload)
+        result = self.tool.execute(text="你好, 世界", source="zh", target="en")
+        self.assertEqual(result["translated_text"], "Hello, world")
+
+    def test_parse_google_response_extracts_translation(self) -> None:
+        payload = [[["Hello, ", "你好, ", None, None, 0], ["world", "世界", None, None, 0]], None, "zh"]
+        translated, detected = TranslatorTool._parse_google_response(payload)
+        self.assertEqual(translated, "Hello, world")
+        self.assertEqual(detected, "zh")
+
+
+class TranslatorRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=YAML_PATH).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "TranslatorTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, TranslatorTool)
+        self.assertEqual(tool.input_keys, ["text"])
+        self.assertEqual(tool.default_target, "en")
+
+    def test_yaml_loads_as_dict(self):
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "translator_tool")
+        self.assertEqual(data["metadata"]["class"], "TranslatorTool")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `TranslatorTool` that translates text between 100+ languages using the free Google Translate public endpoint (`translate.googleapis.com/translate_a/single`), with **no API key required**.

Closes #252.

## Why

Agents frequently need cross-language text conversion without provisioning credentials. The public Google endpoint accepts the standard `client=gtx` query and returns translations for all languages supported by Google Translate, so a key-less tool lowers the barrier for multilingual workflows.

## What's included

- `agentuniverse/agent/action/tool/common_tool/translator_tool.py` — `TranslatorTool` exposing a single `translate(text, source, target)` operation. Default source is `auto` (language detection), default target is `en`. Configurable `request_timeout`. Validates language codes, caps input at 50,000 chars, and returns structured `{status, translated_text, source_language, target_language, ...}` results. All validation/network/parsing failures are returned as `error` dicts instead of raising.
- `agentuniverse/agent/action/tool/common_tool/translator_tool.yaml` — built-in component config (`translator_tool`) with `args_model_schema`.
- `tests/test_agentuniverse/unit/agent/action/tool/test_translator_tool.py` — 18 unit tests covering success path, language defaults, validation (empty/non-string/oversized text, unsupported language codes, identical source/target), network errors, malformed/exceptional payloads, multi-segment concatenation, and YAML/component registration.
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TranslatorTool.md` — Chinese usage docs.

## Usage

```python
from agentuniverse.agent.action.tool.common_tool.translator_tool import TranslatorTool

tool = TranslatorTool()
result = tool.execute(text="你好，世界", source="auto", target="en")
# {'status': 'success', 'translated_text': 'Hello, world', 'source_language': 'zh', 'target_language': 'en', ...}
```

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_translator_tool` — 18 passed.
- [x] No new third-party dependencies (uses already-required `httpx`).
- [x] Network calls are mocked in tests; suite runs fully offline.

## Notes

No credentials or environment variables are required. The tool needs outbound HTTPS access to `translate.googleapis.com`; connection failures are surfaced as `network_error`.
