### PR TITLE
fix(serve): finish successful async request tasks

### DIFF
--- a/agentuniverse/agent_serve/web/request_task.py
+++ b/agentuniverse/agent_serve/web/request_task.py
@@ -215,9 +215,10 @@ class RequestTask:
                 result = await self.async_task
                 if isinstance(result, OutputObject):
                     result = result.to_dict()
+                self.__request_do__.result["result"] = result
+                self.next_state(TaskStateEnum.FINISHED)
                 yield "data:" + json.dumps({"result": result},
                                            ensure_ascii=False) + "\n\n"
-                self.__request_do__.result["result"] = result
             if self.saved:
                 self.update_request_do(force=True)
         except Exception as e:

--- a/tests/test_agentuniverse/unit/agent_serve/web/test_request_task.py
+++ b/tests/test_agentuniverse/unit/agent_serve/web/test_request_task.py
@@ -1,0 +1,34 @@
+import asyncio
+from types import SimpleNamespace
+
+from agentuniverse.agent_serve.web.request_task import (
+    EOF_SIGNAL,
+    RequestTask,
+    TaskStateEnum,
+)
+
+
+def test_async_receive_steps_marks_successful_task_finished():
+    async def run_stream():
+        request_task = RequestTask.__new__(RequestTask)
+        request_task.async_queue = asyncio.Queue()
+        request_task.async_queue.put_nowait(EOF_SIGNAL)
+        request_task.async_task = asyncio.create_task(asyncio.sleep(0, result={"answer": "done"}))
+        request_task.saved = False
+        request_task.__request_do__ = SimpleNamespace(
+            state=TaskStateEnum.INIT.value,
+            result={},
+        )
+
+        stream = request_task.async_receive_steps()
+        result_chunk = await anext(stream)
+        state_at_result = request_task.request_state()
+        await stream.aclose()
+        return request_task, result_chunk, state_at_result
+
+    request_task, result_chunk, state_at_result = asyncio.run(run_stream())
+
+    assert state_at_result == TaskStateEnum.FINISHED.value
+    assert request_task.request_state() == TaskStateEnum.FINISHED.value
+    assert request_task.__request_do__.result == {"result": {"answer": "done"}}
+    assert '"answer": "done"' in result_chunk


### PR DESCRIPTION
## Checklist
- [x] Read contributor guidelines
- [x] Checked open PRs for duplicate work
- [x] Accept maintainer suggestions
- [x] Added regression tests

## Summary
- store the successful async result before emitting its final SSE event
- transition RequestTask from RUNNING to FINISHED before that event is observed
- add regression coverage for consumers that stop after the final result

## Problem
async_receive_steps never performed the RUNNING-to-FINISHED transition on success. Completed requests remained reported as running indefinitely, and code after the final yield could also be skipped when a consumer stopped immediately.

## Tests
- async request-state regression: 1 passed
- Ruff check/format on the new test passed
- py_compile and git diff --check passed

No dependencies or public APIs changed.