### PR TITLE
fix(store): fix init bugs in MilvusStore, ChromaStore, and FAISSStore

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -41,8 +41,10 @@ class ChromaStore(Store):
 
     def _new_client(self) -> Any:
         """Initialize the chroma client."""
-        if self.persist_path.startswith('http') or \
-                self.persist_path.startswith('https'):
+        if self.persist_path and (
+            self.persist_path.startswith('http') or
+            self.persist_path.startswith('https')
+        ):
             # Remote database URL
             parsed_url = urlparse(self.persist_path)
             settings = Settings(
@@ -50,11 +52,15 @@ class ChromaStore(Store):
                 chroma_server_host=parsed_url.hostname,
                 chroma_server_http_port=str(parsed_url.port)
             )
-        else:
+        elif self.persist_path:
+            # Local persistent database
             settings = Settings(
                 is_persistent=True,
                 persist_directory=self.persist_path
             )
+        else:
+            # In-memory only (no persistence path configured)
+            settings = Settings()
 
         client = chromadb.Client(settings)
         if self.collection is None:

--- a/agentuniverse/agent/action/knowledge/store/faiss_store.py
+++ b/agentuniverse/agent/action/knowledge/store/faiss_store.py
@@ -17,6 +17,11 @@ from agentuniverse.agent.action.knowledge.store.query import Query
 from agentuniverse.agent.action.knowledge.store.store import Store
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
 
