### PR TITLE
feat(tool): add Base64ImageTool (encode/decode/info, sandboxed) (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/base64_image_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/base64_image_tool.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Base64 image encoder/decoder tool backed on the Python standard library.
+
+The tool encodes image files to base64 (with an optional ``data:`` URI prefix),
+decodes base64 data back to image files, and reports metadata about a base64
+image (format, dimensions, size). All file access is sandboxed under
+``base_dir`` via :func:`resolve_safe_path`. Pillow (``PIL``) is loaded lazily
+and only required for the ``info`` operation's dimension reporting.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import base64
+import mimetypes
+import os
+import tempfile
+from typing import Any, ClassVar, Dict, Optional
+
+from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_safe_path
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+# Image extensions accepted by encode/decode plus their mime types.
+IMAGE_EXTENSIONS: ClassVar[tuple[str, ...]] = (
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif", ".ico", ".svg",
+)
+# Map common image MIME types (mimetypes does not know all of them by default).
+EXTRA_MIME: ClassVar[Dict[str, str]] = {
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
+    ".ico": "image/x-icon",
+}
+
+MAX_READ_BYTES: ClassVar[int] = 25 * 1024 * 1024   # 25 MB
+MAX_WRITE_BYTES: ClassVar[int] = 50 * 1024 * 1024   # 50 MB
+DATA_URI_PREFIX: ClassVar[str] = "data:"
+
+
+def _lazy_pil():
+    """Import Pillow lazily; raise a helpful error if it is unavailable."""
+    try:
+        from PIL import Image  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised when Pillow missing
+        raise ImportError(
+            "Pillow is required for base64 image info. "
+            "Install it with `pip install Pillow`."
+        ) from exc
+    return Image
+
+
+class Base64ImageTool(Tool):
+    """Encode, decode and inspect images using base64.
+
+    Modes:
+
+    * ``encode`` - read an image file under ``base_dir`` and return base64.
+    * ``decode`` - write base64 payload to an image file under ``base_dir``.
+    * ``info``   - report format/dimensions/size for a base64 image.
+
+    All paths are resolved with :func:`resolve_safe_path` so they cannot
+    escape ``base_dir``. Pillow is only required for ``info``.
+    """
+
+    description: str = (
+        "Encode image files to base64 (optionally as data URIs), decode "
+        "base64 back to image files, and inspect base64 image metadata. "
+        "All paths are sandboxed under base_dir."
+    )
+
+    base_dir: str = "."
+    max_read_bytes: int = MAX_READ_BYTES
+    max_write_bytes: int = MAX_WRITE_BYTES
+
+    def execute(
+        self,
+        mode: str,
+        file_path: Optional[str] = None,
+        data: Optional[str] = None,
+        output_path: Optional[str] = None,
+        as_data_uri: bool = False,
+        overwrite: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run the requested operation and return a structured result."""
+        try:
+            self._validate_config()
+            operation = self._mode(mode)
+            if operation == "encode":
+                return self._encode(file_path, as_data_uri)
+            if operation == "decode":
+                return self._decode(data, output_path, overwrite)
+            return self._info(data)
+        except (TypeError, ValueError) as exc:
+            LOGGER.error(f"Base64ImageTool validation error: {exc}")
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            LOGGER.error(f"Base64ImageTool operation failed: {exc}")
+            return self._error("operation_error", f"Image operation failed: {exc}")
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _error(kind: str, message: str) -> Dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message}
+
+    def _validate_config(self) -> None:
+        for name in ("max_read_bytes", "max_write_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if not isinstance(self.base_dir, str) or not self.base_dir:
+            raise ValueError("base_dir must be a non-empty string")
+
+    @staticmethod
+    def _mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"encode", "decode", "info"}:
+            raise ValueError("mode must be encode, decode, or info")
+        return mode
+
+    def _image_path(self, value: Any) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("file_path must be a non-empty string")
+        ext = os.path.splitext(value)[1].lower()
+        if ext not in IMAGE_EXTENSIONS:
+            raise ValueError(
+                f"file_path must be an image ({', '.join(IMAGE_EXTENSIONS)})"
+            )
+        return str(resolve_safe_path(value, self.base_dir))
+
+    def _output_path(self, value: Any) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("output_path must be a non-empty string")
+        ext = os.path.splitext(value)[1].lower()
+        if ext not in IMAGE_EXTENSIONS:
+            raise ValueError(
+                f"output_path must be an image ({', '.join(IMAGE_EXTENSIONS)})"
+            )
+        return str(resolve_safe_path(value, self.base_dir))
+
+    @staticmethod
+    def _mime_for(path: str) -> str:
+        ext = os.path.splitext(path)[1].lower()
+        if ext in EXTRA_MIME:
+            return EXTRA_MIME[ext]
+        guessed = mimetypes.guess_type(path)[0]
+        return guessed or "application/octet-stream"
+
+    # ----------------------------------------------------------------- encode
+    def _encode(self, file_path: Any, as_data_uri: Any) -> Dict[str, Any]:
+        if not isinstance(as_data_uri, bool):
+            raise TypeError("as_data_uri must be a boolean")
+        path = self._image_path(file_path)
+        if not os.path.isfile(path):
+            raise ValueError(f"file_path does not exist: {path}")
+        size = os.path.getsize(path)
+        if size > self.max_read_bytes:
+            raise ValueError(f"file_path exceeds max_read_bytes ({self.max_read_bytes})")
+        with open(path, "rb") as stream:
+            raw = stream.read()
+        encoded = base64.b64encode(raw).decode("ascii")
+        mime = self._mime_for(path)
+        data_uri = f"{DATA_URI_PREFIX}{mime};base64,{encoded}" if as_data_uri else None
+        return {
+            "status": "success",
+            "mode": "encode",
+            "file_path": path,
+            "base64": encoded,
+            "data_uri": data_uri,
+            "mime_type": mime,
+            "size": size,
+        }
+
+    # ----------------------------------------------------------------- decode
+    def _decode(self, data: Any, output_path: Any, overwrite: Any) -> Dict[str, Any]:
+        if not isinstance(data, str) or not data.strip():
+            raise ValueError("data must be a non-empty base64 string")
+        if not isinstance(overwrite, bool):
+            raise TypeError("overwrite must be a boolean")
+        destination = self._output_path(output_path)
+        payload = self._strip_data_uri(data)
+        try:
+            raw = base64.b64decode(payload, validate=True)
+        except (ValueError, base64.binascii.Error) as exc:
+            raise ValueError(f"data is not valid base64: {exc}") from exc
+        if not raw:
+            raise ValueError("decoded payload is empty")
+        if len(raw) > self.max_write_bytes:
+            raise ValueError(f"decoded payload exceeds max_write_bytes ({self.max_write_bytes})")
+        if os.path.exists(destination) and not overwrite:
+            raise ValueError(f"file exists: {destination}; set overwrite=true")
+        self._atomic_write(destination, raw)
+        mime = self._mime_for(destination)
+        return {
+            "status": "success",
+            "mode": "decode",
+            "output_path": destination,
+            "size": len(raw),
+            "mime_type": mime,
+        }
+
+    @staticmethod
+    def _strip_data_uri(data: str) -> str:
+        """Return the base64 portion, dropping an optional ``data:`` prefix."""
+        stripped = data.strip()
+        if stripped.startswith(DATA_URI_PREFIX):
+            # Format: data:<mime>;base64,<payload>  or  data:<mime>,<payload>
+            comma = stripped.find(",")
+            if comma == -1:
+                raise ValueError("data URI is missing the comma separator")
+            return stripped[comma + 1:]
+        return stripped
+
+    # -------------------------------------------------------------------- info
+    def _info(self, data: Any) -> Dict[str, Any]:
+        if not isinstance(data, str) or not data.strip():
+            raise ValueError("data must be a non-empty base64 string")
+        payload = self._strip_data_uri(data)
+        try:
+            raw = base64.b64decode(payload, validate=True)
+        except (ValueError, base64.binascii.Error) as exc:
+            raise ValueError(f"data is not valid base64: {exc}") from exc
+        info: Dict[str, Any] = {
+            "status": "success",
+            "mode": "info",
+            "size": len(raw),
+            "format": None,
+            "width": None,
+            "height": None,
+        }
+        # Pillow is optional; degrade gracefully when it is unavailable.
+        try:
+            image = _lazy_pil()
+        except ImportError as exc:
+            info["note"] = str(exc)
+            return info
+        with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as tmp:
+            tmp.write(raw)
+            tmp_path = tmp.name
+        try:
+            with image.open(tmp_path) as img:
+                info["format"] = img.format.lower() if img.format else None
+                info["width"], info["height"] = img.size
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        return info
+
+    @staticmethod
+    def _atomic_write(destination: str, content: bytes) -> None:
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=".img-", dir=os.path.dirname(destination), delete=False
+            ) as output:
+                temporary = output.name
+                output.write(content)
+            os.replace(temporary, destination)
+            temporary = None
+        finally:
+            if temporary and os.path.exists(temporary):
+                os.unlink(temporary)

--- a/agentuniverse/agent/action/tool/common_tool/base64_image_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/base64_image_tool.yaml
@@ -1,0 +1,28 @@
+name: base64_image_tool
+description: >-
+  Encode image files to base64 (optionally as data URIs), decode base64 back
+  to image files, and inspect base64 image metadata. All paths are sandboxed
+  under base_dir.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.base64_image_tool
+  class: Base64ImageTool
+input_keys:
+  - mode
+base_dir: .
+max_read_bytes: 26214400
+max_write_bytes: 52428800
+args_model_schema:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: [encode, decode, info]
+    file_path: {type: string, description: "Image file to encode (encode)."}
+    data: {type: string, description: "Base64 payload (decode / info)."}
+    output_path: {type: string, description: "Destination image file (decode)."}
+    as_data_uri: {type: boolean, default: false}
+    overwrite: {type: boolean, default: false}
+  required: [mode]
+  additionalProperties: false

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/Base64ImageTool.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/Base64ImageTool.md
@@ -1,0 +1,88 @@
+# Base64ImageTool
+
+`Base64ImageTool` 提供图片与 base64 之间的转换：将图片文件编码为 base64（可选 `data:` URI 形式）、将 base64 解码为图片文件、以及从 base64 读取图片元信息。仅依赖 Python 标准库（`base64`），`info` 操作的尺寸/格式识别会懒加载 Pillow。
+
+## 功能特性
+
+- 三种模式：`encode`（图片→base64）、`decode`（base64→图片）、`info`（base64→元信息）
+- `encode` 可选 `as_data_uri` 输出完整的 `data:image/png;base64,...` URI
+- `decode` 支持 base64 字符串或 `data:` URI 形式的输入
+- `info` 返回解码后字节大小；若安装 Pillow 还会返回 `format`、`width`、`height`
+- 所有文件路径经 `resolve_safe_path` 限制在 `base_dir` 下，防止路径穿越
+- 写入采用原子替换，未设置 `overwrite=true` 时不覆盖已有文件
+- 支持 png / jpg / jpeg / gif / bmp / webp / tiff / ico / svg 等常见扩展名
+- 校验失败均以结构化 `error` 返回
+
+## 使用方式
+
+```python
+from agentuniverse.agent.action.tool.common_tool.base64_image_tool import Base64ImageTool
+
+tool = Base64ImageTool(base_dir="/srv/agent-images")
+
+# 编码为 base64
+r = tool.execute(mode="encode", file_path="logo.png")
+print(r["base64"], r["mime_type"])
+
+# 编码为 data URI（可直接嵌入 HTML/JSON）
+r = tool.execute(mode="encode", file_path="logo.png", as_data_uri=True)
+print(r["data_uri"])
+
+# 解码为图片文件
+tool.execute(mode="decode", data=r["base64"], output_path="copy.png")
+
+# 读取 base64 图片元信息（需要 Pillow 才能拿到宽高/格式）
+r = tool.execute(mode="info", data=r["base64"])
+print(r["size"], r.get("width"), r.get("height"), r.get("format"))
+```
+
+## YAML 配置
+
+```yaml
+name: base64_image_tool
+description: Encode image files to base64 (optionally as data URIs), decode base64 back to image files, and inspect base64 image metadata. All paths are sandboxed under base_dir.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.base64_image_tool
+  class: Base64ImageTool
+input_keys:
+  - mode
+base_dir: .
+max_read_bytes: 26214400
+max_write_bytes: 52428800
+```
+
+## 参数说明
+
+`execute()` 方法接受以下参数：
+
+| 参数 | 类型 | 默认 | 说明 |
+| --- | --- | --- | --- |
+| `mode` | `str` | - | 操作模式：`encode` / `decode` / `info` |
+| `file_path` | `str` | - | 待编码图片路径（encode） |
+| `data` | `str` | - | base64 字符串或 data URI（decode / info） |
+| `output_path` | `str` | - | 输出图片路径（decode） |
+| `as_data_uri` | `bool` | `False` | encode 时是否输出 data URI |
+| `overwrite` | `bool` | `False` | decode 时是否覆盖已有文件 |
+
+工具字段：`base_dir`（工作根目录）、`max_read_bytes`（单文件读取上限，默认 25MB）、`max_write_bytes`（单次写入上限，默认 50MB）。
+
+返回值：
+
+- `encode`：`base64`、`data_uri`（`as_data_uri=True` 时）、`mime_type`、`size`、`file_path`
+- `decode`：`output_path`、`size`、`mime_type`
+- `info`：`size`、`format`、`width`、`height`（后三项需 Pillow；未安装时 `info` 中含 `note` 说明）
+
+失败时返回 `status='error'` 与 `error_type`（`validation_error` / `operation_error`）。
+
+## 安全说明
+
+- 所有路径限制在 `base_dir` 内，拒绝 `../` 路径穿越与绝对路径越界
+- 仅接受图片扩展名，非图片扩展名会返回校验错误
+- 解码写入使用临时文件 + 原子 `os.replace`，崩溃不会产生半成品
+- 默认不覆盖已有文件，需显式 `overwrite=true`
+
+## 依赖
+
+核心功能仅依赖 Python 标准库（`base64`、`mimetypes`、`os`、`tempfile`）。`info` 操作获取宽高/格式需要 Pillow（`pip install Pillow`）；未安装时 `info` 仍返回字节大小并附带提示。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_base64_image_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_base64_image_tool.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import base64
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool import base64_image_tool as base64_module
+from agentuniverse.agent.action.tool.common_tool.base64_image_tool import Base64ImageTool
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = base64_module.__file__.replace(".py", ".yaml")
+
+PNG_HEADER = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32).decode("ascii")
+
+# Minimal valid 1x1 transparent PNG.
+VALID_PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000d49444154789c63000100000005000100a0f903390000000049454e44ae426082"
+)
+VALID_PNG_B64 = base64.b64encode(VALID_PNG_BYTES).decode("ascii")
+
+
+class Base64ImageToolTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.tool = Base64ImageTool(base_dir=self.directory.name)
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def write(self, name, content):
+        path = os.path.join(self.directory.name, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as handle:
+            handle.write(content)
+        return path
+
+    # ---- encode -------------------------------------------------------------
+    def test_encode_returns_base64(self):
+        self.write("logo.png", b"\x89PNG\r\n\x1a\n" + b"pixel-data")
+        result = self.tool.execute(mode="encode", file_path="logo.png")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["mime_type"], "image/png")
+        self.assertEqual(
+            base64.b64decode(result["base64"]),
+            b"\x89PNG\r\n\x1a\n" + b"pixel-data",
+        )
+
+    def test_encode_as_data_uri(self):
+        self.write("a.jpg", b"jpegbytes")
+        result = self.tool.execute(mode="encode", file_path="a.jpg", as_data_uri=True)
+        self.assertTrue(result["data_uri"].startswith("data:image/jpeg;base64,"))
+        self.assertEqual(
+            result["data_uri"].split(",")[1],
+            base64.b64encode(b"jpegbytes").decode("ascii"),
+        )
+
+    def test_encode_rejects_non_image_extension(self):
+        self.write("notes.txt", b"hi")
+        result = self.tool.execute(mode="encode", file_path="notes.txt")
+        self.assertIn("must be an image", result["error"])
+
+    def test_encode_rejects_missing_file(self):
+        result = self.tool.execute(mode="encode", file_path="nope.png")
+        self.assertIn("does not exist", result["error"])
+
+    def test_encode_rejects_path_escape(self):
+        result = self.tool.execute(mode="encode", file_path="../escape.png")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("escapes", result["error"])
+
+    def test_encode_rejects_oversized(self):
+        self.write("big.png", b"x")
+        self.tool.max_read_bytes = 0
+        # max_read_bytes must be positive, so bump to 1 and write 2 bytes
+        self.tool.max_read_bytes = 1
+        self.write("big2.png", b"xy")
+        result = self.tool.execute(mode="encode", file_path="big2.png")
+        self.assertIn("max_read_bytes", result["error"])
+
+    # ---- decode -------------------------------------------------------------
+    def test_decode_writes_file(self):
+        payload = base64.b64encode(b"hello-image").decode("ascii")
+        result = self.tool.execute(mode="decode", data=payload, output_path="out.png")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["mime_type"], "image/png")
+        with open(os.path.join(self.directory.name, "out.png"), "rb") as handle:
+            self.assertEqual(handle.read(), b"hello-image")
+
+    def test_decode_accepts_data_uri(self):
+        data_uri = "data:image/png;base64," + base64.b64encode(b"x").decode("ascii")
+        result = self.tool.execute(mode="decode", data=data_uri, output_path="o.png")
+        self.assertEqual(result["status"], "success")
+
+    def test_decode_rejects_invalid_base64(self):
+        result = self.tool.execute(mode="decode", data="!!!notbase64!!!", output_path="o.png")
+        self.assertIn("not valid base64", result["error"])
+
+    def test_decode_rejects_non_image_output(self):
+        payload = base64.b64encode(b"x").decode("ascii")
+        result = self.tool.execute(mode="decode", data=payload, output_path="o.txt")
+        self.assertIn("must be an image", result["error"])
+
+    def test_decode_refuses_overwrite_without_flag(self):
+        payload = base64.b64encode(b"x").decode("ascii")
+        self.write("exists.png", b"old")
+        result = self.tool.execute(mode="decode", data=payload, output_path="exists.png")
+        self.assertIn("overwrite=true", result["error"])
+        # existing file is preserved
+        with open(os.path.join(self.directory.name, "exists.png"), "rb") as handle:
+            self.assertEqual(handle.read(), b"old")
+
+    def test_decode_overwrite_flag_replaces(self):
+        payload = base64.b64encode(b"new").decode("ascii")
+        self.write("exists.png", b"old")
+        result = self.tool.execute(
+            mode="decode", data=payload, output_path="exists.png", overwrite=True
+        )
+        self.assertEqual(result["status"], "success")
+        with open(os.path.join(self.directory.name, "exists.png"), "rb") as handle:
+            self.assertEqual(handle.read(), b"new")
+
+    def test_decode_rejects_oversized_payload(self):
+        big = base64.b64encode(b"x" * 200).decode("ascii")
+        self.tool.max_write_bytes = 10
+        result = self.tool.execute(mode="decode", data=big, output_path="o.png")
+        self.assertIn("max_write_bytes", result["error"])
+
+    # ---- info ---------------------------------------------------------------
+    def test_info_reports_size_without_pillow(self):
+        result = self.tool.execute(mode="info", data=VALID_PNG_B64)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["size"], len(VALID_PNG_BYTES))
+        # When Pillow is installed we additionally get dimensions/format.
+        if result.get("width") is not None:
+            self.assertEqual(result["width"], 1)
+            self.assertEqual(result["height"], 1)
+            self.assertEqual(result["format"], "png")
+
+    def test_info_rejects_invalid_base64(self):
+        result = self.tool.execute(mode="info", data="@@@bad@@@")
+        self.assertIn("not valid base64", result["error"])
+
+    def test_info_rejects_empty_data(self):
+        result = self.tool.execute(mode="info", data="   ")
+        self.assertEqual(result["status"], "error")
+
+    # ---- round-trip & validation -------------------------------------------
+    def test_encode_decode_round_trip(self):
+        original = b"\x89PNG\r\n\x1a\n" + b"round" + b"\x00" * 16
+        self.write("src.png", original)
+        encoded = self.tool.execute(mode="encode", file_path="src.png")["base64"]
+        self.tool.execute(mode="decode", data=encoded, output_path="dst.png")
+        with open(os.path.join(self.directory.name, "dst.png"), "rb") as handle:
+            self.assertEqual(handle.read(), original)
+
+    def test_rejects_bad_mode(self):
+        result = self.tool.execute(mode="rotate", file_path="a.png")
+        self.assertIn("mode must be", result["error"])
+
+    def test_as_data_uri_must_be_boolean(self):
+        self.write("a.png", b"x")
+        result = self.tool.execute(mode="encode", file_path="a.png", as_data_uri="yes")
+        self.assertEqual(result["error_type"], "validation_error")
+
+
+class Base64ImageRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=YAML_PATH).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "Base64ImageTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, Base64ImageTool)
+        self.assertEqual(tool.input_keys, ["mode"])
+
+    def test_yaml_loads_as_dict(self):
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "base64_image_tool")
+        self.assertEqual(data["metadata"]["class"], "Base64ImageTool")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `Base64ImageTool` that encodes image files to base64 (optionally as `data:` URIs), decodes base64 back to image files, and inspects base64 image metadata. Core logic uses only the Python standard library (`base64`); Pillow is loaded lazily and only needed for dimension/format reporting in `info`.

Closes #252.

## Why

Agents that embed images in prompts, JSON or HTML need a safe, dependency-light way to move between binary image files and base64. Sandboxing all paths under `base_dir` and using atomic writes keeps the operation safe for untrusted inputs.

## What's included

- `agentuniverse/agent/action/tool/common_tool/base64_image_tool.py` — `Base64ImageTool` with three modes:
  - `encode` — read an image file under `base_dir`, return base64 and optional `data_uri`.
  - `decode` — accept a base64 string or `data:` URI, write to an image file under `base_dir` (atomic, overwrite-gated).
  - `info` — return decoded byte size; with Pillow also `format`, `width`, `height`.
  - All paths resolved via `resolve_safe_path`; accepted extensions include png/jpg/jpeg/gif/bmp/webp/tiff/ico/svg; `max_read_bytes`/`max_write_bytes` guard size.
- `agentuniverse/agent/action/tool/common_tool/base64_image_tool.yaml` — built-in component config with `args_model_schema`.
- `tests/test_agentuniverse/unit/agent/action/tool/test_base64_image_tool.py` — 22 unit tests (encode/data-uri/extension/missing/escape/oversize, decode/data-uri/invalid-base64/non-image/overwrite/oversize, info with/without Pillow, round-trip, validation, registration).
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/Base64ImageTool.md` — Chinese usage docs.

## Usage

```python
from agentuniverse.agent.action.tool.common_tool.base64_image_tool import Base64ImageTool

tool = Base64ImageTool(base_dir="/srv/agent-images")
enc = tool.execute(mode="encode", file_path="logo.png", as_data_uri=True)
tool.execute(mode="decode", data=enc["base64"], output_path="copy.png")
info = tool.execute(mode="info", data=enc["base64"])
```

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_base64_image_tool` — 22 passed.
- [x] Core has no new dependencies (stdlib only); `info` degrades gracefully without Pillow.
- [x] Suite runs fully offline.
