### PR TITLE
feat(agent): validate structured outputs with Pydantic

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -14,6 +14,7 @@ from typing import Optional, Any, List
 
 from langchain_core.runnables import RunnableSerializable, RunnableConfig
 from langchain_core.utils.json import parse_json_markdown
+from pydantic import BaseModel
 
 from agentuniverse.agent.action.knowledge.knowledge import Knowledge
 from agentuniverse.agent.action.knowledge.knowledge_manager import \
@@ -74,6 +75,15 @@ class Agent(ComponentBase, ABC):
         """Return the output keys of the Agent."""
         pass
 
+    def output_model(self) -> Optional[type[BaseModel]]:
+        """Return an optional Pydantic model for structured output validation.
+
+        Subclasses can override this hook to make their public output a typed
+        contract. Returning ``None`` preserves the legacy ``output_keys``-only
+        validation behavior.
+        """
+        return None
+
     @abstractmethod
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
         """Agent parameter parsing.
@@ -124,7 +134,7 @@ class Agent(ComponentBase, ABC):
 
         agent_result = self.parse_result(planner_result)
 
-        self.output_check(agent_result)
+        agent_result = self.validate_output(agent_result)
         output_object = OutputObject(agent_result)
         return output_object
 
@@ -140,7 +150,7 @@ class Agent(ComponentBase, ABC):
 
         agent_result = self.parse_result(agent_result)
 
-        self.output_check(agent_result)
+        agent_result = self.validate_output(agent_result)
         output_object = OutputObject(agent_result)
         return output_object
 
@@ -200,6 +210,25 @@ class Agent(ComponentBase, ABC):
         for key in self.output_keys():
             if key not in kwargs.keys():
                 raise Exception(f'Output must have key: {key}.')
+
+    def validate_output(self, agent_result: dict) -> dict:
+        """Validate and normalize an agent result before exposing it.
+
+        A configured Pydantic model may coerce values and populate defaults.
+        The normalized dictionary is then checked against ``output_keys`` so
+        the existing public output contract remains in force.
+        """
+        if not isinstance(agent_result, dict):
+            raise Exception('Output type must be dict.')
+
+        output_model = self.output_model()
+        if output_model is not None:
+            if not isinstance(output_model, type) or not issubclass(output_model, BaseModel):
+                raise TypeError('output_model() must return a Pydantic BaseModel subclass or None.')
+            agent_result = output_model.model_validate(agent_result).model_dump()
+
+        self.output_check(agent_result)
+        return agent_result
 
     def initialize_by_component_configer(self, component_configer: AgentConfiger) -> 'Agent':
         """Initialize the Agent by the AgentConfiger object.

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Agent/Structured_Agent_Output.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Agent/Structured_Agent_Output.md
@@ -1,0 +1,33 @@
+# Structured Agent Output
+
+An agent normally validates only the keys returned by `output_keys()`. When a
+downstream API or workflow needs a typed contract, override `output_model()`
+and return a Pydantic model.
+
+```python
+from pydantic import BaseModel, Field
+
+from agentuniverse.agent.template.agent_template import AgentTemplate
+
+
+class ResearchResult(BaseModel):
+    answer: str
+    confidence: float = Field(ge=0, le=1)
+    sources: list[str] = []
+
+
+class ResearchAgentTemplate(AgentTemplate):
+    def output_keys(self) -> list[str]:
+        return ["answer", "confidence", "sources"]
+
+    def output_model(self) -> type[BaseModel]:
+        return ResearchResult
+```
+
+Validation runs after `parse_result()` and before `OutputObject` is created in
+both `run()` and `async_run()`. Pydantic coercion and defaults are included in
+the returned dictionary. Invalid nested values raise `ValidationError` before
+they can reach another agent or service.
+
+The hook is optional. Agents that do not override `output_model()` keep the
+existing dictionary and `output_keys()` behavior unchanged.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/智能体/智能体结构化输出.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/智能体/智能体结构化输出.md
@@ -1,0 +1,27 @@
+# 智能体结构化输出
+
+智能体默认只校验 `output_keys()` 返回的字段名。当下游 API 或工作流需要具备类型约束的稳定输出时，可以覆盖 `output_model()`，返回一个 Pydantic 模型。
+
+```python
+from pydantic import BaseModel, Field
+
+from agentuniverse.agent.template.agent_template import AgentTemplate
+
+
+class ResearchResult(BaseModel):
+    answer: str
+    confidence: float = Field(ge=0, le=1)
+    sources: list[str] = []
+
+
+class ResearchAgentTemplate(AgentTemplate):
+    def output_keys(self) -> list[str]:
+        return ["answer", "confidence", "sources"]
+
+    def output_model(self) -> type[BaseModel]:
+        return ResearchResult
+```
+
+同步 `run()` 和异步 `async_run()` 都会在 `parse_result()` 之后、创建 `OutputObject` 之前执行校验。Pydantic 的类型转换与默认值会写入最终结果；嵌套字段不合法时会直接抛出 `ValidationError`，避免错误数据进入其他智能体或服务。
+
+该能力完全可选。没有覆盖 `output_model()` 的既有智能体仍保持原有字典与 `output_keys()` 校验行为。

