### PR TITLE
fix(async): preserve exception-valued results

### DIFF
--- a/agentuniverse/base/util/async_util.py
+++ b/agentuniverse/base/util/async_util.py
@@ -25,9 +25,9 @@ def _async_runner_thread_target(coro: Coroutine[Any, Any, T], result_queue: Queu
     """
     try:
         result = asyncio.run(coro)
-        result_queue.put(result)
-    except Exception as e:
-        result_queue.put(e)
+        result_queue.put((True, result))
+    except BaseException as error:
+        result_queue.put((False, error))
 
 
 def run_async_from_sync(coro: Coroutine[Any, Any, T], timeout: Optional[float] = None) -> T:
@@ -71,13 +71,12 @@ def run_async_from_sync(coro: Coroutine[Any, Any, T], timeout: Optional[float] =
     worker_thread.start()
 
     try:
-        result = result_queue.get(timeout=timeout)
+        succeeded, result = result_queue.get(timeout=timeout)
     except queue.Empty:
         raise TimeoutError(f"Operation timed out after {timeout} seconds")
     finally:
         worker_thread.join(timeout=1.0)
 
-    if isinstance(result, Exception):
+    if not succeeded:
         raise result
-    else:
-        return result
+    return result

--- a/tests/test_agentuniverse/unit/base/util/test_async_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_async_util.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import pytest
+
+from agentuniverse.base.util.async_util import run_async_from_sync
+
+
+def test_run_async_from_sync_returns_exception_objects_as_values():
+    expected = ValueError("result payload")
+
+    async def return_exception():
+        return expected
+
+    assert run_async_from_sync(return_exception()) is expected
+
+
+def test_run_async_from_sync_reraises_coroutine_exceptions():
+    expected = ValueError("coroutine failed")
+
+    async def fail():
+        raise expected
+
+    with pytest.raises(ValueError) as caught:
+        run_async_from_sync(fail())
+
+    assert caught.value is expected
+
+
+def test_run_async_from_sync_propagates_cancellation():
+    async def cancel():
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        run_async_from_sync(cancel(), timeout=0.1)


### PR DESCRIPTION
## Summary

- tag worker-thread queue entries with explicit success or failure state
- return Exception instances normally when a coroutine intentionally uses one as its result
- still re-raise coroutine failures in the caller
- propagate BaseException-based cancellation instead of timing out after the worker exits

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_agentuniverse\unit\base\util\test_async_util.py -q` (3 passed)
- `.venv\Scripts\ruff.exe check tests\test_agentuniverse\unit\base\util\test_async_util.py --no-fix`

## Checklist

- [x] I have read the contributor guidelines.
- [x] I checked open PRs for duplicate changes.
- [x] I accept maintainer-requested changes or closure.
- [x] I added regression tests for this bug fix.
- [ ] Documentation changes are not needed for this internal utility fix.
