### PR TITLE
fix(agent): preserve supervision feedback casing

### DIFF
--- a/agentuniverse/agent/template/supervision_agent_template.py
+++ b/agentuniverse/agent/template/supervision_agent_template.py
@@ -169,13 +169,13 @@ class SupervisionAgentTemplate(AgentTemplate):
             'recommendations:'
         ]
 
+        import re
+
         for marker in feedback_markers:
-            if marker in output.lower():
-                parts = output.lower().split(marker, 1)
-                if len(parts) > 1:
-                    # Extract text after marker until next section or end
-                    feedback_text = parts[1].split('\n\n')[0].strip()
-                    return feedback_text
+            match = re.search(re.escape(marker), output, flags=re.IGNORECASE)
+            if match:
+                # Extract from the original output to preserve user-facing casing.
+                return output[match.end():].split('\n\n', 1)[0].strip()
 
         # If no explicit feedback section, return the full output
         return output

--- a/tests/test_agentuniverse/unit/agent/template/test_supervision_agent_template.py
+++ b/tests/test_agentuniverse/unit/agent/template/test_supervision_agent_template.py
@@ -1,0 +1,12 @@
+"""Tests for supervision result parsing."""
+
+from agentuniverse.agent.template.supervision_agent_template import (
+    SupervisionAgentTemplate,
+)
+
+
+def test_feedback_extraction_preserves_original_text_casing():
+    template = SupervisionAgentTemplate()
+    output = "Status: Review Complete\nFeedback: Keep APIClient and UserID names\n\nScore: 90"
+
+    assert template._extract_feedback(output) == "Keep APIClient and UserID names"


### PR DESCRIPTION
## Summary
- match supervision feedback markers case-insensitively
- slice feedback from the original output instead of a lowercased copy
- preserve identifiers and other case-sensitive user-facing text

## Root cause
Feedback extraction lowercased the entire agent response before returning the matched section.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/template/test_supervision_agent_template.py` (1 passed)
- `git diff --check`