--- a/tests/test_agentuniverse/unit/agent/test_structured_agent_output.py
+++ b/tests/test_agentuniverse/unit/agent/test_structured_agent_output.py
@@ -1,0 +1,101 @@
+import asyncio
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from agentuniverse.agent.agent import Agent
+from agentuniverse.agent.agent_model import AgentModel
+from agentuniverse.agent.input_object import InputObject
+
+
+class _Answer(BaseModel):
+    answer: str
+    confidence: float = Field(ge=0, le=1)
+    sources: list[str] = []
+
+
+class _StructuredAgent(Agent):
+    raw_result: dict = Field(default_factory=dict)
+
+    def input_keys(self) -> list[str]:
+        return []
+
+    def output_keys(self) -> list[str]:
+        return ["answer", "confidence", "sources"]
+
+    def output_model(self) -> type[BaseModel]:
+        return _Answer
+
+    def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        return agent_input
+
+    def parse_result(self, agent_result: dict) -> dict:
+        return agent_result
+
+    def execute(self, input_object: InputObject, agent_input: dict) -> dict:
+        return self.raw_result
+
+    async def async_execute(self, input_object: InputObject, agent_input: dict) -> dict:
+        return self.raw_result
+
+
+def _agent(agent_cls=_StructuredAgent, **raw_result):
+    agent = agent_cls()
+    agent.agent_model = AgentModel(info={})
+    agent.raw_result = raw_result
+    return agent
+
+
+def test_run_validates_and_normalizes_structured_output():
+    agent = _agent(answer="ok", confidence="0.8")
+
+    result = Agent.run.__wrapped__(agent)
+
+    assert result.to_dict() == {
+        "answer": "ok",
+        "confidence": 0.8,
+        "sources": [],
+    }
+
+
+def test_async_run_uses_the_same_structured_output_contract():
+    agent = _agent(answer="ok", confidence=1)
+
+    result = asyncio.run(Agent.async_run.__wrapped__(agent))
+
+    assert result.get_data("confidence") == 1.0
+    assert result.get_data("sources") == []
+
+
+def test_invalid_structured_output_is_rejected():
+    agent = _agent(answer="unsafe", confidence=2)
+
+    with pytest.raises(ValidationError):
+        Agent.run.__wrapped__(agent)
+
+
+def test_agents_without_output_model_keep_legacy_validation():
+    class _LegacyAgent(_StructuredAgent):
+        def output_model(self):
+            return None
+
+        def output_keys(self) -> list[str]:
+            return ["answer"]
+
+    result = Agent.run.__wrapped__(
+        _agent(_LegacyAgent, answer="ok", untyped=object())
+    )
+
+    assert result.get_data("answer") == "ok"
+    assert "untyped" in result.to_dict()
+
+
+def test_output_model_hook_rejects_non_pydantic_classes():
+    class _MisconfiguredAgent(_StructuredAgent):
+        def output_model(self):
+            return dict
+
+    with pytest.raises(TypeError, match="Pydantic BaseModel subclass"):
+        Agent.run.__wrapped__(
+            _agent(_MisconfiguredAgent, answer="ok", confidence=1)
+        )


### PR DESCRIPTION
## Summary
- add optional `Agent.output_model()` Pydantic contracts
- validate sync/async parsed output
- preserve legacy behavior
- add bilingual docs

Closes #885

## Validation
- 13 tests passed
- targeted Ruff and py_compile passed
