### PR TITLE
feat(workflow): add durable checkpoints and resume

### DIFF
--- a/agentuniverse/workflow/graph/graph.py
+++ b/agentuniverse/workflow/graph/graph.py
@@ -5,7 +5,7 @@
 # @Author  : wangchongshi
 # @Email   : wangchongshi.wcs@antgroup.com
 # @FileName: graph.py
-from typing import Optional, Any
+from typing import Optional, Any, Callable
 
 import networkx as nx
 
@@ -63,11 +63,14 @@ class Graph(nx.DiGraph):
         self.add_edge(edge_config.get('source_node_id'), edge_config.get('target_node_id'),
                       source_handler=edge_config.get('source_handler'))
 
-    def run(self, workflow_output: WorkflowOutput) -> None:
+    def run(self, workflow_output: WorkflowOutput,
+            checkpoint_callback: Optional[Callable[[WorkflowOutput], None]] = None) -> None:
         """Run the graph.
 
         Args:
             workflow_output: The workflow output.
+            checkpoint_callback: Called with an isolated state snapshot after
+                every successfully completed node.
         """
         sorted_nodes = list(nx.topological_sort(self))
         predecessor_node: Node | None = None
@@ -79,6 +82,8 @@ class Graph(nx.DiGraph):
                 predecessor_node = next_node
                 continue
             self._run_node(cur_node=next_node, workflow_output=workflow_output)
+            if checkpoint_callback:
+                checkpoint_callback(workflow_output.model_copy(deep=True))
             if next_node.type == NodeEnum.END:
                 break
             predecessor_node = next_node

--- a/agentuniverse/workflow/workflow.py
+++ b/agentuniverse/workflow/workflow.py
@@ -5,7 +5,7 @@
 # @Author  : wangchongshi
 # @Email   : wangchongshi.wcs@antgroup.com
 # @FileName: workflow.py
-from typing import Optional
+from typing import Callable, Optional
 
 from agentuniverse.base.component.component_base import ComponentBase
 from agentuniverse.base.component.component_enum import ComponentEnum
@@ -42,12 +42,53 @@ class Workflow(ComponentBase):
         self.graph = Graph().build(self.id, self.graph_config)
         return self
 
-    def run(self, input_params: dict) -> WorkflowOutput:
+    def run(self, input_params: Optional[dict] = None, *,
+            resume_from: Optional[WorkflowOutput | str | bytes | dict] = None,
+            checkpoint_callback: Optional[Callable[[WorkflowOutput], None]] = None) -> WorkflowOutput:
+        """Run a new workflow or resume one from a durable checkpoint.
+
+        ``checkpoint_callback`` receives a deep-copied snapshot after every
+        successful node. The snapshot can be serialized with
+        :meth:`WorkflowOutput.to_checkpoint_json` and passed back through
+        ``resume_from`` without re-running completed nodes.
+        """
         if self.graph is None:
             raise ValueError('The graph of the workflow is None.')
-        workflow_output = WorkflowOutput(workflow_id=self.id, workflow_start_params=input_params)
-        self.graph.run(workflow_output)
+        if resume_from is None:
+            workflow_output = WorkflowOutput(
+                workflow_id=self.id,
+                workflow_start_params=input_params or {},
+            )
+        else:
+            workflow_output = self._restore_checkpoint(resume_from)
+            if workflow_output.workflow_id != self.id:
+                raise ValueError(
+                    f'Checkpoint workflow id {workflow_output.workflow_id!r} '
+                    f'does not match workflow id {self.id!r}.'
+                )
+            if input_params is not None and input_params != workflow_output.workflow_start_params:
+                raise ValueError('Input parameters do not match the workflow checkpoint.')
+
+        self.graph.run(workflow_output, checkpoint_callback=checkpoint_callback)
         return workflow_output
