### PR TITLE
fix(context): isolate log metadata across contexts

### DIFF
--- a/agentuniverse/base/context/framework_context_manager.py
+++ b/agentuniverse/base/context/framework_context_manager.py
@@ -119,11 +119,7 @@ class FrameworkContextManager:
         self.__context_dict.set({})
 
     def set_log_context(self, context_key: str, context_value: Any):
-        log_context = self.get_context("LOG_CONTEXT")
-        if not log_context:
-            log_context = {
-                context_key: context_value
-            }
-            self.set_context("LOG_CONTEXT", log_context)
-        else:
-            log_context[context_key] = context_value
+        current_context = self.get_context("LOG_CONTEXT")
+        log_context = current_context.copy() if isinstance(current_context, dict) else {}
+        log_context[context_key] = context_value
+        self.set_context("LOG_CONTEXT", log_context)

--- a/tests/test_agentuniverse/unit/base/context/test_framework_context.py
+++ b/tests/test_agentuniverse/unit/base/context/test_framework_context.py
@@ -7,13 +7,14 @@
 
 import asyncio
 import queue
-import time
 import threading
+import time
+from contextvars import copy_context
 
 import pytest
 
-from agentuniverse.base.context.framework_context_manager import FrameworkContextManager
 from agentuniverse.base.context.framework_context import FrameworkContext
+from agentuniverse.base.context.framework_context_manager import FrameworkContextManager
 
 context_manager: FrameworkContextManager = FrameworkContextManager()
 
@@ -73,6 +74,27 @@ def test_set_all_contexts_returns_tokens_for_restoration():
     assert context_manager.get_context("temporary_key") is None
 
     context_manager.reset_context("request_id", original_token)
+    context_manager.clear_all_contexts()
+
+
+def test_log_context_isolated_across_copied_contexts():
+    context_manager.clear_all_contexts()
+    context_manager.set_log_context("request_id", "parent")
+    child_context = copy_context()
+
+    def update_child_context():
+        context_manager.set_log_context("worker_id", "child")
+        return context_manager.get_context("LOG_CONTEXT")
+
+    child_log_context = child_context.run(update_child_context)
+
+    assert child_log_context == {
+        "request_id": "parent",
+        "worker_id": "child",
+    }
+    assert context_manager.get_context("LOG_CONTEXT") == {
+        "request_id": "parent",
+    }
     context_manager.clear_all_contexts()
 
 


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
Use copy-on-write for LOG_CONTEXT so child ContextVar metadata cannot leak into parent or sibling tasks. Invalid non-dict context values are safely replaced.

## Tests
- Targeted pytest: 2 passed
- Ruff import check passed
- py_compile passed
- git diff --check passed

Test: tests/test_agentuniverse/unit/base/context/test_framework_context.py

No dependencies or public APIs changed.