### PR TITLE
fix(agent): isolate output object mappings

### DIFF
--- a/agentuniverse/agent/output_object.py
+++ b/agentuniverse/agent/output_object.py
@@ -9,12 +9,12 @@ import json
 
 class OutputObject(object):
     def __init__(self, params: dict):
-        self.__params = params
-        for k, v in params.items():
+        self.__params = params.copy()
+        for k, v in self.__params.items():
             self.__dict__[k] = v
 
     def to_dict(self):
-        return self.__params
+        return self.__params.copy()
 
     def to_json_str(self):
         return json.dumps(self.__params, ensure_ascii=False)

--- a/tests/test_agentuniverse/unit/agent/test_output_object.py
+++ b/tests/test_agentuniverse/unit/agent/test_output_object.py
@@ -1,0 +1,19 @@
+from agentuniverse.agent.output_object import OutputObject
+
+
+def test_output_object_copies_constructor_params():
+    params = {"output": "original"}
+    output_object = OutputObject(params)
+
+    params["output"] = "changed externally"
+
+    assert output_object.get_data("output") == "original"
+
+
+def test_to_dict_returns_an_independent_mapping():
+    output_object = OutputObject({"output": "original"})
+
+    exported = output_object.to_dict()
+    exported["output"] = "changed externally"
+
+    assert output_object.get_data("output") == "original"


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
Copy constructor mappings before storing OutputObject state and return an independent mapping from to_dict(). This prevents callers from silently mutating an already-produced agent result and aligns OutputObject with InputObject behavior.

## Tests
- OutputObject and InputObject pytest: 4 passed
- Ruff check and format check passed
- py_compile passed
- git diff --check passed

Test: tests/test_agentuniverse/unit/agent/test_output_object.py

Copies are shallow by design to preserve nested identity and compatibility. No dependencies or public APIs changed.