### PR TITLE
fix: operator precedence, missing commas, and identity checks across core modules

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -305,7 +305,7 @@ class Knowledge(ComponentBase):
         """
         return LangchainTool(
             name=self.name,
-            description=self.description or '' + args_description,
+            description=(self.description or '') + args_description,
             func=self.langchain_query,
         )
 
@@ -326,7 +326,7 @@ class Knowledge(ComponentBase):
         """
         return LangchainTool(
             name=self.name,
-            description=self.description or '' + args_description,
+            description=(self.description or '') + args_description,
             func=self.async_langchain_query,
         )
 

--- a/agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py
@@ -217,7 +217,7 @@ class ConversationMemoryModule:
                    pair_id: str):
         if "kwargs" in params:
             params = params['kwargs']
-        if params is str:
+        if isinstance(params, str):
             params = {
                 type: params
             }

--- a/agentuniverse/agent/plan/planner/planner.py
+++ b/agentuniverse/agent/plan/planner/planner.py
@@ -135,7 +135,7 @@ class Planner(ComponentBase):
                                             for key in agent.output_keys()
                                             if output_object.get_data(key) is not None]))
 
-        planner_input['background'] = planner_input['background'] or '' + "\n".join(action_result)
+        planner_input['background'] = (planner_input['background'] or '') + "\n".join(action_result)
 
     def handle_prompt(self, agent_model: AgentModel, planner_input: dict):
         """Prompt module processing.

--- a/agentuniverse/agent/plan/planner/react_planner/react_planner.py
+++ b/agentuniverse/agent/plan/planner/react_planner/react_planner.py
@@ -64,7 +64,7 @@ class ReActPlanner(Planner):
         assemble_memory_input(memory, planner_input)
         stop_sequence = []
         if agent_model.plan.get('stop_sequence'):
-            stop_sequence = agent_model.profile.get('stop_sequence')
+            stop_sequence = agent_model.plan.get('stop_sequence')
         agent = create_react_agent(llm.as_langchain(), tools, prompt.as_langchain(), stop_sequence=stop_sequence,
                                    bind_params=agent_model.llm_params())
         agent_executor = AgentExecutor(agent=agent, tools=tools,

--- a/agentuniverse/base/context/context_archive_utils.py
+++ b/agentuniverse/base/context/context_archive_utils.py
@@ -29,7 +29,7 @@ def get_current_context_archive():
         'context_archive', None)
     if not context_archive:
         context_archive = {}
-        FrameworkContextManager().set_context('context_archive', {})
+        FrameworkContextManager().set_context('context_archive', context_archive)
 
     return context_archive
 

--- a/agentuniverse/llm/default/wenxin_llm.py
+++ b/agentuniverse/llm/default/wenxin_llm.py
@@ -21,8 +21,8 @@ from agentuniverse.llm.llm_output import LLMOutput
 from agentuniverse.llm.wenxin_langchain_instance import WenXinLangChainInstance
 
 TokenModelList = [
-    'ernie-4.5-turbo-32k'
-    'ernie-4.5-8k-preview'
+    'ernie-4.5-turbo-32k',
+    'ernie-4.5-8k-preview',
     'ernie-4.0-8k',
     'ernie-3.5-8k',
     'ernie-speed-8k',


### PR DESCRIPTION
## Summary

Six independent logic bugs across core framework modules, each verified by runtime reproduction.

## Changes

### 1. `planner.py` — operator precedence drops all action results
```python
# Before: + binds tighter than or → action_result discarded when background is non-empty
planner_input['background'] = planner_input['background'] or '' + "\n".join(action_result)
# After:
planner_input['background'] = (planner_input['background'] or '') + "\n".join(action_result)
```
Every planner that calls `run_all_actions` (ExecutingPlanner, RagPlanner, etc.) was affected — tools ran but their output never reached the LLM whenever a background was supplied.

### 2. `knowledge.py` — same precedence bug (×2)
`as_langchain_tool` and `async_as_langchain_tool` both used `self.description or '' + args_description`, silently discarding the JSON schema instructions the LLM needs to call the knowledge tool.

### 3. `wenxin_llm.py` — missing commas merge three model names
Python implicit string concatenation turned `'ernie-4.5-turbo-32k' 'ernie-4.5-8k-preview' 'ernie-4.0-8k'` into one garbled string. All three models were absent from `TokenModelList`, causing the tokenizer to run with `model=''`.

### 4. `context_archive_utils.py` — two separate dicts
`get_current_context_archive` stored `{}` into the framework context but returned a *different* local `{}`. `update_context_archive` wrote into the local dict which was immediately discarded — archiving was a permanent no-op.

### 5. `conversation_memory_module.py` — `params is str` always False
Identity comparison with the `str` type object never matches a string instance. Replaced with `isinstance(params, str)`.

### 6. `react_planner.py` — stop_sequence read from wrong dict
The condition checked `agent_model.plan` but the value was read from `agent_model.profile`, so custom stop sequences never took effect.