### PR TITLE
fix(prompt): extract placeholders from multimodal content

### DIFF
--- a/agentuniverse/prompt/chat_prompt.py
+++ b/agentuniverse/prompt/chat_prompt.py
@@ -56,8 +56,12 @@ class ChatPrompt(Prompt):
         result = []
         placeholder_pattern = re.compile(r'\{(.*?)}')
         for message in self.messages:
-            matches = placeholder_pattern.findall(message.content)
-            result.extend(matches)
+            content_parts = message.content if isinstance(message.content, list) else [message.content]
+            for part in content_parts:
+                if isinstance(part, dict):
+                    part = part.get('text')
+                if isinstance(part, str):
+                    result.extend(placeholder_pattern.findall(part))
         return result
 
     def generate_image_prompt(self, image_urls: list[str]) -> None:

--- a/tests/test_agentuniverse/unit/prompt/test_chat_prompt.py
+++ b/tests/test_agentuniverse/unit/prompt/test_chat_prompt.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.memory.enum import ChatMessageEnum
+from agentuniverse.agent.memory.message import Message
+from agentuniverse.prompt.chat_prompt import ChatPrompt
+
+
+class TestChatPrompt(unittest.TestCase):
+    def test_extract_placeholders_supports_multimodal_content(self):
+        prompt = ChatPrompt(messages=[
+            Message(
+                type=ChatMessageEnum.HUMAN.value,
+                content="Hello {name}",
+            ),
+            Message(
+                type=ChatMessageEnum.HUMAN.value,
+                content=[
+                    {"type": "text", "text": "Describe {topic}"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                ],
+            ),
+        ])
+
+        self.assertEqual(
+            prompt.extract_placeholders(),
+            ["name", "topic"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Placeholder extraction now handles both ordinary string content and multimodal content lists. Text blocks are scanned while non-text blocks are ignored.

## Why

Multimodal chat messages store content as a list of blocks, so passing the entire list to the regular-expression matcher raised `TypeError` during prompt construction.

## Testing

- Added coverage for placeholders across a string message and a multimodal text/image message.

