### PR TITLE
fix(config): handle empty YAML files

### DIFF
--- a/agentuniverse/base/config/configer.py
+++ b/agentuniverse/base/config/configer.py
@@ -200,5 +200,7 @@ class Configer(object):
         """
         with open(path, 'r', encoding='utf-8') as stream:
             config_data = yaml.safe_load(stream)
+        if config_data is None:
+            config_data = {}
         config_data = PlaceholderResolver().resolve(config_data)
         return config_data

--- a/tests/test_agentuniverse/unit/base/config/test_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/test_configer.py
@@ -1,0 +1,15 @@
+import pytest
+
+from agentuniverse.base.config.configer import Configer
+
+
+@pytest.mark.parametrize("contents", ["", "# comment-only configuration\n"])
+def test_empty_yaml_loads_as_mutable_mapping(tmp_path, contents):
+    config_path = tmp_path / "empty.yaml"
+    config_path.write_text(contents, encoding="utf-8")
+
+    configer = Configer(str(config_path)).load()
+
+    assert configer.to_dict() == {}
+    configer.set("enabled", True)
+    assert configer.get("enabled") is True


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked open PRs for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
- normalize YAML safe_load None results to an empty mapping
- keep empty and comment-only configuration files usable through get/set/to_dict
- preserve all existing behavior for non-empty YAML

## Problem
PyYAML returns None for empty or comment-only files. Configer stored that value directly, so subsequent get or set calls crashed even though Configer initializes and documents its value as a dictionary.

## Tests
- empty/comment-only YAML and related config tests: 11 passed
- Ruff check/format on the new tests passed
- py_compile and git diff --check passed

No dependencies or public APIs changed.