### PR TITLE
fix(agent): handle missing LLM parameter config

### DIFF
--- a/agentuniverse/agent/agent_model.py
+++ b/agentuniverse/agent/agent_model.py
@@ -25,7 +25,8 @@ class AgentModel(BaseModel):
             dict: The parameters for the LLM.
         """
         params = {}
-        for key, value in self.profile.get('llm_model').items():
+        llm_model = (self.profile or {}).get('llm_model') or {}
+        for key, value in llm_model.items():
             if key == 'name' or key == 'prompt_processor':
                 continue
             if key == 'model_name':

--- a/tests/test_agentuniverse/unit/agent/test_agent_model.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent_model.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.agent_model import AgentModel
+
+
+class TestAgentModel(unittest.TestCase):
+    def test_llm_params_returns_empty_mapping_without_llm_config(self):
+        self.assertEqual(AgentModel(profile={}).llm_params(), {})
+
+    def test_llm_params_keeps_supported_bind_values(self):
+        model = AgentModel(profile={
+            "llm_model": {
+                "name": "default_llm",
+                "prompt_processor": {"type": "truncate"},
+                "model_name": "gpt-test",
+                "temperature": 0.2,
+            }
+        })
+
+        self.assertEqual(
+            model.llm_params(),
+            {"model": "gpt-test", "temperature": 0.2},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Checklist**

- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md).
- [ ] I have checked for any duplicate features related to this request and communicated with the project maintainers. This is a resubmission under `123123213weqw`; earlier account submissions remain open for now.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide the test results for this bug fix.
- [ ] I have added or modified the documentation related to this PR.
- [ ] I have added examples and notes if needed.

**Please fill in the specific details of this PR:**

- Type: `fix`
- `AgentModel.llm_params()` now treats a missing or null `llm_model` section as an empty configuration.
- This prevents `AttributeError` when profiles are constructed without LLM configuration and preserves existing parameter mapping behavior.

**Test files and results:**

- `tests/test_agentuniverse/unit/agent/test_agent_model.py`
- Result: `2 passed`

**Documentation:**

- None required for this internal bug fix.

