### PR TITLE
fix(context): avoid double-counting store access

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -297,10 +297,7 @@ class ContextManager(ComponentBase):
             **kwargs
         )
 
-        # Mark as accessed for LRU tracking
-        for segment in segments:
-            segment.mark_accessed()
-
+        # Storage backends own access tracking and persistence.
         return segments
 
     def search_context(
@@ -331,10 +328,7 @@ class ContextManager(ComponentBase):
             **kwargs
         )
 
-        # Mark as accessed
-        for segment in results:
-            segment.mark_accessed()
-
+        # Storage backends own access tracking and persistence.
         return results
 
     def get_context_window(self, session_id: str) -> Optional[ContextWindow]:

--- a/tests/test_agentuniverse/unit/agent/context/test_context_manager.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_manager.py
@@ -119,6 +119,20 @@ class TestContextManager:
         assert window is not None
         assert window.session_id == "session_2"
 
+    def test_get_context_records_one_access(self, manager):
+        """One manager read should be recorded once by the backing store."""
+        segment = manager.add_context(
+            "session_1",
+            "System prompt",
+            ContextType.SYSTEM,
+            ContextPriority.CRITICAL,
+        )
+
+        result = manager.get_context("session_1")
+
+        assert result == [segment]
+        assert segment.metadata.access_count == 1
+
     def test_get_context_all(self, manager):
         """Test retrieving all context for a session."""
         manager.create_context_window("session_1")


### PR DESCRIPTION
## Summary
- leave access tracking to context store backends
- prevent manager reads and searches from incrementing RAM segment access metadata twice
- add regression coverage for a single manager read

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_context_manager.py -k records_one_access` (1 passed)
- `git diff --check`