### PR TITLE
fix(store): handle nullable SQLite metadata

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/sqlite_store.py
+++ b/agentuniverse/agent/action/knowledge/store/sqlite_store.py
@@ -217,7 +217,8 @@ class SQLiteStore(Store):
 
             document = Document(id=doc_row[0], text=doc_row[1],
                                 word_count=doc_row[2],
-                                metadata=json.loads(doc_row[3]))
+                                metadata=json.loads(doc_row[3])
+                                if doc_row[3] else None)
             results.append(document)
 
         return results

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_sqlite_store_null_metadata.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_sqlite_store_null_metadata.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import sqlite3
+
+from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.sqlite_store import SQLiteStore
+
+
+def test_query_supports_documents_without_metadata():
+    store = SQLiteStore()
+    store.conn = sqlite3.connect(":memory:")
+    store._create_tables()
+    with store.conn:
+        store.conn.execute(
+            "INSERT INTO documents (id, text, word_count, metadata) "
+            "VALUES (?, ?, ?, ?)",
+            ("doc-1", "hello", 1, None),
+        )
+        store.conn.execute(
+            "INSERT INTO inverted_index (term, doc_id) VALUES (?, ?)",
+            ("hello", "doc-1"),
+        )
+
+    results = store.query(Query(query_str="hello", keywords={"hello"}))
+
+    assert len(results) == 1
+    assert results[0].id == "doc-1"
+    assert results[0].metadata is None


### PR DESCRIPTION
## What changed
- deserialize SQLite metadata only when the stored column contains a value
- add an in-memory regression test for querying a document with null metadata

## Why
Documents are deliberately stored with SQL `NULL` when their metadata is absent, but the query path unconditionally passed that value to `json.loads`, raising a `TypeError` for otherwise valid documents.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/action/knowledge/store/test_sqlite_store_null_metadata.py`
- `git diff --check`
