### PR TITLE
fix(agent): retain GRR fallback results

### DIFF
--- a/agentuniverse/agent/work_pattern/grr_work_pattern.py
+++ b/agentuniverse/agent/work_pattern/grr_work_pattern.py
@@ -139,7 +139,7 @@ class GRRWorkPattern(WorkPattern):
             generating_result = OutputObject({"output": agent_input.get('input')})
         else:
             generating_result = self.generating.run(**input_object.to_dict())
-            grr_round_results['generating_result'] = generating_result.to_dict()
+        grr_round_results['generating_result'] = generating_result.to_dict()
         input_object.add_data('generating_result', generating_result)
         # Also add as expressing_result for compatibility with ReviewingAgentTemplate
         input_object.add_data('expressing_result', generating_result)
@@ -152,7 +152,7 @@ class GRRWorkPattern(WorkPattern):
             generating_result = OutputObject({"output": agent_input.get('input')})
         else:
             generating_result = await self.generating.async_run(**input_object.to_dict())
-            grr_round_results['generating_result'] = generating_result.to_dict()
+        grr_round_results['generating_result'] = generating_result.to_dict()
         input_object.add_data('generating_result', generating_result)
         # Also add as expressing_result for compatibility with ReviewingAgentTemplate
         input_object.add_data('expressing_result', generating_result)
@@ -164,7 +164,7 @@ class GRRWorkPattern(WorkPattern):
             reviewing_result = OutputObject({"score": 100})
         else:
             reviewing_result = self.reviewing.run(**input_object.to_dict())
-            grr_round_results['reviewing_result'] = reviewing_result.to_dict()
+        grr_round_results['reviewing_result'] = reviewing_result.to_dict()
         input_object.add_data('reviewing_result', reviewing_result)
         return reviewing_result.to_dict()
 
@@ -174,7 +174,7 @@ class GRRWorkPattern(WorkPattern):
             reviewing_result = OutputObject({"score": 100})
         else:
             reviewing_result = await self.reviewing.async_run(**input_object.to_dict())
-            grr_round_results['reviewing_result'] = reviewing_result.to_dict()
+        grr_round_results['reviewing_result'] = reviewing_result.to_dict()
         input_object.add_data('reviewing_result', reviewing_result)
         return reviewing_result.to_dict()
 
@@ -184,7 +184,7 @@ class GRRWorkPattern(WorkPattern):
             rewriting_result = OutputObject({})
         else:
             rewriting_result = self.rewriting.run(**input_object.to_dict())
-            grr_round_results['rewriting_result'] = rewriting_result.to_dict()
+        grr_round_results['rewriting_result'] = rewriting_result.to_dict()
         input_object.add_data('rewriting_result', rewriting_result)
         return rewriting_result.to_dict()
 
@@ -194,7 +194,7 @@ class GRRWorkPattern(WorkPattern):
             rewriting_result = OutputObject({})
         else:
             rewriting_result = await self.rewriting.async_run(**input_object.to_dict())
-            grr_round_results['rewriting_result'] = rewriting_result.to_dict()
+        grr_round_results['rewriting_result'] = rewriting_result.to_dict()
         input_object.add_data('rewriting_result', rewriting_result)
         return rewriting_result.to_dict()
 

--- a/tests/test_agentuniverse/unit/agent/work_pattern/test_grr_work_pattern.py
+++ b/tests/test_agentuniverse/unit/agent/work_pattern/test_grr_work_pattern.py
@@ -1,0 +1,32 @@
+"""Tests for Generate-Review-Rewrite work-pattern fallbacks."""
+
+import asyncio
+
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.work_pattern.grr_work_pattern import GRRWorkPattern
+
+
+def _assert_fallback_round(result):
+    round_result = result["result"][0]
+    assert round_result["generating_result"] == {"output": "draft"}
+    assert round_result["reviewing_result"] == {"score": 100}
+
+
+def test_invoke_records_fallback_agent_results():
+    result = GRRWorkPattern().invoke(
+        InputObject({"input": "draft"}),
+        {"input": "draft", "retry_count": 1},
+    )
+
+    _assert_fallback_round(result)
+
+
+def test_async_invoke_records_fallback_agent_results():
+    result = asyncio.run(
+        GRRWorkPattern().async_invoke(
+            InputObject({"input": "draft"}),
+            {"input": "draft", "retry_count": 1},
+        )
+    )
+
+    _assert_fallback_round(result)


### PR DESCRIPTION
## Summary
- record Generate-Review-Rewrite results even when optional agent instances are absent
- keep synchronous and asynchronous fallback behavior aligned
- add regression coverage for both invocation paths

## Root cause
Fallback `OutputObject` values were added to the input context but only real-agent results were copied into each returned round, leaving successful fallback rounds empty.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/work_pattern/test_grr_work_pattern.py` (2 passed)
- `git diff --check`
