### PR TITLE
fix(mcp): close sync session stacks asynchronously

### DIFF
--- a/agentuniverse/base/context/mcp_session_manager.py
+++ b/agentuniverse/base/context/mcp_session_manager.py
@@ -191,9 +191,7 @@ class MCPSessionManager:
         return self.__exit_stack.get()
 
     async def clear_session(self):
-        await self.exit_stack.aclose()
-        self.__exit_stack.set(None)
-        self.__mcp_session_dict.set(None)
+        await self.safe_close_stack_async()
 
 
     def save_mcp_session(self) -> dict:

--- a/tests/test_agentuniverse/unit/base/context/test_mcp_session_manager.py
+++ b/tests/test_agentuniverse/unit/base/context/test_mcp_session_manager.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.base.context.mcp_session_manager import MCPSessionManager
+
+
+class FakeSyncAsyncExitStack:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class TestMCPSessionManager(unittest.IsolatedAsyncioTestCase):
+    async def test_clear_session_closes_sync_stack(self):
+        manager = MCPSessionManager()
+        stack = FakeSyncAsyncExitStack()
+        manager.recover_mcp_session({"server": object()}, stack)
+
+        try:
+            with patch(
+                "agentuniverse.base.context.mcp_session_manager."
+                "SyncAsyncExitStack",
+                FakeSyncAsyncExitStack,
+            ):
+                await manager.clear_session()
+        finally:
+            manager.recover_mcp_session(None, None)
+
+        self.assertTrue(stack.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`clear_session()` now delegates to the existing async-safe cleanup helper, which closes asynchronous and synchronous exit stacks with their appropriate APIs.

## Why

Sessions initialized from synchronous code use `SyncAsyncExitStack`. Calling `aclose()` on that stack raised `AttributeError` and left the session state uncleared.

## Testing

- Added an async regression test that clears a recovered synchronous stack and verifies it is closed.

