### PR TITLE
fix(agent): retain IS fallback results

### DIFF
--- a/agentuniverse/agent/work_pattern/is_work_pattern.py
+++ b/agentuniverse/agent/work_pattern/is_work_pattern.py
@@ -188,7 +188,7 @@ class ISWorkPattern(WorkPattern):
                 'execution_context': execution_context
             }
             implementation_result = self.implementation.run(**checkpoint_input)
-            checkpoint_result['implementation_result'] = implementation_result.to_dict()
+        checkpoint_result['implementation_result'] = implementation_result.to_dict()
         input_object.add_data('implementation_result', implementation_result)
         return implementation_result.to_dict()
 
@@ -207,7 +207,7 @@ class ISWorkPattern(WorkPattern):
                 'execution_context': execution_context
             }
             implementation_result = await self.implementation.async_run(**checkpoint_input)
-            checkpoint_result['implementation_result'] = implementation_result.to_dict()
+        checkpoint_result['implementation_result'] = implementation_result.to_dict()
         input_object.add_data('implementation_result', implementation_result)
         return implementation_result.to_dict()
 
@@ -223,7 +223,7 @@ class ISWorkPattern(WorkPattern):
                 'execution_context': execution_context
             }
             supervision_result = self.supervision.run(**supervision_input)
-            checkpoint_result['supervision_result'] = supervision_result.to_dict()
+        checkpoint_result['supervision_result'] = supervision_result.to_dict()
         input_object.add_data('supervision_result', supervision_result)
         return supervision_result.to_dict()
 
@@ -239,7 +239,7 @@ class ISWorkPattern(WorkPattern):
                 'execution_context': execution_context
             }
             supervision_result = await self.supervision.async_run(**supervision_input)
-            checkpoint_result['supervision_result'] = supervision_result.to_dict()
+        checkpoint_result['supervision_result'] = supervision_result.to_dict()
         input_object.add_data('supervision_result', supervision_result)
         return supervision_result.to_dict()
 
@@ -259,7 +259,7 @@ class ISWorkPattern(WorkPattern):
                 'execution_context': execution_context
             }
             correction_result = self.implementation.run(**correction_input)
-            checkpoint_result['correction_result'] = correction_result.to_dict()
+        checkpoint_result['correction_result'] = correction_result.to_dict()
         return correction_result.to_dict()
 
     async def _async_invoke_correction(self, input_object: InputObject, supervision_result: dict,
@@ -278,7 +278,7 @@ class ISWorkPattern(WorkPattern):
                 'execution_context': execution_context
             }
             correction_result = await self.implementation.async_run(**correction_input)
-            checkpoint_result['correction_result'] = correction_result.to_dict()
+        checkpoint_result['correction_result'] = correction_result.to_dict()
         return correction_result.to_dict()
 
     def _validate_work_pattern_members(self):

--- a/tests/test_agentuniverse/unit/agent/work_pattern/test_is_fallback_results.py
+++ b/tests/test_agentuniverse/unit/agent/work_pattern/test_is_fallback_results.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import asyncio
+
+from agentuniverse.agent.input_object import InputObject
+from agentuniverse.agent.work_pattern.is_work_pattern import ISWorkPattern
+
+
+def _assert_fallback_results(result):
+    checkpoint = result["result"][0]
+    assert checkpoint["implementation_result"] == {"output": "task"}
+    assert checkpoint["supervision_result"] == {
+        "needs_correction": False,
+        "feedback": "",
+    }
+
+
+def test_invoke_retains_fallback_results():
+    pattern = ISWorkPattern()
+    result = pattern.invoke(
+        InputObject({"input": "task"}),
+        {"input": "task", "checkpoint_count": 1},
+    )
+
+    _assert_fallback_results(result)
+
+
+def test_async_invoke_retains_fallback_results():
+    pattern = ISWorkPattern()
+    result = asyncio.run(pattern.async_invoke(
+        InputObject({"input": "task"}),
+        {"input": "task", "checkpoint_count": 1},
+    ))
+
+    _assert_fallback_results(result)


### PR DESCRIPTION
## What changed
- always record implementation, supervision, and correction results in each IS checkpoint
- cover both synchronous and asynchronous fallback execution paths

## Why
Checkpoint dictionaries were populated only inside branches that invoked configured agents. When an optional member was absent, the fallback `OutputObject` was returned and added to history but silently omitted from the public checkpoint result.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/work_pattern/test_is_fallback_results.py`
- `git diff --check`
