### PR TITLE
fix(context): reject impossible token reserves

### DIFF
--- a/agentuniverse/agent/context/context_model.py
+++ b/agentuniverse/agent/context/context_model.py
@@ -10,7 +10,7 @@
 from datetime import datetime
 from enum import Enum
 from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 import uuid
 import hashlib
 
@@ -186,6 +186,13 @@ class ContextWindow(BaseModel):
     # Metadata
     created_at: datetime = Field(default_factory=datetime.now)
     last_updated: datetime = Field(default_factory=datetime.now)
+
+    @model_validator(mode="after")
+    def validate_reserved_tokens(self) -> 'ContextWindow':
+        """Ensure the output reserve does not exceed the total window."""
+        if self.reserved_tokens > self.max_tokens:
+            raise ValueError("reserved_tokens cannot exceed max_tokens")
+        return self
 
     def calculate_available_tokens(self) -> int:
         """Calculate tokens available for new context.

--- a/tests/test_agentuniverse/unit/agent/context/test_context_model.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_model.py
@@ -323,3 +323,12 @@ class TestContextWindow:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_context_window_rejects_reserve_larger_than_capacity():
+    with pytest.raises(ValueError, match="reserved_tokens cannot exceed max_tokens"):
+        ContextWindow(
+            session_id="session-1",
+            max_tokens=100,
+            reserved_tokens=101,
+        )


### PR DESCRIPTION
## Summary
- validate that reserved output tokens do not exceed total context capacity
- fail configuration early instead of creating a permanently zero-capacity input window
- add model-level regression coverage

## Root cause
`ContextWindow` validated both fields independently but did not validate their relationship, so impossible budgets were accepted and silently reported no available input tokens.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_context_model.py` (24 passed)
- `git diff --check`
