### PR TITLE
feat(tool): add MarkdownTableExtractorTool (extract/csv/json, zero-dep) (#252)

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/markdown_table_extractor_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/markdown_table_extractor_tool.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Markdown table extractor tool backed only on the Python standard library.
+
+The tool parses GitHub-Flavored Markdown tables out of arbitrary Markdown text
+and returns them as structured data (header + rows), with helpers to render the
+result as CSV or JSON. Zero third-party dependencies.
+"""
+
+# Public execute() converts validation exceptions into structured tool errors.
+# ruff: noqa: TRY003
+
+import csv
+import io
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from agentuniverse.agent.action.tool.tool import Tool
+from agentuniverse.base.util.logging.logging_util import LOGGER
+
+# A table is a header row, a separator row (---|:--|--:), then >=0 data rows.
+# We match conservatively: each row must contain at least one pipe.
+TABLE_ROW = re.compile(r"^\s*\|.*\|\s*$")
+SEPARATOR = re.compile(r"^\s*\|?[\s:|-]*:?-+[\s:|-]*\|?\s*$")
+# A separator cell must contain at least one dash; only ':', '-', '|', space allowed.
+SEPARATOR_CELL = re.compile(r"^:?-{2,}:?$")
+
+MAX_TEXT_CHARS = 2_000_000
+MAX_TABLES = 1_000
+MAX_ROWS = 100_000
+MAX_COLUMNS = 1_000
+
+
+class MarkdownTableExtractorTool(Tool):
+    """Extract Markdown tables and convert them to structured data.
+
+    Modes:
+
+    * ``extract``       - return all tables as ``{header, rows}`` objects.
+    * ``extract_first`` - return only the first table (or an error if none).
+    * ``to_csv``        - render all tables as a single CSV string.
+    * ``to_json``       - render all tables as a JSON string (list of objects).
+    """
+
+    description: str = (
+        "Extract Markdown tables into structured data and convert them to "
+        "CSV or JSON. Pure-Python regex parsing, zero dependencies."
+    )
+
+    def execute(
+        self,
+        text: str,
+        mode: str = "extract",
+        table_index: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run the requested operation and return a structured result."""
+        try:
+            normalized = self._validate_text(text)
+            operation = self._mode(mode)
+            tables = self._extract_all(normalized)
+            if operation == "extract":
+                return self._format_extract(tables)
+            if operation == "extract_first":
+                return self._format_first(tables)
+            if operation == "to_csv":
+                return self._format_csv(tables, table_index)
+            return self._format_json(tables, table_index)
+        except (TypeError, ValueError) as exc:
+            LOGGER.error(f"MarkdownTableExtractorTool validation error: {exc}")
+            return self._error("validation_error", str(exc))
+        except Exception as exc:
+            LOGGER.error(f"MarkdownTableExtractorTool operation failed: {exc}")
+            return self._error("operation_error", f"Table extraction failed: {exc}")
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _error(kind: str, message: str) -> Dict[str, Any]:
+        return {"status": "error", "error_type": kind, "error": message}
+
+    def _validate_text(self, value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("text must be a string")
+        if len(value) > MAX_TEXT_CHARS:
+            raise ValueError(f"text exceeds MAX_TEXT_CHARS ({MAX_TEXT_CHARS})")
+        return value
+
+    @staticmethod
+    def _mode(value: Any) -> str:
+        if not isinstance(value, str):
+            raise TypeError("mode must be a string")
+        mode = value.strip().lower()
+        if mode not in {"extract", "extract_first", "to_csv", "to_json"}:
+            raise ValueError(
+                "mode must be extract, extract_first, to_csv, or to_json"
+            )
+        return mode
+
+    def _resolve_index(self, value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("table_index must be an integer")
+        if value < 0:
+            raise ValueError("table_index must be >= 0")
+        return value
+
+    # --------------------------------------------------------------- parsing
+    def _extract_all(self, text: str) -> List[Dict[str, Any]]:
+        lines = text.splitlines()
+        tables: List[Dict[str, Any]] = []
+        index = 0
+        while index < len(lines):
+            # Find the next candidate header row.
+            if not self._is_table_row(lines[index]):
+                index += 1
+                continue
+            header_index = index
+            if header_index + 1 >= len(lines):
+                index += 1
+                continue
+            separator_line = lines[header_index + 1]
+            if not self._is_separator(separator_line):
+                index += 1
+                continue
+            header_cells = self._split_row(lines[header_index])
+            rows: List[List[str]] = []
+            cursor = header_index + 2
+            while cursor < len(lines) and self._is_table_row(lines[cursor]):
+                rows.append(self._split_row(lines[cursor]))
+                cursor += 1
+            if len(tables) >= MAX_TABLES:
+                raise ValueError(f"text contains more than MAX_TABLES ({MAX_TABLES})")
+            if len(rows) > MAX_ROWS:
+                raise ValueError(f"a table exceeds MAX_ROWS ({MAX_ROWS})")
+            tables.append(
+                {
+                    "header": header_cells,
+                    "rows": rows,
+                    "row_count": len(rows),
+                    "column_count": len(header_cells),
+                    "start_line": header_index + 1,
+                }
+            )
+            index = cursor
+        return tables
+
+    @staticmethod
+    def _is_table_row(line: str) -> bool:
+        stripped = line.strip()
+        if not stripped:
+            return False
+        # A table row is any non-empty line containing an unescaped pipe.
+        # GFM permits rows with or without surrounding pipes.
+        return "|" in re.sub(r"\\\|", "", stripped)
+
+    def _is_separator(self, line: str) -> bool:
+        if not self._is_table_row(line) and "|" not in line:
+            # Allow separator rows that omit leading/trailing pipes.
+            stripped = line.strip()
+            if not stripped or not SEPARATOR.match(stripped):
+                return False
+        cells = self._split_row(line)
+        if not cells:
+            return False
+        return all(bool(SEPARATOR_CELL.match(cell.strip())) for cell in cells)
+
+    @staticmethod
+    def _split_row(line: str) -> List[str]:
+        stripped = line.strip()
+        # Strip a single leading and trailing pipe.
+        if stripped.startswith("|"):
+            stripped = stripped[1:]
+        if stripped.endswith("|"):
+            stripped = stripped[:-1]
+        # Split on unescaped pipes.
+        parts = re.split(r"(?<!\\)\|", stripped)
+        return [part.strip().replace("\\|", "|") for part in parts]
+
+    # --------------------------------------------------------------- formatting
+    @staticmethod
+    def _format_extract(tables: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {
+            "status": "success",
+            "mode": "extract",
+            "table_count": len(tables),
+            "tables": tables,
+        }
+
+    @staticmethod
+    def _format_first(tables: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not tables:
+            return {
+                "status": "success",
+                "mode": "extract_first",
+                "table_count": 0,
+                "table": None,
+            }
+        first = tables[0]
+        return {
+            "status": "success",
+            "mode": "extract_first",
+            "table_count": len(tables),
+            "table": first,
+        }
+
+    def _format_csv(
+        self, tables: List[Dict[str, Any]], table_index: Optional[int]
+    ) -> Dict[str, Any]:
+        index = self._resolve_index(table_index)
+        if not tables:
+            return {
+                "status": "success",
+                "mode": "to_csv",
+                "table_count": 0,
+                "csv": "",
+            }
+        selected = tables
+        if index is not None:
+            if index >= len(tables):
+                raise ValueError(
+                    f"table_index {index} is out of range (0-{len(tables) - 1})"
+                )
+            selected = [tables[index]]
+        buffer = io.StringIO()
+        writer = csv.writer(buffer, lineterminator="\n")
+        for position, table in enumerate(selected):
+            if position > 0:
+                writer.writerow([])
+            writer.writerow(table["header"])
+            writer.writerows(table["rows"])
+        return {
+            "status": "success",
+            "mode": "to_csv",
+            "table_count": len(tables),
+            "table_index": index,
+            "csv": buffer.getvalue(),
+        }
+
+    def _format_json(
+        self, tables: List[Dict[str, Any]], table_index: Optional[int]
+    ) -> Dict[str, Any]:
+        index = self._resolve_index(table_index)
+        if not tables:
+            return {
+                "status": "success",
+                "mode": "to_json",
+                "table_count": 0,
+                "json": "[]",
+            }
+        selected = tables
+        if index is not None:
+            if index >= len(tables):
+                raise ValueError(
+                    f"table_index {index} is out of range (0-{len(tables) - 1})"
+                )
+            selected = [tables[index]]
+
+        def to_objects(table: Dict[str, Any]) -> List[Dict[str, str]]:
+            header = table["header"]
+            objects: List[Dict[str, str]] = []
+            for row in table["rows"]:
+                obj: Dict[str, str] = {}
+                for cell_index, value in enumerate(row):
+                    key = header[cell_index] if cell_index < len(header) else f"column_{cell_index}"
+                    obj[key] = value
+                objects.append(obj)
+            return objects
+
+        payload = [obj for table in selected for obj in to_objects(table)]
+        return {
+            "status": "success",
+            "mode": "to_json",
+            "table_count": len(tables),
+            "table_index": index,
+            "row_count": len(payload),
+            "json": json.dumps(payload, ensure_ascii=False, indent=2),
+        }

--- a/agentuniverse/agent/action/tool/common_tool/markdown_table_extractor_tool.yaml
+++ b/agentuniverse/agent/action/tool/common_tool/markdown_table_extractor_tool.yaml
@@ -1,0 +1,25 @@
+name: markdown_table_extractor_tool
+description: >-
+  Extract Markdown tables into structured data and convert them to CSV or
+  JSON. Pure-Python regex parsing, zero dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.markdown_table_extractor_tool
+  class: MarkdownTableExtractorTool
+input_keys:
+  - text
+args_model_schema:
+  type: object
+  properties:
+    text: {type: string, description: "Markdown text to scan for tables."}
+    mode:
+      type: string
+      enum: [extract, extract_first, to_csv, to_json]
+      default: extract
+    table_index:
+      type: integer
+      minimum: 0
+      description: "Optional table index for to_csv / to_json."
+  required: [text]
+  additionalProperties: false

--- a/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/MarkdownTableExtractorTool.md
+++ b/docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/MarkdownTableExtractorTool.md
@@ -1,0 +1,90 @@
+# MarkdownTableExtractorTool
+
+`MarkdownTableExtractorTool` 从 Markdown 文本中提取 GFM 风格的表格并转为结构化数据，支持 CSV、JSON 输出。仅使用 Python 标准库（`re`、`csv`、`json`），零第三方依赖。
+
+## 功能特性
+
+- 四种模式：`extract`（全部表格）、`extract_first`（首个表格）、`to_csv`（CSV 字符串）、`to_json`（JSON 对象列表）
+- 解析遵循 GitHub Flavored Markdown 表格语法：表头行 + 分隔行（`---`、`:--`、`--:`、`:--:`）+ 数据行
+- 支持有/无首尾管道符 `|` 的写法
+- 支持单元格内转义管道符 `\|`
+- 自动保留空单元格；分隔行缺少连字符会被识别为非表格
+- `to_csv` / `to_json` 可通过 `table_index` 只处理指定表格
+- 校验失败均以结构化 `error` 返回，不会抛出未捕获异常
+
+## 使用方式
+
+```python
+from agentuniverse.agent.action.tool.common_tool.markdown_table_extractor_tool import MarkdownTableExtractorTool
+
+tool = MarkdownTableExtractorTool()
+
+md = """
+# 报告
+
+| 姓名 | 年龄 | 城市 |
+|------|-----|------|
+| Alice | 30 | Beijing |
+| Bob | 25 | Shanghai |
+"""
+
+# 提取所有表格
+r = tool.execute(text=md, mode="extract")
+print(r["table_count"], r["tables"][0]["header"], r["tables"][0]["rows"])
+
+# 只要第一个表格
+r = tool.execute(text=md, mode="extract_first")
+print(r["table"])
+
+# 转 CSV
+r = tool.execute(text=md, mode="to_csv")
+print(r["csv"])
+
+# 转 JSON（每行变成一个对象）
+r = tool.execute(text=md, mode="to_json")
+print(r["json"])
+```
+
+## YAML 配置
+
+```yaml
+name: markdown_table_extractor_tool
+description: Extract Markdown tables into structured data and convert them to CSV or JSON. Pure-Python regex parsing, zero dependencies.
+tool_type: api
+metadata:
+  type: TOOL
+  module: agentuniverse.agent.action.tool.common_tool.markdown_table_extractor_tool
+  class: MarkdownTableExtractorTool
+input_keys:
+  - text
+```
+
+## 参数说明
+
+`execute()` 方法接受以下参数：
+
+| 参数 | 类型 | 默认 | 说明 |
+| --- | --- | --- | --- |
+| `text` | `str` | - | Markdown 文本，最长 2,000,000 字符 |
+| `mode` | `str` | `extract` | `extract` / `extract_first` / `to_csv` / `to_json` |
+| `table_index` | `int` | - | `to_csv` / `to_json` 时指定表格下标（从 0 开始） |
+
+返回值：
+
+- `extract`：`table_count` 与 `tables`（每个含 `header`、`rows`、`row_count`、`column_count`、`start_line`）
+- `extract_first`：`table`（无表格时为 `null`）与 `table_count`
+- `to_csv`：`csv` 字符串（多表以空行分隔）；无表格时为 `""`
+- `to_json`：`json` 字符串（数据行转为以表头为键的对象列表）；无表格时为 `"[]"`
+
+失败时返回 `status='error'` 与 `error_type`（`validation_error` / `operation_error`）。
+
+## 解析规则说明
+
+- 表头行与数据行必须满足「两端被管道符包围」或「至少包含一个管道符」
+- 分隔行的每个单元格必须至少含两个连字符 `--`，可带冒号表示对齐
+- 仅含冒号/竖线而无连字符的行不会被识别为分隔行
+- 表格之间会被普通文本自然分隔
+
+## 依赖
+
+仅依赖 Python 标准库（`re`、`csv`、`json`、`io`），无需安装任何第三方包。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_markdown_table_extractor_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_markdown_table_extractor_tool.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import json
+import unittest
+
+import yaml
+
+from agentuniverse.agent.action.tool.common_tool import markdown_table_extractor_tool as md_module
+from agentuniverse.agent.action.tool.common_tool.markdown_table_extractor_tool import (
+    MarkdownTableExtractorTool,
+)
+from agentuniverse.agent.action.tool.tool_manager import ToolManager
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.config.application_configer.app_configer import AppConfiger
+from agentuniverse.base.config.application_configer.application_config_manager import ApplicationConfigManager
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.component_configer.configers.tool_configer import ToolConfiger
+from agentuniverse.base.config.configer import Configer
+
+YAML_PATH = md_module.__file__.replace(".py", ".yaml")
+
+SINGLE = """# Title
+
+Some intro text.
+
+| Name | Age | City |
+|------|-----|------|
+| Alice | 30 | Beijing |
+| Bob | 25 | Shanghai |
+
+Trailing paragraph.
+"""
+
+TWO_TABLES = """| A | B |
+|---|---|
+| 1 | 2 |
+
+text in between
+
+| X | Y |
+|---|---|
+| 9 | 8 |
+"""
+
+NO_TABLE = "Just a paragraph. No table here."
+
+
+class MarkdownTableExtractorToolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = MarkdownTableExtractorTool()
+
+    # ---- extract ------------------------------------------------------------
+    def test_extract_single_table(self) -> None:
+        result = self.tool.execute(text=SINGLE, mode="extract")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["table_count"], 1)
+        table = result["tables"][0]
+        self.assertEqual(table["header"], ["Name", "Age", "City"])
+        self.assertEqual(table["rows"], [["Alice", "30", "Beijing"], ["Bob", "25", "Shanghai"]])
+        self.assertEqual(table["row_count"], 2)
+        self.assertEqual(table["column_count"], 3)
+
+    def test_extract_multiple_tables(self) -> None:
+        result = self.tool.execute(text=TWO_TABLES, mode="extract")
+        self.assertEqual(result["table_count"], 2)
+        self.assertEqual(result["tables"][0]["header"], ["A", "B"])
+        self.assertEqual(result["tables"][1]["header"], ["X", "Y"])
+
+    def test_extract_no_table(self) -> None:
+        result = self.tool.execute(text=NO_TABLE, mode="extract")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["table_count"], 0)
+        self.assertEqual(result["tables"], [])
+
+    def test_extract_first(self) -> None:
+        result = self.tool.execute(text=TWO_TABLES, mode="extract_first")
+        self.assertEqual(result["table"]["header"], ["A", "B"])
+        self.assertEqual(result["table"]["rows"], [["1", "2"]])
+
+    def test_extract_first_none(self) -> None:
+        result = self.tool.execute(text=NO_TABLE, mode="extract_first")
+        self.assertIsNone(result["table"])
+
+    def test_table_without_outer_pipes(self) -> None:
+        text = "Name | Age\n--- | ---\nCara | 40"
+        result = self.tool.execute(text=text, mode="extract")
+        self.assertEqual(result["table_count"], 1)
+        self.assertEqual(result["tables"][0]["header"], ["Name", "Age"])
+        self.assertEqual(result["tables"][0]["rows"], [["Cara", "40"]])
+
+    def test_alignment_colons_in_separator(self) -> None:
+        text = "| a | b |\n|:--:|---:|\n| 1 | 2 |"
+        result = self.tool.execute(text=text, mode="extract")
+        self.assertEqual(result["table_count"], 1)
+        self.assertEqual(result["tables"][0]["rows"], [["1", "2"]])
+
+    def test_escaped_pipes_in_cells(self) -> None:
+        text = "| col |\n|-----|\n| a\\|b |"
+        result = self.tool.execute(text=text, mode="extract")
+        self.assertEqual(result["tables"][0]["rows"], [["a|b"]])
+
+    def test_table_with_no_data_rows(self) -> None:
+        text = "| H1 | H2 |\n|----|----|"
+        result = self.tool.execute(text=text, mode="extract")
+        self.assertEqual(result["table_count"], 1)
+        self.assertEqual(result["tables"][0]["row_count"], 0)
+        self.assertEqual(result["tables"][0]["rows"], [])
+
+    def test_separator_without_dashes_rejected(self) -> None:
+        # A row of only pipes/colons (no dash) is not a separator.
+        text = "| a | b |\n| ::: | ::: |\n| 1 | 2 |"
+        result = self.tool.execute(text=text, mode="extract")
+        self.assertEqual(result["table_count"], 0)
+
+    def test_empty_cells_preserved(self) -> None:
+        text = "| a | b |\n|---|---|\n|  |  |"
+        result = self.tool.execute(text=text, mode="extract")
+        self.assertEqual(result["tables"][0]["rows"], [["", ""]])
+
+    # ---- to_csv -------------------------------------------------------------
+    def test_to_csv_single_table(self) -> None:
+        result = self.tool.execute(text=SINGLE, mode="to_csv")
+        self.assertEqual(result["status"], "success")
+        lines = result["csv"].strip().split("\n")
+        self.assertEqual(lines[0], "Name,Age,City")
+        self.assertEqual(lines[1], "Alice,30,Beijing")
+        self.assertEqual(lines[2], "Bob,25,Shanghai")
+
+    def test_to_csv_by_index(self) -> None:
+        result = self.tool.execute(text=TWO_TABLES, mode="to_csv", table_index=1)
+        self.assertEqual(result["table_index"], 1)
+        lines = result["csv"].strip().split("\n")
+        self.assertEqual(lines[0], "X,Y")
+        self.assertEqual(lines[1], "9,8")
+
+    def test_to_csv_out_of_range(self) -> None:
+        result = self.tool.execute(text=SINGLE, mode="to_csv", table_index=5)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("out of range", result["error"])
+
+    def test_to_csv_no_table(self) -> None:
+        result = self.tool.execute(text=NO_TABLE, mode="to_csv")
+        self.assertEqual(result["csv"], "")
+
+    # ---- to_json ------------------------------------------------------------
+    def test_to_json_objects(self) -> None:
+        result = self.tool.execute(text=SINGLE, mode="to_json")
+        data = json.loads(result["json"])
+        self.assertEqual(data[0], {"Name": "Alice", "Age": "30", "City": "Beijing"})
+        self.assertEqual(data[1]["Name"], "Bob")
+
+    def test_to_json_by_index(self) -> None:
+        result = self.tool.execute(text=TWO_TABLES, mode="to_json", table_index=0)
+        data = json.loads(result["json"])
+        self.assertEqual(data, [{"A": "1", "B": "2"}])
+
+    def test_to_json_no_table(self) -> None:
+        result = self.tool.execute(text=NO_TABLE, mode="to_json")
+        self.assertEqual(result["json"], "[]")
+
+    # ---- validation ---------------------------------------------------------
+    def test_rejects_non_string_text(self) -> None:
+        result = self.tool.execute(text=123)
+        self.assertEqual(result["error_type"], "validation_error")
+
+    def test_rejects_bad_mode(self) -> None:
+        result = self.tool.execute(text=SINGLE, mode="convert")
+        self.assertIn("mode must be", result["error"])
+
+    def test_rejects_negative_index(self) -> None:
+        result = self.tool.execute(text=SINGLE, mode="to_csv", table_index=-1)
+        self.assertIn("table_index", result["error"])
+
+
+class MarkdownTableRegistrationTest(unittest.TestCase):
+    def setUp(self):
+        self.config = Configer(path=YAML_PATH).load()
+        try:
+            self.previous = ApplicationConfigManager().app_configer
+        except ValueError:
+            self.previous = None
+
+    def tearDown(self):
+        ApplicationConfigManager().app_configer = self.previous
+
+    def test_schema(self):
+        component = ComponentConfiger().load_by_configer(self.config)
+        self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
+        self.assertEqual(component.metadata_class, "MarkdownTableExtractorTool")
+
+    def test_manager(self):
+        configer = ToolConfiger().load_by_configer(self.config)
+        app = AppConfiger()
+        app.tool_configer_map = {configer.name: configer}
+        ApplicationConfigManager().app_configer = app
+        tool = ToolManager().get_instance_obj(configer.name)
+        self.assertIsInstance(tool, MarkdownTableExtractorTool)
+        self.assertEqual(tool.input_keys, ["text"])
+
+    def test_yaml_loads_as_dict(self):
+        with open(YAML_PATH, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        self.assertEqual(data["name"], "markdown_table_extractor_tool")
+        self.assertEqual(data["metadata"]["class"], "MarkdownTableExtractorTool")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a new `MarkdownTableExtractorTool` that parses GitHub-Flavored Markdown tables out of arbitrary Markdown text and returns them as structured data (`{header, rows}`), with helpers to render the result as CSV or JSON. Pure-Python regex parsing, zero dependencies.

Closes #252.

## Why

Agents consuming Markdown reports, wikis or LLM output frequently need the tabular data as native structures. A dependency-free GFM table parser keeps the tool lightweight and lets agents turn tables into CSV/JSON for downstream processing without external libraries.

## What's included

- `agentuniverse/agent/action/tool/common_tool/markdown_table_extractor_tool.py` — `MarkdownTableExtractorTool` with four modes:
  - `extract` — all tables as `{header, rows, row_count, column_count, start_line}`.
  - `extract_first` — the first table (or `null` when none).
  - `to_csv` — render tables as CSV (multiple tables separated by a blank line); optional `table_index`.
  - `to_json` — render table rows as a list of `{header: cell}` objects; optional `table_index`.
  - Supports tables with or without surrounding pipes, alignment colons in the separator (`:--`, `--:`), and escaped pipes (`\|`) inside cells.
- `agentuniverse/agent/action/tool/common_tool/markdown_table_extractor_tool.yaml` — built-in component config with `args_model_schema`.
- `tests/test_agentuniverse/unit/agent/action/tool/test_markdown_table_extractor_tool.py` — 24 unit tests (single/multiple/no table, extract_first, no-outer-pipes, alignment colons, escaped pipes, empty data rows, non-dash separator rejection, empty cells, to_csv/to_json by index + out-of-range + empty, validation, registration).
- `docs/guidebook/zh/In-Depth_Guides/组件列表/工具列表/MarkdownTableExtractorTool.md` — Chinese usage docs.

## Usage

```python
from agentuniverse.agent.action.tool.common_tool.markdown_table_extractor_tool import MarkdownTableExtractorTool

tool = MarkdownTableExtractorTool()
md = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |"
tool.execute(text=md, mode="extract")        # structured {header, rows}
tool.execute(text=md, mode="to_csv")         # CSV string
tool.execute(text=md, mode="to_json")        # JSON list of objects
```

## Test plan

- [x] `python -m unittest tests.test_agentuniverse.unit.agent.action.tool.test_markdown_table_extractor_tool` — 24 passed.
- [x] No new dependencies (stdlib only).
- [x] Suite runs fully offline.
