### PR TITLE
feat(knowledge): add QualityScorer post-processor (#248)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.py
@@ -1,0 +1,433 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: quality_scorer.py
+
+"""
+Quality scorer — a knowledge post-processing DocProcessor.
+
+Scores each recalled document on overall text quality and optionally drops
+low-quality documents. The score is a weighted average of several
+independent, dependency-free heuristics, each normalised to ``[0.0, 1.0]``:
+
+- **length**          — rewards documents of a useful size. Too-short text is
+                         nearly content-free; too-long text tends to be noise.
+                         Peaks around ``ideal_length``.
+- **sentence_completeness** — fraction of sentence-ending punctuation that is
+                         a real sentence terminator (``. ! ?``) versus other
+                         punctuation, plus a penalty for fragments with no
+                         terminator at all. Detects well-formed prose vs.
+                         keyword soup.
+- **special_char_ratio** — penalises a high proportion of non-alphanumeric,
+                         non-whitespace symbols (``@ # % ^ * ~`` …), a strong
+                         signal of boilerplate / log spam.
+- **repetition**      — penalises repeated content. Measured via the share of
+                         duplicated n-grams (default 8-char shingles) and the
+                         share of the most frequent repeated word.
+- **information_density** — ratio of distinct word tokens to total tokens,
+                         a coarse lexical-diversity signal. Dense, varied
+                         text scores higher than filler.
+
+The final score is ``sum(weight_i * score_i) / sum(weight_i)``. Weights and
+sub-scores are stamped into metadata under ``score_key`` (default
+``quality_score``) so downstream stages (e.g. ``ThresholdFilter``) can use
+them. Documents scoring below ``min_score`` are dropped when ``min_score`` is
+set (``None`` disables dropping — the scorer then only annotates).
+
+Addresses #248 (knowledge post-processing components). It complements
+``ThresholdFilter`` (which filters on an externally-supplied score field):
+this component *produces* a score from text alone, no external signals or
+models required.
+"""
+
+import logging
+import math
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional, Tuple
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Default weights for each sub-score. Keys must match the dimension names.
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "length": 0.15,
+    "sentence_completeness": 0.25,
+    "special_char_ratio": 0.15,
+    "repetition": 0.20,
+    "information_density": 0.25,
+}
+
+# Token / sentence regexes (compiled once).
+_WORD_RE = re.compile(r"[A-Za-z0-9']+")
+_SENTENCE_END_RE = re.compile(r"[.!?]+")
+_ALL_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_SPECIAL_CHAR_RE = re.compile(r"[^\w\s]", re.UNICODE)
+# Punctuation that is NOT a sentence terminator (commas, semicolons, etc.).
+_NON_TERMINATOR_PUNCT_RE = re.compile(r"[,;:()\[\]\"'`/\\|<>{}`~@#$%^&*_+=]")
+
+
+class QualityScorer(DocProcessor):
+    """Score and optionally filter documents by text quality.
+
+    Attributes:
+        min_score: Minimum final score in ``[0.0, 1.0]`` required to keep a
+            document. Documents below this are dropped. Set to ``None`` to
+            disable dropping (the scorer then only annotates metadata).
+            Default ``None``.
+        score_key: Metadata key under which the final score is written.
+            Default ``"quality_score"``.
+        detail_key: Metadata key under which the per-dimension breakdown
+            ``{dim: {score, weight}, ...}`` is written. Set to ``None`` / empty
+            to omit the breakdown. Default ``"quality_detail"``.
+        weights: Per-dimension weights. Keys must be a subset of
+            ``{length, sentence_completeness, special_char_ratio, repetition,
+            information_density}``. Missing dimensions default to
+            ``DEFAULT_WEIGHTS``. Dimensions with weight ``0`` are skipped.
+        ideal_length: Character count at which the ``length`` dimension scores
+            1.0. Below or above this, the score falls off (quadratic within
+            ``[0, 2*ideal]``, then linear decay beyond). Default 500.
+        min_length: Texts shorter than this (in characters) get a ``length``
+            score of 0. Default 20.
+        repetition_shingle_size: Character n-gram size used to measure
+            repetition. Default 8.
+        repetition_word_window: Number of most-common words considered when
+            measuring word repetition. Default 10.
+    """
+
+    min_score: Optional[float] = None
+    score_key: str = "quality_score"
+    detail_key: str = "quality_detail"
+    weights: Dict[str, float] = dict(DEFAULT_WEIGHTS)
+    ideal_length: int = 500
+    min_length: int = 20
+    repetition_shingle_size: int = 8
+    repetition_word_window: int = 10
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query: Query = None) -> List[Document]:
+        """Score each document; drop those below ``min_score`` when set."""
+        if not origin_docs:
+            return []
+
+        self._validate_min_score()
+        weights = self._normalised_weights()
+
+        result: List[Document] = []
+        dropped = 0
+        for doc in origin_docs:
+            text = doc.text or ""
+            breakdown = self._score_all(text, weights)
+            final = self._weighted_average(breakdown, weights)
+
+            kept = True
+            if self.min_score is not None and final < self.min_score:
+                dropped += 1
+                kept = False
+
+            if not kept:
+                continue
+
+            meta = dict(doc.metadata or {})
+            meta[self.score_key] = round(final, 6)
+            if self.detail_key:
+                meta[self.detail_key] = {
+                    dim: {
+                        "score": round(info["score"], 6),
+                        "weight": info["weight"],
+                    }
+                    for dim, info in breakdown.items()
+                }
+            result.append(Document(text=doc.text, metadata=meta))
+
+        if dropped > 0:
+            logger.debug("QualityScorer: dropped %d/%d documents "
+                         "(min_score=%s)", dropped, len(origin_docs),
+                         self.min_score)
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Orchestration
+    # ------------------------------------------------------------------ #
+    def _score_all(self, text: str,
+                   weights: Dict[str, float]) -> Dict[str, Dict[str, float]]:
+        """Compute every active dimension's sub-score.
+
+        Args:
+            text: The document text.
+            weights: Normalised, active dimension weights.
+
+        Returns:
+            Mapping ``dim -> {"score": float, "weight": float}`` for each
+            active dimension.
+        """
+        tokens = _WORD_RE.findall(text.lower())
+        breakdown: Dict[str, Dict[str, float]] = {}
+        for dim in weights:
+            if dim == "length":
+                breakdown[dim] = self._score_length(text)
+            elif dim == "sentence_completeness":
+                breakdown[dim] = self._score_sentence_completeness(text)
+            elif dim == "special_char_ratio":
+                breakdown[dim] = self._score_special_char_ratio(text)
+            elif dim == "repetition":
+                breakdown[dim] = self._score_repetition(text, tokens)
+            elif dim == "information_density":
+                breakdown[dim] = self._score_information_density(tokens)
+            else:
+                # Unknown dimension — skip (already filtered out upstream).
+                continue
+        return breakdown
+
+    def _validate_min_score(self) -> None:
+        """Validate ``min_score`` is None or in ``[0.0, 1.0]``.
+
+        Called from ``_process_docs`` so an invalid value is caught regardless
+        of how the instance was built (configer vs. direct construction).
+        """
+        if self.min_score is None:
+            return
+        try:
+            ms = float(self.min_score)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"min_score must be numeric or null, got {self.min_score!r}."
+            )
+        if not 0.0 <= ms <= 1.0:
+            raise ValueError(
+                f"min_score must be in [0.0, 1.0] or null, got {ms}."
+            )
+
+    def _normalised_weights(self) -> Dict[str, float]:
+        """Return the active (non-zero) weights, validated.
+
+        Raises ``ValueError`` for unknown dimensions. Empty after filtering
+        means the config was all-zeros, which is invalid.
+        """
+        valid = set(DEFAULT_WEIGHTS)
+        active: Dict[str, float] = {}
+        for dim, w in self.weights.items():
+            if dim not in valid:
+                raise ValueError(
+                    f"Unknown quality dimension: {dim!r}. "
+                    f"Valid dimensions: {sorted(valid)}."
+                )
+            try:
+                w = float(w)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"Weight for {dim!r} must be numeric, got {w!r}."
+                )
+            if w < 0:
+                raise ValueError(
+                    f"Weight for {dim!r} must be >= 0, got {w}."
+                )
+            if w > 0:
+                active[dim] = w
+        if not active:
+            raise ValueError(
+                "All quality weights are zero; at least one dimension must "
+                "have a positive weight."
+            )
+        return active
+
+    @staticmethod
+    def _weighted_average(breakdown: Dict[str, Dict[str, float]],
+                          weights: Dict[str, float]) -> float:
+        """Return the weight-normalised average of the active sub-scores."""
+        total_w = sum(weights[dim] for dim in breakdown)
+        if total_w <= 0:
+            return 0.0
+        acc = 0.0
+        for dim, info in breakdown.items():
+            acc += weights[dim] * info["score"]
+        return acc / total_w
+
+    # ------------------------------------------------------------------ #
+    # Dimension scorers — each returns {"score", "weight"} with score in [0,1]
+    # ------------------------------------------------------------------ #
+    def _score_length(self, text: str) -> Dict[str, float]:
+        """Reward documents near ``ideal_length``; penalise very short/long."""
+        n = len(text)
+        if n == 0:
+            return {"score": 0.0, "weight": self.weights["length"]}
+        if n <= self.min_length:
+            return {"score": 0.0, "weight": self.weights["length"]}
+        ideal = max(1, self.ideal_length)
+        if n <= 2 * ideal:
+            # Quadratic peak at ideal_length within [min, 2*ideal].
+            ratio = (n - self.min_length) / max(1, ideal - self.min_length)
+            # Bell shape centred at ratio=1, value 1 at peak.
+            score = 1.0 - (ratio - 1.0) ** 2
+        else:
+            # Beyond 2*ideal, decay linearly toward 0 (never negative).
+            excess = n - 2 * ideal
+            score = max(0.0, 1.0 - excess / (2.0 * ideal))
+        return {"score": self._clamp01(score), "weight": self.weights["length"]}
+
+    def _score_sentence_completeness(self, text: str) -> Dict[str, float]:
+        """Reward proper sentence terminators; penalise fragments / run-ons.
+
+        Combines two signals:
+        - the fraction of punctuation that is a real terminator (``. ! ?``);
+        - a penalty when there are words but no terminator at all.
+        """
+        terminators = _SENTENCE_END_RE.findall(text)
+        non_term_punct = _NON_TERMINATOR_PUNCT_RE.findall(text)
+        word_count = len(_WORD_RE.findall(text))
+
+        if word_count == 0:
+            return {"score": 0.0,
+                    "weight": self.weights["sentence_completeness"]}
+
+        total_punct = len(terminators) + len(non_term_punct)
+        if total_punct == 0:
+            # Words but zero punctuation — likely a fragment / keyword list.
+            return {"score": 0.1,
+                    "weight": self.weights["sentence_completeness"]}
+
+        term_fraction = len(terminators) / total_punct
+        # A document should have roughly one terminator per ~10-25 words.
+        # Too few terminators => run-on; too many => choppy. Both reduce score.
+        if terminators:
+            words_per_sentence = word_count / len(terminators)
+            # Ideal around 15; penalise outside [5, 40].
+            if 5 <= words_per_sentence <= 40:
+                cadence = 1.0
+            else:
+                cadence = max(0.0, 1.0 - abs(words_per_sentence - 15) / 60.0)
+        else:
+            cadence = 0.0
+
+        score = 0.5 * term_fraction + 0.5 * cadence
+        return {"score": self._clamp01(score),
+                "weight": self.weights["sentence_completeness"]}
+
+    def _score_special_char_ratio(self, text: str) -> Dict[str, float]:
+        """Penalise a high ratio of special (non-word, non-space) characters."""
+        if not text:
+            return {"score": 0.0,
+                    "weight": self.weights["special_char_ratio"]}
+        special = len(_SPECIAL_CHAR_RE.findall(text))
+        ratio = special / len(text)
+        # 0 special chars -> 1.0; >= 0.3 special -> 0.0; linear between.
+        score = 1.0 - min(1.0, ratio / 0.3)
+        return {"score": self._clamp01(score),
+                "weight": self.weights["special_char_ratio"]}
+
+    def _score_repetition(self, text: str,
+                          tokens: List[str]) -> Dict[str, float]:
+        """Penalise repeated shingles and dominant repeated words.
+
+        ``repetition_score = 1 - max(shingle_dup_rate, word_dup_rate)``.
+        """
+        weight = self.weights["repetition"]
+
+        # --- shingle (character n-gram) duplication ---
+        shingle_dup = 0.0
+        size = max(1, self.repetition_shingle_size)
+        if len(text) >= size:
+            shingles = [text[i:i + size] for i in range(len(text) - size + 1)]
+            if shingles:
+                counts = Counter(shingles)
+                # Words repeated more than once count as duplicated.
+                dup_count = sum(c for c in counts.values() if c > 1) - sum(
+                    1 for c in counts.values() if c > 1)
+                shingle_dup = max(0.0, dup_count) / len(shingles)
+
+        # --- dominant-word repetition ---
+        word_dup = 0.0
+        if tokens:
+            top = Counter(tokens).most_common(self.repetition_word_window)
+            # Share of tokens taken by the single most frequent word beyond
+            # its first occurrence.
+            if top:
+                freq_word, freq_count = top[0]
+                if freq_count > 1:
+                    word_dup = (freq_count - 1) / len(tokens)
+
+        score = 1.0 - self._clamp01(max(shingle_dup, word_dup))
+        return {"score": score, "weight": weight}
+
+    def _score_information_density(self,
+                                   tokens: List[str]) -> Dict[str, float]:
+        """Reward lexical diversity (distinct tokens / total tokens)."""
+        weight = self.weights["information_density"]
+        if not tokens:
+            return {"score": 0.0, "weight": weight}
+        diversity = len(set(tokens)) / len(tokens)
+        return {"score": self._clamp01(diversity), "weight": weight}
+
+    # ------------------------------------------------------------------ #
+    # Utilities
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _clamp01(value: float) -> float:
+        """Clamp ``value`` to the ``[0.0, 1.0]`` range."""
+        if value < 0.0:
+            return 0.0
+        if value > 1.0:
+            return 1.0
+        return value
+
+    # ------------------------------------------------------------------ #
+    # Config initialisation
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(
+            self, doc_processor_configer: ComponentConfiger) -> "QualityScorer":
+        """Initialise the scorer from its component configuration.
+
+        Validates weights/dimensions and clamps numeric thresholds.
+        """
+        super()._initialize_by_component_configer(doc_processor_configer)
+
+        if hasattr(doc_processor_configer, "min_score"):
+            ms = doc_processor_configer.min_score
+            if ms is None:
+                self.min_score = None
+            else:
+                ms = float(ms)
+                if not 0.0 <= ms <= 1.0:
+                    raise ValueError(
+                        f"min_score must be in [0.0, 1.0] or null, got {ms}."
+                    )
+                self.min_score = ms
+
+        if hasattr(doc_processor_configer, "score_key"):
+            self.score_key = doc_processor_configer.score_key
+
+        if hasattr(doc_processor_configer, "detail_key"):
+            self.detail_key = doc_processor_configer.detail_key
+
+        if hasattr(doc_processor_configer, "weights"):
+            w = doc_processor_configer.weights
+            if not isinstance(w, dict):
+                raise ValueError("weights must be a mapping of dim -> number.")
+            # Validate eagerly via _normalised_weights.
+            self.weights = dict(w)
+            self._normalised_weights()
+
+        if hasattr(doc_processor_configer, "ideal_length"):
+            self.ideal_length = int(doc_processor_configer.ideal_length)
+            if self.ideal_length <= 0:
+                raise ValueError("ideal_length must be a positive integer.")
+
+        if hasattr(doc_processor_configer, "min_length"):
+            self.min_length = max(0, int(doc_processor_configer.min_length))
+
+        if hasattr(doc_processor_configer, "repetition_shingle_size"):
+            self.repetition_shingle_size = max(
+                1, int(doc_processor_configer.repetition_shingle_size))
+
+        if hasattr(doc_processor_configer, "repetition_word_window"):
+            self.repetition_word_window = max(
+                1, int(doc_processor_configer.repetition_word_window))
+
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.yaml
@@ -1,0 +1,19 @@
+name: 'quality_scorer'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.quality_scorer'
+  class: 'QualityScorer'
+description: 'Scores recalled documents on text quality (length, sentence completeness, special-char ratio, repetition, information density) and optionally drops low-quality ones.'
+min_score: null              # documents scoring below this are dropped; null = annotate only
+score_key: 'quality_score'   # metadata key for the final score
+detail_key: 'quality_detail' # metadata key for the per-dimension breakdown; '' to omit
+weights:                     # per-dimension weights; 0 disables a dimension
+  length: 0.15
+  sentence_completeness: 0.25
+  special_char_ratio: 0.15
+  repetition: 0.20
+  information_density: 0.25
+ideal_length: 500            # chars at which the length dimension scores 1.0
+min_length: 20               # texts shorter than this get length score 0
+repetition_shingle_size: 8   # character n-gram size for repetition detection
+repetition_word_window: 10   # most-common words considered for word repetition

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,42 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [QualityScorer](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.yaml)
+
+This component scores each recalled document on overall text quality and optionally drops low-quality ones. The final score is a weighted average of several independent, dependency-free heuristic dimensions, each normalised to `[0.0, 1.0]`. It addresses the *quality assessment / post-processing* direction of issue #248.
+
+The scoring dimensions are: `length` (text length, peaking near `ideal_length`, penalising very short/long text), `sentence_completeness` (fraction of real sentence terminators `.`/`!`/`?` plus a per-sentence word-count cadence), `special_char_ratio` (share of non-word symbols — high values signal log/boilerplate noise), `repetition` (combining character n-gram duplication rate and dominant-word repetition rate), and `information_density` (lexical diversity: distinct tokens / total tokens). The final score is `Σ(weight_i × score_i) / Σweight_i`.
+
+It complements `ThresholdFilter`: `ThresholdFilter` filters on an **externally supplied** score field, while this component **computes** a score from the text alone, with no external signals or models required. With `min_score` set to `null` it only annotates (writing the score to `score_key` and the per-dimension breakdown to `detail_key`) and drops nothing.
+
+The component definition file is as follows:
+```yaml
+name: 'quality_scorer'
+description: 'score recalled documents on text quality'
+min_score: null              # documents scoring below this are dropped; null = annotate only
+score_key: 'quality_score'   # metadata key for the final score
+detail_key: 'quality_detail' # metadata key for the per-dimension breakdown; '' to omit
+weights:                     # per-dimension weights; 0 disables a dimension
+  length: 0.15
+  sentence_completeness: 0.25
+  special_char_ratio: 0.15
+  repetition: 0.20
+  information_density: 0.25
+ideal_length: 500            # chars at which the length dimension scores 1.0
+min_length: 20               # texts shorter than this get length score 0
+repetition_shingle_size: 8   # character n-gram size for repetition detection
+repetition_word_window: 10   # most-common words considered for word repetition
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.quality_scorer'
+  class: 'QualityScorer'
+```
+- min_score: Minimum final score in `[0.0, 1.0]`; documents below it are dropped. Set to `null` to annotate without dropping.
+- score_key: Metadata key under which each document's final quality score is written.
+- detail_key: Metadata key for the per-dimension `{dim: {score, weight}}` breakdown; set to empty to omit.
+- weights: Mapping of per-dimension weights; keys must be a subset of `{length, sentence_completeness, special_char_ratio, repetition, information_density}`. A weight of 0 skips that dimension; at least one dimension must be positive.
+- ideal_length: Character count at which the `length` dimension scores 1.0; shorter or longer text is penalised.
+- min_length: Texts shorter than this many characters get a `length` score of 0.
+- repetition_shingle_size: Character n-gram size used for repetition detection.
+- repetition_word_window: Number of most-common words considered when measuring word repetition.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,42 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [QualityScorer](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.yaml)
+
+该组件对召回文档的文本质量进行打分，并可丢弃低分文档。最终分数是若干个互相独立、无第三方依赖的启发式维度的加权平均，每个维度归一化到 `[0.0, 1.0]`。对应 issue #248 的*质量评估 / 后处理*方向。
+
+打分维度包括：`length`（文本长度，在 `ideal_length` 附近得分最高，过短/过长扣分）、`sentence_completeness`（句子完整度，考察真正的句末终止符 `.`/`!`/`?` 占比与每句词数节奏）、`special_char_ratio`（特殊符号占比，过高说明是日志/样板噪声）、`repetition`（重复内容，综合字符 n-gram 重复率与最高频词重复率）、`information_density`（词法多样性，不同词数 / 总词数）。最终分数为 `Σ(weight_i × score_i) / Σweight_i`。
+
+它与 `ThresholdFilter` 互补：`ThresholdFilter` 依据**外部提供**的分数字段做过滤，而本组件**从文本本身**计算出一个分数，无需任何外部信号或模型。`min_score` 为 `null` 时仅做标注（把分数写入 `score_key`、把各维度明细写入 `detail_key`），不丢弃任何文档。
+
+组件定义文件如下：
+```yaml
+name: 'quality_scorer'
+description: '对召回文档做文本质量打分'
+min_score: null              # 低于此分数的文档被丢弃；null = 仅标注
+score_key: 'quality_score'   # 最终分数的 metadata 键
+detail_key: 'quality_detail' # 各维度明细的 metadata 键；'' 表示不写入
+weights:                     # 各维度权重；0 表示禁用该维度
+  length: 0.15
+  sentence_completeness: 0.25
+  special_char_ratio: 0.15
+  repetition: 0.20
+  information_density: 0.25
+ideal_length: 500            # length 维度得 1.0 时的字符数
+min_length: 20               # 短于此长度的文本 length 维度得 0
+repetition_shingle_size: 8   # 重复检测的字符 n-gram 大小
+repetition_word_window: 10   # 词重复检测考虑的最高频词数量
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.quality_scorer'
+  class: 'QualityScorer'
+```
+- min_score: 最低最终分数，取值 `[0.0, 1.0]`；低于此值的文档被丢弃。设为 `null` 则仅标注不丢弃。
+- score_key: 写入每个文档最终质量分数的 metadata 键。
+- detail_key: 写入各维度 `{dim: {score, weight}}` 明细的 metadata 键；设为空则不写入。
+- weights: 各维度权重映射，键必须是 `{length, sentence_completeness, special_char_ratio, repetition, information_density}` 的子集；某维度权重为 0 即跳过；至少一个维度需为正。
+- ideal_length: `length` 维度得 1.0 时的字符数；过短或过长都会扣分。
+- min_length: 文本短于此字符数时 `length` 维度直接得 0。
+- repetition_shingle_size: 重复检测所用的字符 n-gram 大小。
+- repetition_word_window: 词重复检测中考虑的最高频词数量。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_quality_scorer.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_quality_scorer.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for QualityScorer DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.quality_scorer \
+    import QualityScorer
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+# A well-formed English paragraph used as a "high quality" baseline.
+_GOOD_TEXT = (
+    "The quick brown fox jumps over the lazy dog. "
+    "Machine learning models require large amounts of clean training data. "
+    "Document quality affects retrieval accuracy in meaningful ways. "
+    "Consistent punctuation and varied vocabulary improve readability. "
+    "Agents perform better when their knowledge base is well curated."
+)
+
+
+class TestQualityScorer(unittest.TestCase):
+
+    def _score(self, docs, **kwargs):
+        proc = QualityScorer(**kwargs)
+        return proc.process_docs(docs, None)
+
+    def _single(self, text, **kwargs):
+        result = self._score([Document(text=text)], **kwargs)
+        return result[0] if result else None
+
+    # ------------------------------------------------------------------ #
+    # annotation mode (min_score None) — nothing is dropped
+    # ------------------------------------------------------------------ #
+    def test_annotates_score_in_metadata(self):
+        doc = self._single(_GOOD_TEXT)
+        self.assertIn("quality_score", doc.metadata)
+        self.assertIsInstance(doc.metadata["quality_score"], float)
+
+    def test_detail_breakdown_written(self):
+        doc = self._single(_GOOD_TEXT)
+        detail = doc.metadata["quality_detail"]
+        for dim in ["length", "sentence_completeness", "special_char_ratio",
+                    "repetition", "information_density"]:
+            self.assertIn(dim, detail)
+            self.assertIn("score", detail[dim])
+            self.assertIn("weight", detail[dim])
+
+    def test_score_in_unit_range(self):
+        for text in ["", "a", _GOOD_TEXT, "!!!! @@@@ #### ****"]:
+            doc = self._single(text)
+            if doc is None:
+                continue
+            s = doc.metadata["quality_score"]
+            self.assertGreaterEqual(s, 0.0)
+            self.assertLessEqual(s, 1.0)
+
+    def test_good_text_scores_higher_than_garbage(self):
+        good = self._single(_GOOD_TEXT).metadata["quality_score"]
+        garbage = self._single("@@@@ #### $$$$ %%%% **** !!!! @@@@").metadata[
+            "quality_score"]
+        self.assertGreater(good, garbage)
+
+    # ------------------------------------------------------------------ #
+    # min_score dropping
+    # ------------------------------------------------------------------ #
+    def test_min_score_drops_low_quality(self):
+        # Pure symbol garbage scores very low; min_score 0.5 drops it.
+        docs = [Document(text="@@@ #### $$$ %%% **** @@@ @@@ @@@")]
+        result = self._score(docs, min_score=0.5)
+        self.assertEqual(len(result), 0)
+
+    def test_min_score_keeps_high_quality(self):
+        docs = [Document(text=_GOOD_TEXT)]
+        result = self._score(docs, min_score=0.3)
+        self.assertEqual(len(result), 1)
+
+    def test_min_score_none_keeps_everything(self):
+        docs = [Document(text="@@@ ###"), Document(text=_GOOD_TEXT)]
+        result = self._score(docs, min_score=None)
+        self.assertEqual(len(result), 2)
+
+    def test_invalid_min_score_raises(self):
+        # min_score outside [0.0, 1.0] is rejected at construction time.
+        with self.assertRaises(Exception):
+            QualityScorer(min_score=2.0).process_docs(
+                [Document(text="hi")], None)
+
+    # ------------------------------------------------------------------ #
+    # individual dimensions
+    # ------------------------------------------------------------------ #
+    def test_length_dimension_penalises_short_text(self):
+        # Very short text -> length sub-score low; long text around ideal higher.
+        short = self._single("hi there friend.").metadata["quality_detail"]
+        good = self._single(_GOOD_TEXT).metadata["quality_detail"]
+        self.assertLessEqual(short["length"]["score"],
+                             good["length"]["score"] + 0.05)
+
+    def test_special_char_ratio_penalises_symbols(self):
+        clean = self._single("normal english words here.").metadata[
+            "quality_detail"]
+        symbols = self._single("@@@@@@@@@@#######").metadata["quality_detail"]
+        self.assertGreater(clean["special_char_ratio"]["score"],
+                           symbols["special_char_ratio"]["score"])
+
+    def test_repetition_penalises_duplicates(self):
+        varied = self._single(_GOOD_TEXT).metadata["quality_detail"]
+        repeated = self._single(" ".join(["same"] * 40) + ".").metadata[
+            "quality_detail"]
+        self.assertGreater(varied["repetition"]["score"],
+                           repeated["repetition"]["score"])
+
+    def test_information_density_rewards_variety(self):
+        varied = self._single(_GOOD_TEXT).metadata["quality_detail"]
+        repetitive = self._single("the the the the the the.").metadata[
+            "quality_detail"]
+        self.assertGreater(varied["information_density"]["score"],
+                           repetitive["information_density"]["score"])
+
+    # ------------------------------------------------------------------ #
+    # weights / config
+    # ------------------------------------------------------------------ #
+    def test_custom_weights_respected(self):
+        # Only sentence_completeness with weight 1 -> final == that sub-score.
+        doc = self._single(_GOOD_TEXT,
+                           weights={"sentence_completeness": 1.0})
+        detail = doc.metadata["quality_detail"]
+        self.assertAlmostEqual(doc.metadata["quality_score"],
+                               detail["sentence_completeness"]["score"],
+                               places=5)
+
+    def test_zero_weight_dimension_omitted(self):
+        doc = self._single(_GOOD_TEXT, weights={
+            "length": 0.0, "sentence_completeness": 1.0})
+        detail = doc.metadata["quality_detail"]
+        self.assertNotIn("length", detail)
+        self.assertIn("sentence_completeness", detail)
+
+    def test_unknown_dimension_raises(self):
+        proc = QualityScorer(weights={"bogus": 1.0})
+        with self.assertRaises(ValueError):
+            proc.process_docs([Document(text="hi")], None)
+
+    def test_all_zero_weights_raises(self):
+        proc = QualityScorer(weights={
+            "length": 0, "sentence_completeness": 0,
+            "special_char_ratio": 0, "repetition": 0,
+            "information_density": 0})
+        with self.assertRaises(ValueError):
+            proc.process_docs([Document(text="hi")], None)
+
+    # ------------------------------------------------------------------ #
+    # edge cases / metadata
+    # ------------------------------------------------------------------ #
+    def test_empty_input(self):
+        proc = QualityScorer()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_empty_text_dropped_with_min_score(self):
+        docs = [Document(text="")]
+        result = self._score(docs, min_score=0.5)
+        self.assertEqual(len(result), 0)
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text=_GOOD_TEXT, metadata={"source": "wiki"})
+        result = self._score([doc])
+        self.assertEqual(result[0].metadata["source"], "wiki")
+        self.assertIn("quality_score", result[0].metadata)
+
+    def test_detail_key_empty_omits_breakdown(self):
+        doc = self._single(_GOOD_TEXT, detail_key="")
+        self.assertNotIn("quality_detail", doc.metadata)
+        self.assertIn("quality_score", doc.metadata)
+
+    def test_custom_score_key(self):
+        doc = self._single(_GOOD_TEXT, score_key="my_quality")
+        self.assertIn("my_quality", doc.metadata)
+        self.assertNotIn("quality_score", doc.metadata)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds a new knowledge post-processing component **QualityScorer** (#248, quality-assessment direction).

A dependency-free `DocProcessor` that scores each recalled document on overall text quality and optionally drops low-quality ones. The score is a weighted average of several independent heuristics, each normalised to `[0.0, 1.0]`.

## Scoring dimensions

| Dimension | What it measures |
|---|---|
| `length` | Text length — peaks near `ideal_length`, penalises very short/long text |
| `sentence_completeness` | Real sentence terminators (`. ! ?`) share + per-sentence word-count cadence |
| `special_char_ratio` | Share of non-word symbols — high values signal log/boilerplate noise |
| `repetition` | Combines character n-gram duplication rate and dominant-word repetition rate |
| `information_density` | Lexical diversity — distinct tokens / total tokens |

The final score is `Σ(weight_i × score_i) / Σweight_i`.

## Behaviour

- `min_score`: documents scoring below this are dropped; `null` (default) annotates without dropping.
- `score_key`: metadata key for the final score (default `quality_score`).
- `detail_key`: metadata key for the per-dimension `{dim: {score, weight}}` breakdown (default `quality_detail`; set `''` to omit).
- `weights`: per-dimension weights; a weight of `0` disables a dimension; unknown dimensions / all-zero configs raise on init.

It complements `ThresholdFilter` (which filters on an **externally supplied** score field): this component **computes** a score from the text alone, with no external signals or models.

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.py` (~430 lines)
- `agentuniverse/agent/action/knowledge/doc_processor/quality_scorer.yaml`
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_quality_scorer.py` (21 tests)
- `docs/.../DocProcessor.md` (zh + en, new section appended)

## Test plan

All 21 unit tests pass (`python .../test_quality_scorer.py`), covering: annotation mode, score range, good-vs-garbage ordering, `min_score` dropping (drop/keep/null), per-dimension behaviour (length, special-char, repetition, information density), custom weights, zero-weight omission, unknown-dimension and all-zero-weight validation, metadata preservation, custom/empty detail keys, and empty input.

Closes #248.
