### PR TITLE
fix(reader): avoid scanned PDF OCR debug prints

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/scanned_pdf_ocr_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/scanned_pdf_ocr_reader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from agentuniverse.agent.action.knowledge.reader.reader import Reader
 from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.base.util.logging.logging_util import LOGGER
 
 
 class ScannedPdfOCRReader(Reader):
@@ -19,7 +20,7 @@ class ScannedPdfOCRReader(Reader):
     """
 
     def _load_data(self, file: Union[str, Path], ext_info: Optional[Dict] = None) -> List[Document]:
-        print(f"debugging: ScannedPdfOCRReader start load file={file}")
+        LOGGER.debug("ScannedPdfOCRReader start load file={}".format(file))
         if isinstance(file, str):
             file = Path(file)
         if not isinstance(file, Path) or not file.exists():
@@ -29,7 +30,7 @@ class ScannedPdfOCRReader(Reader):
         engines: List[str] = []
         try:
             import pypdf  # type: ignore
-            print("debugging: ScannedPdfOCRReader using pypdf first")
+            LOGGER.debug("ScannedPdfOCRReader using pypdf first")
             with open(file, "rb") as fp:
                 pdf = pypdf.PdfReader(fp)
                 for i, page in enumerate(pdf.pages):
@@ -42,7 +43,7 @@ class ScannedPdfOCRReader(Reader):
                         texts.append(ocr_txt)
                         engines.append(ocr_engine)
         except Exception as e:
-            print(f"debugging: ScannedPdfOCRReader pypdf failed: {e}")
+            LOGGER.debug("ScannedPdfOCRReader pypdf failed: {}".format(e))
             # If pypdf fails, OCR every page
             num_pages = self._count_pdf_pages(file)
             for i in range(num_pages):
@@ -73,7 +74,7 @@ class ScannedPdfOCRReader(Reader):
         except Exception:
             raise ImportError("pdf2image is required: `pip install pdf2image`. Also install poppler.")
 
-        print(f"debugging: ScannedPdfOCRReader converting page {page_index} to image")
+        LOGGER.debug("ScannedPdfOCRReader converting page {} to image".format(page_index))
         images = convert_from_path(str(file), first_page=page_index + 1, last_page=page_index + 1)
         if not images:
             return "", "none"
@@ -81,7 +82,7 @@ class ScannedPdfOCRReader(Reader):
         # Try PaddleOCR
         try:
             from paddleocr import PaddleOCR  # type: ignore
-            print("debugging: ScannedPdfOCRReader using PaddleOCR")
+            LOGGER.debug("ScannedPdfOCRReader using PaddleOCR")
             ocr = PaddleOCR(use_angle_cls=True, lang='ch')
             result = ocr.ocr(images[0], cls=True)
             lines = []
@@ -92,21 +93,21 @@ class ScannedPdfOCRReader(Reader):
                         lines.append(txt)
             return "\n".join(lines), "paddleocr"
         except Exception as e_paddle:
-            print(f"debugging: ScannedPdfOCRReader PaddleOCR failed: {e_paddle}")
+            LOGGER.debug("ScannedPdfOCRReader PaddleOCR failed: {}".format(e_paddle))
 
         # Fallback to pytesseract
         try:
             import pytesseract  # type: ignore
-            print("debugging: ScannedPdfOCRReader using pytesseract")
+            LOGGER.debug("ScannedPdfOCRReader using pytesseract")
             text = pytesseract.image_to_string(images[0], lang='chi_sim+eng')
             return text, "pytesseract"
         except Exception as e_tess:
-            print(f"debugging: ScannedPdfOCRReader pytesseract failed: {e_tess}")
+            LOGGER.debug("ScannedPdfOCRReader pytesseract failed: {}".format(e_tess))
 
         # Fallback to easyocr
         try:
             import easyocr  # type: ignore
-            print("debugging: ScannedPdfOCRReader using easyocr")
+            LOGGER.debug("ScannedPdfOCRReader using easyocr")
             reader = easyocr.Reader(['ch_sim', 'en'])
             result = reader.readtext(images[0], detail=0)
             return "\n".join(result), "easyocr"

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_scanned_pdf_ocr_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_scanned_pdf_ocr_reader.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import builtins
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.reader.image.scanned_pdf_ocr_reader import ScannedPdfOCRReader
+
+
+class ScannedPdfOCRReaderTest(unittest.TestCase):
+    def test_load_data_logs_pypdf_fallback_without_printing(self):
+        reader = ScannedPdfOCRReader()
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as fp:
+            pdf_file = Path(fp.name)
+
+            with patch.object(builtins, "print") as mock_print, \
+                    patch.object(reader, "_count_pdf_pages", return_value=1), \
+                    patch.object(reader, "_ocr_pdf_page", return_value=("ocr text", "fake-ocr")), \
+                    patch("agentuniverse.agent.action.knowledge.reader.image.scanned_pdf_ocr_reader.LOGGER") as mock_logger:
+                docs = reader._load_data(pdf_file)
+
+        self.assertEqual(docs[0].text, "ocr text")
+        self.assertEqual(docs[0].metadata["engine"], "fake-ocr")
+        mock_print.assert_not_called()
+        self.assertGreaterEqual(mock_logger.debug.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** **请详细填写本次PR的内容:**
- Replace ScannedPdfOCRReader runtime debug prints with LOGGER.debug calls.
- Keep fallback diagnostics for pypdf, pdf page conversion, and OCR engines without writing directly to stdout.
- Add regression coverage that verifies the fallback path logs through LOGGER and does not call print.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_scanned_pdf_ocr_reader.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/action/knowledge/reader/image/scanned_pdf_ocr_reader.py tests/test_agentuniverse/unit/agent/action/knowledge/reader/image/test_scanned_pdf_ocr_reader.py`: passed.
- Full pytest run was not completed locally because this environment is missing pytest/project runtime dependencies such as langchain_core.
**Please list the names of the docs that were added or modified in this PR (fill in as needed):** **请列出本次PR新增或修改的文档名称(按需填写):**

- None.
