### PR TITLE
fix(util): reject non-object JSON parse results

### DIFF
--- a/agentuniverse/base/util/common_util.py
+++ b/agentuniverse/base/util/common_util.py
@@ -191,6 +191,10 @@ def parse_and_check_json_markdown(text: str, expected_keys: List[str]) -> dict:
         json_obj = parse_json_markdown(text)
     except json.JSONDecodeError as e:
         raise Exception(f"Got invalid JSON object. Error: {e}")
+    if not isinstance(json_obj, dict):
+        raise ValueError(
+            f"Expected a JSON object, but got {json_obj!r}"
+        )
     for key in expected_keys:
         if key not in json_obj:
             raise Exception(

--- a/tests/test_agentuniverse/unit/base/util/test_common_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_common_util.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.base.util.common_util import parse_and_check_json_markdown
+
+
+class TestParseAndCheckJsonMarkdown(unittest.TestCase):
+    def test_accepts_json_object_with_expected_keys(self):
+        result = parse_and_check_json_markdown(
+            '{"answer": 42}',
+            ["answer"],
+        )
+
+        self.assertEqual(result, {"answer": 42})
+
+    def test_rejects_partial_parser_none_result_as_invalid_json(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected a JSON object",
+        ):
+            parse_and_check_json_markdown('{"answer":]', ["answer"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reject non-object results from partial JSON parsing with a clear validation error.

## Root cause

`parse_partial_json` can return `None` for mismatched closing delimiters. `parse_and_check_json_markdown` then attempted key membership against that value and raised an unrelated `TypeError`, obscuring the invalid model output.

The validator now checks that parsing produced a dictionary before validating expected keys.

## User impact

Malformed or non-object JSON output now fails with an actionable `ValueError`. Valid JSON objects and expected-key validation are unchanged.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/base/util/test_common_util.py -q` — 2 passed
- Python compilation — passed
- `git diff --check` — passed
