### PR TITLE
fix(agent): report applied IS corrections accurately

### DIFF
--- a/agentuniverse/agent/work_pattern/is_work_pattern.py
+++ b/agentuniverse/agent/work_pattern/is_work_pattern.py
@@ -74,10 +74,11 @@ class ISWorkPattern(WorkPattern):
 
             # Check if correction is needed
             needs_correction = supervision_result.get('needs_correction', False)
+            correction_applied = False
 
             if needs_correction and execution_context['corrections_made'] < max_corrections:
                 # Execute correction
-                correction_result = self._invoke_correction(
+                self._invoke_correction(
                     input_object,
                     supervision_result,
                     checkpoint_result,
@@ -86,13 +87,14 @@ class ISWorkPattern(WorkPattern):
                     execution_context
                 )
                 execution_context['corrections_made'] += 1
+                correction_applied = True
 
             # Store checkpoint history
             execution_context['checkpoint_history'].append({
                 'checkpoint': checkpoint_idx,
                 'implementation': implementation_result,
                 'supervision': supervision_result,
-                'corrected': needs_correction
+                'corrected': correction_applied
             })
 
             is_results.append(checkpoint_result)
@@ -148,10 +150,11 @@ class ISWorkPattern(WorkPattern):
 
             # Check if correction is needed
             needs_correction = supervision_result.get('needs_correction', False)
+            correction_applied = False
 
             if needs_correction and execution_context['corrections_made'] < max_corrections:
                 # Execute correction
-                correction_result = await self._async_invoke_correction(
+                await self._async_invoke_correction(
                     input_object,
                     supervision_result,
                     checkpoint_result,
@@ -160,13 +163,14 @@ class ISWorkPattern(WorkPattern):
                     execution_context
                 )
                 execution_context['corrections_made'] += 1
+                correction_applied = True
 
             # Store checkpoint history
             execution_context['checkpoint_history'].append({
                 'checkpoint': checkpoint_idx,
                 'implementation': implementation_result,
                 'supervision': supervision_result,
-                'corrected': needs_correction
+                'corrected': correction_applied
             })
 
             is_results.append(checkpoint_result)

--- a/tests/test_agentuniverse/unit/agent/work_pattern/test_is_work_pattern.py
+++ b/tests/test_agentuniverse/unit/agent/work_pattern/test_is_work_pattern.py
@@ -1,0 +1,48 @@
+"""Tests for the implementation-supervision work pattern."""
+
+import asyncio
+
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.work_pattern.is_work_pattern import ISWorkPattern
+
+
+class _CorrectionLimitedPattern(ISWorkPattern):
+    def _invoke_implementation(self, *args, **kwargs):
+        return {"output": "initial"}
+
+    def _invoke_supervision(self, *args, **kwargs):
+        return {"needs_correction": True, "feedback": "revise"}
+
+    def _invoke_correction(self, *args, **kwargs):
+        raise AssertionError("correction limit should prevent this call")
+
+    async def _async_invoke_implementation(self, *args, **kwargs):
+        return {"output": "initial"}
+
+    async def _async_invoke_supervision(self, *args, **kwargs):
+        return {"needs_correction": True, "feedback": "revise"}
+
+    async def _async_invoke_correction(self, *args, **kwargs):
+        raise AssertionError("correction limit should prevent this call")
+
+
+def test_invoke_does_not_report_blocked_correction_as_applied():
+    result = _CorrectionLimitedPattern().invoke(
+        InputObject({"input": "goal"}),
+        {"input": "goal", "checkpoint_count": 1, "max_corrections": 0},
+    )
+
+    assert result["execution_context"]["checkpoint_history"][0]["corrected"] is False
+    assert result["execution_context"]["corrections_made"] == 0
+
+
+def test_async_invoke_does_not_report_blocked_correction_as_applied():
+    result = asyncio.run(
+        _CorrectionLimitedPattern().async_invoke(
+            InputObject({"input": "goal"}),
+            {"input": "goal", "checkpoint_count": 1, "max_corrections": 0},
+        )
+    )
+
+    assert result["execution_context"]["checkpoint_history"][0]["corrected"] is False
+    assert result["execution_context"]["corrections_made"] == 0


### PR DESCRIPTION
## Summary
- distinguish requested corrections from corrections actually executed
- report `corrected=false` when the configured correction limit blocks execution
- keep synchronous and asynchronous IS work-pattern behavior aligned
- add regression coverage for both invocation paths

## Root cause
Checkpoint history copied `needs_correction` directly into `corrected`, so it reported a correction even when `max_corrections` prevented the correction agent from running.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/work_pattern/test_is_work_pattern.py` (2 passed)
- `git diff --check`
