### PR TITLE
fix(store): FAISS index rebuild, Chroma hierarchical query, and empty embedding guards

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_hierarchical_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_hierarchical_store.py
@@ -59,7 +59,7 @@ class ChromaHierarchicalStore(ChromaStore):
             if len(top_k_ids) > 0:
                 all_results = []
                 top_k = self.similarity_top_k_list[depth] if len(
-                                self.similarity_top_k_list) >= depth + 1 else self.similarity_top_k,
+                                self.similarity_top_k_list) >= depth + 1 else self.similarity_top_k
                 for parent_id in top_k_ids:
                     # Query for each parent_id
                     if len(embedding) > 0:
@@ -74,12 +74,25 @@ class ChromaHierarchicalStore(ChromaStore):
                             query_texts=[query.query_str],
                             where={"hierarchical_parent": parent_id}
                         )
-                    all_results.extend(results)
+                    if results and results.get('ids') and results['ids'][0]:
+                        for i in range(len(results['ids'][0])):
+                            all_results.append({
+                                'id': results['ids'][0][i],
+                                'distance': results['distances'][0][i] if results.get('distances') else 0,
+                                'document': results['documents'][0][i] if results.get('documents') else None,
+                                'metadata': results['metadatas'][0][i] if results.get('metadatas') else None,
+                            })
                 sorted_results = sorted(all_results,
                                         key=lambda x: x['distance'])
 
-                # Select the top k results
-                query_result = sorted_results[:top_k]
+                # Select the top k results and rebuild QueryResult format
+                top_results = sorted_results[:top_k]
+                query_result = {
+                    'ids': [[r['id'] for r in top_results]],
+                    'distances': [[r['distance'] for r in top_results]],
+                    'documents': [[r['document'] for r in top_results]],
+                    'metadatas': [[r['metadata'] for r in top_results]],
+                }
 
             else:
                 filter_condition = {

--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -133,7 +133,7 @@ class ChromaStore(Store):
             self.collection.upsert(
                 documents=[document.text],
                 metadatas=[document.metadata],
-                embeddings=[embedding] if embedding is not None else None,
+                embeddings=[embedding] if len(embedding) > 0 else None,
                 ids=[document.id]
             )
 
@@ -148,7 +148,7 @@ class ChromaStore(Store):
             self.collection.update(
                 documents=[document.text],
                 metadatas=[document.metadata],
-                embeddings=[embedding] if embedding is not None else None,
+                embeddings=[embedding] if len(embedding) > 0 else None,
                 ids=[document.id]
             )
 

--- a/agentuniverse/agent/action/knowledge/store/faiss_store.py
+++ b/agentuniverse/agent/action/knowledge/store/faiss_store.py
@@ -401,6 +401,7 @@ class FAISSStore(Store):
     def _reset_faiss_index(self):
         """Reset the FAISS index to empty state."""
         self.faiss_index = None
+        self.document_store = {}
         self.id_to_index = {}
         self.index_to_id = {}
         self._next_index = 0


### PR DESCRIPTION
## Summary

Three vector-store bugs that cause silent data loss or crashes on common operations.

## Changes

### 1. `faiss_store.py` — `delete_document` permanently destroys the search index

`_reset_faiss_index()` cleared `faiss_index`, `id_to_index`, `index_to_id` but **not** `document_store`. When `delete_document` then called `insert_document` to rebuild, every remaining doc hit `if document.id in self.document_store: continue` and was skipped. Result: after deleting a single document, **all queries returned empty forever**. Since `upsert_document`/`update_document` call `delete_document`, updates were broken too.

**Fix:** Clear `document_store` in `_reset_faiss_index()`.

### 2. `chroma_hierarchical_store.py` — depth>0 query path crashes in three ways

**(a)** Trailing comma turned `top_k` into a tuple `(10,)` → TypeError when passed as `n_results`.

**(b)** `all_results.extend(results)` on a Chroma `QueryResult` dict iterates its **string keys** (`'ids'`, `'distances'`, ...), so `sorted(..., key=lambda x: x['distance'])` indexed a string with a string → TypeError.

**(c)** The flat list was fed to `to_documents` which expects QueryResult-shaped dicts.

**Fix:** Removed trailing comma; rewrote the merge to flatten per-hit rows from each QueryResult and rebuild a proper QueryResult dict for the final return.

### 3. `chroma_store.py` — upsert/update send empty embedding `[[]]` to Chroma

`document.embedding` defaults to `[]` (never `None`), so `embedding is not None` is always True and `[[]]` is sent → chromadb validation error. `insert_document` already used the correct `len(embedding) > 0` guard. Aligned upsert/update to match.