### PR TITLE
fix(prompt): extract placeholders from multimodal content

### DIFF
--- a/agentuniverse/prompt/chat_prompt.py
+++ b/agentuniverse/prompt/chat_prompt.py
@@ -56,8 +56,12 @@ class ChatPrompt(Prompt):
         result = []
         placeholder_pattern = re.compile(r'\{(.*?)}')
         for message in self.messages:
-            matches = placeholder_pattern.findall(message.content)
-            result.extend(matches)
+            content_parts = message.content if isinstance(message.content, list) else [message.content]
+            for part in content_parts:
+                if isinstance(part, dict):
+                    part = part.get('text')
+                if isinstance(part, str):
+                    result.extend(placeholder_pattern.findall(part))
         return result
 
     def generate_image_prompt(self, image_urls: list[str]) -> None:

--- a/tests/test_agentuniverse/unit/prompt/test_chat_prompt.py
+++ b/tests/test_agentuniverse/unit/prompt/test_chat_prompt.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from agentuniverse.agent.memory.enum import ChatMessageEnum
+from agentuniverse.agent.memory.message import Message
+from agentuniverse.prompt.chat_prompt import ChatPrompt
+
+
+class TestChatPrompt(unittest.TestCase):
+    def test_extract_placeholders_supports_multimodal_content(self):
+        prompt = ChatPrompt(messages=[
+            Message(
+                type=ChatMessageEnum.HUMAN.value,
+                content="Hello {name}",
+            ),
+            Message(
+                type=ChatMessageEnum.HUMAN.value,
+                content=[
+                    {"type": "text", "text": "Describe {topic}"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                ],
+            ),
+        ])
+
+        self.assertEqual(
+            prompt.extract_placeholders(),
+            ["name", "topic"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Checklist**

- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md).
- [ ] I have checked for any duplicate features related to this request and communicated with the project maintainers. This is a resubmission under `123123213weqw`; earlier account submissions remain open for now.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide the test results for this bug fix.
- [ ] I have added or modified the documentation related to this PR.
- [ ] I have added examples and notes if needed.

**Please fill in the specific details of this PR:**

- Type: `fix`
- Placeholder extraction now supports both string message content and multimodal content lists.
- Text blocks are scanned for placeholders while image and other non-text blocks are ignored.

**Test files and results:**

- `tests/test_agentuniverse/unit/prompt/test_chat_prompt.py`
- Result: `1 passed`

**Documentation:**

- None required for this internal bug fix.
