### PR TITLE
fix(planner): avoid workflow node result prints

### DIFF
--- a/agentuniverse/agent/plan/planner/workflow_planner/workflow_planner.py
+++ b/agentuniverse/agent/plan/planner/workflow_planner/workflow_planner.py
@@ -8,6 +8,7 @@
 from agentuniverse.agent.agent_model import AgentModel
 from agentuniverse.agent.input_object import InputObject
 from agentuniverse.agent.plan.planner.planner import Planner
+from agentuniverse.base.util.logging.logging_util import LOGGER
 from agentuniverse.workflow.workflow import Workflow
 from agentuniverse.workflow.workflow_manager import WorkflowManager
 from agentuniverse.workflow.workflow_output import WorkflowOutput
@@ -34,5 +35,5 @@ class WorkflowPlanner(Planner):
             raise Exception('Workflow graph is None, please add nodes and edges to the workflow graph.')
         workflow = workflow.build()
         workflow_output: WorkflowOutput = workflow.run(input_object.to_dict())
-        print(workflow_output.workflow_node_results)
+        LOGGER.debug("Workflow node results: {}".format(workflow_output.workflow_node_results))
         return workflow_output.workflow_end_params

--- a/tests/test_agentuniverse/unit/agent/plan/planner/workflow_planner/test_workflow_planner.py
+++ b/tests/test_agentuniverse/unit/agent/plan/planner/workflow_planner/test_workflow_planner.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import builtins
+import unittest
+from unittest.mock import Mock, patch
+
+from agentuniverse.agent.plan.planner.workflow_planner.workflow_planner import WorkflowPlanner
+
+
+class WorkflowPlannerTest(unittest.TestCase):
+    def test_invoke_logs_node_results_without_printing(self):
+        planner = WorkflowPlanner()
+        agent_model = Mock(plan={"planner": {"workflow_id": "workflow"}})
+        workflow_output = Mock(
+            workflow_node_results={"node": "ok"},
+            workflow_end_params={"answer": "done"}
+        )
+        workflow = Mock(graph_config={"nodes": []})
+        workflow.build.return_value = workflow
+        workflow.run.return_value = workflow_output
+        input_object = Mock()
+        input_object.to_dict.return_value = {"input": "hello"}
+
+        with patch("agentuniverse.agent.plan.planner.workflow_planner.workflow_planner.WorkflowManager") as manager_cls, \
+                patch("agentuniverse.agent.plan.planner.workflow_planner.workflow_planner.LOGGER") as mock_logger, \
+                patch.object(builtins, "print") as mock_print:
+            manager_cls.return_value.get_instance_obj.return_value = workflow
+            result = planner.invoke(agent_model, {}, input_object)
+
+        self.assertEqual(result, {"answer": "done"})
+        mock_logger.debug.assert_called_once_with("Workflow node results: {'node': 'ok'}")
+        mock_print.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** **请详细填写本次PR的内容:**
- Replace WorkflowPlanner node-result print output with LOGGER.debug.
- Keep planner behavior unchanged while avoiding unsolicited stdout output during workflow execution.
- Add regression coverage that invokes a mocked workflow planner path and verifies stdout is not used.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent/plan/planner/workflow_planner/test_workflow_planner.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent/plan/planner/workflow_planner/workflow_planner.py tests/test_agentuniverse/unit/agent/plan/planner/workflow_planner/test_workflow_planner.py`: passed.
- Full pytest run was not completed locally because this environment is missing pytest/project runtime dependencies such as langchain_core.
**Please list the names of the docs that were added or modified in this PR (fill in as needed):** **请列出本次PR新增或修改的文档名称(按需填写):**

- None.
