### PR TITLE
feat(workflow): add per-node retry policies

### DIFF
--- a/agentuniverse/workflow/node/node.py
+++ b/agentuniverse/workflow/node/node.py
@@ -5,14 +5,16 @@
 # @Author  : wangchongshi
 # @Email   : wangchongshi.wcs@antgroup.com
 # @FileName: node.py
+import time
 from abc import abstractmethod
 from typing import Optional, Dict, List, Any
 
 from pydantic import BaseModel
 
-from agentuniverse.workflow.node.enum import NodeEnum, NodeStatusEnum
-from agentuniverse.workflow.node.node_output import NodeOutput
+from agentuniverse.workflow.node.enum import NodeEnum
 from agentuniverse.workflow.node.node_config import NodeOutputParams, NodeInputParams
+from agentuniverse.workflow.node.node_output import NodeOutput
+from agentuniverse.workflow.node.retry_policy import RetryPolicy
 from agentuniverse.workflow.workflow_output import WorkflowOutput
 
 
@@ -29,6 +31,7 @@ class Node(BaseModel):
     type: NodeEnum = None
     workflow_id: Optional[str] = None
     position: Optional[dict] = None
+    retry_policy: RetryPolicy | None = None
     _data: Optional[NodeData] = None
     _data_cls = NodeData
 
@@ -41,7 +44,25 @@ class Node(BaseModel):
         raise NotImplementedError
 
     def run(self, workflow_output: WorkflowOutput) -> NodeOutput:
