### PR TITLE
fix(context): clamp decay under clock skew

### DIFF
--- a/agentuniverse/agent/context/context_model.py
+++ b/agentuniverse/agent/context/context_model.py
@@ -81,7 +81,10 @@ class ContextMetadata(BaseModel):
             return 0.0
 
         time_since_access = (datetime.now() - self.last_accessed).total_seconds() / 3600  # hours
-        decay_factor = max(0.0, 1.0 - (time_since_access * self.decay_rate / 24))  # 24 hours baseline
+        decay_factor = min(
+            1.0,
+            max(0.0, 1.0 - (time_since_access * self.decay_rate / 24)),
+        )  # 24 hours baseline
 
         return self.relevance_score * decay_factor
 

--- a/tests/test_agentuniverse/unit/agent/context/test_context_model.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_model.py
@@ -323,3 +323,14 @@ class TestContextWindow:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_decay_does_not_increase_relevance_for_future_access_time():
+    """Clock skew must not turn decay into a relevance boost."""
+    metadata = ContextMetadata(
+        last_accessed=datetime.now() + timedelta(days=10),
+        relevance_score=0.8,
+        decay_rate=0.5,
+    )
+
+    assert metadata.calculate_decay() == pytest.approx(0.8)


### PR DESCRIPTION
## Summary
- clamp context decay factors to the documented 0–1 range
- prevent future `last_accessed` timestamps caused by clock skew from increasing relevance
- add regression coverage for a future access timestamp

## Root cause
Negative elapsed time made the linear decay factor exceed 1.0, turning decay into a relevance boost.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_context_model.py` (24 passed)
- `git diff --check`
