### PR TITLE
fix(context): preserve non-summarizable segments

### DIFF
--- a/agentuniverse/agent/context/compressor/summarize_compressor.py
+++ b/agentuniverse/agent/context/compressor/summarize_compressor.py
@@ -123,17 +123,22 @@ class SummarizeCompressor(ContextCompressor):
             if seg.priority != ContextPriority.CRITICAL and seg.id not in preserve_ids
         ]
 
-        critical_tokens = self.calculate_total_tokens(critical_segments)
+        # Types outside summarize_types are passthrough content, not disposable.
+        passthrough_segments = [
+            seg for seg in summarizable if seg.type not in self.summarize_types
+        ]
+        preserved_segments = critical_segments + passthrough_segments
+        preserved_tokens = self.calculate_total_tokens(preserved_segments)
 
-        if critical_tokens >= target_tokens:
-            # CRITICAL alone exceeds target, return as-is
+        if preserved_tokens >= target_tokens:
+            # Content not eligible for summarization is returned as-is.
             elapsed_ms = (time.time() - start_time) * 1000
             metrics = self.create_metrics(
-                original_segments, critical_segments, elapsed_ms, "summarize"
+                original_segments, preserved_segments, elapsed_ms, "summarize"
             )
-            return critical_segments, metrics
+            return preserved_segments, metrics
 
-        available_tokens = target_tokens - critical_tokens
+        available_tokens = target_tokens - preserved_tokens
 
         # Step 2: Group segments for summarization
         groups = self._group_for_summarization(summarizable)
@@ -167,7 +172,7 @@ class SummarizeCompressor(ContextCompressor):
                 tokens_used += summary_seg.tokens
 
         # Step 4: Combine results
-        result = critical_segments + summarized
+        result = preserved_segments + summarized
 
         elapsed_ms = (time.time() - start_time) * 1000
         metrics = self.create_metrics(

--- a/tests/test_agentuniverse/unit/agent/context/compressor/test_summarize_compressor.py
+++ b/tests/test_agentuniverse/unit/agent/context/compressor/test_summarize_compressor.py
@@ -1,0 +1,34 @@
+"""Tests for LLM-based context summarization."""
+
+from agentuniverse.agent.context.compressor.summarize_compressor import (
+    SummarizeCompressor,
+)
+from agentuniverse.agent.context.context_model import (
+    ContextPriority,
+    ContextSegment,
+    ContextType,
+)
+
+
+def test_compress_preserves_types_not_configured_for_summarization():
+    compressor = SummarizeCompressor()
+    compressor._llm = object()
+    tool_result = ContextSegment(
+        type=ContextType.TOOL_RESULT,
+        priority=ContextPriority.MEDIUM,
+        content="tool output",
+        tokens=10,
+    )
+    background = ContextSegment(
+        type=ContextType.BACKGROUND,
+        priority=ContextPriority.MEDIUM,
+        content="background " * 100,
+        tokens=100,
+    )
+
+    compressed, _ = compressor.compress(
+        [tool_result, background],
+        target_tokens=50,
+    )
+
+    assert any(segment.id == tool_result.id for segment in compressed)


### PR DESCRIPTION
## Summary
- preserve context types that are not configured for LLM summarization
- account for passthrough tokens before allocating the summary budget
- add regression coverage for tool-result context

## Root cause
The grouping step silently skipped unsupported types, and the final result only combined critical segments with summaries, causing valid context such as tool results to disappear.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/compressor/test_summarize_compressor.py` (1 passed)
- `git diff --check`