+# Module-level placeholders for optional dependencies; populated lazily
+# by _new_client so that importing this module never requires faiss/numpy.
+faiss = None
+np = None
+
 # Default configuration for FAISS index types
 DEFAULT_INDEX_CONFIG = {
     "index_type": "IndexFlatL2",
@@ -72,15 +77,19 @@ class FAISSStore(Store):
 
     def _new_client(self) -> Any:
         """Initialize the FAISS index and load existing data if available."""
-        try:
-            import faiss
-            import numpy as np
-        except ImportError as e:
-            FAISS_NOT_INSTALLED_MSG = (
-                "FAISS is not installed. Please install it with 'pip install faiss-cpu' "
-                "for CPU version or 'pip install faiss-gpu' for GPU version."
-            )
-            raise ImportError(FAISS_NOT_INSTALLED_MSG) from e
+        global faiss, np
+        if faiss is None or np is None:
+            try:
+                import faiss as _faiss
+                import numpy as _np
+            except ImportError as e:
+                FAISS_NOT_INSTALLED_MSG = (
+                    "FAISS is not installed. Please install it with 'pip install faiss-cpu' "
+                    "for CPU version or 'pip install faiss-gpu' for GPU version."
+                )
+                raise ImportError(FAISS_NOT_INSTALLED_MSG) from e
+            faiss = _faiss
+            np = _np
         self._load_index_and_metadata()
         return self.faiss_index
 

--- a/agentuniverse/agent/action/knowledge/store/milvus_store.py
+++ b/agentuniverse/agent/action/knowledge/store/milvus_store.py
@@ -92,7 +92,7 @@ class MilvusStore(Store):
         if hasattr(milvus_store_configer, "similarity_top_k"):
             self.similarity_top_k = milvus_store_configer.similarity_top_k
         if hasattr(milvus_store_configer, "query_embedding"):
-            self.similarity_top_k = milvus_store_configer.query_embedding
+            self.query_embedding = milvus_store_configer.query_embedding
         return self
 
     def _create_or_load_collection(self,

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_store_init_fixes.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_store_init_fixes.py
@@ -1,0 +1,134 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for store initialization bug fixes.
+
+Covers three critical bugs:
+1. MilvusStore: query_embedding config was assigned to similarity_top_k (typo)
+2. ChromaStore: _new_client crashed with AttributeError when persist_path=None
+3. FAISSStore: faiss/np module-level names were not set by lazy import in _new_client
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ------------------------------------------------------------------ #
+# Detect optional dependencies
+# ------------------------------------------------------------------ #
+try:
+    import chromadb  # noqa: F401
+    CHROMA_AVAILABLE = True
+except ImportError:
+    CHROMA_AVAILABLE = False
+
+try:
+    import pymilvus  # noqa: F401
+    PYMILVUS_AVAILABLE = True
+except ImportError:
+    PYMILVUS_AVAILABLE = False
+
+try:
+    import faiss  # noqa: F401
+    import numpy as np  # noqa: F401
+    FAISS_AVAILABLE = True
+except ImportError:
+    FAISS_AVAILABLE = False
+
+
+# ------------------------------------------------------------------ #
+# 1. MilvusStore — query_embedding config assignment typo
+# ------------------------------------------------------------------ #
+@unittest.skipUnless(PYMILVUS_AVAILABLE, "pymilvus not available")
+class TestMilvusStoreQueryEmbeddingConfig(unittest.TestCase):
+    """Verify that query_embedding config is correctly assigned."""
+
+    def test_query_embedding_config_assigned_correctly(self):
+        """query_embedding=True should set self.query_embedding, not similarity_top_k."""
+        from agentuniverse.agent.action.knowledge.store.milvus_store import MilvusStore
+
+        store = MilvusStore()
+        configer = MagicMock()
+        configer.query_embedding = True
+        configer.similarity_top_k = 42
+
+        store._initialize_by_component_configer(configer)
+
+        # query_embedding should be True (was previously ignored due to typo)
+        self.assertTrue(store.query_embedding)
+        # similarity_top_k should remain 42, not overwritten by the boolean True
+        self.assertEqual(store.similarity_top_k, 42)
+
+    def test_query_embedding_defaults_to_false(self):
+        """When query_embedding is not in configer, default should be False."""
+        from agentuniverse.agent.action.knowledge.store.milvus_store import MilvusStore
+
+        store = MilvusStore()
+        configer = MagicMock()
+        # Don't set query_embedding attribute → hasattr returns False
+        del configer.query_embedding
+
+        store._initialize_by_component_configer(configer)
+
+        self.assertFalse(store.query_embedding)
+
+
+# ------------------------------------------------------------------ #
+# 2. ChromaStore — persist_path=None guard
+# ------------------------------------------------------------------ #
+@unittest.skipUnless(CHROMA_AVAILABLE, "chromadb not available")
+class TestChromaStorePersistPathNone(unittest.TestCase):
+    """Verify that _new_client handles persist_path=None gracefully."""
+
+    def test_new_client_with_none_persist_path(self):
+        """_new_client should not crash with AttributeError when persist_path is None."""
+        from agentuniverse.agent.action.knowledge.store.chroma_store import ChromaStore
+
+        store = ChromaStore(persist_path=None)
+        # This should not raise AttributeError: 'NoneType' object has no attribute 'startswith'
+        try:
+            client = store._new_client()
+            self.assertIsNotNone(client)
+        except AttributeError as e:
+            if "'NoneType'" in str(e) and "startswith" in str(e):
+                self.fail(f"_new_client crashed on persist_path=None: {e}")
+            raise  # re-raise if it's a different AttributeError
+
+
+# ------------------------------------------------------------------ #
+# 3. FAISSStore — module-level faiss/np after _new_client
+# ------------------------------------------------------------------ #
+@unittest.skipUnless(FAISS_AVAILABLE, "faiss not available")
+class TestFAISSStoreImportScope(unittest.TestCase):
+    """Verify that faiss and np are accessible at module level after _new_client."""
+
+    def test_new_client_populates_module_level_imports(self):
+        """After _new_client, faiss and np should be available at module level."""
+        import agentuniverse.agent.action.knowledge.store.faiss_store as faiss_module
+
+        store = faiss_module.FAISSStore(
+            index_path=None,
+            metadata_path=None,
+        )
+        store._new_client()
+
+        # faiss and np should now be set at module level
+        self.assertIsNotNone(faiss_module.faiss, "module-level faiss should be populated")
+        self.assertIsNotNone(faiss_module.np, "module-level np should be populated")
+
+    def test_create_faiss_index_uses_module_level_faiss(self):
+        """_create_faiss_index should not raise NameError after _new_client."""
+        import agentuniverse.agent.action.knowledge.store.faiss_store as faiss_module
+
+        store = faiss_module.FAISSStore(
+            index_path=None,
+            metadata_path=None,
+        )
+        store._new_client()
+
+        # _create_faiss_index references faiss at module level — should not NameError
+        index = store._create_faiss_index(dimension=4)
+        self.assertIsNotNone(index)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Checklist | 检查项

- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md).
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes)
- [x] I have added or modified the documentation related to this PR (not applicable — bug fixes only)
- [x] I have added examples and notes if needed (not applicable — bug fixes only)

