### PR TITLE
fix(mcp): close sync session stacks asynchronously

### DIFF
--- a/agentuniverse/base/context/mcp_session_manager.py
+++ b/agentuniverse/base/context/mcp_session_manager.py
@@ -191,9 +191,7 @@ class MCPSessionManager:
         return self.__exit_stack.get()
 
     async def clear_session(self):
-        await self.exit_stack.aclose()
-        self.__exit_stack.set(None)
-        self.__mcp_session_dict.set(None)
+        await self.safe_close_stack_async()
 
 
     def save_mcp_session(self) -> dict:

--- a/tests/test_agentuniverse/unit/base/context/test_mcp_session_manager.py
+++ b/tests/test_agentuniverse/unit/base/context/test_mcp_session_manager.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from agentuniverse.base.context.mcp_session_manager import MCPSessionManager
+
+
+class FakeSyncAsyncExitStack:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class TestMCPSessionManager(unittest.IsolatedAsyncioTestCase):
+    async def test_clear_session_closes_sync_stack(self):
+        manager = MCPSessionManager()
+        stack = FakeSyncAsyncExitStack()
+        manager.recover_mcp_session({"server": object()}, stack)
+
+        try:
+            with patch(
+                "agentuniverse.base.context.mcp_session_manager."
+                "SyncAsyncExitStack",
+                FakeSyncAsyncExitStack,
+            ):
+                await manager.clear_session()
+        finally:
+            manager.recover_mcp_session(None, None)
+
+        self.assertTrue(stack.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Checklist**

- [x] I have read and understood the [contributor guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md).
- [ ] I have checked for any duplicate features related to this request and communicated with the project maintainers. This is a resubmission under `123123213weqw`; earlier account submissions remain open for now.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide the test results for this bug fix.
- [ ] I have added or modified the documentation related to this PR.
- [ ] I have added examples and notes if needed.

**Please fill in the specific details of this PR:**

- Type: `fix`
- `clear_session()` now delegates to the async-safe cleanup helper.
- Synchronous and asynchronous MCP exit stacks are closed through their appropriate APIs.

**Test files and results:**

- `tests/test_agentuniverse/unit/base/context/test_mcp_session_manager.py`
- Result: `1 passed`

**Documentation:**

- None required for this internal bug fix.
