### PR TITLE
fix(context): honor zero max age in routing

### DIFF
--- a/agentuniverse/agent/context/router/context_router.py
+++ b/agentuniverse/agent/context/router/context_router.py
@@ -170,7 +170,7 @@ class ContextRouter(ComponentBase):
 
         # Check for recency hint
         max_age_hours = kwargs.get("max_age_hours")
-        if max_age_hours and max_age_hours <= 24:
+        if max_age_hours is not None and max_age_hours <= 24:
             # Recent context likely in hot/warm
             return [t for t in tiers if t in ["hot", "warm"]]
 

--- a/tests/test_agentuniverse/unit/agent/context/test_context_router_zero_age.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_context_router_zero_age.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from agentuniverse.agent.context.router.context_router import ContextRouter
+
+
+def test_zero_max_age_excludes_cold_storage():
+    router = ContextRouter(
+        name="test_router",
+        enable_warm_tier=True,
+        enable_cold_tier=True,
+    )
+
+    assert router.route_read(
+        task_type="data_analysis", max_age_hours=0
+    ) == ["hot", "warm"]


### PR DESCRIPTION
## What changed
- recognize zero as a valid `max_age_hours` recency hint
- add a regression test showing that cold storage is excluded for a zero-hour read window

## Why
The router previously checked `max_age_hours` by truthiness. A zero-hour window consequently searched cold storage even though all requested context must be recent.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/context/test_context_router_zero_age.py`
- `git diff --check`
