### PR TITLE
fix(prompt): guarantee progress when splitting text

### DIFF
--- a/agentuniverse/base/util/prompt_util.py
+++ b/agentuniverse/base/util/prompt_util.py
@@ -40,10 +40,23 @@ def summarize_by_map_reduce(texts: List[str], llm: LLM, summary_prompt, combine_
 
 def split_text_on_tokens(text: str, text_token: int, chunk_size=800, chunk_overlap=100) -> List[str]:
     """Split incoming text and return chunks using tokenizer."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    if chunk_overlap < 0:
+        raise ValueError("chunk_overlap must not be negative")
+    if chunk_overlap >= chunk_size:
+        raise ValueError("chunk_overlap must be smaller than chunk_size")
+    if not text:
+        return [""]
+    if text_token <= 0:
+        raise ValueError("text_token must be greater than zero")
+
     # calculate the number of characters represented by each token.
     char_per_token = len(text) / text_token
-    chunk_char_size = int(chunk_size * char_per_token)
-    chunk_char_overlap = int(chunk_overlap * char_per_token)
+    chunk_char_size = max(1, int(chunk_size * char_per_token))
+    chunk_char_overlap = min(
+        int(chunk_overlap * char_per_token), chunk_char_size - 1
+    )
 
     result = []
     current_position = 0

--- a/tests/test_agentuniverse/unit/base/util/test_prompt_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_prompt_util.py
@@ -1,0 +1,36 @@
+import pytest
+
+from agentuniverse.base.util.prompt_util import split_text_on_tokens
+
+
+def test_split_empty_text_with_zero_tokens():
+    assert split_text_on_tokens("", 0) == [""]
+
+
+@pytest.mark.parametrize(
+    ("chunk_size", "chunk_overlap", "message"),
+    [
+        (0, 0, "chunk_size must be greater than zero"),
+        (10, -1, "chunk_overlap must not be negative"),
+        (10, 10, "chunk_overlap must be smaller than chunk_size"),
+        (10, 11, "chunk_overlap must be smaller than chunk_size"),
+    ],
+)
+def test_split_text_rejects_invalid_chunk_configuration(
+    chunk_size, chunk_overlap, message
+):
+    with pytest.raises(ValueError, match=message):
+        split_text_on_tokens("content", 1, chunk_size, chunk_overlap)
+
+
+def test_split_text_makes_progress_when_character_chunks_round_to_same_size():
+    chunks = split_text_on_tokens(
+        "abc", text_token=100, chunk_size=40, chunk_overlap=39
+    )
+
+    assert chunks == ["a", "b", "c"]
+
+
+def test_split_non_empty_text_requires_positive_token_count():
+    with pytest.raises(ValueError, match="text_token must be greater than zero"):
+        split_text_on_tokens("content", 0)


### PR DESCRIPTION
## Summary

- validate chunk size and overlap before splitting prompt text
- return a stable empty chunk for empty input instead of dividing by zero
- clamp character overlap so rounding can never produce a zero or negative step
- reject non-positive token counts for non-empty text with an actionable error

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_agentuniverse\unit\base\util\test_prompt_util.py -q` (7 passed)
- `.venv\Scripts\ruff.exe check tests\test_agentuniverse\unit\base\util\test_prompt_util.py --no-fix`

## Checklist

- [x] I have read the contributor guidelines.
- [x] I checked open PRs for duplicate changes.
- [x] I accept maintainer-requested changes or closure.
- [x] I added regression tests for this bug fix.
- [ ] Documentation changes are not needed for this internal utility fix.
