### PR TITLE
fix(memory): generate unique conversation message IDs

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_message.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_message.py
@@ -36,7 +36,7 @@ class ConversationMessage(Message):
         content (Optional[str]): Message content.
         metadata (Optional[dict]): The metadata of the message.
     """
-    id: Optional[str | int] = uuid.uuid4().hex
+    id: Optional[str | int] = Field(default_factory=lambda: uuid.uuid4().hex)
     trace_id: Optional[str] = None
     conversation_id: Optional[str] = None
     source: Optional[str] = None

--- a/tests/test_agentuniverse/unit/agent/memory/test_conversation_message.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_conversation_message.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.memory.conversation_memory.conversation_message import (
+    ConversationMessage,
+)
+
+
+class TestConversationMessage(unittest.TestCase):
+    def test_default_ids_are_unique_per_message(self):
+        first = ConversationMessage()
+        second = ConversationMessage()
+
+        self.assertIsNotNone(first.id)
+        self.assertIsNotNone(second.id)
+        self.assertNotEqual(first.id, second.id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Generate a fresh default identifier for every `ConversationMessage`.

## Root cause

The UUID expression was evaluated once when the model class was imported. Its resulting string then became the default for every instance, so separately created conversation messages could share the same identifier.

The field now uses Pydantic's `default_factory`, which evaluates the UUID generator for each new message.

## User impact

Conversation messages created without an explicit ID now receive distinct identifiers. Explicitly supplied IDs remain unchanged.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/memory/test_conversation_message.py -q` — 1 passed
- Python compilation — passed
- `git diff --check` — passed
