### PR TITLE
fix(llm): parse OpenAI token detail variants

### DIFF
--- a/agentuniverse/llm/llm_output.py
+++ b/agentuniverse/llm/llm_output.py
@@ -118,8 +118,12 @@ class TokenUsage(BaseModel):
 
         # ---------- image/audio ----------
         if "input_tokens" in usage:
-            det_in = usage.get("input_tokens_details", {})
-            det_out = usage.get("output_token_details", {})
+            det_in = usage.get("input_tokens_details") or usage.get(
+                "input_token_details", {}
+            )
+            det_out = usage.get("output_tokens_details") or usage.get(
+                "output_token_details", {}
+            )
 
             return cls(
                 text_in=det_in.get("text_tokens", usage["input_tokens"]),
@@ -131,23 +135,6 @@ class TokenUsage(BaseModel):
                 audio_out=det_out.get("audio_tokens", 0),
                 cached_out=det_out.get("cached_tokens", 0),
                 reasoning_out=det_out.get("reasoning_tokens", 0),
-            )
-
-        # ---------- Realtime ----------
-        if "input_tokens" in usage and "output_tokens" in usage:
-            return cls(
-                text_in=usage.get("input_token_details", {}).get(
-                    "text_tokens", usage["input_tokens"]
-                ),
-                audio_in=usage.get("input_token_details", {}).get("audio_tokens", 0),
-                cached_in=usage.get("input_token_details", {}).get("cached_tokens", 0),
-                text_out=usage.get("output_token_details", {}).get(
-                    "text_tokens", usage["output_tokens"]
-                ),
-                audio_out=usage.get("output_token_details", {}).get("audio_tokens", 0),
-                cached_out=usage.get("output_token_details", {}).get(
-                    "cached_tokens", 0
-                ),
             )
 
         return cls()

--- a/tests/test_agentuniverse/unit/llm/test_llm_output.py
+++ b/tests/test_agentuniverse/unit/llm/test_llm_output.py
@@ -1,0 +1,47 @@
+from agentuniverse.llm.llm_output import TokenUsage
+
+
+def test_from_openai_parses_realtime_singular_detail_keys():
+    usage = TokenUsage.from_openai(
+        {
+            "input_tokens": 13,
+            "output_tokens": 9,
+            "input_token_details": {
+                "text_tokens": 8,
+                "audio_tokens": 2,
+                "cached_tokens": 3,
+            },
+            "output_token_details": {
+                "text_tokens": 5,
+                "audio_tokens": 4,
+            },
+        }
+    )
+
+    assert usage.text_in == 8
+    assert usage.audio_in == 2
+    assert usage.cached_in == 3
+    assert usage.text_out == 5
+    assert usage.audio_out == 4
+
+
+def test_from_openai_parses_plural_output_detail_keys():
+    usage = TokenUsage.from_openai(
+        {
+            "input_tokens": 12,
+            "output_tokens": 5,
+            "input_tokens_details": {
+                "text_tokens": 5,
+                "image_tokens": 7,
+            },
+            "output_tokens_details": {
+                "text_tokens": 1,
+                "image_tokens": 4,
+            },
+        }
+    )
+
+    assert usage.text_in == 5
+    assert usage.image_in == 7
+    assert usage.text_out == 1
+    assert usage.image_out == 4


### PR DESCRIPTION
## Summary

- accept both singular Realtime and plural image/audio token-detail field names
- preserve modality-specific input and output counts instead of collapsing them into text totals
- remove the unreachable duplicate Realtime parsing branch

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_agentuniverse\unit\llm\test_llm_output.py -q` (2 passed)
- `.venv\Scripts\ruff.exe check tests\test_agentuniverse\unit\llm\test_llm_output.py --no-fix`

## Checklist

- [x] I have read the contributor guidelines.
- [x] I checked open PRs for duplicate changes.
- [x] I accept maintainer-requested changes or closure.
- [x] I added regression tests for this bug fix.
- [ ] Documentation changes are not needed for this compatibility fix.
