### PR TITLE
fix(context): scope Chroma counts to sessions

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -461,9 +461,9 @@ class ChromaContextStore(ContextStore):
         try:
             results = self._collection.get(
                 where={"session_id": session_id},
-                limit=1  # We only need count, not data
+                include=[]
             )
-            return self._collection.count()
+            return len(results.get("ids", []))
         except Exception:
             return 0
 

--- a/tests/test_agentuniverse/unit/agent/context/test_chroma_context_store.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_chroma_context_store.py
@@ -1,0 +1,26 @@
+"""Tests for the Chroma-backed context store."""
+
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+class _FakeCollection:
+    def __init__(self):
+        self._sessions = {
+            "session-1": ["segment-1", "segment-2"],
+            "session-2": ["segment-3"],
+        }
+
+    def get(self, *, where, include=None):
+        return {"ids": self._sessions.get(where["session_id"], [])}
+
+    def count(self):
+        return sum(len(ids) for ids in self._sessions.values())
+
+
+def test_count_is_scoped_to_requested_session():
+    store = ChromaContextStore()
+    store._collection = _FakeCollection()
+
+    assert store.count("session-1") == 2
+    assert store.count("session-2") == 1
+    assert store.count("missing") == 0


### PR DESCRIPTION
## Summary
- count only Chroma documents matching the requested session
- avoid returning the collection-wide total for every session
- request IDs only and add multi-session regression coverage

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_chroma_context_store.py` (1 passed)
- `git diff --check`