### PR TITLE
fix(context): reserve hybrid summary budget

### DIFF
--- a/agentuniverse/agent/context/compressor/adaptive_compressor.py
+++ b/agentuniverse/agent/context/compressor/adaptive_compressor.py
@@ -413,7 +413,10 @@ class AdaptiveCompressor(ContextCompressor):
 
         # Step 2: Summarize background/reference
         if summarizable and tokens_used < target_tokens:
-            sum_target = int(target_tokens * 0.4) - tokens_used  # 40% budget
+            sum_target = min(
+                int(target_tokens * 0.4),
+                target_tokens - tokens_used,
+            )  # Dedicated 40% budget, capped by remaining space
             if sum_target > 0:
                 sum_compressed, _ = self._summarize_compressor.compress(
                     summarizable, sum_target, **kwargs

--- a/tests/test_agentuniverse/unit/agent/context/compressor/test_adaptive_hybrid_budget.py
+++ b/tests/test_agentuniverse/unit/agent/context/compressor/test_adaptive_hybrid_budget.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from unittest.mock import Mock
+
+from agentuniverse.agent.context.compressor.adaptive_compressor import (
+    AdaptiveCompressor,
+)
+from agentuniverse.agent.context.context_model import (
+    ContextPriority,
+    ContextSegment,
+    ContextType,
+)
+
+
+def test_hybrid_gives_summarization_its_own_budget():
+    compressor = AdaptiveCompressor(name="adaptive")
+    high = ContextSegment(
+        type=ContextType.TASK,
+        priority=ContextPriority.HIGH,
+        content="important",
+        tokens=20,
+    )
+    background = ContextSegment(
+        type=ContextType.BACKGROUND,
+        priority=ContextPriority.MEDIUM,
+        content="background",
+        tokens=60,
+    )
+
+    compressor._selective_compressor = Mock()
+    compressor._selective_compressor.compress.return_value = ([high], None)
+    compressor._selective_compressor.estimate_information_loss.return_value = 0.0
+    compressor._summarize_compressor = Mock()
+    compressor._summarize_compressor.compress.return_value = ([background], None)
+    compressor._truncate_compressor = Mock()
+
+    compressor._hybrid_compress([high, background], 100, {})
+
+    assert compressor._summarize_compressor.compress.call_args.args[1] == 40


### PR DESCRIPTION
## What changed
- give the hybrid summarization phase its documented 40% token allocation
- cap that allocation by the actual remaining global budget
- add a regression test for the budget passed to the summarization compressor

## Why
The implementation subtracted tokens used by the preceding high-priority phase from the summarization phase's own 40% share. Whenever high-priority context consumed that share, summarization was skipped entirely and background/reference context was lost.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/context/compressor/test_adaptive_hybrid_budget.py`
- `git diff --check`
