### PR TITLE
fix(core): make singleton initialization thread-safe

### DIFF
--- a/agentuniverse/base/annotation/singleton.py
+++ b/agentuniverse/base/annotation/singleton.py
@@ -6,16 +6,20 @@
 # @Email   : jerry.zzw@antgroup.com
 # @FileName: singleton.py
 from functools import wraps
+from threading import Lock
 
 
 def singleton(cls):
     """Decorator to make a class a Singleton class (only one instance), using closure."""
     instances = {}
+    instance_lock = Lock()
 
     @wraps(cls)
     def get_instance(*args, **kwargs):
         if cls not in instances:
-            instances[cls] = cls(*args, **kwargs)
+            with instance_lock:
+                if cls not in instances:
+                    instances[cls] = cls(*args, **kwargs)
         return instances[cls]
 
     return get_instance

--- a/tests/test_agentuniverse/unit/base/annotation/test_singleton.py
+++ b/tests/test_agentuniverse/unit/base/annotation/test_singleton.py
@@ -1,0 +1,28 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+from agentuniverse.base.annotation.singleton import singleton
+
+
+def test_singleton_constructs_only_once_under_concurrency():
+    worker_count = 16
+    start = Barrier(worker_count)
+    construction_count = 0
+
+    @singleton
+    class SharedComponent:
+        def __init__(self):
+            nonlocal construction_count
+            time.sleep(0.02)
+            construction_count += 1
+
+    def create_component():
+        start.wait()
+        return SharedComponent()
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        instances = list(executor.map(lambda _: create_component(), range(worker_count)))
+
+    assert len({id(instance) for instance in instances}) == 1
+    assert construction_count == 1


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked open PRs for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
- guard first singleton construction with a per-class lock
- retain the fast unlocked path after initialization
- add a deterministic 16-thread regression test

## Problem
The singleton decorator used an unsynchronized check-then-create sequence. Concurrent first access allowed every thread to observe a missing instance and construct its own object, breaking singleton guarantees for shared managers and context services.

## Tests
- concurrent singleton regression: 1 passed
- Ruff check/format on the new test passed
- py_compile and git diff --check passed

No dependencies or public APIs changed.