### PR TITLE
fix(serve): honor context future cancellation

### DIFF
--- a/agentuniverse/agent_serve/web/thread_with_result.py
+++ b/agentuniverse/agent_serve/web/thread_with_result.py
@@ -72,6 +72,9 @@ class ThreadPoolExecutorWithReturnValue(ThreadPoolExecutor):
         future._context_pack = context_pack
 
         def context_wrapper():
+            if not future.set_running_or_notify_cancel():
+                return
+
             otel_token = None
             try:
                 otel_token = ContextCoordinator.recover_context(context_pack)

--- a/tests/test_agentuniverse/unit/agent_serve/web/test_thread_with_result.py
+++ b/tests/test_agentuniverse/unit/agent_serve/web/test_thread_with_result.py
@@ -1,0 +1,45 @@
+from threading import Event
+
+from agentuniverse.agent_serve.web.thread_with_result import (
+    ThreadPoolExecutorWithReturnValue,
+)
+
+
+def test_cancelled_queued_future_does_not_run_callable():
+    first_started = Event()
+    release_first = Event()
+    second_ran = Event()
+
+    def block_worker():
+        first_started.set()
+        release_first.wait(timeout=2)
+
+    with ThreadPoolExecutorWithReturnValue(max_workers=1) as executor:
+        first = executor.submit(block_worker)
+        assert first_started.wait(timeout=2)
+
+        second = executor.submit(second_ran.set)
+        assert second.cancel()
+        release_first.set()
+
+        first.result(timeout=2)
+
+    assert second.cancelled()
+    assert not second_ran.is_set()
+
+
+def test_running_future_cannot_be_cancelled():
+    started = Event()
+    release = Event()
+
+    def wait_for_release():
+        started.set()
+        release.wait(timeout=2)
+        return "done"
+
+    with ThreadPoolExecutorWithReturnValue(max_workers=1) as executor:
+        future = executor.submit(wait_for_release)
+        assert started.wait(timeout=2)
+        assert not future.cancel()
+        release.set()
+        assert future.result(timeout=2) == "done"


### PR DESCRIPTION
## Summary

- transition the custom context-aware Future to RUNNING before invoking its callable
- skip queued work when callers cancel it
- make cancellation of already-running work follow standard Future semantics

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_agentuniverse\unit\agent_serve\web\test_thread_with_result.py -q` (2 passed)
- `.venv\Scripts\ruff.exe check tests\test_agentuniverse\unit\agent_serve\web\test_thread_with_result.py --no-fix`

## Checklist

- [x] I have read the contributor guidelines.
- [x] I checked open PRs for duplicate changes.
- [x] I accept maintainer-requested changes or closure.
- [x] I added regression tests for this bug fix.
- [ ] Documentation changes are not needed for this internal behavior fix.