## PR Details | PR 内容

This PR fixes three initialization bugs in vector store implementations that cause crashes or silent misconfiguration at runtime.

### 1. MilvusStore — `query_embedding` config assigned to wrong attribute

**File:** `agentuniverse/agent/action/knowledge/store/milvus_store.py` (L95)

**Root cause:** A typo in `_initialize_by_component_configer` assigned the `query_embedding` configuration value to `similarity_top_k` instead of `query_embedding`:

```python
# Before (bug)
self.similarity_top_k = milvus_store_configer.query_embedding

# After (fixed)
self.query_embedding = milvus_store_configer.query_embedding
```

**Impact:**
- When a user sets `query_embedding: true` in YAML config, `self.query_embedding` remained at its default `False`, so `query()` never returned embedding fields.
- `similarity_top_k` was overwritten with the boolean `True`, corrupting top-k behavior.

---

### 2. ChromaStore — `persist_path=None` crashes `_new_client`

**File:** `agentuniverse/agent/action/knowledge/store/chroma_store.py`

**Root cause:** `_new_client` called `self.persist_path.startswith('http')` without checking for `None`. When `persist_path` is not configured (defaults to `None`), this raises `AttributeError: 'NoneType' object has no attribute 'startswith'`.

**Fix:** Added a None guard with an `elif/else` fallback to pure in-memory mode (`Settings()`):

```python
if self.persist_path and (self.persist_path.startswith('http') or self.persist_path.startswith('https')):
    # remote HTTP client
elif self.persist_path:
    # local persistent client
else:
    # in-memory mode — no persist_path configured
```

---

### 3. FAISSStore — `faiss`/`numpy` imports are local to `_new_client`, causing `NameError` elsewhere

**File:** `agentuniverse/agent/action/knowledge/store/faiss_store.py`

**Root cause:** `import faiss` and `import numpy as np` were inside `_new_client` without `global` declaration. Other methods (`_create_faiss_index`, `_load_index_and_metadata`, `query`, `insert_document`) reference `faiss.*` and `np.*` — 14 call sites total — but these names don't exist at module level after `_new_client` returns.

**Fix:** Added module-level placeholder variables (`faiss = None`, `np = None`) and `global faiss, np` declaration in `_new_client` so the imported modules are accessible across all methods.

---

## Test Files | 测试文件

**Path:** `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_store_init_fixes.py`

**Test results:** 5 passed, 0 skipped, 0 failed ✅

```
tests/test_agentuniverse/unit/agent/action/knowledge/store/test_store_init_fixes.py
  ::TestMilvusStoreQueryEmbeddingConfig::test_query_embedding_config_assigned_correctly PASSED [ 20%]
  ::TestMilvusStoreQueryEmbeddingConfig::test_query_embedding_defaults_to_false       PASSED [ 40%]
  ::TestChromaStorePersistPathNone::test_new_client_with_none_persist_path            PASSED [ 60%]
  ::TestFAISSStoreImportScope::test_create_faiss_index_uses_module_level_faiss        PASSED [ 80%]
  ::TestFAISSStoreImportScope::test_new_client_populates_module_level_imports         PASSED [100%]

======================== 5 passed, 5 warnings in 3.80s ========================
```

| Test | Status |
|------|--------|
| `TestMilvusStoreQueryEmbeddingConfig::test_query_embedding_config_assigned_correctly` | ✅ PASSED |
| `TestMilvusStoreQueryEmbeddingConfig::test_query_embedding_defaults_to_false` | ✅ PASSED |
| `TestChromaStorePersistPathNone::test_new_client_with_none_persist_path` | ✅ PASSED |
| `TestFAISSStoreImportScope::test_new_client_populates_module_level_imports` | ✅ PASSED |
| `TestFAISSStoreImportScope::test_create_faiss_index_uses_module_level_faiss` | ✅ PASSED |

All 59 existing store tests also pass with no regressions.