### PR TITLE
fix(context): initialize adaptive compressor config

### DIFF
--- a/agentuniverse/agent/context/compressor/adaptive_compressor.py
+++ b/agentuniverse/agent/context/compressor/adaptive_compressor.py
@@ -63,12 +63,14 @@ class AdaptiveCompressor(ContextCompressor):
         summarize_weight: Weight for summarize strategy (quality)
     """
 
+    name: Optional[str] = None
     time_critical_threshold_ms: float = 500.0
     quality_threshold: float = 0.9  # Target: >=90% preservation
     enable_hybrid: bool = True
     truncate_weight: float = 1.0
     selective_weight: float = 1.0
     summarize_weight: float = 1.0
+    llm_name: str = "default_llm"
 
     def __init__(self, **kwargs):
         """Initialize adaptive compressor."""
@@ -99,7 +101,7 @@ class AdaptiveCompressor(ContextCompressor):
         self._summarize_compressor = SummarizeCompressor(
             name=f"{self.name}_summarize",
             compression_ratio=self.compression_ratio,
-            llm_name=kwargs.get("llm_name", "default_llm")
+            llm_name=self.llm_name
         )
 
         return self

--- a/tests/test_agentuniverse/unit/agent/context/compressor/test_adaptive_compressor.py
+++ b/tests/test_agentuniverse/unit/agent/context/compressor/test_adaptive_compressor.py
@@ -8,6 +8,7 @@
 
 import pytest
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 from agentuniverse.agent.context.compressor.adaptive_compressor import AdaptiveCompressor
 from agentuniverse.agent.context.compressor.truncate_compressor import TruncateCompressor
@@ -39,6 +40,20 @@ class TestAdaptiveCompressor:
         adaptive.selective_weight = 1.0
         adaptive.summarize_weight = 0.0  # Disable summarize (requires LLM)
         return adaptive
+
+    def test_initialize_propagates_configured_llm_name(self):
+        """Initialization should not depend on an out-of-scope kwargs mapping."""
+        compressor = AdaptiveCompressor(
+            name="test_adaptive",
+            compression_ratio=0.6,
+            llm_name="summary_llm",
+        )
+
+        compressor.initialize_by_component_configer(
+            SimpleNamespace(default_symbol=False)
+        )
+
+        assert compressor._summarize_compressor.llm_name == "summary_llm"
 
     @pytest.fixture
     def sample_segments(self):


### PR DESCRIPTION
## Summary
- retain the adaptive compressor name required when constructing child compressors
- propagate the configured summarization LLM instead of reading an undefined `kwargs` variable
- add a regression test covering component initialization

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/compressor/test_adaptive_compressor.py` (17 passed)
- `ruff check --no-fix --select F821 ...`
- `git diff --check`