### PR TITLE
fix(memory): preserve message IDs in serialization

### DIFF
--- a/agentuniverse/agent/memory/message.py
+++ b/agentuniverse/agent/memory/message.py
@@ -57,7 +57,8 @@ class Message(BaseModel):
 
     def to_dict(self) -> dict:
         """Convert the agentUniverse(aU) message class to the dict."""
-        return {"type": self.type, "content": self.content, "metadata": self.metadata, "source": self.source}
+        return {"id": self.id, "type": self.type, "content": self.content,
+                "metadata": self.metadata, "source": self.source}
 
     @staticmethod
     def from_dict(message_dict: dict) -> 'Message':

--- a/tests/test_agentuniverse/unit/agent/memory/test_message_serialization.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_message_serialization.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.memory.message import Message
+
+
+class TestMessageSerialization(unittest.TestCase):
+    def test_to_dict_preserves_id_for_round_trip(self):
+        message = Message(
+            id="message-1",
+            type="human",
+            content="hello",
+            source="user",
+        )
+
+        restored = Message.from_dict(message.to_dict())
+
+        self.assertEqual(restored.id, "message-1")
+        self.assertEqual(restored.type, message.type)
+        self.assertEqual(restored.content, message.content)
+        self.assertEqual(restored.source, message.source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Preserve message identifiers when converting `Message` objects to dictionaries.

## Root cause

`Message.from_dict` supports the `id` field, but `Message.to_dict` omitted it. A serialize-and-restore round trip therefore silently replaced an existing identifier with `None`.

The dictionary representation now includes the message ID alongside the existing type, content, metadata, and source fields.

## User impact

Message identity survives dictionary serialization, persistence, and transport. Messages without an ID continue to serialize with `id: null`.

## Tests

- `python -m pytest tests/test_agentuniverse/unit/agent/memory/test_message_serialization.py -q` — 1 passed
- Python compilation — passed
- `git diff --check` — passed
