### PR TITLE
fix(tool): omit absent optional body fields

### DIFF
--- a/agentuniverse/agent/action/tool/api_tool.py
+++ b/agentuniverse/agent/action/tool/api_tool.py
@@ -182,8 +182,6 @@ class APITool(Tool):
                             )
                         elif 'default' in property:
                             body[name] = property['default']
-                        else:
-                            body[name] = None
                     break
 
         # replace path parameters

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
+import json
 import unittest
+from unittest.mock import patch
 
 from agentuniverse.agent.action.tool.api_tool import APITool
 
@@ -54,6 +56,37 @@ class TestAPIToolTypeConversion(unittest.TestCase):
         )
 
         self.assertIs(result, False)
+
+    def test_request_body_omits_missing_optional_properties(self):
+        self.tool.openapi_spec = {
+            "operation": {"parameters": []},
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "required": ["name"],
+                            "properties": {
+                                "name": {"type": "string"},
+                                "nickname": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        with patch(
+            "agentuniverse.agent.action.tool.api_tool.ssrf_proxy.post"
+        ) as post:
+            self.tool.do_http_request(
+                "https://example.com/users",
+                "post",
+                {},
+                {"name": "Ada"},
+            )
+
+        request_body = json.loads(post.call_args.kwargs["data"])
+        self.assertEqual(request_body, {"name": "Ada"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Keep omitted optional OpenAPI request-body properties out of the serialized payload.

## Root cause

`APITool.do_http_request` populated every schema property and assigned `None` when an optional property had neither an input value nor a default. JSON serialization turned those absent values into explicit `null` fields, which can override server-side defaults or fail schemas where the property is optional but not nullable.

The request builder now adds a property only when the caller supplied it, the schema requires it, or the schema defines a default.

## User impact

API tools now preserve the distinction between an omitted optional field and an explicitly null field. Supplied values, required-field validation, and schema defaults are unchanged.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py -q` — 6 passed
- Python compilation — passed
- `git diff --check` — passed
