### PR TITLE
fix(context): filter Redis search by query matches

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -218,7 +218,10 @@ class RedisContextStore(ContextStore):
                 if term in content_lower:
                     score += 2.0
 
-            # Priority bonus
+            if score <= 0:
+                continue
+
+            # Priority only ranks segments that matched the query.
             priority_bonus = {
                 ContextPriority.CRITICAL: 10.0,
                 ContextPriority.HIGH: 5.0,
@@ -230,9 +233,7 @@ class RedisContextStore(ContextStore):
 
             # Decay factor
             score *= segment.calculate_decay()
-
-            if score > 0:
-                scored.append((segment, score))
+            scored.append((segment, score))
 
         # Sort by score and return top_k
         scored.sort(key=lambda x: x[1], reverse=True)

--- a/tests/test_agentuniverse/unit/agent/context/test_redis_context_store.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_redis_context_store.py
@@ -1,0 +1,42 @@
+"""Tests for the Redis-backed context store."""
+
+from agentuniverse.agent.context.context_model import (
+    ContextPriority,
+    ContextSegment,
+    ContextType,
+)
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+class _FakeRedis:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def hgetall(self, key):
+        return self._entries
+
+
+def test_search_excludes_segments_without_query_matches():
+    store = RedisContextStore()
+    matching = ContextSegment(
+        type=ContextType.CONVERSATION,
+        priority=ContextPriority.LOW,
+        content="contains the needle",
+        tokens=3,
+        session_id="session-1",
+    )
+    unrelated = ContextSegment(
+        type=ContextType.SYSTEM,
+        priority=ContextPriority.CRITICAL,
+        content="completely unrelated",
+        tokens=2,
+        session_id="session-1",
+    )
+    store._redis = _FakeRedis({
+        matching.id.encode(): store._serialize_segment(matching),
+        unrelated.id.encode(): store._serialize_segment(unrelated),
+    })
+
+    results = store.search("needle", "session-1")
+
+    assert [segment.id for segment in results] == [matching.id]


### PR DESCRIPTION
## Summary
- exclude Redis context segments that do not match the search phrase or terms
- apply priority and decay only as ranking factors after a textual match
- add regression coverage where an unrelated critical segment previously leaked into results

## Root cause
The priority bonus was added before checking whether a segment matched the query. Since every priority has a positive bonus, every stored segment became a search result.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_redis_context_store.py` (1 passed)
- `git diff --check`
