### PR TITLE
fix(context): prioritize cold tier for history queries

### DIFF
--- a/agentuniverse/agent/context/router/context_router.py
+++ b/agentuniverse/agent/context/router/context_router.py
@@ -310,6 +310,6 @@ class ContextRouter(ComponentBase):
             # Prioritize cold tier if available
             if "cold" in tiers:
                 tiers.remove("cold")
-                tiers.append("cold")  # Search last (but include)
+                tiers.insert(0, "cold")
 
         return tiers

--- a/tests/test_agentuniverse/unit/agent/context/test_context_router.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_router.py
@@ -1,0 +1,14 @@
+"""Tests for context tier routing."""
+
+from agentuniverse.agent.context.router.context_router import ContextRouter
+
+
+def test_historical_queries_prioritize_cold_storage():
+    router = ContextRouter(enable_warm_tier=True, enable_cold_tier=True)
+
+    tiers = router.optimize_search_order(
+        "show previous archived results",
+        task_type="data_analysis",
+    )
+
+    assert tiers == ["cold", "hot", "warm"]


### PR DESCRIPTION
## Summary
- move cold storage to the front of the search order for historical queries
- retain configured tier availability filtering
- add regression coverage for data-analysis history searches

## Root cause
The historical-query branch removed cold storage and appended it back to the end, contradicting its own priority behavior and searching archival data last.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_context_router.py` (1 passed)
- `git diff --check`
