### PR TITLE
fix(workflow): preserve node configs during graph build

### DIFF
--- a/agentuniverse/workflow/graph/graph.py
+++ b/agentuniverse/workflow/graph/graph.py
@@ -47,11 +47,12 @@ class Graph(nx.DiGraph):
         node_id = node_config.get('id')
         if self.has_node(node_id):
             return
-        node_cls = NODE_CLS_MAPPING[node_config.get('type')]
-        node_type = node_config.pop('type')
+        node_type = node_config.get('type')
+        node_cls = NODE_CLS_MAPPING[node_type]
+        node_kwargs = node_config.copy()
+        node_kwargs.pop('type')
         node_instance = node_cls(type=NodeEnum.from_value(node_type), workflow_id=workflow_id,
-                                 **node_config)
-        node_config['type'] = node_type
+                                 **node_kwargs)
         self.add_node(node_id, instance=node_instance, type=node_type)
 
     def _add_graph_edge(self, edge_config: dict) -> None:

--- a/tests/test_agentuniverse/unit/workflow/graph/test_graph.py
+++ b/tests/test_agentuniverse/unit/workflow/graph/test_graph.py
@@ -1,0 +1,60 @@
+import pytest
+
+from agentuniverse.workflow.graph import graph as graph_module
+from agentuniverse.workflow.graph.graph import Graph
+from agentuniverse.workflow.node.enum import NodeEnum
+
+
+def test_add_graph_node_preserves_config_when_initialization_fails(monkeypatch):
+    class NodeInitializationError(RuntimeError):
+        pass
+
+    class FailingNode:
+        def __init__(self, **kwargs):
+            raise NodeInitializationError
+
+    node_config = {
+        "id": "start_node",
+        "type": NodeEnum.START.value,
+        "name": "Start",
+    }
+    original_config = node_config.copy()
+    monkeypatch.setitem(
+        graph_module.NODE_CLS_MAPPING,
+        NodeEnum.START.value,
+        FailingNode,
+    )
+
+    with pytest.raises(NodeInitializationError):
+        Graph()._add_graph_node("workflow", node_config)
+
+    assert node_config == original_config
+
+
+def test_add_graph_node_builds_from_copy_without_mutating_config(monkeypatch):
+    class CapturingNode:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    node_config = {
+        "id": "start_node",
+        "type": NodeEnum.START.value,
+        "name": "Start",
+    }
+    original_config = node_config.copy()
+    monkeypatch.setitem(
+        graph_module.NODE_CLS_MAPPING,
+        NodeEnum.START.value,
+        CapturingNode,
+    )
+
+    graph = Graph()
+    graph._add_graph_node("workflow", node_config)
+
+    assert node_config == original_config
+    assert graph.nodes["start_node"]["instance"].kwargs == {
+        "id": "start_node",
+        "name": "Start",
+        "type": NodeEnum.START,
+        "workflow_id": "workflow",
+    }


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked open PRs for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
- build workflow nodes from a shallow copy of each node configuration
- preserve the caller-owned configuration on both successful and failed initialization
- keep the existing node constructor arguments and graph metadata unchanged

## Problem
Graph._add_graph_node temporarily removed type from the caller's dictionary. If node construction raised, restoration never ran, so a failed build corrupted the reusable workflow configuration and a retry failed differently.

## Tests
- new workflow graph tests: 2 passed
- Ruff check/format on the new tests passed
- py_compile and git diff --check passed

No dependencies or public APIs changed.