### PR TITLE
fix(agent): update contextual iteration history

### DIFF
--- a/agentuniverse/agent/template/contextual_iteration_agent_template.py
+++ b/agentuniverse/agent/template/contextual_iteration_agent_template.py
@@ -82,15 +82,6 @@ class ContextualIterationAgentTemplate(AgentTemplate):
             continue_res = self.invoke_chain(continue_chain, agent_input, input_object, **kwargs)
             res = res + '\n' + continue_res
 
-            if i==self.iteration-1:
-                break
-            # judge whether loop
-            if not self.if_loop_prompt_version:
-                continue
-            loop_res = self.invoke_chain(if_loop_prompt_chain, agent_input, input_object, **kwargs)
-            if not self.if_loop(loop_res):
-                break
-
             lc_prompt_template = continue_prompt.as_langchain()
             prompt_input_dict = {key: agent_input[key] for key in
                                  lc_prompt_template.input_variables
@@ -101,6 +92,14 @@ class ContextualIterationAgentTemplate(AgentTemplate):
             })
             agent_input['chat_history'] = json.dumps(conversation_history,
                                                      ensure_ascii=False)
+
+            if i == self.iteration - 1:
+                break
+            # judge whether loop
+            if self.if_loop_prompt_version:
+                loop_res = self.invoke_chain(if_loop_prompt_chain, agent_input, input_object, **kwargs)
+                if not self.if_loop(loop_res):
+                    break
 
         assemble_memory_output(memory=memory,
                                agent_input=agent_input,
@@ -155,16 +154,6 @@ class ContextualIterationAgentTemplate(AgentTemplate):
                                              input_object, **kwargs)
             res = res + '\n' + continue_res
 
-            if i == self.iteration - 1:
-                break
-            # judge whether loop
-            if not self.if_loop_prompt_version:
-                continue
-            loop_res = await self.async_invoke_chain(if_loop_prompt_chain, agent_input,
-                                         input_object, **kwargs)
-            if not self.if_loop(loop_res):
-                break
-
             lc_prompt_template = continue_prompt.as_langchain()
             prompt_input_dict = {key: agent_input[key] for key in
                                  lc_prompt_template.input_variables
@@ -175,6 +164,15 @@ class ContextualIterationAgentTemplate(AgentTemplate):
             })
             agent_input['chat_history'] = json.dumps(conversation_history,
                                                      ensure_ascii=False)
