### PR TITLE
fix(context): honor zero reserved token budgets

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -179,8 +179,16 @@ class ContextManager(ComponentBase):
         # Get task-specific configuration
         task_config = self.task_configs.get(task_type or "dialogue", {})
 
-        max_tokens = kwargs.get("max_tokens") or task_config.get("max_tokens", self.default_max_tokens)
-        reserved_tokens = kwargs.get("reserved_tokens") or task_config.get("reserved_tokens", self.default_reserved_tokens)
+        max_tokens = (
+            kwargs["max_tokens"]
+            if kwargs.get("max_tokens") is not None
+            else task_config.get("max_tokens", self.default_max_tokens)
+        )
+        reserved_tokens = (
+            kwargs["reserved_tokens"]
+            if kwargs.get("reserved_tokens") is not None
+            else task_config.get("reserved_tokens", self.default_reserved_tokens)
+        )
 
         # Calculate component budgets based on task ratios
         input_budget = max_tokens - reserved_tokens

--- a/tests/test_agentuniverse/unit/agent/context/test_context_manager.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_manager.py
@@ -63,6 +63,16 @@ class TestContextManager:
         assert window.reserved_tokens == 1000
         assert window.total_tokens == 0
 
+    def test_create_context_window_allows_zero_reserved_tokens(self, manager):
+        """An explicit zero reserve should override task and manager defaults."""
+        window = manager.create_context_window(
+            session_id="session_1",
+            reserved_tokens=0,
+        )
+
+        assert window.reserved_tokens == 0
+        assert window.calculate_input_tokens() == window.max_tokens
+
     def test_create_context_window_code_generation(self, manager):
         """Test creating context window for code generation task."""
         window = manager.create_context_window(


### PR DESCRIPTION
## Summary
- distinguish explicit zero token settings from missing values
- allow callers to allocate the full context window by setting `reserved_tokens=0`
- retain task/default fallbacks only when an override is absent

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_context_manager.py -k zero_reserved_tokens` (1 passed)
- `git diff --check`