### PR TITLE
fix(prompt): handle empty text during token splitting

### DIFF
--- a/agentuniverse/base/util/prompt_util.py
+++ b/agentuniverse/base/util/prompt_util.py
@@ -40,6 +40,9 @@ def summarize_by_map_reduce(texts: List[str], llm: LLM, summary_prompt, combine_
 
 def split_text_on_tokens(text: str, text_token: int, chunk_size=800, chunk_overlap=100) -> List[str]:
     """Split incoming text and return chunks using tokenizer."""
+    if not text:
+        return [text]
+
     # calculate the number of characters represented by each token.
     char_per_token = len(text) / text_token
     chunk_char_size = int(chunk_size * char_per_token)

--- a/tests/test_agentuniverse/unit/base/util/test_prompt_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_prompt_util.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.base.util.prompt_util import split_text_on_tokens
+
+
+class TestSplitTextOnTokens(unittest.TestCase):
+    def test_empty_text_does_not_divide_by_zero(self):
+        self.assertEqual(split_text_on_tokens("", text_token=0), [""])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Handle empty text safely in token-based prompt splitting.

## Root cause

An empty string commonly has a token count of zero. `split_text_on_tokens` divided the text length by that count before checking the input, causing a `ZeroDivisionError` instead of returning a usable chunk.

The splitter now returns the empty input as a single empty chunk before performing token-ratio calculations.

## User impact

Prompt processing can accept empty optional content without crashing. Splitting behavior for non-empty text is unchanged.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/base/util/test_prompt_util.py -q` — 1 passed
- Python compilation — passed
- `git diff --check` — passed