+
+            if i == self.iteration - 1:
+                break
+            # judge whether loop
+            if self.if_loop_prompt_version:
+                loop_res = await self.async_invoke_chain(if_loop_prompt_chain, agent_input,
+                                             input_object, **kwargs)
+                if not self.if_loop(loop_res):
+                    break
 
         assemble_memory_output(memory=memory,
                                agent_input=agent_input,

--- a/tests/test_agentuniverse/unit/agent/template/test_contextual_iteration_agent_template.py
+++ b/tests/test_agentuniverse/unit/agent/template/test_contextual_iteration_agent_template.py
@@ -1,0 +1,123 @@
+import asyncio
+import json
+from typing import ClassVar
+
+from agentuniverse.agent.agent import Agent
+from agentuniverse.agent.agent_model import AgentModel
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.template.contextual_iteration_agent_template import (
+    ContextualIterationAgentTemplate,
+)
+
+
+class _FakePrompt:
+    input_variables: ClassVar[list[str]] = ["chat_history"]
+
+    def as_langchain(self):
+        return self
+
+    def format(self, **kwargs):
+        return kwargs.get("chat_history", "")
+
+    def __or__(self, other):
+        return self
+
+
+class _FakeLLM:
+    def as_langchain_runnable(self, params):
+        return object()
+
+
+def _make_agent():
+    agent = ContextualIterationAgentTemplate()
+    agent.agent_model = AgentModel(
+        info={"name": "contextual"},
+        profile={"llm_model": {"name": "fake"}},
+        memory={},
+        action={},
+    )
+    agent.iteration = 2
+    agent.continue_prompt_version = "continue"
+    agent.if_loop_prompt_version = None
+    return agent
+
+
+def _configure_dependencies(monkeypatch):
+    prompt = _FakePrompt()
+    module = (
+        "agentuniverse.agent.template.contextual_iteration_agent_template"
+    )
+    monkeypatch.setattr(f"{module}.assemble_memory_input", lambda *args, **kwargs: None)
+    monkeypatch.setattr(f"{module}.assemble_memory_output", lambda *args, **kwargs: None)
+    monkeypatch.setattr(f"{module}.process_llm_token", lambda *args, **kwargs: None)
+    monkeypatch.setattr(f"{module}.StrOutputParser", lambda: object())
+    monkeypatch.setattr(Agent, "process_prompt", lambda *args, **kwargs: prompt)
+    return prompt
+
+
+def test_sync_iterations_include_previous_continuation_in_history(monkeypatch):
+    prompt = _configure_dependencies(monkeypatch)
+    agent = _make_agent()
+    observed_histories = []
+    responses = iter(["initial", "continue-1", "continue-2"])
+
+    def invoke_chain(self, chain, agent_input, input_object, **kwargs):
+        observed_histories.append(agent_input.get("chat_history"))
+        return next(responses)
+
+    monkeypatch.setattr(ContextualIterationAgentTemplate, "invoke_chain", invoke_chain)
+
+    result = agent.customized_execute(
+        InputObject({}), {"input": "question"}, None, _FakeLLM(), prompt
+    )
+
+    assert result["output"] == "initial\ncontinue-1\ncontinue-2"
+    assert len(json.loads(observed_histories[2])) == 2
+    assert json.loads(observed_histories[2])[-1]["assistant"] == "continue-1"
+
+
+def test_loop_decision_sees_latest_continuation(monkeypatch):
+    prompt = _configure_dependencies(monkeypatch)
+    agent = _make_agent()
+    agent.if_loop_prompt_version = "judge"
+    observed_histories = []
+    responses = iter(["initial", "continue-1", "no"])
+
+    def invoke_chain(self, chain, agent_input, input_object, **kwargs):
+        observed_histories.append(agent_input.get("chat_history"))
+        return next(responses)
+
+    monkeypatch.setattr(ContextualIterationAgentTemplate, "invoke_chain", invoke_chain)
+
+    result = agent.customized_execute(
+        InputObject({}), {"input": "question"}, None, _FakeLLM(), prompt
+    )
+
+    assert result["output"] == "initial\ncontinue-1"
+    decision_history = json.loads(observed_histories[2])
+    assert decision_history[-1]["assistant"] == "continue-1"
+
+
+def test_async_iterations_include_previous_continuation_in_history(monkeypatch):
+    prompt = _configure_dependencies(monkeypatch)
+    agent = _make_agent()
+    observed_histories = []
+    responses = iter(["initial", "continue-1", "continue-2"])
+
+    async def invoke_chain(self, chain, agent_input, input_object, **kwargs):
+        observed_histories.append(agent_input.get("chat_history"))
+        return next(responses)
+
+    monkeypatch.setattr(
+        ContextualIterationAgentTemplate, "async_invoke_chain", invoke_chain
+    )
+
+    result = asyncio.run(
+        agent.customized_async_execute(
+            InputObject({}), {"input": "question"}, None, _FakeLLM(), prompt
+        )
+    )
+
+    assert result["output"] == "initial\ncontinue-1\ncontinue-2"
+    assert len(json.loads(observed_histories[2])) == 2
+    assert json.loads(observed_histories[2])[-1]["assistant"] == "continue-1"


### PR DESCRIPTION
## Summary

- append every continuation response to chat history before the next iteration
- make optional loop-decision prompts see the latest continuation
- keep sync and async contextual-iteration behavior aligned
- avoid repeatedly invoking continuation prompts with stale history

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_agentuniverse\unit\agent\template\test_contextual_iteration_agent_template.py -q` (3 passed)
- `.venv\Scripts\ruff.exe check tests\test_agentuniverse\unit\agent\template\test_contextual_iteration_agent_template.py --no-fix`

The regression suite covers sync iteration, async iteration, and the loop-decision path.

## Checklist

- [x] I have read the contributor guidelines.
- [x] I checked open PRs for duplicate changes.
- [x] I accept maintainer-requested changes or closure.
- [x] I added regression tests for this bug fix.
- [ ] Documentation changes are not needed for this correctness fix.
