### PR TITLE
feat(knowledge): add XmlSplitter pre-processor (#258)

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.py
@@ -1,0 +1,310 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/07/23
+# @FileName: xml_splitter.py
+
+"""
+XML structure splitter — a knowledge pre-processing DocProcessor.
+
+Parses each recalled document as XML and emits one chunk per element,
+recording the element path (e.g. ``root > items > item``) as metadata.
+Useful for indexing structured, tag-based sources (SVG, NLM/JATS articles,
+TEI, Maven POMs, sitemaps, configuration) where each element should be a
+retrievable unit.
+
+Sibling of ``JsonSplitter`` (#258): both walk a structured document and
+record a path per chunk. This one targets angle-bracket markup using the
+standard library ``xml.etree.ElementTree`` parser, so it has **no third-party
+dependency**.
+
+Traversal rules:
+
+- Each element becomes a candidate chunk whose text is the concatenation of
+  its own ``.text`` and the non-tag ``text``/``tail`` of its subtree (i.e. the
+  element's visible text content).
+- The path is the chain of tags from the root to the element, joined with
+  ``" > "`` (configurable via ``path_key``).
+- ``max_depth`` caps traversal: at that depth, a subtree is serialised back to
+  an XML string rather than descended into, producing one chunk for the whole
+  subtree.
+- Leaf elements (no element children) always emit their own text chunk.
+- ``include_attributes`` controls whether element attributes are rendered into
+  the chunk text (``[id=42 lang=en]``) and into the path.
+- Non-XML / malformed documents are passed through unchanged.
+"""
+
+import logging
+import re
+from typing import List, Optional, Tuple
+from xml.etree import ElementTree as ET
+
+from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import \
+    DocProcessor
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.config.component_configer.component_configer import \
+    ComponentConfiger
+
+logger = logging.getLogger(__name__)
+
+# Sentinel tag used for free-floating text chunks (text that sits between
+# elements at the root level, or tail text of an element handled separately).
+_TEXT_TAG = "#text"
+
+
+def _local_tag(tag: str) -> str:
+    """Strip an XML namespace prefix from ``tag``.
+
+    ``ElementTree`` serialises namespaced tags as ``{uri}local``. We collapse
+    that to just ``local`` so paths stay readable and stable across documents
+    that differ only by namespace URI.
+    """
+    if tag and tag.startswith("{"):
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _attrs_to_str(attrs: dict) -> str:
+    """Render an attribute mapping as ``[k=v k2=v2]`` (empty if no attrs)."""
+    if not attrs:
+        return ""
+    return "[" + " ".join(f"{k}={v}" for k, v in attrs.items()) + "]"
+
+
+class XmlSplitter(DocProcessor):
+    """Split XML documents into one chunk per element, recording the path.
+
+    Attributes:
+        path_key: Metadata key under which the element path is written.
+            Default ``"xml_path"``.
+        max_depth: Maximum traversal depth (``None`` = unlimited). At
+            ``max_depth`` a nested subtree is serialised back to an XML string
+            rather than descended into. ``max_depth=1`` yields only the root.
+        include_attributes: When ``True``, each element's attributes are
+            rendered into the chunk text (as ``[k=v ...]``) and appended to
+            the path. Default ``False``.
+        drop_empty: If ``True`` (default), elements with no visible text and
+            no attributes (when ``include_attributes`` is on) are not emitted
+            as chunks.
+        path_separator: String used to join tags in the path. Default ``" > "``.
+        root_name: Name to use for the root level of the path. ``None`` (the
+            default) uses the root element's own tag, so a document
+            ``<items>…</items>`` produces paths starting with ``items``.
+    """
+
+    path_key: str = "xml_path"
+    max_depth: Optional[int] = None
+    include_attributes: bool = False
+    drop_empty: bool = True
+    path_separator: str = " > "
+    root_name: Optional[str] = None
+
+    def _process_docs(self, origin_docs: List[Document],
+                      query=None) -> List[Document]:
+        """Parse each document as XML and split it into element chunks.
+
+        Documents that are empty or not valid XML are returned unchanged.
+        """
+        if not origin_docs:
+            return []
+
+        self._validate_max_depth()
+        result: List[Document] = []
+        for doc in origin_docs:
+            text = doc.text or ""
+            root = self._parse_xml(text)
+            if root is None:
+                # Not valid XML — keep the original document untouched.
+                result.append(doc)
+                continue
+
+            base_meta = dict(doc.metadata or {})
+            root_label = self.root_name or _local_tag(root.tag)
+            for path, chunk_text in self._walk(root, depth=1, prefix=root_label):
+                if self.drop_empty and not chunk_text.strip():
+                    continue
+                meta = dict(base_meta)
+                meta[self.path_key] = path
+                result.append(Document(text=chunk_text, metadata=meta))
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Parsing
+    # ------------------------------------------------------------------ #
+    def _validate_max_depth(self) -> None:
+        """Validate ``max_depth`` is None or a positive integer.
+
+        Called from ``_process_docs`` so an invalid value is caught regardless
+        of how the instance was built (configer vs. direct construction).
+        """
+        if self.max_depth is None:
+            return
+        try:
+            md = int(self.max_depth)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"max_depth must be an integer or null, got {self.max_depth!r}."
+            )
+        if md < 1:
+            raise ValueError(
+                f"max_depth must be >= 1 or null, got {md}."
+            )
+
+    def _parse_xml(self, text: str) -> Optional[ET.Element]:
+        """Parse ``text`` as XML, returning the root element or ``None``.
+
+        Tolerates leading whitespace/BOM. Returns ``None`` for empty input or
+        any parse error so the caller can pass the document through unchanged.
+        """
+        if not text or not text.strip():
+            return None
+        try:
+            # ``fromstring`` requires a single root element; wrap defensively.
+            return ET.fromstring(text)
+        except ET.ParseError:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Traversal
+    # ------------------------------------------------------------------ #
+    def _walk(self, element: ET.Element, depth: int,
+              prefix: str) -> List[Tuple[str, str]]:
+        """Recursively walk ``element`` yielding ``(path, text)`` chunk pairs.
+
+        Args:
+            element: The current XML element.
+            depth: Current depth (root is depth 1).
+            prefix: Path string of the parent level (root label for the root).
+
+        Returns:
+            List of ``(path, chunk_text)`` tuples in document order.
+        """
+        results: List[Tuple[str, str]] = []
+        at_max = self.max_depth is not None and depth >= self.max_depth
+
+        children = list(element)
+
+        if at_max or not children:
+            # Emit a chunk for this element: either it is a leaf, or we have
+            # hit max_depth and serialise the whole subtree.
+            if at_max and children:
+                text = self._serialise(element)
+            else:
+                text = self._element_text(element)
+            text = self._decorate(text, element)
+            results.append((prefix, text))
+            return results
+
+        # Internal element: emit a chunk for its own direct text (if any),
+        # then recurse into children. Direct text becomes a chunk under the
+        # element's path so the element's own prose is still retrievable.
+        own_text = self._direct_text(element)
+        if own_text and own_text.strip():
+            results.append((prefix, self._decorate(own_text, element)))
+
+        for child in children:
+            child_tag = _local_tag(child.tag)
+            child_path = prefix + self.path_separator + child_tag
+            if self.include_attributes and child.attrib:
+                child_path += " " + _attrs_to_str(child.attrib)
+            results.extend(self._walk(child, depth + 1, child_path))
+
+            # The child's ``tail`` (text after the child's closing tag, before
+            # the next sibling) belongs to the parent's prose scope.
+            tail = (child.tail or "").strip()
+            if tail:
+                results.append((prefix + self.path_separator + _TEXT_TAG, tail))
+
+        return results
+
+    # ------------------------------------------------------------------ #
+    # Text extraction helpers
+    # ------------------------------------------------------------------ #
+    def _element_text(self, element: ET.Element) -> str:
+        """Return all visible text inside ``element`` (its full subtree).
+
+        Joins ``element.text`` and every ``.text``/``.tail`` in the subtree in
+        document order, mirroring how a browser would render the element.
+        """
+        parts: List[str] = []
+        if element.text:
+            parts.append(element.text)
+        for node in element.iter():
+            if node is element:
+                continue
+            if node.text:
+                parts.append(node.text)
+            if node.tail:
+                parts.append(node.tail)
+        return " ".join(p.strip() for p in parts if p and p.strip())
+
+    def _direct_text(self, element: ET.Element) -> str:
+        """Return only the text directly under ``element`` (not in children).
+
+        This is ``element.text`` plus the ``tail`` of each immediate child —
+        i.e. the prose that belongs to this element rather than its children.
+        """
+        parts: List[str] = []
+        if element.text:
+            parts.append(element.text)
+        for child in element:
+            if child.tail:
+                parts.append(child.tail)
+        return " ".join(p.strip() for p in parts if p and p.strip())
+
+    def _decorate(self, text: str, element: ET.Element) -> str:
+        """Optionally prepend an element's attribute string to ``text``."""
+        if not self.include_attributes:
+            return text
+        attrs = _attrs_to_str(element.attrib)
+        if not attrs:
+            return text
+        if text:
+            return f"{attrs} {text}"
+        return attrs
+
+    def _serialise(self, element: ET.Element) -> str:
+        """Serialise ``element`` back to a compact XML string.
+
+        Used when ``max_depth`` is reached so a whole subtree becomes one
+        chunk rather than being descended into.
+        """
+        return ET.tostring(element, encoding="unicode", method="xml")
+
+    # ------------------------------------------------------------------ #
+    # Config initialisation
+    # ------------------------------------------------------------------ #
+    def _initialize_by_component_configer(
+            self, doc_processor_configer: ComponentConfiger) -> "XmlSplitter":
+        """Initialise the splitter from its component configuration."""
+        super()._initialize_by_component_configer(doc_processor_configer)
+
+        if hasattr(doc_processor_configer, "path_key"):
+            self.path_key = doc_processor_configer.path_key
+
+        if hasattr(doc_processor_configer, "max_depth"):
+            md = doc_processor_configer.max_depth
+            if md is None:
+                self.max_depth = None
+            else:
+                md = int(md)
+                if md < 1:
+                    raise ValueError(
+                        f"max_depth must be >= 1 or null, got {md}."
+                    )
+                self.max_depth = md
+
+        if hasattr(doc_processor_configer, "include_attributes"):
+            self.include_attributes = bool(
+                doc_processor_configer.include_attributes)
+
+        if hasattr(doc_processor_configer, "drop_empty"):
+            self.drop_empty = bool(doc_processor_configer.drop_empty)
+
+        if hasattr(doc_processor_configer, "path_separator"):
+            self.path_separator = doc_processor_configer.path_separator
+
+        if hasattr(doc_processor_configer, "root_name"):
+            self.root_name = doc_processor_configer.root_name
+
+        return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.yaml
+++ b/agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.yaml
@@ -1,0 +1,12 @@
+name: 'xml_splitter'
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.xml_splitter'
+  class: 'XmlSplitter'
+description: 'Splits XML documents into one chunk per element, recording the element path (e.g. root > items > item) as metadata.'
+path_key: 'xml_path'        # metadata key for the element path
+max_depth: null             # max traversal depth; null = unlimited, 1 = root only
+include_attributes: false   # render element attributes into chunk text and path
+drop_empty: true            # do not emit chunks with no visible text
+path_separator: ' > '       # string used to join tags in the path
+root_name: null             # name for the root level of the path; null = use root tag

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/DocProcessor.md
@@ -309,3 +309,33 @@ metadata:
 - counter: How each document's size is measured: `estimate` (chars/4, default), `tiktoken` (BPE tokens), `char`, or `word`.
 - truncate: When true, the first document that would exceed the budget is shortened to the remaining budget and kept as the last result; when false, processing stops at that document.
 - tiktoken_encoding: tiktoken encoding used when `counter` is `tiktoken`.
