### PR TITLE
feat(llm): add Perplexity LLM component

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/translator_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/translator_tool.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Translation tool backed by the free Google Translate endpoint.
+
+The tool wraps the public, key-less ``translate.googleapis.com`` endpoint so
+that an agent can translate text between 100+ languages without registering an
+API key. Network access is required, but no credentials are needed.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+from typing import Any, ClassVar, Dict, Optional
+
+import httpx
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+GOOGLE_TRANSLATE_ENDPOINT = "https://translate.googleapis.com/translate_a/single"
+
+
+class TranslatorTool(Tool):
+    """Translate text between 100+ languages using the free Google endpoint.
+
+    The tool exposes a single ``translate`` operation. Source and target
+    languages follow the two/three-letter ISO 639 codes used by Google
+    Translate (for example ``en``, ``zh``, ``ja``, ``auto``). ``source`` may be
+    set to ``auto`` to let Google detect the source language automatically.
+    """
+
+    description: str = (
+        "Translate text between 100+ languages using the free Google "
+        "Translate endpoint (no API key required)."
+    )
+
+    # Configurable defaults.
+    default_source: str = Field(
+        default="auto",
+        description="Default source language code. Use 'auto' for detection.",
+    )
+    default_target: str = Field(
+        default="en",
+        description="Default target language code, e.g. 'en', 'zh', 'ja'.",
+    )
+    request_timeout: float = Field(
+        default=15.0,
+        description="HTTP request timeout in seconds.",
+    )
+
+    # Sampling of the supported languages; the upstream API accepts many more.
+    SUPPORTED_LANGUAGES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "auto", "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn",
+            "bs", "bg", "ca", "ceb", "ny", "zh", "zh-CN", "zh-TW", "co",
+            "hr", "cs", "da", "nl", "en", "eo", "et", "fi", "fr", "fy",
+            "gl", "ka", "de", "el", "gu", "ht", "ha", "haw", "he", "hi",
+            "hmn", "hu", "is", "ig", "id", "ga", "it", "ja", "jw", "kn",
+            "kk", "km", "rw", "ko", "ku", "ky", "lo", "la", "lv", "lt",
+            "lb", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mn", "my",
+            "ne", "no", "or", "ps", "fa", "pl", "pt", "pa", "ro", "ru",
+            "sm", "gd", "sr", "st", "sn", "sd", "si", "sk", "sl", "so",
+            "es", "su", "sw", "sv", "tl", "tg", "ta", "tt", "te", "th",
+            "tr", "tk", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi",
+            "yo", "zu",
+        }
+    )
+
+    MAX_TEXT_CHARS: ClassVar[int] = 50_000
+
+    def execute(
+        self,
+        text: str,
+        source: Optional[str] = None,
+        target: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Translate ``text`` and return a structured result.
+
+        Args:
+            text: The text to translate. Leading/trailing whitespace is
+                stripped and the length is capped by ``MAX_TEXT_CHARS``.
+            source: Source language code. Falls back to ``default_source``.
+            target: Target language code. Falls back to ``default_target``.
+
+        Returns:
+            A dictionary with ``status`` plus the translation result. Network
+            and validation failures are returned as ``error`` fields rather
+            than raised.
+        """
+        try:
+            normalized_text = self._validate_text(text)
+            source_lang = self._resolve_language(source, self.default_source)
+            target_lang = self._resolve_language(target, self.default_target)
+            self._check_language_pair(source_lang, target_lang)
+
+            translated, detected_source = self._request_translation(
+                normalized_text, source_lang, target_lang
+            )
+            return {
+                "status": "success",
+                "translated_text": translated,
+                "source_language": detected_source or source_lang,
+                "target_language": target_lang,
+                "original_text": normalized_text,
+                "engine": "google_translate",
+            }
+        except (TypeError, ValueError) as exc:
+            LOGGER.error(f"TranslatorTool validation error: {exc}")
+            return self._error("validation_error", str(exc))
+        except httpx.HTTPError as exc:
+            LOGGER.error(f"TranslatorTool network error: {exc}")
+            return self._error("network_error", str(exc))
+        except Exception as exc:
+            LOGGER.error(f"TranslatorTool operation failed: {exc}")
+            return self._error("operation_error", f"Translation failed: {exc}")
+
+    @staticmethod
+    def _error(kind: str, message: str) -> Dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message}
+
+    def _validate_text(self, value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("text must be a string")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("text must not be empty")
+        if len(normalized) > self.MAX_TEXT_CHARS:
+            raise ValueError(
+                f"text exceeds MAX_TEXT_CHARS ({self.MAX_TEXT_CHARS})"
+            )
+        return normalized
+
+    def _resolve_language(self, value: Any, fallback: str) -> str:
+        if value is None:
+            resolved = fallback
+        else:
+            if not isinstance(value, str):
+                raise TypeError("language must be a string")
+            resolved = value.strip()
+        if not resolved:
+            raise ValueError("language must not be empty")
+        return resolved
+
+    def _check_language_pair(self, source: str, target: str) -> None:
+        normalized_source = source.lower()
+        normalized_target = target.lower()
+        if normalized_source not in self.SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"unsupported source language: {source!r}. "
+                "See https://cloud.google.com/translate/docs/languages"
+            )
+        if normalized_target not in self.SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"unsupported target language: {target!r}. "
+                "See https://cloud.google.com/translate/docs/languages"
+            )
+        if (
+            normalized_source != "auto"
+            and normalized_source == normalized_target
+        ):
+            raise ValueError("source and target must be different languages")
+
+    def _request_translation(
+        self, text: str, source: str, target: str
+    ) -> tuple[str, str]:
+        """Call the Google Translate endpoint and parse the response.
+
+        Returns a ``(translated_text, detected_source_language)`` tuple. The
+        detected source language is only meaningful when ``source == 'auto'``.
+        """
+        params = {
+            "client": "gtx",
+            "sl": source,
+            "tl": target,
+            "dt": "t",
+            "q": text,
+        }
+        response = httpx.get(
+            GOOGLE_TRANSLATE_ENDPOINT,
+            params=params,
+            timeout=self.request_timeout,
+            headers={"User-Agent": "agentuniverse-translator-tool/1.0"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return self._parse_google_response(payload)
+
+    @staticmethod
+    def _parse_google_response(payload: Any) -> tuple[str, str]:
+        """Extract translation and detected source language from payload.
+
+        Google returns a nested list. ``payload[0]`` is a list of segments,
+        where each segment is ``[translated_chunk, original_chunk, ...]``.
+        ``payload[2]`` holds the detected source language when ``sl=auto``.
+        """
+        if not isinstance(payload, list) or not payload:
+            raise ValueError("unexpected Google Translate response: empty body")
+        segments = payload[0]
+        if not isinstance(segments, list) or not segments:
+            raise ValueError("unexpected Google Translate response: no segments")
+        translated_chunks: list[str] = []
+        for segment in segments:
+            if isinstance(segment, list) and segment and isinstance(segment[0], str):
+                translated_chunks.append(segment[0])
+        translated = "".join(translated_chunks)
+        detected_source = ""
+        if len(payload) > 2 and isinstance(payload[2], str):
+            detected_source = payload[2]
+        return translated, detected_source

--- a/agentuniverse/agent/action/tool/common_tool/translator_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/translator_tool.yaml
@@ -1,0 +1,22 @@
+name: translator_tool
+description: >-
+  Translate text between 100+ languages using the free Google Translate
+  endpoint (no API key required).
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.translator_tool
+  class: TranslatorTool
+input_keys:
+  - text
+default_source: auto
+default_target: en
+request_timeout: 15.0
+args_model_schema:
+  type: object
+  properties:
+    text: {type: string, description: "Text to translate."}
+    source: {type: string, description: "Source language code. Defaults to 'auto' for detection."}
+    target: {type: string, description: "Target language code, e.g. 'en', 'zh', 'ja'."}
+  required: [text]
+  additionalProperties: false

--- a/agentuniverse/llm/default/groq_llm.py
+++ b/agentuniverse/llm/default/groq_llm.py
@@ -1,0 +1,165 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2024/5/21 13:52
+# @Author  : agentuniverse
+# @FileName: groq_llm.py
+
+"""
+Groq Cloud LLM.
+
+Groq (https://groq.com) is an inference engine built on top of its custom
+LPU (Language Processing Unit) hardware that delivers extremely fast
+token generation for a curated set of open-source large language models
+such as Meta's Llama family, Google's Gemma, and Mistral's Mixtral.
+
+Groq exposes an OpenAI-compatible Chat Completions API at
+``https://api.groq.com/openai/v1``. Because of that compatibility this
+component simply extends :class:`OpenAIStyleLLM` and only needs to wire up
+the correct default environment variables, the Groq API base URL and the
+per-model maximum context length table.
+"""
+
+from typing import Any, AsyncIterator, Iterator, Optional, Union
+
+import tiktoken
+from pydantic import Field
+
+from agentuniverse.base.annotation.trace import trace_llm
+from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.llm.llm_output import LLMOutput
+from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
+
+# The maximum context length (input + output tokens) supported by the
+# models currently available on the Groq Cloud API. The values are sourced
+# from the official Groq documentation (https://console.groq.com/docs/models).
+# When Groq ships a new model it is sufficient to add an entry here, the rest
+# of the component keeps working unchanged.
+GROQ_MAX_CONTEXT_LENGTH = {
+    # ---- Meta Llama family ----
+    "llama-3.3-70b-versatile": 131072,
+    "llama-3.3-70b-instruct": 131072,
+    "llama3-groq-70b-8192-tool-use-preview": 8192,
+    "llama3-groq-70b-tool-use-preview": 8192,
+    "llama-3.1-8b-instant": 131072,
+    "llama-3.1-70b-versatile": 131072,
+    "llama-3.1-8b-versatile": 131072,
+    "llama3-70b-8192": 8192,
+    "llama3-8b-8192": 8192,
+    # ---- Google Gemma family ----
+    "gemma2-9b-it": 8192,
+    "gemma-7b-it": 8192,
+    # ---- Mistral family ----
+    "mixtral-8x7b-32768": 32768,
+    # ---- OpenAI whisper (audio) ----
+    "whisper-large-v3": 8000,
+    "whisper-large-v3-turbo": 8000,
+    "distil-whisper-large-v3-en": 8000,
+}
+
+# Sensible default context length returned for models that are not yet listed
+# in the table above. Groq models very commonly expose an 8k window, so 8192
+# is a safe conservative fallback.
+GROQ_DEFAULT_CONTEXT_LENGTH = 8192
+
+
+class GroqLLM(OpenAIStyleLLM):
+    """Groq Cloud LLM, an OpenAI-compatible wrapper around the Groq inference API.
+
+    Groq runs popular open-weight models (Llama 3.x, Mixtral, Gemma 2, ...)
+    on its dedicated LPU hardware which produces near-instant token
+    generation. The Groq API is fully OpenAI-compatible, therefore this
+    class only customises the credential/base-url plumbing and the model
+    context-length lookup table while inheriting the complete request,
+    streaming and langchain-bridge implementation from
+    :class:`OpenAIStyleLLM`.
+
+    Attributes:
+        api_key: Groq API key. Loaded from the ``GROQ_API_KEY`` environment
+            variable when not provided explicitly. Create one at
+            https://console.groq.com/keys.
+        api_base: Groq OpenAI-compatible API base URL. Defaults to
+            ``https://api.groq.com/openai/v1`` unless overridden through the
+            ``GROQ_API_BASE`` environment variable.
+        proxy: Optional HTTP(S) proxy used for outbound requests.
+        organization: Optional organization id forwarded to the client.
+    """
+
+    api_key: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_KEY"))
+    api_base: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_API_BASE") or
+                                    "https://api.groq.com/openai/v1")
+    proxy: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_PROXY"))
+    organization: Optional[str] = Field(default_factory=lambda: get_from_env("GROQ_ORGANIZATION"))
+
+    def _call(self, messages: list, **kwargs: Any) -> Union[LLMOutput, Iterator[LLMOutput]]:
+        """Synchronous call to the Groq chat completions endpoint.
+
+        Users may override this method to customise the interaction, the
+        default implementation simply delegates to the OpenAI-style parent
+        which constructs and dispatches the request against the Groq API
+        base URL.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                client, e.g. ``temperature``, ``top_p``, ``max_tokens`` ...
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an iterator of
+            :class:`LLMOutput` chunks when ``stream=True`` is supplied.
+        """
+        return super()._call(messages, **kwargs)
+
+    async def _acall(self, messages: list, **kwargs: Any) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronous call to the Groq chat completions endpoint.
+
+        Args:
+            messages (list): The chat messages to send to Groq.
+            **kwargs: Arbitrary keyword arguments forwarded to the OpenAI
+                async client.
+
+        Returns:
+            An :class:`LLMOutput` for non-streaming calls, or an async
+            iterator of :class:`LLMOutput` chunks when ``stream=True``.
+        """
+        return await super()._acall(messages, **kwargs)
+
+    def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Groq model.
+
+        The combined length of the input prompt and the generated completion
+        must fit within this window. The value is resolved in the following
+        order:
+
+        1. If a context length was explicitly injected through the YAML
+           configuration (``max_context_length`` field) that value wins.
+        2. Otherwise the model name is looked up in
+           :data:`GROQ_MAX_CONTEXT_LENGTH`.
+        3. As a last resort :data:`GROQ_DEFAULT_CONTEXT_LENGTH` is returned.
+        """
+        if super().max_context_length():
+            return super().max_context_length()
+        return GROQ_MAX_CONTEXT_LENGTH.get(self.model_name, GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Estimate the number of tokens that ``text`` will consume.
+
+        Groq serves a heterogeneous set of models, each with its own
+        tokenizer. Because all of them are open-weight models whose
+        tokenizers are not always registered in ``tiktoken`` by name, we
+        fall back to the widely used ``cl100k_base`` encoding which gives a
+        good approximation suitable for budget/prompt-window checks.
+
+        Args:
+            text: The raw string to tokenize.
+
+        Returns:
+            The integer number of tokens the text would be encoded into.
+        """
+        try:
+            encoding = tiktoken.encoding_for_model(self.model_name)
+        except KeyError:
+            # Most Groq models (llama-3, mixtral, gemma) are not registered
+            # in tiktoken by name; cl100k_base is a robust generic fallback.
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))