+
+    def resume(self, checkpoint: WorkflowOutput | str | bytes | dict, *,
+               checkpoint_callback: Optional[Callable[[WorkflowOutput], None]] = None) -> WorkflowOutput:
+        """Resume this workflow from an object, mapping, or JSON checkpoint."""
+        return self.run(
+            resume_from=checkpoint,
+            checkpoint_callback=checkpoint_callback,
+        )
+
+    @staticmethod
+    def _restore_checkpoint(checkpoint: WorkflowOutput | str | bytes | dict) -> WorkflowOutput:
+        if isinstance(checkpoint, WorkflowOutput):
+            return checkpoint.model_copy(deep=True)
+        if isinstance(checkpoint, (str, bytes)):
+            return WorkflowOutput.from_checkpoint_json(checkpoint)
+        if isinstance(checkpoint, dict):
+            return WorkflowOutput.model_validate(checkpoint)
+        raise TypeError('checkpoint must be a WorkflowOutput, dict, JSON string, or bytes.')
 
     def initialize_by_component_configer(self, component_configer: WorkflowConfiger) -> 'Workflow':
         """Initialize the Workflow by the ComponentConfiger object.

--- a/agentuniverse/workflow/workflow_output.py
+++ b/agentuniverse/workflow/workflow_output.py
@@ -22,3 +22,12 @@ class WorkflowOutput(BaseModel):
     workflow_node_results: Optional[Dict[str, NodeOutput]] = dict()
     workflow_start_params: Optional[Dict[str, Any]] = dict()
     workflow_end_params: Optional[Dict[str, Any]] = dict()
+
+    def to_checkpoint_json(self) -> str:
+        """Serialize the complete workflow state for durable storage."""
+        return self.model_dump_json()
+
+    @classmethod
+    def from_checkpoint_json(cls, checkpoint: str | bytes) -> 'WorkflowOutput':
+        """Restore a workflow state previously serialized as JSON."""
+        return cls.model_validate_json(checkpoint)

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Workflow/Durable_Checkpoints.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Workflow/Durable_Checkpoints.md
@@ -1,0 +1,33 @@
+# Durable Workflow Checkpoints
+
+Long-running workflows can persist progress after every successful node and
+resume later without repeating completed work.
+
+```python
+from pathlib import Path
+
+
+def save_checkpoint(snapshot):
+    Path("workflow-checkpoint.json").write_text(
+        snapshot.to_checkpoint_json(),
+        encoding="utf-8",
+    )
+
+
+result = workflow.run(
+    {"input": "prepare the report"},
+    checkpoint_callback=save_checkpoint,
+)
+```
+
+If the process is interrupted, restore the last snapshot:
+
+```python
+checkpoint = Path("workflow-checkpoint.json").read_text(encoding="utf-8")
+result = workflow.resume(checkpoint, checkpoint_callback=save_checkpoint)
+```
+
+`resume()` accepts a `WorkflowOutput`, dictionary, JSON string, or JSON bytes.
+The workflow id is checked before execution, and a resumed run skips every node
+already present in `workflow_node_results`. Callbacks receive deep copies so a
+storage adapter cannot accidentally mutate the live execution state.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/工作流/持久化检查点.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/工作流/持久化检查点.md
@@ -1,0 +1,29 @@
+# 工作流持久化检查点
+
+长时间运行的工作流可以在每个节点成功后保存执行进度，并在进程中断后从最近的检查点继续，而不重复执行已经完成的节点。
+
+```python
+from pathlib import Path
+
+
+def save_checkpoint(snapshot):
+    Path("workflow-checkpoint.json").write_text(
+        snapshot.to_checkpoint_json(),
+        encoding="utf-8",
+    )
+
+
+result = workflow.run(
+    {"input": "生成报告"},
+    checkpoint_callback=save_checkpoint,
+)
+```
+
+进程中断后读取最近的快照：
+
+```python
+checkpoint = Path("workflow-checkpoint.json").read_text(encoding="utf-8")
+result = workflow.resume(checkpoint, checkpoint_callback=save_checkpoint)
+```
+
+`resume()` 支持 `WorkflowOutput`、字典、JSON 字符串或 JSON 字节。恢复前会校验工作流 ID，执行时会跳过 `workflow_node_results` 中已经完成的节点。回调收到的是深拷贝，存储适配器不会意外修改正在运行的状态。

--- a/tests/test_agentuniverse/unit/workflow/test_workflow_checkpoint.py
+++ b/tests/test_agentuniverse/unit/workflow/test_workflow_checkpoint.py
@@ -1,0 +1,115 @@
+from typing import ClassVar
+
+import pytest
+
+from agentuniverse.workflow.graph.graph import Graph
+from agentuniverse.workflow.node.enum import NodeEnum, NodeStatusEnum
+from agentuniverse.workflow.node.node import Node
+from agentuniverse.workflow.node.node_output import NodeOutput
+from agentuniverse.workflow.workflow import Workflow
+from agentuniverse.workflow.workflow_output import WorkflowOutput
+
+
+class _RecordingNode(Node):
+    calls: ClassVar[dict[str, int]] = {}
+
+    def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
+        self.calls[self.id] = self.calls.get(self.id, 0) + 1
+        return NodeOutput(
+            node_id=self.id,
+            status=NodeStatusEnum.SUCCEEDED,
+            result={"call": self.calls[self.id]},
+        )
+
+
+class _Interruption(RuntimeError):
+    pass
+
+
+def _workflow() -> Workflow:
+    graph = Graph()
+    for node_id, node_type in (
+        ("start", NodeEnum.START),
+        ("work", NodeEnum.TOOL),
+        ("end", NodeEnum.END),
+    ):
+        graph.add_node(
+            node_id,
+            instance=_RecordingNode(id=node_id, type=node_type, data={}),
+            type=node_type.value,
+        )
+    graph.add_edge("start", "work", source_handler=None)
+    graph.add_edge("work", "end", source_handler=None)
+    return Workflow(id="durable-workflow", graph=graph)
+
+
+def test_checkpoint_callback_can_persist_partial_progress_and_resume():
+    _RecordingNode.calls = {}
+    workflow = _workflow()
+    checkpoints = []
+
+    def persist_then_interrupt(snapshot: WorkflowOutput):
+        checkpoints.append(snapshot.to_checkpoint_json())
+        if "work" in snapshot.workflow_node_results:
+            raise _Interruption
+
+    with pytest.raises(_Interruption):
+        workflow.run(
+            {"input": "question"},
+            checkpoint_callback=persist_then_interrupt,
+        )
+
+    assert _RecordingNode.calls == {"start": 1, "work": 1}
+
+    result = workflow.resume(checkpoints[-1])
+
+    assert _RecordingNode.calls == {"start": 1, "work": 1, "end": 1}
+    assert set(result.workflow_node_results) == {"start", "work", "end"}
+    assert result.workflow_start_params == {"input": "question"}
+
+
+def test_checkpoint_json_round_trip_preserves_node_status():
+    output = WorkflowOutput(
+        workflow_id="durable-workflow",
+        workflow_node_results={
+            "node": NodeOutput(node_id="node", status=NodeStatusEnum.SUCCEEDED),
+        },
+    )
+
+    restored = WorkflowOutput.from_checkpoint_json(output.to_checkpoint_json())
+
+    assert restored.workflow_node_results["node"].status is NodeStatusEnum.SUCCEEDED
+
+
+def test_resume_does_not_mutate_the_supplied_checkpoint_object():
+    _RecordingNode.calls = {}
+    workflow = _workflow()
+    checkpoint = WorkflowOutput(
+        workflow_id="durable-workflow",
+        workflow_node_results={
+            "start": NodeOutput(node_id="start", status=NodeStatusEnum.SUCCEEDED),
+        },
+    )
+
+    result = workflow.resume(checkpoint)
+
+    assert set(checkpoint.workflow_node_results) == {"start"}
+    assert set(result.workflow_node_results) == {"start", "work", "end"}
+
+
+def test_resume_rejects_a_checkpoint_for_another_workflow():
+    workflow = _workflow()
+
+    with pytest.raises(ValueError, match="does not match"):
+        workflow.resume(WorkflowOutput(workflow_id="another-workflow"))
+
+
+def test_resume_rejects_changed_start_parameters():
+    workflow = _workflow()
+    checkpoint = WorkflowOutput(
+        workflow_id="durable-workflow",
+        workflow_start_params={"input": "original"},
+    )
+
+    with pytest.raises(ValueError, match="Input parameters"):
+        workflow.run({"input": "changed"}, resume_from=checkpoint)


### PR DESCRIPTION
## Summary
- persist a deep-copied `WorkflowOutput` after each successful node
- serialize checkpoints to JSON and restore from objects, mappings, strings, or bytes
- resume without re-running completed nodes
- validate workflow identity and unchanged start parameters
- add English/Chinese docs

Closes #886

## Validation
- workflow checkpoint tests: 5 passed
- targeted Ruff and py_compile: passed

## Checklist
- [x] Existing `run(input_params)` remains compatible
- [x] Tests and bilingual docs included
- [x] No new dependency