+
+### [XmlSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.yaml)
+
+This component splits each recalled XML document into one chunk per element, recording the element path (e.g. `root > items > item`) as metadata. It suits structured, tag-based sources (SVG, NLM/JATS articles, TEI, Maven POMs, sitemaps, configuration) where each element should be a retrievable unit. It addresses the *knowledge pre-processing* direction of issue #258.
+
+It is the sibling of `JsonSplitter` (#258): both walk a structured document and record a path per chunk. This one targets angle-bracket markup using the standard-library `xml.etree.ElementTree` parser, so it has **no third-party dependency**.
+
+Each element becomes a candidate chunk whose text is its visible content. The path is the chain of tags from the root to the element, joined with `" > "` (configurable via `path_key`). `max_depth` caps traversal — at that depth a subtree is serialised back to an XML string rather than descended into; leaf elements always emit their own text chunk. `include_attributes` renders element attributes into the chunk text and path. XML namespaces are stripped from paths so `{http://example.com}child` becomes `child`. Non-XML / malformed documents are passed through unchanged.
+
+The component definition file is as follows:
+```yaml
+name: 'xml_splitter'
+description: 'split XML documents into one chunk per element, recording the path'
+path_key: 'xml_path'        # metadata key for the element path
+max_depth: null             # max traversal depth; null = unlimited, 1 = root only
+include_attributes: false   # render element attributes into chunk text and path
+drop_empty: true            # do not emit chunks with no visible text
+path_separator: ' > '       # string used to join tags in the path
+root_name: null             # name for the root level of the path; null = use root tag
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.xml_splitter'
+  class: 'XmlSplitter'
+```
+- path_key: Metadata key under which each chunk's element path is written.
+- max_depth: Maximum traversal depth; `null` (default) is unlimited, `1` yields only the root. At `max_depth` a nested subtree is serialised as an XML string into one chunk.
+- include_attributes: When true, each element's attributes are rendered into the chunk text (as `[k=v ...]`) and appended to the path.
+- drop_empty: When true (default), elements with no visible text (and no attributes, when `include_attributes` is on) are not emitted.
+- path_separator: String used to join tags in the path; default `" > "`.
+- root_name: Name used for the root level of the path; `null` (default) uses the root element's own tag.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/DocProcessor.md
@@ -310,3 +310,33 @@ metadata:
 - counter: 计量每个文档大小的方式：`estimate`（字符数/4，默认）、`tiktoken`（BPE token）、`char`、`word`。
 - truncate: 为真时，第一个会超出预算的文档被截断到剩余预算大小并作为最后一个结果保留；为假时遇到该文档即停止。
  - tiktoken_encoding: 当 `counter` 为 `tiktoken` 时使用的 tiktoken 编码。
+
+### [XmlSplitter](../../../../../../agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.yaml)
+
+该组件把召回的 XML 文档按元素切分，每个元素产出一个 chunk，并把元素路径（如 `root > items > item`）记录到 metadata。适用于基于标签的结构化数据源（SVG、NLM/JATS 论文、TEI、Maven POM、站点地图、配置文件），其中每个元素都应是一个可检索单元。对应 issue #258 的*知识预处理*方向。
+
+它是 `JsonSplitter`（#258）的姊妹组件：两者都遍历结构化文档并为每个 chunk 记录路径。本组件面向尖括号标记，使用标准库 `xml.etree.ElementTree` 解析，因此**无第三方依赖**。
+
+每个元素成为一个候选 chunk，其文本为该元素的可见内容。路径是从根到该元素的标签链，用 `" > "` 连接（可通过 `path_key` 配置）。`max_depth` 限制遍历深度——到达该深度时把子树序列化回 XML 字符串而非继续下钻；叶子元素始终产出自己的文本 chunk。`include_attributes` 可把元素属性渲染进 chunk 文本与路径。XML 命名空间会被从路径中剥离，`{http://example.com}child` 会变成 `child`。非 XML / 格式错误的文档原样返回。
+
+组件定义文件如下：
+```yaml
+name: 'xml_splitter'
+description: '按元素切分 XML 文档，并记录元素路径'
+path_key: 'xml_path'        # 元素路径的 metadata 键
+max_depth: null             # 最大遍历深度；null = 不限，1 = 仅根
+include_attributes: false   # 是否把元素属性渲染进 chunk 文本与路径
+drop_empty: true            # 是否跳过无可见文本的 chunk
+path_separator: ' > '       # 路径中连接标签的分隔符
+root_name: null             # 路径根层的名称；null = 使用根标签
+metadata:
+  type: 'DOC_PROCESSOR'
+  module: 'agentuniverse.agent.action.knowledge.doc_processor.xml_splitter'
+  class: 'XmlSplitter'
+```
+- path_key: 写入每个 chunk 元素路径的 metadata 键。
+- max_depth: 最大遍历深度；`null`（默认）为不限，`1` 仅产出根。到达 `max_depth` 时，嵌套子树被序列化为一个 XML 字符串 chunk。
+- include_attributes: 为真时，每个元素的属性被渲染进 chunk 文本（形如 `[k=v ...]`）并追加到路径。
+- drop_empty: 为真（默认）时，无可见文本（且开启 `include_attributes` 时也无属性）的元素不会被产出。
+- path_separator: 路径中连接标签的字符串，默认 `" > "`。
+- root_name: 路径根层使用的名称；`null`（默认）使用根元素自身的标签。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_xml_splitter.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_xml_splitter.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Tests for XmlSplitter DocProcessor."""
+
+import unittest
+
+from agentuniverse.agent.action.knowledge.doc_processor.xml_splitter \
+    import XmlSplitter
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class TestXmlSplitter(unittest.TestCase):
+
+    def _split(self, xml_text, **kwargs):
+        proc = XmlSplitter(**kwargs)
+        return proc.process_docs([Document(text=xml_text)], None)
+
+    def _paths(self, docs):
+        return {d.metadata["xml_path"] for d in docs}
+
+    # ------------------------------------------------------------------ #
+    # basic splitting
+    # ------------------------------------------------------------------ #
+    def test_flat_elements(self):
+        docs = self._split("<root><a>hello</a><b>world</b></root>")
+        paths = self._paths(docs)
+        self.assertIn("root > a", paths)
+        self.assertIn("root > b", paths)
+        texts = " ".join(d.text for d in docs)
+        self.assertIn("hello", texts)
+        self.assertIn("world", texts)
+
+    def test_nested_elements(self):
+        docs = self._split("<root><a><b>deep</b></a></root>")
+        paths = self._paths(docs)
+        self.assertIn("root > a > b", paths)
+
+    def test_repeated_elements(self):
+        docs = self._split(
+            "<items><item>one</item><item>two</item></items>")
+        paths = self._paths(docs)
+        self.assertIn("items > item", paths)
+        texts = {d.text for d in docs if d.metadata["xml_path"] == "items > item"}
+        self.assertEqual(texts, {"one", "two"})
+
+    # ------------------------------------------------------------------ #
+    # max_depth
+    # ------------------------------------------------------------------ #
+    def test_max_depth_serialises_subtree(self):
+        # max_depth=2 -> at depth 2, <b>'s subtree is serialised as XML text.
+        docs = self._split("<root><a><b>deep</b></a></root>", max_depth=2)
+        self.assertTrue(len(docs) >= 1)
+        joined = " ".join(d.text for d in docs)
+        self.assertIn("deep", joined)
+
+    def test_max_depth_one_yields_root(self):
+        docs = self._split("<root><a>x</a><b>y</b></root>", max_depth=1)
+        # Only the root chunk, serialised as XML.
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["xml_path"], "root")
+        self.assertIn("x", docs[0].text)
+        self.assertIn("y", docs[0].text)
+
+    # ------------------------------------------------------------------ #
+    # attributes
+    # ------------------------------------------------------------------ #
+    def test_include_attributes_in_text(self):
+        docs = self._split('<item id="42">content</item>',
+                           include_attributes=True)
+        self.assertTrue(any("id=42" in d.text for d in docs))
+
+    def test_include_attributes_off_by_default(self):
+        docs = self._split('<item id="42">content</item>')
+        self.assertTrue(all("id=42" not in d.text for d in docs))
+
+    # ------------------------------------------------------------------ #
+    # drop_empty / edge cases
+    # ------------------------------------------------------------------ #
+    def test_drop_empty_skips_textless_elements(self):
+        docs = self._split("<root><a></a><b>real</b></root>", drop_empty=True)
+        texts = [d.text for d in docs if d.metadata["xml_path"] == "root > a"]
+        self.assertEqual(texts, [])
+
+    def test_drop_empty_false_keeps_textless(self):
+        docs = self._split("<root><a></a><b>real</b></root>", drop_empty=False)
+        # Empty element kept as a chunk with empty/whitespace text.
+        a_chunks = [d for d in docs if d.metadata["xml_path"] == "root > a"]
+        self.assertEqual(len(a_chunks), 1)
+
+    def test_non_xml_returned_unchanged(self):
+        docs = self._split("just plain text, not xml")
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].text, "just plain text, not xml")
+        self.assertNotIn("xml_path", docs[0].metadata or {})
+
+    def test_empty_input(self):
+        proc = XmlSplitter()
+        self.assertEqual(proc.process_docs([], None), [])
+
+    def test_empty_text_returned_unchanged(self):
+        docs = self._split("")
+        self.assertEqual(len(docs), 1)
+        self.assertNotIn("xml_path", docs[0].metadata or {})
+
+    # ------------------------------------------------------------------ #
+    # namespaces, metadata, config
+    # ------------------------------------------------------------------ #
+    def test_namespace_stripped_from_path(self):
+        docs = self._split(
+            '<root xmlns="http://example.com"><child>x</child></root>')
+        paths = self._paths(docs)
+        self.assertIn("root > child", paths)
+        self.assertFalse(any("example.com" in p for p in paths))
+
+    def test_preserves_original_metadata(self):
+        doc = Document(text="<root><a>1</a></root>", metadata={"src": "api"})
+        proc = XmlSplitter()
+        docs = proc.process_docs([doc], None)
+        for d in docs:
+            self.assertEqual(d.metadata["src"], "api")
+            self.assertIn("xml_path", d.metadata)
+
+    def test_custom_path_key(self):
+        docs = self._split("<root><a>1</a></root>", path_key="my_path")
+        self.assertIn("my_path", docs[0].metadata)
+        self.assertNotIn("xml_path", docs[0].metadata)
+
+    def test_custom_root_name(self):
+        docs = self._split("<items><a>1</a></items>", root_name="doc")
+        paths = self._paths(docs)
+        self.assertIn("doc > a", paths)
+        self.assertFalse(any(p.startswith("items") for p in paths))
+
+    def test_invalid_max_depth_raises(self):
+        with self.assertRaises(Exception):
+            XmlSplitter(max_depth=0).process_docs(
+                [Document(text="<a/>")], None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds a new knowledge pre-processing component **XmlSplitter** (#258, knowledge pre-processing direction).

A dependency-free `DocProcessor` that splits each recalled XML document into one chunk per element, recording the element path (e.g. `root > items > item`) as metadata. Useful for indexing structured, tag-based sources (SVG, NLM/JATS articles, TEI, Maven POMs, sitemaps, configuration) where each element should be a retrievable unit.

## Behaviour

- Uses the standard-library `xml.etree.ElementTree` parser — **no third-party dependency**.
- `path_key` records the element path (chain of tags joined with `" > "`).
- `max_depth` caps traversal: at that depth a subtree is serialised back to an XML string rather than descended into; leaf elements always emit their own text chunk.
- `include_attributes` renders element attributes into the chunk text (as `[k=v ...]`) and appends them to the path.
- XML namespaces are stripped from paths so `{http://example.com}child` becomes `child`.
- Non-XML / malformed documents are passed through unchanged.
- `drop_empty` skips elements with no visible text.

It is the sibling of `JsonSplitter` (#258): both walk a structured document and record a path per chunk.

## Files

- `agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.py` (~310 lines)
- `agentuniverse/agent/action/knowledge/doc_processor/xml_splitter.yaml`
- `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_xml_splitter.py` (17 tests)
- `docs/.../DocProcessor.md` (zh + en, new section appended)

## Test plan

All 17 unit tests pass (`python .../test_xml_splitter.py`), covering: flat/nested/repeated elements, `max_depth` (serialise subtree / root-only), `include_attributes` on/off, `drop_empty` on/off, non-XML passthrough, empty input/text, namespace stripping, metadata preservation, custom `path_key`/`root_name`, and invalid `max_depth` validation.

Closes #258.