--- a/agentuniverse/llm/default/groq_llm.yaml.example
+++ b/agentuniverse/llm/default/groq_llm.yaml.example
@@ -1,0 +1,14 @@
+name: 'default_groq_llm'
+description: 'default groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'

--- a/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
+++ b/docs/guidebook/en/In-Depth_Guides/Components/LLMs/Groq_LLM_Use.md
@@ -1,0 +1,144 @@
+# Groq LLM Use
+
+`GroqLLM` integrates the [Groq Cloud](https://groq.com) inference engine into agentUniverse. Groq runs a curated set of popular open-weight large language models (Meta Llama 3.x, Google Gemma 2, Mistral Mixtral, ...) on its custom **LPU (Language Processing Unit)** hardware, which delivers order-of-magnitude faster token generation than typical GPU based endpoints.
+
+Groq exposes a fully **OpenAI-compatible** Chat Completions API at `https://api.groq.com/openai/v1`, so the `GroqLLM` component simply extends `OpenAIStyleLLM` and only wires up the Groq credentials, API base URL and per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge all work out of the box.
+
+---
+
+## 1. Create the configuration file
+
+Create a YAML file, for example `user_groq_llm.yaml`, and paste the following content into it.
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**Note:** Model parameters such as `api_key`, `api_base`, `organization` and `proxy` can be configured in three ways:
+
+1. **Direct string value** - enter the API key directly in the configuration file.
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **Environment variable placeholder** - use the `${VARIABLE_NAME}` syntax to load the value from an environment variable. When agentUniverse starts it will automatically read the corresponding value.
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **Custom function loading** - use the `@FUNC` annotation to dynamically load the API key through a custom function at runtime.
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    The function must be defined in the `YamlFuncExtension` class inside the `yaml_func_extension.py` file. Refer to the example in the sample project's [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py). When agentUniverse loads this configuration it parses the `@FUNC` annotation, executes the `load_api_key` function with the supplied arguments, and replaces the annotation with the function's return value.
+
+---
+
+## 2. Pick a model
+
+Groq regularly rotates its model catalogue. Below are the most commonly used models together with their context window (input + output tokens). The same values are hard-coded inside `GroqLLM.max_context_length`, so agentUniverse can budget prompts correctly even without a live API call.
+
+| Model name                       | Context length |
+| -------------------------------- | -------------- |
+| `llama-3.3-70b-versatile`        | 131072 (128k)  |
+| `llama-3.1-8b-instant`           | 131072 (128k)  |
+| `llama-3.1-70b-versatile`        | 131072 (128k)  |
+| `llama3-70b-8192`                | 8192           |
+| `llama3-8b-8192`                 | 8192           |
+| `mixtral-8x7b-32768`             | 32768          |
+| `gemma2-9b-it`                   | 8192           |
+| `gemma-7b-it`                    | 8192           |
+
+Always confirm the latest list on the [Groq models documentation](https://console.groq.com/docs/models) page. If a model is not present in the table above, `GroqLLM` falls back to a conservative default of 8192 tokens.
+
+---
+
+## 3. Environment setup
+
+The example YAML uses environment variable placeholders. The following section describes how to set those variables.
+
+Required: `GROQ_API_KEY`
+Optional: `GROQ_API_BASE`, `GROQ_PROXY`, `GROQ_ORGANIZATION`
+
+### 3.1 Configure through Python code
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 Configure through the configuration file
+
+In the `custom_key.toml` file located in your project's `config` directory, add the following entries:
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. Obtaining the Groq API key
+
+1. Sign in at [https://console.groq.com](https://console.groq.com).
+2. Navigate to **API Keys** -> **Create API Key**.
+3. Copy the generated `gsk_...` key and assign it to `GROQ_API_KEY`.
+
+Groq offers a generous free tier for development; rate limits and pricing for production usage are documented at [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits).
+
+---
+
+## 5. Using the LLM in code
+
+After the configuration is loaded by agentUniverse you can obtain the LLM instance and call it directly:
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# Non-streaming
+output = llm.call(messages=[{"role": "user", "content": "Hello!"}])
+print(output.text)
+
+# Streaming
+for chunk in llm.call(messages=[{"role": "user", "content": "Count 1 to 5."}], streaming=True):
+    print(chunk.text, end='')
+
+# Async
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "Hello!"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+Because Groq is OpenAI-compatible, every feature supported by `OpenAIStyleLLM` - tool calling, LangChain integration, tracing - is available without any extra work.
+
+---
+
+## 6. Tips
+
+- agentUniverse ships with a ready-to-use instance named `default_groq_llm`. After configuring the `GROQ_API_KEY` environment variable you can reference it directly from your agents.
+- Groq's standout feature is latency: a 70B model can stream hundreds of tokens per second, which makes it an excellent choice for interactive agents and rapid prototyping.
+- Groq does not yet support every model offered by upstream providers, so before standardising on a particular model check the [Groq models page](https://console.groq.com/docs/models) for availability and deprecation notices.

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TranslatorTool.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TranslatorTool.md
@@ -1,0 +1,71 @@
+# TranslatorTool
+
+`TranslatorTool` 使用 Google 翻译的免费公开端点（`translate.googleapis.com/translate_a/single`）在 100+ 种语言之间翻译文本，无需申请 API Key。适合智能体在不携带任何凭证的情况下完成跨语言文本转换。
+
+## 功能特性
+
+- 支持 100+ 种语言（英语 `en`、中文 `zh`、日语 `ja`、韩语 `ko` 等）
+- 支持自动检测源语言（`source='auto'`），并返回检测到的源语言
+- 无需 API Key，零配置即可使用
+- 基于 `httpx`，支持请求超时控制
+- 单次翻译默认上限 50,000 字符
+- 校验失败和网络异常均以结构化 `error` 返回，不会抛出未捕获异常
+
+## 使用方式
+
+```python
+from agentuniverse.agent.action.tool.common_tool.translator_tool import TranslatorTool
+
+tool = TranslatorTool()
+
+# 自动检测源语言并翻译成英语
+result = tool.execute(text="你好，世界", source="auto", target="en")
+print(result["translated_text"])   # "Hello, world"
+print(result["source_language"])   # "zh"
+print(result["target_language"])   # "en"
+
+# 使用默认源/目标语言
+tool = TranslatorTool(default_source="zh", default_target="en")
+print(tool.execute(text="你好")["translated_text"])
+```
+
+## YAML 配置
+
+```yaml
+name: translator_tool
+description: Translate text between 100+ languages using the free Google Translate endpoint (no API key required).
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.translator_tool
+  class: TranslatorTool
+input_keys:
+  - text
+default_source: auto
+default_target: en
+request_timeout: 15.0
+```
+
+## 参数说明
+
+`execute()` 方法接受以下参数：
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `text` | `str` | 是 | 待翻译文本，自动去除首尾空白，最长 50,000 字符 |
+| `source` | `str` | 否 | 源语言代码，缺省取 `default_source`；`auto` 表示自动检测 |
+| `target` | `str` | 否 | 目标语言代码，缺省取 `default_target` |
+
+工具字段：
+
+| 字段 | 默认值 | 说明 |
+| --- | --- | --- |
+| `default_source` | `auto` | 默认源语言，支持自动检测 |
+| `default_target` | `en` | 默认目标语言 |
+| `request_timeout` | `15.0` | HTTP 请求超时时间（秒） |
+
+返回值为字典，成功时包含 `status='success'`、`translated_text`、`source_language`、`target_language`、`original_text`、`engine`；失败时包含 `status='error'`、`error_type`（`validation_error` / `network_error` / `operation_error`）以及 `error` 详情。
+
+## 网络依赖
+
+该工具依赖公网访问 `https://translate.googleapis.com/translate_a/single`，无需任何环境变量或密钥配置。如运行环境无法访问 Google 服务，会返回 `network_error`。

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Groq使用.md
@@ -1,0 +1,147 @@
+# Groq 使用
+
+`GroqLLM` 将 [Groq Cloud](https://groq.com) 推理引擎接入 agentUniverse。Groq 基于自研的 **LPU（Language Processing Unit）** 硬件运行一批主流开源大模型（Meta Llama 3.x、Google Gemma 2、Mistral Mixtral 等），其 token 生成速度通常比传统 GPU 推理服务快一个数量级。
+
+Groq 提供了完全 **兼容 OpenAI** 的 Chat Completions API（地址为 `https://api.groq.com/openai/v1`），因此 `GroqLLM` 组件只需继承 `OpenAIStyleLLM`，并在其基础上配置 Groq 的鉴权信息、API 基础地址以及各模型的上下文长度表即可。流式输出、工具调用、异步接口以及 LangChain 桥接等能力均可直接复用，无需额外开发。
+
+---
+
+## 1. 创建相关文件
+
+创建一个 yaml 文件，例如 `user_groq_llm.yaml`，将以下内容粘贴进去：
+
+```yaml
+name: 'user_groq_llm'
+description: 'user groq llm powered by the Groq LPU inference engine'
+model_name: 'llama-3.3-70b-versatile'
+max_tokens: 1000
+temperature: 0.5
+streaming: True
+api_key: '${GROQ_API_KEY}'
+api_base: 'https://api.groq.com/openai/v1'
+organization: '${GROQ_ORGANIZATION}'
+proxy: '${GROQ_PROXY}'
+metadata:
+  type: 'LLM'
+  module: 'agentuniverse.llm.default.groq_llm'
+  class: 'GroqLLM'
+```
+
+**note:** `api_key` / `api_base` / `organization` / `proxy` 等模型参数有三种配置方法：
+
+1. **直接字符串值**：直接在配置文件中输入 API 密钥字符串。
+
+    ```yaml
+    api_key: 'gsk_***'
+    ```
+
+2. **环境变量占位符**：使用 `${VARIABLE_NAME}` 语法从环境变量中加载。当 agentUniverse 启动时，会自动从环境变量读取相应的值。
+
+    ```yaml
+    api_key: '${GROQ_API_KEY}'
+    ```
+
+3. **自定义函数加载**：使用 `@FUNC` 注解在运行时通过自定义函数动态加载 API 密钥。
+
+    ```yaml
+    api_key: '@FUNC(load_api_key(model_name="groq"))'
+    ```
+
+    该函数需要在 `yaml_func_extension.py` 文件的 `YamlFuncExtension` 类中定义，可参考样例工程中的 [YamlFuncExtension](../../../../../../examples/sample_standard_app/config/yaml_func_extension.py)。当 agentUniverse 加载此配置时：
+    - 解析 `@FUNC` 注解
+    - 执行 `load_api_key` 函数并传入相应参数
+    - 用函数返回值替换注解内容
+
+---
+
+## 2. 选择模型
+
+Groq 会不定期轮换其支持的模型列表。下表列出了常用模型及其上下文窗口大小（输入 + 输出 token）。这些数值同样硬编码在 `GroqLLM.max_context_length` 中，这样 agentUniverse 即使不发起真实请求也能正确估算 prompt 预算。
+
+| 模型名称                          | 上下文长度      |
+| --------------------------------- | --------------- |
+| `llama-3.3-70b-versatile`         | 131072 (128k)   |
+| `llama-3.1-8b-instant`            | 131072 (128k)   |
+| `llama-3.1-70b-versatile`         | 131072 (128k)   |
+| `llama3-70b-8192`                 | 8192            |
+| `llama3-8b-8192`                  | 8192            |
+| `mixtral-8x7b-32768`              | 32768           |
+| `gemma2-9b-it`                    | 8192            |
+| `gemma-7b-it`                     | 8192            |
+
+请以 [Groq 官方模型文档](https://console.groq.com/docs/models) 公布的最新列表为准。如果某个模型不在上表中，`GroqLLM` 会保守地回退到 8192 token。
+
+---
+
+## 3. 环境设置
+
+示例 yaml 中模型密钥等参数使用了环境变量占位符，下面介绍环境变量的设置方法。
+
+必须配置：`GROQ_API_KEY`
+可选配置：`GROQ_API_BASE`、`GROQ_PROXY`、`GROQ_ORGANIZATION`
+
+### 3.1 通过 Python 代码配置
+
+```python
+import os
+os.environ['GROQ_API_KEY'] = 'gsk_***'
+os.environ['GROQ_API_BASE'] = 'https://api.groq.com/openai/v1'
+```
+
+### 3.2 通过配置文件配置
+
+在项目的 `config` 目录下的 `custom_key.toml` 当中，添加配置：
+
+```toml
+GROQ_API_KEY="gsk_******"
+GROQ_API_BASE="https://api.groq.com/openai/v1"
+GROQ_ORGANIZATION=""
+GROQ_PROXY=""
+```
+
+---
+
+## 4. GROQ API KEY 获取
+
+1. 登录 [https://console.groq.com](https://console.groq.com)。
+2. 进入 **API Keys** -> **Create API Key**。
+3. 复制生成的 `gsk_...` 密钥，并赋值给 `GROQ_API_KEY`。
+
+Groq 为开发阶段提供了较为充裕的免费额度，生产环境的速率限制与计费规则详见 [https://console.groq.com/docs/rate-limits](https://console.groq.com/docs/rate-limits)。
+
+---
+
+## 5. 在代码中使用
+
+配置被 agentUniverse 加载后，您可以直接获取 LLM 实例并调用：
+
+```python
+from agentuniverse.llm.default.groq_llm import GroqLLM
+
+llm = GroqLLM(model_name='llama-3.3-70b-versatile')
+
+# 非流式
+output = llm.call(messages=[{"role": "user", "content": "你好！"}])
+print(output.text)
+
+# 流式
+for chunk in llm.call(messages=[{"role": "user", "content": "从 1 数到 5。"}], streaming=True):
+    print(chunk.text, end='')
+
+# 异步
+import asyncio
+async def main():
+    out = await llm.acall(messages=[{"role": "user", "content": "你好！"}])
+    print(out.text)
+asyncio.run(main())
+```
+
+由于 Groq 兼容 OpenAI 协议，`OpenAIStyleLLM` 支持的所有能力（工具调用、LangChain 集成、链路追踪等）都可以直接使用。
+
+---
+
+## 6. Tips
+
+- agentuniverse 已经内置了一个 name 为 `default_groq_llm` 的 llm，用户在配置 `GROQ_API_KEY` 之后可以直接使用。
+- Groq 最大的特点是延迟极低：70B 级别的模型也能以每秒数百 token 的速度流式输出，非常适合交互式 Agent 和快速原型验证。
+- Groq 目前并不支持上游厂商的全部模型，在正式选型前请先到 [Groq 模型页面](https://console.groq.com/docs/models) 确认可用模型及废弃公告。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_translator_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_translator_tool.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import Mock, patch
+
+import httpx
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool import translator_tool as translator_module
+from agentuniverse.agent.action.tool.common_tool.translator_tool import TranslatorTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = translator_module.__file__.replace(".py", ".yaml")
+
+
+def httpx_response_mock(*, json_data=None):
+    response = Mock()
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TranslatorToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = TranslatorTool()
+
+    def _google_payload(self, translated="Hello", detected="en"):
+        # Google's nested-list response format:
+        # payload[0] = list of [translated_chunk, original_chunk, ...] segments
+        # payload[2] = detected source language (when sl=auto)
+        return [[[translated, "你好", None, None, 1]], None, detected]
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_returns_translated_text(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("Hello", "zh"))
+        result = self.tool.execute(text="你好", source="auto", target="en")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["translated_text"], "Hello")
+        self.assertEqual(result["source_language"], "zh")
+        self.assertEqual(result["target_language"], "en")
+        self.assertEqual(result["engine"], "google_translate")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_uses_defaults_when_omitted(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("Bonjour", ""))
+        tool = TranslatorTool(default_source="fr", default_target="en")
+        result = tool.execute(text="bonjour")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["target_language"], "en")
+        call_params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(call_params["sl"], "fr")
+        self.assertEqual(call_params["tl"], "en")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_explicit_languages(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("Hallo", "de"))
+        result = self.tool.execute(text="hello", source="en", target="de")
+        self.assertEqual(result["translated_text"], "Hallo")
+        self.assertEqual(result["source_language"], "de")
+        self.assertEqual(result["target_language"], "de")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_passes_timeout_and_query(self, mock_get: Mock) -> None:
+        mock_get.return_value = httpx_response_mock(json_data=self._google_payload("x", "en"))
+        self.tool.execute(text="hi", source="en", target="zh")
+        kwargs = mock_get.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], self.tool.request_timeout)
+        self.assertEqual(kwargs["params"]["q"], "hi")
+        self.assertEqual(kwargs["params"]["sl"], "en")
+        self.assertEqual(kwargs["params"]["tl"], "zh")
+        self.assertEqual(kwargs["params"]["client"], "gtx")
+
+    def test_translate_rejects_empty_text(self) -> None:
+        result = self.tool.execute(text="   ")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("empty", result["error"])
+
+    def test_translate_rejects_non_string_text(self) -> None:
+        result = self.tool.execute(text=123)
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_translate_rejects_unsupported_source(self) -> None:
+        result = self.tool.execute(text="hi", source="klingon", target="en")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unsupported source language", result["error"])
+
+    def test_translate_rejects_unsupported_target(self) -> None:
+        result = self.tool.execute(text="hi", source="en", target="klingon")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unsupported target language", result["error"])
+
+    def test_translate_rejects_same_source_and_target(self) -> None:
+        result = self.tool.execute(text="hi", source="en", target="en")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("different languages", result["error"])
+
+    def test_translate_rejects_oversized_text(self) -> None:
+        original = TranslatorTool.MAX_TEXT_CHARS
+        TranslatorTool.MAX_TEXT_CHARS = 5
+        try:
+            result = self.tool.execute(text="abcdefgh")
+        finally:
+            TranslatorTool.MAX_TEXT_CHARS = original
+        self.assertEqual(result["status"], "error")
+        self.assertIn("MAX_TEXT_CHARS", result["error"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_handles_network_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = httpx.ConnectError("boom")
+        result = self.tool.execute(text="hi", source="en", target="zh")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "network_error")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_handles_malformed_payload(self, mock_get: Mock) -> None:
+        # Non-empty payload whose segment list is empty raises ValueError in
+        # the response parser, surfaced as a validation_error.
+        mock_get.return_value = httpx_response_mock(json_data=[[]])
+        result = self.tool.execute(text="hi", source="en", target="zh")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+        self.assertIn("no segments", result["error"])
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_handles_unexpected_exception(self, mock_get: Mock) -> None:
+        # response.json() raising a non-(TypeError/ValueError) becomes operation_error.
+        mock_get.return_value = httpx_response_mock(json_data=None)
+        mock_get.return_value.json.side_effect = RuntimeError("decode failed")
+        result = self.tool.execute(text="hi", source="en", target="zh")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "operation_error")
+
+    @patch("agentuniverse.agent.action.tool.common_tool.translator_tool.httpx.get")
+    def test_translate_multi_segment_concatenation(self, mock_get: Mock) -> None:
+        payload = [[["Hello, ", "你好, ", None, None, 0], ["world", "世界", None, None, 0]], None, "zh"]
+        mock_get.return_value = httpx_response_mock(json_data=payload)
+        result = self.tool.execute(text="你好, 世界", source="zh", target="en")
+        self.assertEqual(result["translated_text"], "Hello, world")
+
+    def test_parse_google_response_extracts_translation(self) -> None:
+        payload = [[["Hello, ", "你好, ", None, None, 0], ["world", "世界", None, None, 0]], None, "zh"]
+        translated, detected = TranslatorTool._parse_google_response(payload)
+        self.assertEqual(translated, "Hello, world")
+        self.assertEqual(detected, "zh")
+
+
+class TranslatorRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=YAML_PATH).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "TranslatorTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, TranslatorTool)
+        self.assertEqual(tool.input_keys, ["text"])
+        self.assertEqual(tool.default_target, "en")
+
+    def test_yaml_loads_as_dict(self):
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "translator_tool")
+        self.assertEqual(data["metadata"]["class"], "TranslatorTool")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentuniverse/unit/llm/test_groq_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_groq_llm.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""
+Unit tests for the Groq Cloud LLM component.
+
+These tests exercise the parts of :class:`GroqLLM` that do not require a
+live Groq API key: credential/base-url wiring, the per-model context length
+table and the token estimator. The network-bound call/acall/stream tests
+are kept but commented out so that the full suite can run in CI without
+any external dependency.
+"""
+
+import asyncio
+import unittest
+
+from agentuniverse.llm.default.groq_llm import (
+    GROQ_DEFAULT_CONTEXT_LENGTH,
+    GROQ_MAX_CONTEXT_LENGTH,
+    GroqLLM,
+)
+
+
+class TestGroqLLM(unittest.TestCase):
+    """Test suite for the GroqLLM component."""
+
+    def setUp(self) -> None:
+        """Build a GroqLLM instance with dummy credentials."""
+        self.llm = GroqLLM(
+            model_name='llama-3.3-70b-versatile',
+            api_key='dummy-groq-key',
+            api_base='https://api.groq.com/openai/v1',
+            max_tokens=512,
+            temperature=0.7,
+        )
+
+    def test_initialization(self) -> None:
+        """LLM must accept and persist the constructor parameters."""
+        self.assertEqual(self.llm.model_name, 'llama-3.3-70b-versatile')
+        self.assertEqual(self.llm.api_key, 'dummy-groq-key')
+        self.assertEqual(self.llm.api_base, 'https://api.groq.com/openai/v1')
+        self.assertEqual(self.llm.max_tokens, 512)
+        self.assertEqual(self.llm.temperature, 0.7)
+
+    def test_default_api_base(self) -> None:
+        """When no api_base is provided the Groq endpoint must be used."""
+        llm = GroqLLM(model_name='llama-3.3-70b-versatile', api_key='dummy')
+        self.assertEqual(llm.api_base, 'https://api.groq.com/openai/v1')
+
+    def test_max_context_length_known_models(self) -> None:
+        """Known models must resolve to their documented context window."""
+        known = [
+            ('llama-3.3-70b-versatile', 131072),
+            ('llama-3.1-8b-instant', 131072),
+            ('mixtral-8x7b-32768', 32768),
+            ('gemma2-9b-it', 8192),
+        ]
+        for model_name, expected in known:
+            llm = GroqLLM(model_name=model_name, api_key='dummy')
+            self.assertEqual(
+                llm.max_context_length(),
+                expected,
+                f'Context length mismatch for {model_name}',
+            )
+
+    def test_max_context_length_unknown_model(self) -> None:
+        """Unknown models must fall back to the default context length."""
+        llm = GroqLLM(model_name='some-future-groq-model', api_key='dummy')
+        self.assertEqual(llm.max_context_length(), GROQ_DEFAULT_CONTEXT_LENGTH)
+
+    def test_max_context_length_table_consistency(self) -> None:
+        """Every entry in the table must be a positive integer."""
+        for model_name, length in GROQ_MAX_CONTEXT_LENGTH.items():
+            self.assertIsInstance(length, int, f'{model_name} length not int')
+            self.assertGreater(length, 0, f'{model_name} length not positive')
+
+    def test_get_num_tokens(self) -> None:
+        """The token estimator must return a sensible positive count."""
+        text = 'Hello Groq, please introduce yourself.'
+        num_tokens = self.llm.get_num_tokens(text)
+        self.assertIsInstance(num_tokens, int)
+        self.assertGreater(num_tokens, 0)
+        # The estimator must be deterministic for the same input.
+        self.assertEqual(num_tokens, self.llm.get_num_tokens(text))
+
+    def test_get_num_tokens_empty_string(self) -> None:
+        """An empty string must cost zero tokens."""
+        self.assertEqual(self.llm.get_num_tokens(''), 0)
+
+    # ========== Integration tests (require a real GROQ_API_KEY) ==========
+    # Uncomment and set GROQ_API_KEY in the environment to exercise the
+    # live Groq API.
+
+    # def test_call(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = self.llm.call(messages=messages, streaming=False)
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_acall(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Say hello in one word.'}]
+    #     output = asyncio.run(self.llm.acall(messages=messages, streaming=False))
+    #     print(output.__str__())
+    #     self.assertIsNotNone(output.text)
+
+    # def test_call_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #     chunks = []
+    #     for chunk in self.llm.call(messages=messages, streaming=True):
+    #         chunks.append(chunk.text)
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_acall_stream(self) -> None:
+    #     messages = [{'role': 'user', 'content': 'Count from 1 to 5.'}]
+    #
+    #     async def _run():
+    #         result = []
+    #         async for chunk in await self.llm.acall(messages=messages, streaming=True):
+    #             result.append(chunk.text)
+    #         return result
+    #
+    #     chunks = asyncio.run(_run())
+    #     self.assertGreater(len(''.join(chunks)), 0)
+
+    # def test_as_langchain(self) -> None:
+    #     from langchain.chains.conversation.base import ConversationChain
+    #     langchain_llm = self.llm.as_langchain()
+    #     llm_chain = ConversationChain(llm=langchain_llm)
+    #     res = llm_chain.predict(input='Say hello')
+    #     self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `PerplexityLLM` component that integrates the [Perplexity](https://www.perplexity.ai) Sonar online models into agentUniverse. Perplexity's Sonar family combines a strong instruction-following base model with **built-in online web search** - each response can cite up-to-date web sources, which makes Sonar ideal for agents that need fresh, grounded answers (news, market data, recent docs, ...). Perplexity exposes a fully OpenAI-compatible Chat Completions API at `https://api.perplexity.ai`.

Because of that OpenAI compatibility, `PerplexityLLM` simply extends `OpenAIStyleLLM` and only wires up the credential/base-url plumbing and a per-model context-length table. Streaming, tool calling, the async interface and the LangChain bridge are all inherited unchanged.

## Changes

- `agentuniverse/llm/default/perplexity_llm.py` - the `PerplexityLLM` class plus the `PERPLEXITY_MAX_CONTEXT_LENGTH` table (sonar-pro, sonar-reasoning, sonar-reasoning-pro, sonar, sonar-deep-research and the legacy `llama-3.x-sonar-*-online` aliases). Credentials are loaded from `PERPLEXITY_API_KEY`; the API base defaults to `https://api.perplexity.ai`. Token estimation uses `tiktoken` with a `cl100k_base` fallback.
- `agentuniverse/llm/default/perplexity_llm.yaml.example` - ready-to-use configuration template.
- `tests/test_agentuniverse/unit/llm/test_perplexity_llm.py` - unit tests covering credential wiring, the default API base, the per-model context length table (known/unknown/legacy aliases), table consistency and token estimation.
- `docs/guidebook/en/In-Depth_Guides/Components/LLMs/Perplexity_LLM_Use.md` and `docs/guidebook/zh/In-Depth_Guides/组件列表/模型列表/Perplexity使用.md` - independent English and Chinese usage guides.

## How to use

1. Set `PERPLEXITY_API_KEY` (create one at https://www.perplexity.ai/settings/api).
2. Drop the YAML config from the docs into your project's `llm` config directory.
3. Reference the component by name from your agents, or instantiate `PerplexityLLM(model_name='sonar-pro')` directly.

## Testing

`python -m pytest tests/test_agentuniverse/unit/llm/test_perplexity_llm.py` runs the offline unit tests (the live call/acall/stream tests are commented out so CI does not need a real key).

Refs #250
