### PR TITLE
feat(tool): add TextStatisticsTool (counts + readability, zero-dep) (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/text_statistics_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/text_statistics_tool.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Text statistics tool backed only on the Python standard library.
+
+The tool computes a wide range of readability and structural metrics for a
+piece of text: character/word/sentence/paragraph counts, average lengths,
+estimated reading time and a readability complexity score. Zero third-party
+dependencies.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import math
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+# Word boundary that keeps apostrophes/hyphens inside a word ("don't", "well-known").
+WORD_PATTERN = re.compile(r"[A-Za-z0-9']+(?:[-'][A-Za-z0-9']+)*")
+# Sentence terminators. Handles common abbreviations best-effort.
+SENTENCE_SPLIT = re.compile(r"[.!?]+(?:[\"')\]]?)|\u3002|\uff01|\uff1f")
+# Paragraphs are blocks separated by two or more newlines (also handle CRLF).
+PARAGRAPH_SPLIT = re.compile(r"\n\s*\n")
+# Syllable counting is language specific; this is an English heuristic.
+VOWEL_GROUPS = re.compile(r"[aeiouy]+", re.IGNORECASE)
+
+MAX_TEXT_CHARS = 1_000_000
+
+
+class TextStatisticsTool(Tool):
+    """Compute character, word, sentence, paragraph and readability metrics."""
+
+    description: str = (
+        "Analyze text to compute counts, average lengths, estimated reading "
+        "time and a readability complexity score. Zero dependencies."
+    )
+
+    words_per_minute: int = Field(
+        default=200,
+        description="Reading speed in words per minute for time estimates.",
+    )
+    min_syllables: int = Field(
+        default=1,
+        description="Minimum syllables returned per word by the heuristic.",
+    )
+
+    def execute(
+        self,
+        text: str,
+        words_per_minute: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Analyze ``text`` and return a structured statistics report."""
+        try:
+            normalized = self._validate_text(text)
+            wpm = self._resolve_wpm(words_per_minute)
+            words = self._words(normalized)
+            sentences = self._sentences(normalized)
+            paragraphs = self._paragraphs(normalized)
+            syllables = self._total_syllables(words)
+            char_counts = self._char_counts(normalized)
+            averages = self._averages(
+                len(words), len(sentences), len(paragraphs), syllables
+            )
+            reading_time = self._reading_time(len(words), wpm)
+            averages["chars_per_word"] = round(
+                char_counts["no_spaces"] / len(words), 2
+            ) if words else 0.0
+            complexity = self._complexity(
+                len(words), len(sentences), syllables, char_counts
+            )
+            return {
+                "status": "success",
+                "mode": "analyze",
+                "counts": {
+                    "characters": char_counts["total"],
+                    "characters_no_spaces": char_counts["no_spaces"],
+                    "letters": char_counts["letters"],
+                    "digits": char_counts["digits"],
+                    "whitespace": char_counts["whitespace"],
+                    "words": len(words),
+                    "unique_words": len({w.lower() for w in words}),
+                    "sentences": len(sentences),
+                    "paragraphs": len(paragraphs),
+                    "syllables": syllables,
+                },
+                "averages": averages,
+                "reading_time_seconds": reading_time["seconds"],
+                "reading_time": reading_time["human"],
+                "words_per_minute": wpm,
+                "complexity": complexity,
+                "longest_word": max(words, key=len) if words else "",
+            }
+        except (TypeError, ValueError) as exc:
+            LOGGER.error(f"TextStatisticsTool validation error: {exc}")
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            LOGGER.error(f"TextStatisticsTool operation failed: {exc}")
+            return self._error("operation_error", f"Text analysis failed: {exc}")
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _error(kind: str, message: str) -> Dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message}
+
+    def _validate_text(self, value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("text must be a string")
+        if len(value) > MAX_TEXT_CHARS:
+            raise ValueError(
+                f"text exceeds MAX_TEXT_CHARS ({MAX_TEXT_CHARS})"
+            )
+        return value
+
+    def _resolve_wpm(self, value: Any) -> int:
+        if value is None:
+            return self.words_per_minute
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("words_per_minute must be an integer")
+        if value < 1 or value > 2000:
+            raise ValueError("words_per_minute must be between 1 and 2000")
+        return value
+
+    @staticmethod
+    def _words(text: str) -> List[str]:
+        return WORD_PATTERN.findall(text)
+
+    def _sentences(self, text: str) -> List[str]:
+        raw = SENTENCE_SPLIT.split(text)
+        sentences = [chunk.strip() for chunk in raw if chunk and chunk.strip()]
+        # A bare fragment with no terminator still counts as a sentence.
+        if not sentences and text.strip():
+            return [text.strip()]
+        return sentences
+
+    @staticmethod
+    def _paragraphs(text: str) -> List[str]:
+        if not text.strip():
+            return []
+        blocks = PARAGRAPH_SPLIT.split(text)
+        return [block.strip() for block in blocks if block.strip()]
+
+    @staticmethod
+    def _char_counts(text: str) -> Dict[str, int]:
+        total = len(text)
+        whitespace = sum(1 for c in text if c.isspace())
+        letters = sum(1 for c in text if c.isalpha())
+        digits = sum(1 for c in text if c.isdigit())
+        return {
+            "total": total,
+            "no_spaces": total - whitespace,
+            "letters": letters,
+            "digits": digits,
+            "whitespace": whitespace,
+        }
+
+    def _count_syllables(self, word: str) -> int:
+        """Heuristic English syllable counter.
+
+        Counts vowel groups, subtracts silent trailing ``e`` and floors the
+        result at ``min_syllables`` (default 1) so every word contributes.
+        """
+        if not word:
+            return 0
+        groups = VOWEL_GROUPS.findall(word)
+        count = len(groups)
+        lowered = word.lower()
+        # Subtract silent 'e' at the end (e.g. "name" -> 1, "the" -> 1).
+        if count > 1 and lowered.endswith("e"):
+            count -= 1
+        return max(self.min_syllables, count)
+
+    def _total_syllables(self, words: List[str]) -> int:
+        return sum(self._count_syllables(w) for w in words)
+
+    @staticmethod
+    def _averages(
+        words: int, sentences: int, paragraphs: int, syllables: int
+    ) -> Dict[str, float]:
+        words_per_sentence = words / sentences if sentences else 0.0
+        sentences_per_paragraph = sentences / paragraphs if paragraphs else 0.0
+        words_per_paragraph = words / paragraphs if paragraphs else 0.0
+        syllables_per_word = syllables / words if words else 0.0
+        return {
+            "words_per_sentence": round(words_per_sentence, 2),
+            "sentences_per_paragraph": round(sentences_per_paragraph, 2),
+            "words_per_paragraph": round(words_per_paragraph, 2),
+            "syllables_per_word": round(syllables_per_word, 2),
+            "chars_per_word": 0.0,
+        }
+
+    @staticmethod
+    def _reading_time(words: int, wpm: int) -> Dict[str, Any]:
+        seconds = (words / wpm) * 60 if wpm else 0.0
+        total = int(round(seconds))
+        minutes, secs = divmod(total, 60)
+        return {"seconds": round(seconds, 2), "human": f"{minutes}m {secs}s"}
+
+    def _complexity(
+        self,
+        words: int,
+        sentences: int,
+        syllables: int,
+        char_counts: Dict[str, int],
+    ) -> Dict[str, Any]:
+        """Flesch Reading Ease plus a derived 0-100 difficulty score.
+
+        The Flesch scale rewards short words and short sentences. We invert it
+        so higher = more complex, then clamp to 0-100.
+        """
+        if words == 0 or sentences == 0:
+            return {
+                "flesch_reading_ease": None,
+                "flesch_kincaid_grade": None,
+                "difficulty_score": 0,
+                "difficulty_label": "n/a",
+            }
+        syllables_per_word = syllables / words
+        words_per_sentence = words / sentences
+        flesch_ease = 206.835 - 84.6 * syllables_per_word - 1.015 * words_per_sentence
+        flesch_ease = round(max(0.0, min(100.0, flesch_ease)), 2)
+        grade = round(0.39 * words_per_sentence + 11.8 * syllables_per_word - 15.59, 2)
+        grade = max(0.0, grade)
+        difficulty = round(100.0 - flesch_ease, 2)
+        return {
+            "flesch_reading_ease": flesch_ease,
+            "flesch_kincaid_grade": grade,
+            "difficulty_score": difficulty,
+            "difficulty_label": self._difficulty_label(difficulty),
+        }
+
+    @staticmethod
+    def _difficulty_label(score: float) -> str:
+        if score >= 70:
+            return "very difficult"
+        if score >= 55:
+            return "difficult"
+        if score >= 40:
+            return "moderate"
+        if score >= 25:
+            return "easy"
+        return "very easy"

--- a/agentuniverse/agent/action/tool/common_tool/text_statistics_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/text_statistics_tool.yaml
@@ -1,0 +1,25 @@
+name: text_statistics_tool
+description: >-
+  Analyze text to compute character/word/sentence/paragraph counts, average
+  lengths, estimated reading time and a readability complexity score.
+  Zero dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.text_statistics_tool
+  class: TextStatisticsTool
+input_keys:
+  - text
+words_per_minute: 200
+min_syllables: 1
+args_model_schema:
+  type: object
+  properties:
+    text: {type: string, description: "The text to analyze."}
+    words_per_minute:
+      type: integer
+      minimum: 1
+      maximum: 2000
+      description: "Reading speed used for the reading-time estimate."
+  required: [text]
+  additionalProperties: false

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TextStatisticsTool.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TextStatisticsTool.md
@@ -1,0 +1,79 @@
+# TextStatisticsTool
+
+`TextStatisticsTool` 对一段文本进行结构与可读性分析，返回字符数、单词数、句子数、段落数、音节数、各类平均值、阅读时间估算以及复杂度评分。仅依赖 Python 标准库，零第三方依赖。
+
+## 功能特性
+
+- 计数：字符总数、不含空格字符数、字母数、数字数、空白字符数、单词数、唯一单词数（不区分大小写）、句子数、段落数、音节数
+- 平均值：每句单词数、每段句子数、每段单词数、每单词音节数、每单词字符数
+- 阅读时间估算：基于可配置的阅读速度（默认 200 词/分钟）
+- 复杂度评分：Flesch 阅读容易度、Flesch-Kincaid 年级、0-100 难度分数与中文标签（very easy / easy / moderate / difficult / very difficult）
+- 支持中英文标点切句（`.` `。` `!` `！` `?` `？`）
+- 音节计数采用英文启发式（元音组 + 词尾静音 `e` 处理）
+- 最长单词、校验失败均以结构化 `error` 返回
+
+## 使用方式
+
+```python
+from agentuniverse.agent.action.tool.common_tool.text_statistics_tool import TextStatisticsTool
+
+tool = TextStatisticsTool()
+
+r = tool.execute(text="Hello world. This is a readability test for the agent.")
+print(r["counts"])        # 字符/单词/句子/段落/音节计数
+print(r["averages"])      # 每句词数、每段句数等
+print(r["reading_time"])  # 例: "0m 3s"
+print(r["complexity"])    # flesch_reading_ease / flesch_kincaid_grade / difficulty_score
+
+# 自定义阅读速度
+r = tool.execute(text="...", words_per_minute=150)
+```
+
+## YAML 配置
+
+```yaml
+name: text_statistics_tool
+description: Analyze text to compute character/word/sentence/paragraph counts, average lengths, estimated reading time and a readability complexity score. Zero dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.text_statistics_tool
+  class: TextStatisticsTool
+input_keys:
+  - text
+words_per_minute: 200
+min_syllables: 1
+```
+
+## 参数说明
+
+`execute()` 方法接受以下参数：
+
+| 参数 | 类型 | 默认 | 说明 |
+| --- | --- | --- | --- |
+| `text` | `str` | - | 待分析文本，最长 1,000,000 字符 |
+| `words_per_minute` | `int` | `200` | 阅读速度，范围 1-2000，仅本次调用生效 |
+
+工具字段：`words_per_minute`（阅读速度默认值）、`min_syllables`（每个单词返回的最小音节数，默认 1）。
+
+返回值（`status='success'` 时）：
+
+- `counts`：`characters`、`characters_no_spaces`、`letters`、`digits`、`whitespace`、`words`、`unique_words`、`sentences`、`paragraphs`、`syllables`
+- `averages`：`words_per_sentence`、`sentences_per_paragraph`、`words_per_paragraph`、`syllables_per_word`、`chars_per_word`
+- `reading_time_seconds`、`reading_time`（形如 `0m 3s`）、`words_per_minute`
+- `complexity`：`flesch_reading_ease`、`flesch_kincaid_grade`、`difficulty_score`、`difficulty_label`（空文本时为 `n/a`）
+- `longest_word`
+
+失败时返回 `status='error'` 与 `error_type`（`validation_error` / `operation_error`）。
+
+## 算法说明
+
+- 单词切分保留撇号与连字符（`don't`、`well-known` 视为单个词）
+- 句子切分支持英文 `.!?` 与中文 `。！？`
+- 段落由两个及以上换行分隔
+- Flesch 公式：`206.835 - 84.6 × (音节/词) - 1.015 × (词/句)`，结果限制在 0-100
+- 难度分数为 `100 - Flesch 容易度`，越高表示越难
+
+## 依赖
+
+仅依赖 Python 标准库（`re`、`math`），无需安装任何第三方包。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_text_statistics_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_text_statistics_tool.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool import text_statistics_tool as text_module
+from agentuniverse.agent.action.tool.common_tool.text_statistics_tool import TextStatisticsTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = text_module.__file__.replace(".py", ".yaml")
+
+
+class TextStatisticsToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = TextStatisticsTool()
+
+    def analyze(self, text: str, **kwargs):
+        return self.tool.execute(text=text, **kwargs)
+
+    def test_counts_basic_sentence(self) -> None:
+        result = self.analyze("Hello world. This is a test.")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["counts"]["words"], 6)
+        self.assertEqual(result["counts"]["sentences"], 2)
+        self.assertEqual(result["counts"]["paragraphs"], 1)
+
+    def test_counts_characters(self) -> None:
+        result = self.analyze("Hi there!")
+        self.assertEqual(result["counts"]["characters"], len("Hi there!"))
+        self.assertEqual(result["counts"]["characters_no_spaces"], 8)
+        self.assertEqual(result["counts"]["whitespace"], 1)
+
+    def test_letters_and_digits(self) -> None:
+        result = self.analyze("abc 123 def")
+        self.assertEqual(result["counts"]["letters"], 6)
+        self.assertEqual(result["counts"]["digits"], 3)
+
+    def test_multiple_paragraphs(self) -> None:
+        text = "First paragraph here.\n\nSecond one.\n\nThird paragraph."
+        result = self.analyze(text)
+        self.assertEqual(result["counts"]["paragraphs"], 3)
+
+    def test_unique_word_count_case_insensitive(self) -> None:
+        result = self.analyze("Hello hello HELLO world")
+        self.assertEqual(result["counts"]["words"], 4)
+        self.assertEqual(result["counts"]["unique_words"], 2)
+
+    def test_question_and_exclamation_split_sentences(self) -> None:
+        result = self.analyze("What? Yes! Okay.")
+        self.assertEqual(result["counts"]["sentences"], 3)
+
+    def test_averages_words_per_sentence(self) -> None:
+        result = self.analyze("One sentence. Two words here.")
+        self.assertEqual(result["averages"]["words_per_sentence"], 2.5)
+
+    def test_chars_per_word(self) -> None:
+        result = self.analyze("hello world")
+        # 10 non-space chars / 2 words = 5.0
+        self.assertEqual(result["averages"]["chars_per_word"], 5.0)
+
+    def test_syllables_per_word(self) -> None:
+        result = self.analyze("hello world")
+        self.assertGreater(result["averages"]["syllables_per_word"], 0.0)
+
+    def test_reading_time_default_wpm(self) -> None:
+        # 200 wpm => 200 words = 60s.
+        text = " ".join(["word"] * 200) + "."
+        result = self.analyze(text)
+        self.assertAlmostEqual(result["reading_time_seconds"], 60.0, delta=0.5)
+        self.assertEqual(result["words_per_minute"], 200)
+
+    def test_reading_time_custom_wpm(self) -> None:
+        text = " ".join(["word"] * 100) + "."
+        result = self.analyze(text, words_per_minute=100)
+        self.assertAlmostEqual(result["reading_time_seconds"], 60.0, delta=0.5)
+        self.assertEqual(result["words_per_minute"], 100)
+
+    def test_complexity_for_simple_text(self) -> None:
+        result = self.analyze("The cat sat on the mat. The dog ran fast.")
+        comp = result["complexity"]
+        self.assertIsNotNone(comp["flesch_reading_ease"])
+        self.assertIsNotNone(comp["flesch_kincaid_grade"])
+        self.assertIn(comp["difficulty_label"], {
+            "very easy", "easy", "moderate", "difficult", "very difficult"
+        })
+
+    def test_complexity_none_for_empty_words(self) -> None:
+        result = self.analyze("   ... !!!  ")
+        self.assertEqual(result["counts"]["words"], 0)
+        self.assertIsNone(result["complexity"]["flesch_reading_ease"])
+        self.assertEqual(result["complexity"]["difficulty_label"], "n/a")
+
+    def test_longest_word(self) -> None:
+        result = self.analyze("a quick brown hippopotamus")
+        self.assertEqual(result["longest_word"], "hippopotamus")
+
+    def test_rejects_non_string_text(self) -> None:
+        result = self.tool.execute(text=42)
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_rejects_bad_wpm(self) -> None:
+        result = self.analyze("hi there", words_per_minute=0)
+        self.assertIn("words_per_minute", result["error"])
+        result = self.analyze("hi there", words_per_minute=99999)
+        self.assertIn("words_per_minute", result["error"])
+
+    def test_chinese_full_stop_sentence_split(self) -> None:
+        result = self.analyze("你好。世界！测试？")
+        self.assertEqual(result["counts"]["sentences"], 3)
+
+    def test_syllable_heuristic_silent_e(self) -> None:
+        # "name" -> 1 (silent e), "testing" -> 2
+        self.assertEqual(self.tool._count_syllables("name"), 1)
+        self.assertEqual(self.tool._count_syllables("testing"), 2)
+        self.assertEqual(self.tool._count_syllables("a"), 1)
+
+
+class TextStatisticsRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=YAML_PATH).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "TextStatisticsTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, TextStatisticsTool)
+        self.assertEqual(tool.input_keys, ["text"])
+        self.assertEqual(tool.words_per_minute, 200)
+
+    def test_yaml_loads_as_dict(self):
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "text_statistics_tool")
+        self.assertEqual(data["metadata"]["class"], "TextStatisticsTool")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `TextStatisticsTool` that analyzes a piece of text and returns character/word/sentence/paragraph/syllable counts, average lengths, an estimated reading time and a readability complexity score. Zero third-party dependencies (stdlib `re` + `math` only).

Closes #252.

## Why

Agents that summarize, grade or route content benefit from cheap, offline readability and structural metrics. A dependency-free implementation keeps the tool lightweight and deterministic, and supports both English and Chinese sentence terminators.

## What's included

- `agentuniverse/agent/action/tool/common_tool/text_statistics_tool.py` — `TextStatisticsTool` with a single `analyze(text)` operation.
  - Counts: characters, characters without spaces, letters, digits, whitespace, words, unique words (case-insensitive), sentences, paragraphs, syllables.
  - Averages: words/sentence, sentences/paragraph, words/paragraph, syllables/word, chars/word.
  - Reading-time estimate via configurable `words_per_minute` (default 200).
  - Complexity: Flesch Reading Ease, Flesch-Kincaid grade, 0–100 difficulty score + label.
  - English-heuristic syllable counter (vowel groups + silent trailing 'e'), longest word.
- `agentuniverse/agent/action/tool/common_tool/text_statistics_tool.yaml` — built-in component config with `args_model_schema`.
- `tests/test_agentuniverse/unit/agent/action/tool/test_text_statistics_tool.py` — 21 unit tests covering counts, averages, reading time, complexity, Chinese sentence splitting, syllable heuristics, validation, and registration.
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/TextStatisticsTool.md` — Chinese usage docs.

## Usage

```python
from agentuniverse.agent.action.tool.common_tool.text_statistics_tool import TextStatisticsTool

tool = TextStatisticsTool()
r = tool.execute(text="Hello world. This is a readability test for the agent.")
print(r["counts"], r["averages"], r["reading_time"], r["complexity"])
```

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_text_statistics_tool` — 21 passed.
- [x] No new dependencies (stdlib only).
- [x] Suite runs fully offline.
