### PR TITLE
fix(context): preserve Chroma segment metadata

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -168,6 +168,8 @@ class ChromaContextStore(ContextStore):
                 "access_count": segment.metadata.access_count,
                 "relevance_score": segment.metadata.relevance_score,
                 "decay_rate": segment.metadata.decay_rate,
+                "context_metadata": segment.metadata.model_dump_json(),
+                "related_ids": json.dumps(segment.related_ids),
             }
 
             # Add optional fields
@@ -534,14 +536,19 @@ class ChromaContextStore(ContextStore):
         priority = ContextPriority(metadata["priority"])
         tokens = metadata["tokens"]
 
-        # Reconstruct ContextMetadata
-        ctx_metadata = ContextMetadata(
-            created_at=datetime.fromisoformat(metadata["created_at"]),
-            last_accessed=datetime.fromisoformat(metadata["last_accessed"]),
-            access_count=metadata["access_count"],
-            relevance_score=metadata["relevance_score"],
-            decay_rate=metadata["decay_rate"],
-        )
+        # Reconstruct rich metadata when available while retaining compatibility
+        # with documents written before full metadata serialization was added.
+        serialized_metadata = metadata.get("context_metadata")
+        if serialized_metadata:
+            ctx_metadata = ContextMetadata.model_validate_json(serialized_metadata)
+        else:
+            ctx_metadata = ContextMetadata(
+                created_at=datetime.fromisoformat(metadata["created_at"]),
+                last_accessed=datetime.fromisoformat(metadata["last_accessed"]),
+                access_count=metadata["access_count"],
+                relevance_score=metadata["relevance_score"],
+                decay_rate=metadata["decay_rate"],
+            )
 
         # Create segment
         segment = ContextSegment(
@@ -553,6 +560,7 @@ class ChromaContextStore(ContextStore):
             metadata=ctx_metadata,
             session_id=metadata["session_id"],
             parent_id=metadata.get("parent_id"),
+            related_ids=json.loads(metadata.get("related_ids", "[]")),
             task_id=metadata.get("task_id"),
             agent_id=metadata.get("agent_id"),
         )

--- a/tests/test_agentuniverse/unit/agent/context/test_chroma_context_metadata.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_chroma_context_metadata.py
@@ -1,0 +1,45 @@
+"""Tests for Chroma context metadata serialization."""
+
+from agentuniverse.agent.context.context_model import (
+    ContextMetadata,
+    ContextPriority,
+    ContextSegment,
+    ContextType,
+)
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+class _CapturingCollection:
+    def add(self, **kwargs):
+        self.payload = kwargs
+
+
+def test_chroma_round_trip_preserves_rich_metadata_and_relationships():
+    store = ChromaContextStore()
+    store._collection = _CapturingCollection()
+    segment = ContextSegment(
+        type=ContextType.REFERENCE,
+        priority=ContextPriority.HIGH,
+        content="reference",
+        tokens=3,
+        session_id="session-1",
+        related_ids=["related-1", "related-2"],
+        metadata=ContextMetadata(
+            source_type="knowledge_base",
+            source_id="doc-7",
+            keywords=["api", "contract"],
+            entities={"service": "billing"},
+            compressed=True,
+            compression_ratio=0.5,
+            custom={"tenant": "alpha"},
+        ),
+    )
+
+    store.add([segment], session_id="session-1")
+    restored = store._metadata_to_segment(
+        store._collection.payload["documents"][0],
+        store._collection.payload["metadatas"][0],
+    )
+
+    assert restored.metadata == segment.metadata
+    assert restored.related_ids == segment.related_ids


### PR DESCRIPTION
## Summary
- serialize complete `ContextMetadata` into Chroma-compatible string metadata
- preserve related segment IDs across cold-storage round trips
- retain backward compatibility with legacy Chroma documents
- add rich metadata round-trip coverage

## Root cause
The Chroma adapter persisted only timestamps and ranking fields, dropping source provenance, keywords, entities, compression state, custom metadata, and relationships during reconstruction.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_chroma_context_metadata.py` (1 passed)
- `git diff --check`
