### PR TITLE
feat(tool): add PasswordGeneratorTool (secrets-based, zero-dep) (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/password_generator_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/password_generator_tool.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Password generator tool backed only on the Python standard library.
+
+The tool relies on :mod:`secrets` for cryptographically strong randomness and
+:mod:`string` for character pools, so it has zero third-party dependencies. It
+exposes three operations: ``generate``, ``generate_batch`` and ``check_strength``.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import math
+import string
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+# Character pools.
+UPPERCASE = string.ascii_uppercase
+LOWERCASE = string.ascii_lowercase
+DIGITS = string.digits
+# A conservative, unambiguous symbol set.
+SYMBOLS = "!@#$%^&*()-_=+[]{};:,.?/"
+# Characters that are visually similar and often excluded for readability.
+SIMILAR_CHARS = set("Il1O0o") | set("|`'\"")
+
+MIN_LENGTH = 4
+MAX_LENGTH = 256
+MAX_BATCH = 1000
+
+
+class PasswordGeneratorTool(Tool):
+    """Generate cryptographically strong passwords and rate their strength.
+
+    The tool has three modes selected via the ``mode`` parameter:
+
+    * ``generate``       - create a single password
+    * ``generate_batch`` - create several passwords at once
+    * ``check_strength`` - score an existing password
+
+    All randomness comes from :mod:`secrets`, making the output safe for use as
+    real credentials.
+    """
+
+    description: str = (
+        "Generate cryptographically strong passwords (secrets-based) and "
+        "check password strength. Zero third-party dependencies."
+    )
+
+    # Default character-set composition.
+    default_length: int = Field(
+        default=16, description="Default password length."
+    )
+    include_uppercase: bool = Field(default=True, description="Include A-Z.")
+    include_lowercase: bool = Field(default=True, description="Include a-z.")
+    include_digits: bool = Field(default=True, description="Include 0-9.")
+    include_symbols: bool = Field(
+        default=True, description="Include a curated set of symbols."
+    )
+    exclude_similar: bool = Field(
+        default=False,
+        description="Exclude visually similar characters (Il1O0o|`'\").",
+    )
+
+    def execute(
+        self,
+        mode: str = "generate",
+        length: Optional[int] = None,
+        count: int = 1,
+        password: Optional[str] = None,
+        include_uppercase: Optional[bool] = None,
+        include_lowercase: Optional[bool] = None,
+        include_digits: Optional[bool] = None,
+        include_symbols: Optional[bool] = None,
+        exclude_similar: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run the requested operation and return a structured result.
+
+        Per-call keyword arguments override the tool's defaults for that
+        invocation only.
+        """
+        try:
+            operation = self._mode(mode)
+            composition = self._composition(
+                include_uppercase,
+                include_lowercase,
+                include_digits,
+                include_symbols,
+                exclude_similar,
+            )
+            if operation == "generate":
+                resolved_length = self._resolve_length(length, count=count)
+                return self._generate_one(resolved_length, composition)
+            if operation == "generate_batch":
+                resolved_length = self._resolve_length(length, count=count)
+                return self._generate_batch(resolved_length, count, composition)
+            return self._check_strength(password)
+        except (TypeError, ValueError) as exc:
+            LOGGER.error(f"PasswordGeneratorTool validation error: {exc}")
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            LOGGER.error(f"PasswordGeneratorTool operation failed: {exc}")
+            return self._error("operation_error", f"Password operation failed: {exc}")
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _error(kind: str, message: str) -> Dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message}
+
+    @staticmethod
+    def _mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"generate", "generate_batch", "check_strength"}:
+            raise ValueError(
+                "mode must be generate, generate_batch, or check_strength"
+            )
+        return mode
+
+    def _composition(
+        self,
+        upper: Optional[bool],
+        lower: Optional[bool],
+        digits: Optional[bool],
+        symbols: Optional[bool],
+        similar: Optional[bool],
+    ) -> Dict[str, Any]:
+        """Merge per-call overrides with the tool-level defaults."""
+        resolved_upper = self.include_uppercase if upper is None else upper
+        resolved_lower = self.include_lowercase if lower is None else lower
+        resolved_digits = self.include_digits if digits is None else digits
+        resolved_symbols = self.include_symbols if symbols is None else symbols
+        resolved_similar = self.exclude_similar if similar is None else similar
+        for name, val in (
+            ("include_uppercase", resolved_upper),
+            ("include_lowercase", resolved_lower),
+            ("include_digits", resolved_digits),
+            ("include_symbols", resolved_symbols),
+            ("exclude_similar", resolved_similar),
+        ):
+            if not isinstance(val, bool):
+                raise TypeError(f"{name} must be a boolean")
+
+        pool = ""
+        classes: List[str] = []
+        if resolved_upper:
+            pool += UPPERCASE
+            classes.append(UPPERCASE)
+        if resolved_lower:
+            pool += LOWERCASE
+            classes.append(LOWERCASE)
+        if resolved_digits:
+            pool += DIGITS
+            classes.append(DIGITS)
+        if resolved_symbols:
+            pool += SYMBOLS
+            classes.append(SYMBOLS)
+        if resolved_similar:
+            pool = "".join(c for c in pool if c not in SIMILAR_CHARS)
+            classes = [
+                "".join(c for c in group if c not in SIMILAR_CHARS)
+                for group in classes
+            ]
+        if not pool:
+            raise ValueError(
+                "at least one character class must be enabled "
+                "(uppercase, lowercase, digits, or symbols)"
+            )
+        # Drop any class that became empty after similarity filtering.
+        classes = [group for group in classes if group]
+        return {
+            "pool": pool,
+            "classes": classes,
+            "uppercase": resolved_upper,
+            "lowercase": resolved_lower,
+            "digits": resolved_digits,
+            "symbols": resolved_symbols,
+            "exclude_similar": resolved_similar,
+        }
+
+    def _resolve_length(self, length: Any, count: int = 1) -> int:
+        if length is None:
+            resolved = self.default_length
+        else:
+            if isinstance(length, bool) or not isinstance(length, int):
+                raise TypeError("length must be an integer")
+            resolved = length
+        if resolved < MIN_LENGTH:
+            raise ValueError(f"length must be at least {MIN_LENGTH}")
+        if resolved > MAX_LENGTH:
+            raise ValueError(f"length must be at most {MAX_LENGTH}")
+        return resolved
+
+    @staticmethod
+    def _validate_count(value: Any) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("count must be an integer")
+        if value < 1:
+            raise ValueError("count must be at least 1")
+        if value > MAX_BATCH:
+            raise ValueError(f"count must be at most {MAX_BATCH}")
+        return value
+
+    def _generate_one(
+        self, length: int, composition: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        import secrets
+
+        pool: str = composition["pool"]
+        classes: List[str] = composition["classes"]
+        characters: List[str] = []
+        # Guarantee at least one character from every requested class so the
+        # password cannot silently drop a category.
+        for group in classes:
+            characters.append(secrets.choice(group))
+        remaining = length - len(characters)
+        if remaining < 0:
+            # If length < number of classes we fall back to pure sampling.
+            characters = []
+            remaining = length
+        characters.extend(secrets.choice(pool) for _ in range(remaining))
+        # Shuffle so the guaranteed characters are not front-loaded.
+        for index in range(len(characters) - 1, 0, -1):
+            swap = secrets.randbelow(index + 1)
+            characters[index], characters[swap] = characters[swap], characters[index]
+        password = "".join(characters)
+        entropy = self._entropy_bits(len(pool), length)
+        return {
+            "status": "success",
+            "mode": "generate",
+            "password": password,
+            "length": length,
+            "entropy_bits": round(entropy, 2),
+            "pool_size": len(pool),
+            "composition": {
+                "uppercase": composition["uppercase"],
+                "lowercase": composition["lowercase"],
+                "digits": composition["digits"],
+                "symbols": composition["symbols"],
+                "exclude_similar": composition["exclude_similar"],
+            },
+        }
+
+    def _generate_batch(
+        self, length: int, count: int, composition: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        validated = self._validate_count(count)
+        passwords: List[Dict[str, Any]] = [
+            self._generate_one(length, composition) for _ in range(validated)
+        ]
+        entropy = passwords[0]["entropy_bits"] if passwords else 0.0
+        return {
+            "status": "success",
+            "mode": "generate_batch",
+            "count": validated,
+            "passwords": [item["password"] for item in passwords],
+            "length": length,
+            "entropy_bits": entropy,
+            "pool_size": passwords[0]["pool_size"] if passwords else 0,
+        }
+
+    def _check_strength(self, value: Any) -> Dict[str, Any]:
+        if not isinstance(value, str):
+            raise TypeError("password must be a string")
+        if not value:
+            raise ValueError("password must not be empty")
+        length = len(value)
+        pool_size = self._estimate_pool_size(value)
+        entropy = self._entropy_bits(pool_size, length)
+        issues: List[str] = []
+        if length < 8:
+            issues.append("length < 8")
+        if length < 12:
+            issues.append("length < 12 (consider 12+ characters)")
+        if not any(c.islower() for c in value):
+            issues.append("no lowercase letters")
+        if not any(c.isupper() for c in value):
+            issues.append("no uppercase letters")
+        if not any(c.isdigit() for c in value):
+            issues.append("no digits")
+        if not any(not c.isalnum() for c in value):
+            issues.append("no symbols")
+        score = self._score(entropy, issues)
+        return {
+            "status": "success",
+            "mode": "check_strength",
+            "length": length,
+            "pool_size": pool_size,
+            "entropy_bits": round(entropy, 2),
+            "score": score,
+            "rating": self._rating(score),
+            "issues": issues,
+        }
+
+    @staticmethod
+    def _estimate_pool_size(value: str) -> int:
+        size = 0
+        if any(c.islower() for c in value):
+            size += len(LOWERCASE)
+        if any(c.isupper() for c in value):
+            size += len(UPPERCASE)
+        if any(c.isdigit() for c in value):
+            size += len(DIGITS)
+        if any(not c.isalnum() for c in value):
+            size += len(SYMBOLS)
+        return size or 1
+
+    @staticmethod
+    def _entropy_bits(pool_size: int, length: int) -> float:
+        if pool_size <= 1 or length <= 0:
+            return 0.0
+        return length * math.log2(pool_size)
+
+    @staticmethod
+    def _score(entropy: float, issues: List[str]) -> int:
+        """Map entropy and issues onto a 0-100 score."""
+        if entropy >= 100:
+            base = 100
+        elif entropy >= 80:
+            base = 90
+        elif entropy >= 60:
+            base = 75
+        elif entropy >= 45:
+            base = 60
+        elif entropy >= 35:
+            base = 45
+        elif entropy >= 28:
+            base = 30
+        else:
+            base = 15
+        penalty = min(len(issues) * 8, 40)
+        return max(0, min(100, base - penalty))
+
+    @staticmethod
+    def _rating(score: int) -> str:
+        if score >= 85:
+            return "very strong"
+        if score >= 70:
+            return "strong"
+        if score >= 50:
+            return "moderate"
+        if score >= 30:
+            return "weak"
+        return "very weak"

--- a/agentuniverse/agent/action/tool/common_tool/password_generator_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/password_generator_tool.yaml
@@ -1,0 +1,44 @@
+name: password_generator_tool
+description: >-
+  Generate cryptographically strong passwords (secrets-based) and check
+  password strength. Zero third-party dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.password_generator_tool
+  class: PasswordGeneratorTool
+input_keys:
+  - mode
+default_length: 16
+include_uppercase: true
+include_lowercase: true
+include_digits: true
+include_symbols: true
+exclude_similar: false
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: [generate, generate_batch, check_strength]
+      default: generate
+    length:
+      type: integer
+      minimum: 4
+      maximum: 256
+      description: "Password length (generate / generate_batch)."
+    count:
+      type: integer
+      minimum: 1
+      maximum: 1000
+      description: "Number of passwords for generate_batch."
+    password:
+      type: string
+      description: "Password to score (check_strength)."
+    include_uppercase: {type: boolean}
+    include_lowercase: {type: boolean}
+    include_digits: {type: boolean}
+    include_symbols: {type: boolean}
+    exclude_similar: {type: boolean}
+  required: [mode]
+  additionalProperties: false

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/PasswordGeneratorTool.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/PasswordGeneratorTool.md
@@ -1,0 +1,77 @@
+# PasswordGeneratorTool
+
+`PasswordGeneratorTool` 使用 Python 标准库的 `secrets` 模块生成密码学安全的随机密码，并评估已有密码的强度。零第三方依赖，适合在智能体工作流中创建或校验凭证。
+
+## 功能特性
+
+- 三种模式：`generate`（单个）、`generate_batch`（批量）、`check_strength`（强度评分）
+- 可控字符集：大写字母 `A-Z`、小写字母 `a-z`、数字 `0-9` 以及精选符号集
+- 支持 `exclude_similar` 排除易混淆字符（`Il1O0o`、`` ` ``、`'`、`"`、`|`）
+- 基于字符池大小和长度的熵估算（bits）
+- 生成时保证每个启用的字符类至少出现一个字符，并打乱顺序避免前置聚集
+- 强度评分结合熵值与缺失类别给出 0-100 分及评级（very weak / weak / moderate / strong / very strong）
+- 校验失败均以结构化 `error` 返回，不会抛出未捕获异常
+
+## 使用方式
+
+```python
+from agentuniverse.agent.action.tool.common_tool.password_generator_tool import PasswordGeneratorTool
+
+tool = PasswordGeneratorTool()
+
+# 生成单个 16 位强密码
+r = tool.execute(mode="generate")
+print(r["password"], r["entropy_bits"], r["score"] if "score" in r else "")
+
+# 批量生成 5 个 24 位、排除易混淆字符的密码
+batch = tool.execute(mode="generate_batch", length=24, count=5, exclude_similar=True)
+print(batch["passwords"])
+
+# 评估已有密码强度
+s = tool.execute(mode="check_strength", password="my-old-pass")
+print(s["score"], s["rating"], s["issues"])
+```
+
+## YAML 配置
+
+```yaml
+name: password_generator_tool
+description: Generate cryptographically strong passwords (secrets-based) and check password strength. Zero third-party dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.password_generator_tool
+  class: PasswordGeneratorTool
+input_keys:
+  - mode
+default_length: 16
+include_uppercase: true
+include_lowercase: true
+include_digits: true
+include_symbols: true
+exclude_similar: false
+```
+
+## 参数说明
+
+`execute()` 方法接受以下参数：
+
+| 参数 | 类型 | 默认 | 说明 |
+| --- | --- | --- | --- |
+| `mode` | `str` | `generate` | 操作模式：`generate` / `generate_batch` / `check_strength` |
+| `length` | `int` | `default_length` | 密码长度，范围 4-256（generate / generate_batch） |
+| `count` | `int` | `1` | 批量生成数量，范围 1-1000（generate_batch） |
+| `password` | `str` | - | 待评分密码（check_strength） |
+| `include_uppercase` | `bool` | `True` | 是否包含大写字母 |
+| `include_lowercase` | `bool` | `True` | 是否包含小写字母 |
+| `include_digits` | `bool` | `True` | 是否包含数字 |
+| `include_symbols` | `bool` | `True` | 是否包含符号 |
+| `exclude_similar` | `bool` | `False` | 是否排除易混淆字符 |
+
+工具字段：`default_length`、`include_uppercase`、`include_lowercase`、`include_digits`、`include_symbols`、`exclude_similar`。调用时传入的同名参数仅在本次调用生效，不会修改工具默认值。
+
+返回值：`generate` 返回 `password`、`length`、`entropy_bits`、`pool_size`、`composition`；`generate_batch` 返回 `passwords` 列表与 `count`；`check_strength` 返回 `length`、`pool_size`、`entropy_bits`、`score`、`rating`、`issues`。失败时返回 `status='error'` 与 `error_type`（`validation_error` / `operation_error`）。
+
+## 依赖
+
+仅依赖 Python 标准库（`secrets`、`string`、`math`），无需安装任何第三方包。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_password_generator_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_password_generator_tool.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import string
+import unittest
+
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool import password_generator_tool as password_module
+from agentuniverse.agent.action.tool.common_tool.password_generator_tool import (
+    PasswordGeneratorTool,
+    SYMBOLS,
+)
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = password_module.__file__.replace(".py", ".yaml")
+
+UPPERCASE = string.ascii_uppercase
+LOWERCASE = string.ascii_lowercase
+DIGITS = string.digits
+
+
+class PasswordGeneratorToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = PasswordGeneratorTool()
+
+    # ---- generate -----------------------------------------------------------
+    def test_generate_default_length(self) -> None:
+        result = self.tool.execute(mode="generate")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["password"]), self.tool.default_length)
+        self.assertGreater(result["entropy_bits"], 0)
+
+    def test_generate_custom_length(self) -> None:
+        result = self.tool.execute(mode="generate", length=32)
+        self.assertEqual(len(result["password"]), 32)
+
+    def test_generate_contains_all_enabled_classes(self) -> None:
+        result = self.tool.execute(mode="generate", length=20)
+        password = result["password"]
+        self.assertTrue(any(c.isupper() for c in password))
+        self.assertTrue(any(c.islower() for c in password))
+        self.assertTrue(any(c.isdigit() for c in password))
+        self.assertTrue(any(c in SYMBOLS for c in password))
+
+    def test_generate_only_lowercase(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            length=20,
+            include_uppercase=False,
+            include_lowercase=True,
+            include_digits=False,
+            include_symbols=False,
+        )
+        password = result["password"]
+        self.assertEqual(password, password.lower())
+        self.assertTrue(all(c in LOWERCASE for c in password))
+
+    def test_generate_only_digits(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            length=12,
+            include_uppercase=False,
+            include_lowercase=False,
+            include_digits=True,
+            include_symbols=False,
+        )
+        self.assertTrue(all(c in DIGITS for c in result["password"]))
+
+    def test_generate_exclude_similar(self) -> None:
+        similar = set("Il1O0o") | set("|`'\"")
+        result = self.tool.execute(mode="generate", length=40, exclude_similar=True)
+        self.assertFalse(any(c in similar for c in result["password"]))
+
+    def test_generate_uniqueness(self) -> None:
+        first = self.tool.execute(mode="generate", length=24)["password"]
+        second = self.tool.execute(mode="generate", length=24)["password"]
+        self.assertNotEqual(first, second)
+
+    def test_generate_requires_at_least_one_class(self) -> None:
+        result = self.tool.execute(
+            mode="generate",
+            include_uppercase=False,
+            include_lowercase=False,
+            include_digits=False,
+            include_symbols=False,
+        )
+        self.assertEqual(result["status"], "error")
+        self.assertIn("at least one character class", result["error"])
+
+    def test_generate_rejects_too_short(self) -> None:
+        result = self.tool.execute(mode="generate", length=3)
+        self.assertIn("at least 4", result["error"])
+
+    def test_generate_rejects_too_long(self) -> None:
+        result = self.tool.execute(mode="generate", length=999)
+        self.assertIn("at most 256", result["error"])
+
+    def test_generate_rejects_non_integer_length(self) -> None:
+        result = self.tool.execute(mode="generate", length=16.0)
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_generate_rejects_bad_mode(self) -> None:
+        result = self.tool.execute(mode="rotate")
+        self.assertIn("mode must be", result["error"])
+
+    # ---- generate_batch -----------------------------------------------------
+    def test_generate_batch_returns_count(self) -> None:
+        result = self.tool.execute(mode="generate_batch", length=16, count=5)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["passwords"]), 5)
+        self.assertTrue(all(len(p) == 16 for p in result["passwords"]))
+
+    def test_generate_batch_all_unique(self) -> None:
+        result = self.tool.execute(mode="generate_batch", length=24, count=10)
+        self.assertEqual(len(set(result["passwords"])), 10)
+
+    def test_generate_batch_rejects_zero_count(self) -> None:
+        result = self.tool.execute(mode="generate_batch", count=0)
+        self.assertIn("at least 1", result["error"])
+
+    def test_generate_batch_rejects_huge_count(self) -> None:
+        result = self.tool.execute(mode="generate_batch", count=5000)
+        self.assertIn("at most 1000", result["error"])
+
+    # ---- check_strength -----------------------------------------------------
+    def test_check_strength_weak_password(self) -> None:
+        result = self.tool.execute(mode="check_strength", password="abc")
+        self.assertEqual(result["status"], "success")
+        self.assertLess(result["score"], 50)
+        self.assertIn(result["rating"], {"weak", "very weak"})
+
+    def test_check_strength_strong_password(self) -> None:
+        result = self.tool.execute(mode="check_strength", password="C0rrect-Horse-Battery!Staple#42")
+        self.assertEqual(result["status"], "success")
+        self.assertGreaterEqual(result["score"], 70)
+
+    def test_check_strength_flags_missing_classes(self) -> None:
+        result = self.tool.execute(mode="check_strength", password="alllowercase")
+        self.assertIn("no uppercase letters", result["issues"])
+        self.assertIn("no digits", result["issues"])
+        self.assertIn("no symbols", result["issues"])
+
+    def test_check_strength_rejects_empty(self) -> None:
+        result = self.tool.execute(mode="check_strength", password="")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("empty", result["error"])
+
+    def test_check_strength_rejects_non_string(self) -> None:
+        result = self.tool.execute(mode="check_strength", password=123456)
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_check_strength_entropy_grows_with_length(self) -> None:
+        short = self.tool.execute(mode="check_strength", password="Aa1!abcd")["entropy_bits"]
+        long = self.tool.execute(mode="check_strength", password="Aa1!abcdAa1!abcdAa1!")["entropy_bits"]
+        self.assertGreater(long, short)
+
+    def test_check_strength_pool_size_reflects_classes(self) -> None:
+        digits_only = self.tool.execute(mode="check_strength", password="123456789012")["pool_size"]
+        mixed = self.tool.execute(mode="check_strength", password="Abcdef12!@")["pool_size"]
+        self.assertGreater(mixed, digits_only)
+
+
+class PasswordRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=YAML_PATH).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "PasswordGeneratorTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, PasswordGeneratorTool)
+        self.assertEqual(tool.input_keys, ["mode"])
+        self.assertEqual(tool.default_length, 16)
+
+    def test_yaml_loads_as_dict(self):
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "password_generator_tool")
+        self.assertEqual(data["metadata"]["class"], "PasswordGeneratorTool")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `PasswordGeneratorTool` that generates cryptographically strong passwords and scores existing passwords using only the Python standard library (`secrets`, `string`, `math`). Zero third-party dependencies.

Closes #252.

## Why

Agents often need to mint or audit credentials without pulling extra packages. Relying on `secrets` (the stdlib CSPRNG) keeps the output safe for real use, and a built-in strength check lets an agent validate user-supplied passwords inline.

## What's included

- `agentuniverse/agent/action/tool/common_tool/translator_tool.py` → `agentuniverse/agent/action/tool/common_tool/password_generator_tool.py` — `PasswordGeneratorTool` with three modes:
  - `generate` — one password of configurable length (4–256).
  - `generate_batch` — up to 1000 passwords.
  - `check_strength` — entropy + missing-class analysis, 0–100 score and rating.
  - Character classes (uppercase/lowercase/digits/symbols) toggle independently; `exclude_similar` drops ambiguous chars (`Il1O0o`). Each enabled class is guaranteed to appear at least once, then the result is shuffled.
- `agentuniverse/agent/action/tool/common_tool/password_generator_tool.yaml` — built-in component config with `args_model_schema`.
- `tests/test_agentuniverse/unit/agent/action/tool/test_password_generator_tool.py` — 26 unit tests (generate length/class/uniqueness, exclude_similar, batch count/uniqueness, strength scoring/entropy growth/pool size, validation, registration).
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/PasswordGeneratorTool.md` — Chinese usage docs.

## Usage

```python
from agentuniverse.agent.action.tool.common_tool.password_generator_tool import PasswordGeneratorTool

tool = PasswordGeneratorTool()
tool.execute(mode="generate")                                 # default 16-char password
tool.execute(mode="generate_batch", length=24, count=5, exclude_similar=True)
tool.execute(mode="check_strength", password="my-old-pass")   # score + rating + issues
```

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_password_generator_tool` — 26 passed.
- [x] No new dependencies (stdlib only).
- [x] Suite runs fully offline.
