### PR TITLE
fix(context): filter expired RAM id lookups

### DIFF
--- a/agentuniverse/agent/context/store/ram_context_store.py
+++ b/agentuniverse/agent/context/store/ram_context_store.py
@@ -299,6 +299,8 @@ class RamContextStore(ContextStore):
         for segment_id in segment_ids:
             if segment_id in session_storage:
                 segment = session_storage[segment_id]
+                if self._is_expired(segment):
+                    continue
                 segment.mark_accessed()
                 session_storage.move_to_end(segment_id)  # LRU update
                 segments.append(segment)

--- a/tests/test_agentuniverse/unit/agent/context/test_ram_context_expiry.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_ram_context_expiry.py
@@ -1,0 +1,27 @@
+"""Expiration behavior for the in-memory context store."""
+
+from datetime import datetime, timedelta
+
+from agentuniverse.agent.context.context_model import (
+    ContextMetadata,
+    ContextSegment,
+    ContextType,
+)
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+def test_get_by_ids_does_not_return_expired_segments():
+    store = RamContextStore(ttl_hours=1)
+    expired = ContextSegment(
+        type=ContextType.CONVERSATION,
+        content="expired",
+        tokens=1,
+        metadata=ContextMetadata(
+            created_at=datetime.now() - timedelta(hours=2),
+            last_accessed=datetime.now() - timedelta(hours=2),
+        ),
+    )
+    store.add([expired], session_id="session-1")
+
+    assert store.get_by_ids("session-1", [expired.id]) == []
+    assert expired.metadata.access_count == 0


### PR DESCRIPTION
## Summary
- apply RAM-store TTL checks to direct ID retrieval
- avoid marking expired segments as accessed
- align `get_by_ids` behavior with normal reads and searches

## Root cause
The optimized ID lookup bypassed `_is_expired`, exposing data that the other retrieval paths correctly filtered out.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/context/test_ram_context_expiry.py` (1 passed)
- `git diff --check`
