### PR TITLE
fix(agent): normalize reviewing boolean strings

### DIFF
--- a/agentuniverse/agent/template/reviewing_agent_template.py
+++ b/agentuniverse/agent/template/reviewing_agent_template.py
@@ -37,9 +37,10 @@ class ReviewingAgentTemplate(AgentTemplate):
         output = parse_json_markdown(output)
 
         is_useful = output.get('is_useful')
-        if is_useful is None:
-            is_useful = False
-        is_useful = bool(is_useful)
+        if isinstance(is_useful, str):
+            is_useful = is_useful.strip().lower() in {"true", "1", "yes"}
+        else:
+            is_useful = bool(is_useful)
         if is_useful:
             score = 80
         else:

--- a/tests/test_agentuniverse/unit/agent/template/test_reviewing_agent_template.py
+++ b/tests/test_agentuniverse/unit/agent/template/test_reviewing_agent_template.py
@@ -1,0 +1,19 @@
+"""Tests for reviewing-agent result parsing."""
+
+import pytest
+
+from agentuniverse.agent.template.reviewing_agent_template import ReviewingAgentTemplate
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_score"),
+    [("false", 0), ("False", 0), ("true", 80), ("YES", 80)],
+)
+def test_parse_result_normalizes_string_booleans(value, expected_score):
+    template = ReviewingAgentTemplate()
+
+    result = template.parse_result(
+        {"output": f'{{"is_useful": "{value}", "suggestion": "review"}}'}
+    )
+
+    assert result["score"] == expected_score


### PR DESCRIPTION
## Summary
- normalize string forms of the reviewing agent's `is_useful` field
- treat `"false"` and `"False"` as false rather than truthy Python strings
- cover common true and false spellings

## Root cause
Calling `bool()` on any non-empty string turns the model output `"false"` into `True`, incorrectly assigning a passing score.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/template/test_reviewing_agent_template.py` (4 passed)
- `git diff --check`
