### PR TITLE
fix(logging): support default logger initialization

### DIFF
--- a/agentuniverse/base/util/logging/logging_config.py
+++ b/agentuniverse/base/util/logging/logging_config.py
@@ -59,17 +59,19 @@ class LoggingConfig(object):
                 the path of the toml file
         """
         self.__config = None
+        if config_path is None:
+            self._disable_extended_modules()
+            return
+
         try:
             self.__config = Configer().load_by_path(config_path).value['LOG_CONFIG']
         except (FileNotFoundError, TypeError):
             print("can't find log config file, use default config")
-            for log_module in LoggingConfig.log_extend_module_list:
-                LoggingConfig.log_extend_module_switch[log_module] = False
+            self._disable_extended_modules()
             return
         except (tomli.TOMLDecodeError, KeyError):
             print("log config file isn't a valid toml, use default config.")
-            for log_module in LoggingConfig.log_extend_module_list:
-                LoggingConfig.log_extend_module_switch[log_module] = False
+            self._disable_extended_modules()
             return
 
         for log_module in LoggingConfig.log_extend_module_list:
@@ -123,6 +125,12 @@ class LoggingConfig(object):
             LoggingConfig.sls_log_send_interval = float(
                 self._get_config_or_default("ALIYUN_SLS_CONFIG",
                                             "sls_log_send_interval"))
+
+    @staticmethod
+    def _disable_extended_modules() -> None:
+        """Disable optional log sinks when no valid configuration is loaded."""
+        for log_module in LoggingConfig.log_extend_module_list:
+            LoggingConfig.log_extend_module_switch[log_module] = False
 
     def _get_config_or_default(self, section, key, default_value=None):
         """Get config attribute from toml data, return default_value if no such

--- a/tests/test_agentuniverse/unit/base/util/logging/test_logging_util.py
+++ b/tests/test_agentuniverse/unit/base/util/logging/test_logging_util.py
@@ -19,6 +19,14 @@ test_context = {"LOG_CONTEXT": {"REQUEST_ID": "1111-2222-3333",
                                 "AGENT_ID": "TEST_AGENT"}}
 
 
+def test_logging_config_without_path_uses_safe_defaults():
+    LoggingConfig.log_extend_module_switch["sls_log"] = True
+
+    LoggingConfig()
+
+    assert LoggingConfig.log_extend_module_switch["sls_log"] is False
+
+
 def test_logging_util():
     LoggingConfig.log_path = "./.test_log_dir"
 


### PR DESCRIPTION
**Checklist**

- [x] I have read and understood the contributor guidelines.
- [x] I have checked for duplicate fixes related to this request.
- [x] I accept maintainers' suggestions to change or close this PR.
- [x] Regression tests are included and results are provided below.
- [ ] User-facing documentation was not required.

**Details**

- Treat a missing logging configuration path as supported default initialization.
- Disable optional remote logging sinks safely when no valid configuration is loaded.
- Reuse the fallback helper for missing and invalid configuration files.

**Tests**

- Logging unit suite: 2 passed.
- Python compilation and `git diff --check`: passed.

**Docs**

- None.
