### PR TITLE
fix(server): avoid async request timeout prints

### DIFF
--- a/agentuniverse/agent_serve/web/request_task.py
+++ b/agentuniverse/agent_serve/web/request_task.py
@@ -188,7 +188,7 @@ class RequestTask:
                 output: str = await asyncio.wait_for(self.async_queue.get(), timeout=0.5)
             except asyncio.TimeoutError:
                 await asyncio.sleep(1)
-                print("Waiting for data timed out. Retrying...")
+                LOGGER.debug("Waiting for async request data timed out. Retrying...")
                 if self.async_task and self.async_task.done():
                     LOGGER.error("Task finished without EOF")
                     break

--- a/tests/test_agentuniverse/unit/agent_serve/web/test_request_task.py
+++ b/tests/test_agentuniverse/unit/agent_serve/web/test_request_task.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import asyncio
+import builtins
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from agentuniverse.agent_serve.web.request_task import RequestTask
+
+
+class RequestTaskTest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_receive_steps_logs_timeout_without_printing(self):
+        task = object.__new__(RequestTask)
+        task.async_queue = Mock()
+        task.async_queue.get = AsyncMock()
+        task.async_task = Mock(done=Mock(return_value=True))
+        task.next_state = Mock()
+
+        with patch("agentuniverse.agent_serve.web.request_task.asyncio.wait_for",
+                   side_effect=asyncio.TimeoutError), \
+                patch("agentuniverse.agent_serve.web.request_task.asyncio.sleep",
+                      new=AsyncMock()), \
+                patch("agentuniverse.agent_serve.web.request_task.LOGGER") as mock_logger, \
+                patch.object(builtins, "print") as mock_print:
+            async for _ in task.async_receive_steps():
+                pass
+
+        mock_logger.debug.assert_called_once_with(
+            "Waiting for async request data timed out. Retrying..."
+        )
+        mock_logger.error.assert_called_once_with("Task finished without EOF")
+        mock_print.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When submitting a PR, please confirm the following points and put [x] in the boxes one by one.** **在提出pr时，请确认了以下几点，并逐一使用[x]符号确认为选。**

**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [x] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [ ] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明(非必要，根据实际PR内容按需添加)
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要，根据实际PR内容按需添加)

**Please fill in the specific details of this PR:** **请详细填写本次PR的内容:**
- Replace the async request receive timeout print with LOGGER.debug.
- Keep the existing retry behavior and EOF error handling unchanged.
- Add regression coverage for the timeout branch to ensure the message is logged without printing to stdout.

**Please provide the path of test files and submit screenshots or files of the test results(fill in as needed):** **请填写测试文件路径并提供测试结果截图或文件(按需填写):**

- `tests/test_agentuniverse/unit/agent_serve/web/test_request_task.py`
- `git diff --check`: passed.
- `python -m py_compile agentuniverse/agent_serve/web/request_task.py tests/test_agentuniverse/unit/agent_serve/web/test_request_task.py`: passed.
- Full pytest run was not completed locally because this environment is missing pytest/project runtime dependencies such as langchain_core.
**Please list the names of the docs that were added or modified in this PR (fill in as needed):** **请列出本次PR新增或修改的文档名称(按需填写):**

- None.
