### PR TITLE
fix(config): reject unresolved YAML functions

### DIFF
--- a/agentuniverse/base/util/system_util.py
+++ b/agentuniverse/base/util/system_util.py
@@ -116,7 +116,7 @@ def process_yaml_func(func_expr: str, yaml_func_instance: Any) -> str:
         Exception: If an error occurs while calling the method.
     """
     # Return an empty string if the function expression is None
-    if not func_expr or yaml_func_instance is None:
+    if not func_expr:
         return func_expr
 
     if func_expr.startswith('@FUNC(') and yaml_func_instance is None:
@@ -179,7 +179,7 @@ def process_dict_with_funcs(input_dict: dict, yaml_func_instance: Any) -> dict:
         ValueError: If @FUNC expression is provided but `yaml_func_instance` is None.
         Exception: If an error occurs while calling the method.
     """
-    if not input_dict or yaml_func_instance is None:
+    if not input_dict:
         return input_dict
 
     processed_dict = {}

--- a/tests/test_agentuniverse/unit/base/util/test_system_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_system_util.py
@@ -1,0 +1,25 @@
+import pytest
+
+from agentuniverse.base.util.system_util import (
+    process_dict_with_funcs,
+    process_yaml_func,
+)
+
+
+def test_process_yaml_func_requires_extension_for_function_expression():
+    with pytest.raises(ValueError, match="yaml_func_extension.py is required"):
+        process_yaml_func('@FUNC(load_secret("api_key"))', None)
+
+
+def test_process_dict_with_funcs_rejects_nested_unresolved_expression():
+    config = {"provider": {"api_key": '@FUNC(load_secret("api_key"))'}}
+
+    with pytest.raises(ValueError, match="yaml_func_extension.py is required"):
+        process_dict_with_funcs(config, None)
+
+
+def test_plain_config_does_not_require_extension():
+    config = {"provider": {"name": "demo"}}
+
+    assert process_dict_with_funcs(config, None) == config
+    assert process_yaml_func("literal-value", None) == "literal-value"


### PR DESCRIPTION
## Summary

- raise an actionable error when an `@FUNC(...)` YAML expression has no function extension
- apply the same validation recursively to nested configuration dictionaries
- continue accepting ordinary literal configuration without an extension

This prevents unresolved secret/config expressions from silently reaching components as literal strings.

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_agentuniverse\unit\base\util\test_system_util.py -q` (3 passed)
- `.venv\Scripts\ruff.exe check tests\test_agentuniverse\unit\base\util\test_system_util.py --no-fix`

## Checklist

- [x] I have read the contributor guidelines.
- [x] I checked open PRs for duplicate changes.
- [x] I accept maintainer-requested changes or closure.
- [x] I added regression tests for this bug fix.
- [ ] Documentation changes are not needed for this error-handling fix.
