### PR TITLE
fix(parser): support plain LangChain generations

### DIFF
--- a/agentuniverse/base/util/reasoning_output_parse.py
+++ b/agentuniverse/base/util/reasoning_output_parse.py
@@ -18,15 +18,15 @@ class ReasoningOutputParser(StrOutputParser):
         if not result:
             return ""
 
-        reasoning_text = ""
-        if result[0].message.additional_kwargs:
-            additional_kwargs = getattr(result[0].message, "additional_kwargs")
-            if additional_kwargs and "reasoning_content" in additional_kwargs:
-                reasoning_text = result[0].message.additional_kwargs.get("reasoning_content")
+        generation = result[0]
+        message = getattr(generation, "message", None)
+        additional_kwargs = getattr(message, "additional_kwargs", None)
+        if additional_kwargs:
+            reasoning_text = additional_kwargs.get("reasoning_content", "")
             return {
-                "text": result[0].text,
+                "text": generation.text,
                 "reasoning_content": reasoning_text
             }
         return {
-            "text": result[0].text,
+            "text": generation.text,
         }

--- a/tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py
+++ b/tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, Generation
+
+from agentuniverse.base.util.reasoning_output_parse import ReasoningOutputParser
+
+
+class TestReasoningOutputParser(unittest.TestCase):
+    def test_plain_generation_without_message_is_supported(self):
+        result = ReasoningOutputParser().parse_result(
+            [Generation(text="answer")]
+        )
+
+        self.assertEqual(result, {"text": "answer"})
+
+    def test_chat_generation_keeps_reasoning_content(self):
+        result = ReasoningOutputParser().parse_result([
+            ChatGeneration(
+                message=AIMessage(
+                    content="answer",
+                    additional_kwargs={"reasoning_content": "analysis"},
+                )
+            )
+        ])
+
+        self.assertEqual(
+            result,
+            {"text": "answer", "reasoning_content": "analysis"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Allow `ReasoningOutputParser` to handle both plain LangChain generations and chat generations.

## Root cause

The parser unconditionally accessed `generation.message.additional_kwargs`. Plain `Generation` objects expose `text` but do not have a `message` attribute, so otherwise valid non-chat LLM output raised `AttributeError`.

The parser now reads the optional message and reasoning metadata defensively while keeping the existing reasoning-content response shape for chat generations.

## User impact

The reasoning parser can be used with standard text LLM pipelines as well as chat pipelines. Existing chat reasoning metadata remains available.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py -q` — 2 passed
- Python compilation — passed
- `git diff --check` — passed
