### PR TITLE
fix(agent): handle missing LLM parameter config

### DIFF
--- a/agentuniverse/agent/agent_model.py
+++ b/agentuniverse/agent/agent_model.py
@@ -25,7 +25,8 @@ class AgentModel(BaseModel):
             dict: The parameters for the LLM.
         """
         params = {}
-        for key, value in self.profile.get('llm_model').items():
+        llm_model = (self.profile or {}).get('llm_model') or {}
+        for key, value in llm_model.items():
             if key == 'name' or key == 'prompt_processor':
                 continue
             if key == 'model_name':

--- a/tests/test_agentuniverse/unit/agent/test_agent_model.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent_model.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.agent_model import AgentModel
+
+
+class TestAgentModel(unittest.TestCase):
+    def test_llm_params_returns_empty_mapping_without_llm_config(self):
+        self.assertEqual(AgentModel(profile={}).llm_params(), {})
+
+    def test_llm_params_keeps_supported_bind_values(self):
+        model = AgentModel(profile={
+            "llm_model": {
+                "name": "default_llm",
+                "prompt_processor": {"type": "truncate"},
+                "model_name": "gpt-test",
+                "temperature": 0.2,
+            }
+        })
+
+        self.assertEqual(
+            model.llm_params(),
+            {"model": "gpt-test", "temperature": 0.2},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`AgentModel.llm_params()` now treats a missing or null `llm_model` section as an empty configuration instead of calling `.items()` on `None`.

## Why

Profiles can be built incrementally and do not always include an LLM configuration. Reading bind parameters from those profiles should return an empty mapping rather than raising `AttributeError`.

## Testing

- Added coverage for an empty profile.
- Kept coverage for model-name mapping and ignored configuration fields.

