### PR TITLE
fix(context): track stored knowledge segment ids

### DIFF
--- a/agentuniverse/agent/context/sync/knowledge_context_synchronizer.py
+++ b/agentuniverse/agent/context/sync/knowledge_context_synchronizer.py
@@ -184,7 +184,7 @@ class KnowledgeContextSynchronizer:
                 )
             )
 
-            self.context_manager.add_context(
+            stored_segment = self.context_manager.add_context(
                 session_id,
                 segment.content,
                 segment.type,
@@ -192,7 +192,7 @@ class KnowledgeContextSynchronizer:
                 metadata=segment.metadata.model_dump()
             )
 
-            new_segment_ids.append(segment.id)
+            new_segment_ids.append(stored_segment.id)
             result.segments_added += 1
 
         # Update mapping

--- a/tests/test_agentuniverse/unit/agent/context/sync/test_knowledge_context_synchronizer.py
+++ b/tests/test_agentuniverse/unit/agent/context/sync/test_knowledge_context_synchronizer.py
@@ -1,0 +1,33 @@
+"""Tests for knowledge-to-context synchronization."""
+
+from types import SimpleNamespace
+
+from agentuniverse.agent.context.sync.knowledge_context_synchronizer import (
+    KnowledgeContextSynchronizer,
+)
+
+
+class _RecordingContextManager:
+    def __init__(self):
+        self.added = []
+
+    def add_context(self, *args, **kwargs):
+        segment = SimpleNamespace(id=f"stored-{len(self.added)}")
+        self.added.append(segment)
+        return segment
+
+
+def test_sync_tracks_ids_returned_by_context_manager():
+    manager = _RecordingContextManager()
+    synchronizer = KnowledgeContextSynchronizer(manager)
+
+    result = synchronizer.sync_knowledge_to_context(
+        knowledge_id="guide",
+        documents=["first", "second"],
+        session_id="session-1",
+    )
+
+    assert result.segments_added == 2
+    assert synchronizer._knowledge_context_map["guide"] == [
+        segment.id for segment in manager.added
+    ]


### PR DESCRIPTION
## Summary
- track the segment IDs actually returned by `ContextManager.add_context`
- keep knowledge-to-context mappings aligned with persisted segments
- add regression coverage using a context manager that assigns storage IDs

## Root cause
The synchronizer created a temporary `ContextSegment`, then asked the context manager to create and store a different segment, but recorded the temporary ID. Later invalidation and update lookups could not find the stored context.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/sync/test_knowledge_context_synchronizer.py` (1 passed)
- `git diff --check`
