### PR TITLE
fix: text splitter separator, Flask request parsing, and trace plugin fold

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/character_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/character_text_splitter.py
@@ -30,7 +30,7 @@ class CharacterTextSplitter(DocProcessor):
     """
     chunk_size: int = 200
     chunk_overlap: int = 20
-    separator: str = "/n/n"
+    separator: str = "\n\n"
     __splitter: Optional[Splitter] = None
 
 

--- a/agentuniverse/agent_serve/web/web_util.py
+++ b/agentuniverse/agent_serve/web/web_util.py
@@ -40,7 +40,7 @@ def request_param(func):
             req_data = request.args.to_dict()
         # Get the post params from body according to different content type.
         else:
-            if "application/json" in request.headers.get("Content-Type"):
+            if "application/json" in (request.headers.get("Content-Type") or ""):
                 raw_data = request.data.decode('utf-8')
                 req_data = json.loads(raw_data)
             else:
@@ -108,7 +108,7 @@ async def async_agent_run_queue(agent_id, **kwargs):
         return res
     finally:
         if stream:
-            await asyncio.to_thread(stream.put_nowait, '{"type": "EOF"}')
+            stream.put_nowait('{"type": "EOF"}')
 
 
 def make_standard_response(success: bool,

--- a/agentuniverse/base/annotation/trace.py
+++ b/agentuniverse/base/annotation/trace.py
@@ -60,7 +60,7 @@ def _llm_plugins(func):
     llm_plugins = ApplicationConfigManager().app_configer.llm_plugins
     warp_func = func
     for item in llm_plugins:
-        warp_func = item(func)
+        warp_func = item(warp_func)
     return warp_func
 
 
@@ -92,10 +92,11 @@ def _get_llm_info(func, *args, **kwargs):
         temperature = None
         if self and hasattr(self, 'channel_model_config'):
             temperature = self.channel_model_config.get('temperature')
-        if not temperature and hasattr(self, 'temperature'):
-            temperature = self.temperature or -1
-        else:
-            temperature = -1
+        if not temperature:
+            if self and hasattr(self, 'temperature'):
+                temperature = self.temperature or -1
+            else:
+                temperature = -1
 
     params = {
         'temperature': temperature,


### PR DESCRIPTION
## Summary

Three bugs affecting text processing, HTTP serving, and LLM plugin/trace infrastructure.

## Changes

### 1. `character_text_splitter.py` — separator typo disables all splitting

```python
# Before: forward slashes — the literal string '/n/n' almost never appears in text
separator: str = "/n/n"
# After:
separator: str = "\n\n"
```

Documents passed through **completely unsplit**, producing oversized chunks that blow past LLM context limits. Every user of `CharacterTextSplitter` with default config was affected.

### 2. `web_util.py` — two serving bugs

**(a)** `request.headers.get("Content-Type")` returns `None` when a POST request has no Content-Type header → `TypeError: argument of type 'NoneType' is not iterable` → 500 for every such request. Added `or ""` guard.

**(b)** `async_agent_run_queue` dispatched `asyncio.Queue.put_nowait` via `asyncio.to_thread`. `asyncio.Queue` is explicitly **not thread-safe** — `put_nowait` must run on the event-loop thread. The consumer could hang waiting for an EOF that never lands. Now calls `put_nowait` directly in the coroutine.

### 3. `trace.py` — two trace infrastructure bugs

**(a)** `_llm_plugins` fold: each plugin wrapped the original `func` instead of the accumulated `warp_func`. With N>1 plugins, the first N−1 were silently dropped.

```python
# Before:
warp_func = item(func)
# After:
warp_func = item(warp_func)
```

**(b)** Temperature if/else nesting: when the channel config supplied a valid temperature (e.g. 0.7), the `else` branch of `if not temperature` executed and **overwrote it with -1**. The channel-configured temperature could never survive.