### PR TITLE
fix(tool): isolate tool input mappings

### DIFF
--- a/agentuniverse/agent/action/tool/tool.py
+++ b/agentuniverse/agent/action/tool/tool.py
@@ -27,12 +27,12 @@ class ToolInput(BaseModel):
 
     def __init__(self, params: dict, **kwargs):
         super().__init__(**kwargs)
-        self.__origin_params = params
-        for k, v in params.items():
+        self.__origin_params = params.copy()
+        for k, v in self.__origin_params.items():
             self.__dict__[k] = v
 
     def to_dict(self):
-        return self.__origin_params
+        return self.__origin_params.copy()
 
     def to_json_str(self):
         return json.dumps(self.__origin_params, ensure_ascii=False)

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_tool_input.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_tool_input.py
@@ -1,0 +1,19 @@
+from agentuniverse.agent.action.tool.tool import ToolInput
+
+
+def test_tool_input_copies_constructor_params():
+    params = {"query": "original"}
+    tool_input = ToolInput(params)
+
+    params["query"] = "changed externally"
+
+    assert tool_input.get_data("query") == "original"
+
+
+def test_tool_input_to_dict_returns_independent_mapping():
+    tool_input = ToolInput({"query": "original"})
+
+    exported = tool_input.to_dict()
+    exported["query"] = "changed externally"
+
+    assert tool_input.get_data("query") == "original"


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked open PRs for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
- copy the constructor mapping before storing ToolInput state
- return an independent mapping from to_dict()
- align the legacy tool-input boundary with InputObject and OutputObject

## Problem
ToolInput retained the caller-owned dictionary and returned that same internal dictionary from to_dict(). External mutations could silently alter input observed by a running legacy tool.

## Tests
- pytest test_tool_input.py + test_tool_async_compatibility.py: 4 passed
- Ruff check/format on the new test passed
- py_compile and git diff --check passed

No dependencies or public APIs changed. Copies are shallow by design.