### PR TITLE
fix(tool): preserve archive member lookup names

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/secure_archive_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/secure_archive_tool.py
@@ -128,6 +128,7 @@ class SecureArchiveTool(Tool):
         return path.as_posix().rstrip("/")
 
     def _entries(self, path: str) -> list[dict[str, Any]]:
+        """Return safe public names alongside private archive lookup names."""
         entries: list[dict[str, Any]] = []
         if self._kind(path) == "zip":
             try:
@@ -141,6 +142,7 @@ class SecureArchiveTool(Tool):
                         entries.append(
                             {
                                 "name": self._safe_member_name(item.filename),
+                                "_source_name": item.filename,
                                 "size": item.file_size,
                                 "compressed_size": item.compress_size,
                                 "is_dir": item.is_dir(),
@@ -157,6 +159,7 @@ class SecureArchiveTool(Tool):
                         entries.append(
                             {
                                 "name": self._safe_member_name(item.name),
+                                "_source_name": item.name,
                                 "size": item.size,
                                 "compressed_size": None,
                                 "is_dir": item.isdir(),
@@ -269,7 +272,14 @@ class SecureArchiveTool(Tool):
 
     @staticmethod
     def _list(path: str, entries: list[dict[str, Any]]) -> dict[str, Any]:
-        return {"status": "success", "mode": "list", "file_path": path, "entries": entries, "entry_count": len(entries)}
+        public_entries = [{key: item[key] for key in ("name", "size", "compressed_size", "is_dir")} for item in entries]
+        return {
+            "status": "success",
+            "mode": "list",
+            "file_path": path,
+            "entries": public_entries,
+            "entry_count": len(entries),
+        }
 
     def _info(self, path: str, entries: list[dict[str, Any]]) -> dict[str, Any]:
         return {
@@ -319,7 +329,7 @@ class SecureArchiveTool(Tool):
                     if item["is_dir"]:
                         os.makedirs(destination, exist_ok=True)
                         continue
-                    with archive.open(item["name"]) as source:
+                    with archive.open(item["_source_name"]) as source:
                         self._atomic_copy(source, destination, item["size"])
                     extracted.append(destination)
         else:
@@ -328,7 +338,7 @@ class SecureArchiveTool(Tool):
                     if item["is_dir"]:
                         os.makedirs(destination, exist_ok=True)
                         continue
-                    source = archive.extractfile(item["name"])
+                    source = archive.extractfile(item["_source_name"])
                     if source is None:
                         raise ValueError(f"unable to read archive member: {item['name']}")
                     with source:

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_secure_archive_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_secure_archive_tool.py
@@ -1,5 +1,7 @@
+import io
 import os
 import stat
+import tarfile
 import tempfile
 import unittest
 import zipfile
@@ -59,6 +61,35 @@ class SecureArchiveToolTest(unittest.TestCase):
         result = self.tool.execute(mode="extract", file_path="bundle.zip", output_dir="out", members=["nested/b.txt"])
         self.assertEqual(len(result["output_paths"]), 1)
         self.assertFalse(os.path.exists(os.path.join(self.directory.name, "out/a.txt")))
+
+    def test_extracts_zip_member_with_backslashes(self):
+        with zipfile.ZipFile(os.path.join(self.directory.name, "windows.zip"), "w") as archive:
+            archive.writestr("nested\\file.txt", b"payload")
+
+        listed = self.tool.execute(mode="list", file_path="windows.zip")
+        self.assertEqual(listed["status"], "success")
+        self.assertEqual(listed["entries"][0]["name"], "nested/file.txt")
+        self.assertEqual(
+            set(listed["entries"][0]),
+            {"name", "size", "compressed_size", "is_dir"},
+        )
+
+        result = self.tool.execute(mode="extract", file_path="windows.zip", output_dir="windows-out")
+        self.assertEqual(result["status"], "success")
+        with open(os.path.join(self.directory.name, "windows-out/nested/file.txt"), "rb") as stream:
+            self.assertEqual(stream.read(), b"payload")
+
+    def test_extracts_tar_member_with_backslashes(self):
+        payload = b"payload"
+        with tarfile.open(os.path.join(self.directory.name, "windows.tar"), "w") as archive:
+            info = tarfile.TarInfo("nested\\file.txt")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+
+        result = self.tool.execute(mode="extract", file_path="windows.tar", output_dir="tar-windows-out")
+        self.assertEqual(result["status"], "success")
+        with open(os.path.join(self.directory.name, "tar-windows-out/nested/file.txt"), "rb") as stream:
+            self.assertEqual(stream.read(), payload)
 
     def test_create_refuses_overwrite(self):
         self.tool.execute(mode="create", file_path="bundle.zip", input_paths=["a.txt"])


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** | **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认勾选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for duplicate fixes and reported the reproduced bug in #831 before implementation.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted regression tests and included the test results below.
- [ ] I have added or modified public documentation (not needed; there is no public API or schema change).
- [ ] I have added examples and notes if needed (not needed for this internal lookup fix).

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**

- Keep each ZIP/TAR member's original stored name for archive-internal lookup after its safe normalized name has passed traversal and duplicate validation.
- Continue using only the normalized name for member selection and destination resolution.
- Strip the private lookup name from `list` results, preserving the existing public entry schema.
- Add ZIP and TAR regressions for Windows-style backslash member names.

Fixes #831.

On unmodified `master@b9190690`, the reproducer returns `operation_error` because `zipfile` cannot find the normalized name. This branch extracts the payload to `nested/file.txt` while retaining the existing safety checks.

**Please provide the path of test files and submit screenshots or files of the test results:** | **请填写测试文件路径并提供测试结果截图或文件:**

- Test file: `tests/test_agentuniverse/unit/agent/action/tool/test_secure_archive_tool.py`
- Focused SecureArchiveTool suite: 18 tests passed.
- Complete `tests/test_agentuniverse/unit/agent/action/tool` suite: 273 tests passed.
- Black 24.10.0, Ruff 0.8.4 format, targeted Ruff lint, Python 3.11 compileall, and `git diff --check`: passed.
- The only unignored Ruff finding in the source file is the pre-existing `UP038` at line 80, reproduced unchanged on `origin/master`; no new lint finding is introduced.

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**

- No public documentation change; `_entries` now documents the safe/public versus private/archive name boundary.
