### PR TITLE
fix(context): honor zero max age when pruning

### DIFF
--- a/agentuniverse/agent/context/context_store.py
+++ b/agentuniverse/agent/context/context_store.py
@@ -258,7 +258,7 @@ class ContextStore(ComponentBase):
                 return True
 
         # Check age
-        if max_age_hours:
+        if max_age_hours is not None:
             age_hours = (datetime.now() - segment.metadata.created_at).total_seconds() / 3600
             if age_hours > max_age_hours:
                 return True

--- a/tests/test_agentuniverse/unit/agent/context/test_context_store_pruning.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_store_pruning.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from datetime import datetime, timedelta
+
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+def test_zero_max_age_prunes_existing_segments():
+    store = RamContextStore(name="test_store", ttl_hours=24)
+    segment = ContextSegment(
+        type=ContextType.BACKGROUND,
+        content="Existing context",
+        tokens=2,
+    )
+    segment.metadata.created_at = datetime.now() - timedelta(seconds=1)
+    store.add([segment], session_id="session")
+
+    assert store.prune(
+        "session", max_age_hours=0, min_decay_score=0
+    ) == 1
+    assert store.count("session") == 0


### PR DESCRIPTION
## What changed
- treat `max_age_hours=0` as an explicit pruning threshold instead of as an absent option
- add a regression test covering removal of an already-existing segment at the zero-hour boundary

## Why
`ContextStore._should_prune` used a truthiness check, so zero disabled the age check. Callers requesting an immediate age cutoff therefore retained non-critical context unexpectedly.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/context/test_context_store_pruning.py`
- `git diff --check`
