### PR TITLE
fix(component): clear stale default registration

### DIFF
--- a/agentuniverse/base/component/component_manager_base.py
+++ b/agentuniverse/base/component/component_manager_base.py
@@ -44,7 +44,9 @@ class ComponentManagerBase(Generic[ComponentTypeVar]):
 
     def unregister(self, component_instance_name: str):
         """Unregister the component instance abstractmethod."""
-        self._instance_obj_map.pop(component_instance_name)
+        component_instance = self._instance_obj_map.pop(component_instance_name)
+        if self._instance_obj_map.get("__default_instance__") is component_instance:
+            self._instance_obj_map.pop("__default_instance__")
 
     def get_instance_obj(self, component_instance_name: str,
                          appname: str = None, new_instance: bool = True,

--- a/tests/test_agentuniverse/unit/base/component/test_component_manager_base.py
+++ b/tests/test_agentuniverse/unit/base/component/test_component_manager_base.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.component.component_manager_base import ComponentManagerBase
+
+
+def test_unregister_removes_default_alias_for_same_component():
+    manager = ComponentManagerBase(ComponentEnum.TOOL)
+    component = SimpleNamespace(default_symbol=True)
+    component_code = "test_app.tool.default_tool"
+    manager.register(component_code, component)
+
+    manager.unregister(component_code)
+
+    assert manager.get_default_instance() is None
+    assert manager.get_instance_name_list() == []
+
+
+def test_unregister_non_default_component_preserves_default_alias():
+    manager = ComponentManagerBase(ComponentEnum.TOOL)
+    default_component = SimpleNamespace(default_symbol=True)
+    other_component = SimpleNamespace(default_symbol=False)
+    manager.register("test_app.tool.default_tool", default_component)
+    manager.register("test_app.tool.other_tool", other_component)
+
+    manager.unregister("test_app.tool.other_tool")
+
+    assert manager.get_default_instance() is default_component


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked open PRs for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
- remove the reserved default alias when its registered component is unregistered
- compare by object identity so unregistering another component keeps the active default
- add coverage for both lifecycle paths

## Problem
ComponentManagerBase.register stores default components under both their instance code and __default_instance__. unregister removed only the requested key, leaving a stale default component available after it had supposedly been unregistered.

## Tests
- component-manager and strict-registration tests: 8 passed
- Ruff check/format on the new tests passed
- py_compile and git diff --check passed

No dependencies or public APIs changed.