### PR TITLE
fix(context): hash knowledge document boundaries

### DIFF
--- a/agentuniverse/agent/context/sync/knowledge_context_synchronizer.py
+++ b/agentuniverse/agent/context/sync/knowledge_context_synchronizer.py
@@ -14,6 +14,7 @@ system and Context system, enabling:
 4. Selective invalidation of outdated context
 """
 
+import json
 from datetime import datetime
 from typing import List, Optional, Dict, Any
 from enum import Enum
@@ -421,7 +422,9 @@ class KnowledgeContextSynchronizer:
             Hash string
         """
         import hashlib
-        content = "".join(documents)
+        content = json.dumps(
+            documents, ensure_ascii=False, separators=(",", ":")
+        )
         return hashlib.sha256(content.encode()).hexdigest()
 
     def get_knowledge_version(self, knowledge_id: str) -> Optional[KnowledgeVersion]:

--- a/tests/test_agentuniverse/unit/agent/context/sync/test_knowledge_hash.py
+++ b/tests/test_agentuniverse/unit/agent/context/sync/test_knowledge_hash.py
@@ -1,0 +1,13 @@
+"""Tests for knowledge change detection."""
+
+from agentuniverse.agent.context.sync.knowledge_context_synchronizer import (
+    KnowledgeContextSynchronizer,
+)
+
+
+def test_document_boundaries_affect_knowledge_hash():
+    synchronizer = KnowledgeContextSynchronizer(context_manager=None)
+
+    assert synchronizer._compute_hash(["ab", "c"]) != synchronizer._compute_hash(
+        ["a", "bc"]
+    )


### PR DESCRIPTION
## Summary
- encode the knowledge document list structurally before hashing
- make document boundaries participate in change detection
- add regression coverage for ambiguous concatenations

## Root cause
Hashing `"".join(documents)` made different document lists such as `["ab", "c"]` and `["a", "bc"]` indistinguishable, allowing real updates to be skipped.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/sync/test_knowledge_hash.py` (1 passed)
- `git diff --check`
