### PR TITLE
fix(memory): render messages without trace metadata

### DIFF
--- a/agentuniverse/base/util/memory_util.py
+++ b/agentuniverse/base/util/memory_util.py
@@ -64,13 +64,15 @@ def get_memory_string(messages: List[Message], agent_id=None) -> str:
         elif m.type == ChatMessageEnum.AI.value:
             role = "AI"
         elif m.type == ChatMessageEnum.INPUT.value or m.type == ChatMessageEnum.OUTPUT.value:
-            if current_trace_id == m.trace_id:
+            message_trace_id = getattr(m, 'trace_id', None)
+            if current_trace_id is not None and current_trace_id == message_trace_id:
                 continue
-            role: str = m.metadata.get('prefix', "")
+            metadata = m.metadata or {}
+            role: str = metadata.get('prefix', "")
             if agent_id:
                 role = role.replace(f"智能体 {agent_id}", " 你")
                 role = role.replace(f"Agent {agent_id}", " You")
-            m_str = f"{m.metadata.get('timestamp')} {role}:{m.content}"
+            m_str = f"{metadata.get('timestamp')} {role}:{m.content}"
             string_messages.append(m_str)
             continue
         else:

--- a/tests/test_agentuniverse/unit/base/util/test_memory_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_memory_util.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.memory.message import Message
+from agentuniverse.base.util.memory_util import get_memory_string
+
+
+class TestGetMemoryString(unittest.TestCase):
+    def test_plain_input_message_without_trace_fields_is_rendered(self):
+        message = Message(
+            type="input",
+            content="hello",
+            metadata={},
+        )
+
+        result = get_memory_string([message])
+
+        self.assertIn("hello", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Checklist**

- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md).
- [ ] I have checked for any duplicate features related to this request and communicated with the project maintainers. This is a resubmission under `123123213weqw`; earlier account submissions remain open for now.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide the test results for this bug fix.
- [ ] I have added or modified the documentation related to this PR.
- [ ] I have added examples and notes if needed.

**Please fill in the specific details of this PR:**

- Type: `fix`
- Memory formatting now reads trace information defensively and tolerates messages without trace fields or metadata.
- Messages are filtered only when an active trace ID and message trace ID are both present and equal.

**Test files and results:**

- `tests/test_agentuniverse/unit/base/util/test_memory_util.py`
- Result: `1 passed`

**Documentation:**

- None required for this internal bug fix.