-        return self._run(workflow_output)
+        policy = self.retry_policy or RetryPolicy()
+        attempt = 1
+        while True:
+            try:
+                node_output = self._run(workflow_output)
+            except Exception:
+                if attempt >= policy.max_attempts:
+                    raise
+                attempt += 1
+                delay = policy.delay_before_attempt(attempt)
+                if delay:
+                    time.sleep(delay)
+            else:
+                if attempt > 1:
+                    node_output.metadata = {
+                        **(node_output.metadata or {}),
+                        'attempt_count': attempt,
+                    }
+                return node_output
 
     @staticmethod
     def _resolve_input_params(input_params: List[NodeInputParams],

--- a/agentuniverse/workflow/node/retry_policy.py
+++ b/agentuniverse/workflow/node/retry_policy.py
@@ -1,0 +1,38 @@
+"""Retry policy for workflow node execution."""
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class RetryPolicyConfigurationError(ValueError):
+    """Raised when retry delay bounds are inconsistent."""
+
+    def __init__(self):
+        super().__init__('initial_delay cannot be greater than max_delay')
+
+
+class RetryPolicy(BaseModel):
+    """Deterministic retry settings for an individual workflow node.
+
+    ``max_attempts`` includes the first execution. A value of one therefore
+    preserves the existing fail-fast behavior.
+    """
+
+    max_attempts: int = Field(default=1, ge=1)
+    initial_delay: float = Field(default=0, ge=0)
+    backoff_multiplier: float = Field(default=2, ge=1)
+    max_delay: float | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def validate_delay_bounds(self) -> 'RetryPolicy':
+        if self.max_delay is not None and self.initial_delay > self.max_delay:
+            raise RetryPolicyConfigurationError
+        return self
+
+    def delay_before_attempt(self, attempt: int) -> float:
+        """Return the delay before a retry attempt numbered from two."""
+        if attempt < 2:
+            return 0
+        delay = self.initial_delay * self.backoff_multiplier ** (attempt - 2)
+        if self.max_delay is not None:
+            delay = min(delay, self.max_delay)
+        return delay

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Workflow/Node_Retry_Policy.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Workflow/Node_Retry_Policy.md
@@ -1,0 +1,28 @@
+# Workflow Node Retry Policy
+
+Individual workflow nodes can opt into deterministic retries for transient
+failures. Existing nodes remain fail-fast because the default is one attempt.
+
+Add `retry_policy` to a node in the workflow graph configuration:
+
+```yaml
+graph:
+  nodes:
+    - id: fetch-data
+      type: tool
+      retry_policy:
+        max_attempts: 4
+        initial_delay: 0.5
+        backoff_multiplier: 2
+        max_delay: 5
+      data:
+        # existing node configuration
+```
+
+`max_attempts` includes the initial call. Delays use exponential backoff and
+are capped by `max_delay` when it is set. The original exception is re-raised
+after the final attempt. A node that succeeds after retrying adds
+`attempt_count` to its output metadata for observability.
+
+Retries are opt-in because tool and agent nodes may perform side effects. Only
+enable them when the operation is idempotent or otherwise safe to repeat.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/工作流/节点重试策略.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/工作流/节点重试策略.md
@@ -1,0 +1,23 @@
+# 工作流节点重试策略
+
+工作流中的单个节点可以针对瞬时故障启用确定性的重试策略。默认最大尝试次数为 1，因此既有节点仍保持快速失败行为。
+
+在工作流图的节点配置中添加 `retry_policy`：
+
+```yaml
+graph:
+  nodes:
+    - id: fetch-data
+      type: tool
+      retry_policy:
+        max_attempts: 4
+        initial_delay: 0.5
+        backoff_multiplier: 2
+        max_delay: 5
+      data:
+        # 原有节点配置
+```
+
+`max_attempts` 包含首次调用。等待时间按指数增长，并在配置 `max_delay` 时受到上限约束。超过最终尝试次数后会重新抛出原始异常；重试后成功的节点会在输出元数据中写入 `attempt_count`，便于观测实际尝试次数。
+
+工具或智能体节点可能产生外部副作用，因此重试是显式启用的。只应为幂等或能够安全重复的操作配置该策略。

--- a/tests/test_agentuniverse/unit/workflow/test_node_retry_policy.py
+++ b/tests/test_agentuniverse/unit/workflow/test_node_retry_policy.py
@@ -1,0 +1,113 @@
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from agentuniverse.workflow.node.enum import NodeEnum, NodeStatusEnum
+from agentuniverse.workflow.node.node import Node
+from agentuniverse.workflow.node.node_output import NodeOutput
+from agentuniverse.workflow.node.retry_policy import RetryPolicy
+from agentuniverse.workflow.workflow_output import WorkflowOutput
+
+
+class _TransientFailure(RuntimeError):
+    pass
+
+
+class _FlakyNode(Node):
+    failures_before_success: int = 0
+    calls: int = 0
+
+    def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
+        self.calls += 1
+        if self.calls <= self.failures_before_success:
+            raise _TransientFailure
+        return NodeOutput(
+            node_id=self.id,
+            status=NodeStatusEnum.SUCCEEDED,
+            metadata={"source": "test"},
+        )
+
+
+def test_node_retries_transient_failure_and_reports_attempt_count():
+    node = _FlakyNode(
+        id="flaky",
+        type=NodeEnum.TOOL,
+        data={},
+        failures_before_success=2,
+        retry_policy={"max_attempts": 3},
+    )
+
+    result = node.run(WorkflowOutput(workflow_id="workflow"))
+
+    assert node.calls == 3
+    assert result.metadata == {"source": "test", "attempt_count": 3}
+
+
+def test_node_preserves_fail_fast_behavior_by_default():
+    node = _FlakyNode(
+        id="flaky",
+        type=NodeEnum.TOOL,
+        data={},
+        failures_before_success=1,
+    )
+
+    with pytest.raises(_TransientFailure):
+        node.run(WorkflowOutput(workflow_id="workflow"))
+
+    assert node.calls == 1
+
+
+def test_node_reraises_original_exception_after_attempt_limit():
+    node = _FlakyNode(
+        id="flaky",
+        type=NodeEnum.TOOL,
+        data={},
+        failures_before_success=5,
+        retry_policy={"max_attempts": 2},
+    )
+
+    with pytest.raises(_TransientFailure):
+        node.run(WorkflowOutput(workflow_id="workflow"))
+
+    assert node.calls == 2
+
+
+def test_retry_policy_applies_capped_exponential_backoff():
+    node = _FlakyNode(
+        id="flaky",
+        type=NodeEnum.TOOL,
+        data={},
+        failures_before_success=3,
+        retry_policy={
+            "max_attempts": 4,
+            "initial_delay": 0.5,
+            "backoff_multiplier": 3,
+            "max_delay": 2,
+        },
+    )
+
+    with patch("agentuniverse.workflow.node.node.time.sleep") as sleep:
+        node.run(WorkflowOutput(workflow_id="workflow"))
+
+    assert [call.args[0] for call in sleep.call_args_list] == [0.5, 1.5, 2]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"max_attempts": 0},
+        {"initial_delay": -1},
+        {"backoff_multiplier": 0.5},
+        {"initial_delay": 2, "max_delay": 1},
+    ],
+)
+def test_retry_policy_rejects_invalid_configuration(values):
+    with pytest.raises(ValidationError):
+        RetryPolicy(**values)
+
+
+def test_retry_policy_delay_is_zero_before_retry():
+    policy = RetryPolicy(initial_delay=1)
+
+    assert policy.delay_before_attempt(1) == 0


### PR DESCRIPTION
## Summary
- add opt-in `RetryPolicy` configuration to every workflow node
- support bounded attempts and capped exponential backoff
- preserve fail-fast defaults and re-raise the original final exception
- record `attempt_count` after a successful retry
- add idempotency guidance and English/Chinese docs

This is orchestration-level behavior for workflow nodes and does not duplicate the generic Tool wrapper in #693.

Closes #887

## Validation
- node retry policy tests: 9 passed
- targeted Ruff and py_compile: passed

## Checklist
- [x] Default behavior unchanged
- [x] Tests and bilingual docs included
- [x] No new dependency
