### PR TITLE
fix(context): bound benchmark quality scores

### DIFF
--- a/agentuniverse/agent/context/benchmark/benchmark_suite.py
+++ b/agentuniverse/agent/context/benchmark/benchmark_suite.py
@@ -115,7 +115,10 @@ class BenchmarkMetrics:
             "resource": max(0, (1 - self.memory_usage_mb / 1000)) * 100,
         }
 
-        return sum(score * weights[category] for category, score in scores.items())
+        weighted_score = sum(
+            score * weights[category] for category, score in scores.items()
+        )
+        return max(0.0, min(100.0, weighted_score))
 
 
 @dataclass

--- a/tests/test_agentuniverse/unit/agent/context/benchmark/test_benchmark_suite.py
+++ b/tests/test_agentuniverse/unit/agent/context/benchmark/test_benchmark_suite.py
@@ -1,0 +1,20 @@
+"""Tests for context benchmark metric aggregation."""
+
+from agentuniverse.agent.context.benchmark.benchmark_suite import BenchmarkMetrics
+
+
+def test_overall_score_is_clamped_to_documented_range():
+    poor_metrics = BenchmarkMetrics(
+        compression_ratio=2.0,
+        average_latency_ms=1000.0,
+        memory_usage_mb=5000.0,
+    )
+    inflated_metrics = BenchmarkMetrics(
+        multi_turn_coherence=2.0,
+        compression_ratio=0.7,
+        retrieval_precision=2.0,
+        retrieval_recall=2.0,
+    )
+
+    assert poor_metrics.get_score() == 0.0
+    assert inflated_metrics.get_score() == 100.0


### PR DESCRIPTION
## Summary
- clamp the aggregate context benchmark score to its documented 0–100 range
- preserve existing category weighting and scoring behavior within the valid range
- cover both severely poor and inflated metric inputs

## Root cause
Individual category formulas can become negative or exceed 100 for out-of-range or severely failing measurements, allowing the weighted overall quality score to violate its public 0–100 contract.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/benchmark/test_benchmark_suite.py` (1 passed)
- `git diff --check`
