### PR TITLE
fix(agent): return stable peer fallback output

### DIFF
--- a/agentuniverse/agent/template/peer_agent_template.py
+++ b/agentuniverse/agent/template/peer_agent_template.py
@@ -82,8 +82,9 @@ class PeerAgentTemplate(AgentTemplate):
         peer_results: list[dict] = agent_result.get('result', [])
         for item in reversed(peer_results):
             expressing_result = item.get('expressing_result')
-            if expressing_result:
+            if expressing_result and expressing_result.get('output') is not None:
                 return {'output': expressing_result.get('output')}
+        return {'output': ''}
 
     def _generate_agents(self) -> dict:
         planning_agent = self._get_and_validate_agent(self.planning_agent_name, PlanningAgentTemplate)

--- a/tests/test_agentuniverse/unit/agent/template/test_peer_agent_template.py
+++ b/tests/test_agentuniverse/unit/agent/template/test_peer_agent_template.py
@@ -1,0 +1,12 @@
+"""Tests for peer-agent result parsing."""
+
+from agentuniverse.agent.template.peer_agent_template import PeerAgentTemplate
+
+
+def test_parse_result_returns_empty_output_when_no_expression_exists():
+    template = PeerAgentTemplate()
+
+    assert template.parse_result({"result": []}) == {"output": ""}
+    assert template.parse_result(
+        {"result": [{"expressing_result": {}}]}
+    ) == {"output": ""}


### PR DESCRIPTION
## Summary
- make peer-agent result parsing always return its documented output mapping
- use an empty string when no expressing result exists
- add coverage for empty and incomplete peer results

## Root cause
`parse_result` fell through with an implicit `None`, which breaks callers expecting a dictionary from every agent template parser.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_agentuniverse/unit/agent/template/test_peer_agent_template.py` (1 passed)
- `git diff --check`
