### PR TITLE
fix(agent): provide rewriting input defaults

### DIFF
--- a/agentuniverse/agent/template/rewriting_agent_template.py
+++ b/agentuniverse/agent/template/rewriting_agent_template.py
@@ -51,8 +51,9 @@ class RewritingAgentTemplate(AgentTemplate):
 
         # Get the generated content
         generating_result = input_object.get_data('generating_result')
-        if generating_result:
-            agent_input['generated_content'] = generating_result.get_data('output', '')
+        agent_input['generated_content'] = (
+            generating_result.get_data('output', '') if generating_result else ''
+        )
 
         # Get review feedback and suggestions
         reviewing_result = input_object.get_data('reviewing_result')
@@ -60,9 +61,14 @@ class RewritingAgentTemplate(AgentTemplate):
             agent_input['review_score'] = reviewing_result.get_data('score', 0)
             agent_input['review_suggestion'] = reviewing_result.get_data('suggestion', '')
             agent_input['review_output'] = reviewing_result.get_data('output', '')
+        else:
+            agent_input['review_score'] = 0
+            agent_input['review_suggestion'] = ''
+            agent_input['review_output'] = ''
 
         # Get expert framework guidance if available
-        agent_input['expert_framework'] = input_object.get_data('expert_framework', {}).get('rewriting', '')
+        expert_framework = input_object.get_data('expert_framework') or {}
+        agent_input['expert_framework'] = expert_framework.get('rewriting', '')
 
         return agent_input
 

--- a/tests/test_agentuniverse/unit/agent/template/test_rewriting_input_defaults.py
+++ b/tests/test_agentuniverse/unit/agent/template/test_rewriting_input_defaults.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.template.rewriting_agent_template import (
+    RewritingAgentTemplate,
+)
+
+
+def test_parse_input_populates_prompt_fields_without_prior_results():
+    template = RewritingAgentTemplate()
+    result = template.parse_input(
+        InputObject({"input": "draft", "expert_framework": None}), {}
+    )
+
+    assert result == {
+        "input": "draft",
+        "generated_content": "",
+        "review_score": 0,
+        "review_suggestion": "",
+        "review_output": "",
+        "expert_framework": "",
+    }


### PR DESCRIPTION
## What changed
- populate every rewriting prompt field when generation or review results are absent
- safely accept an explicitly null expert framework
- add a regression test for the fallback input path

## Why
The rewriting template only created prompt variables when prior result objects were truthy. Optional/fallback workflows could therefore reach prompt formatting with missing keys, while `expert_framework: null` raised an attribute error.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/template/test_rewriting_input_defaults.py`
- `git diff --check`
