### PR TITLE
fix(store): preserve Qdrant document ids

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/qdrant_store.py
+++ b/agentuniverse/agent/action/knowledge/store/qdrant_store.py
@@ -95,6 +95,14 @@ class QdrantStore(Store):
                 vectors_config={self.VECTOR_NAME: VectorParams(size=dim, distance=metric)},
             )
 
+    @staticmethod
+    def _point_id(document_id: str) -> str:
+        """Return the Qdrant-compatible ID used for a document."""
+        try:
+            return str(uuid.UUID(str(document_id)))
+        except (ValueError, TypeError, AttributeError):
+            return str(uuid.uuid5(uuid.NAMESPACE_URL, str(document_id)))
+
     def query(self, query: Query, **kwargs) -> List[Document]:
         if self.client is None:
             return []
@@ -138,12 +146,12 @@ class QdrantStore(Store):
 
             self._ensure_collection(dim=len(vector))
 
-            payload = {"text": document.text, "metadata": document.metadata}
-            try:
-                point_id = str(uuid.UUID(str(document.id)))
-            except Exception:
-                # fallback to deterministic UUID5 if document id is not UUID
-                point_id = str(uuid.uuid5(uuid.NAMESPACE_URL, str(document.id)))
+            payload = {
+                "id": str(document.id),
+                "text": document.text,
+                "metadata": document.metadata,
+            }
+            point_id = self._point_id(document.id)
             points.append(
                 PointStruct(
                     id=point_id,
@@ -161,7 +169,10 @@ class QdrantStore(Store):
     def delete_document(self, document_id: str, **kwargs):
         if self.client is None:
             return
-        self.client.delete(collection_name=self.collection_name, points_selector=[document_id])
+        self.client.delete(
+            collection_name=self.collection_name,
+            points_selector=[self._point_id(document_id)],
+        )
 
     @staticmethod
     def to_documents(results) -> List[Document]:
@@ -179,7 +190,7 @@ class QdrantStore(Store):
                 vector = []
             documents.append(
                 Document(
-                    id=str(scored_point.id),
+                    id=str(payload.get("id") or scored_point.id),
                     text=text,
                     embedding=vector,
                     metadata=metadata,

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_document_ids.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_document_ids.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from unittest.mock import Mock
+
+from qdrant_client import QdrantClient
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.qdrant_store import QdrantStore
+
+
+def test_non_uuid_document_ids_round_trip_and_delete_consistently():
+    client = Mock(spec=QdrantClient)
+    client.collection_exists.return_value = True
+    store = QdrantStore(client=client)
+    document = Document(
+        id="source-document-id",
+        text="content",
+        embedding=[0.1, 0.2],
+    )
+
+    store.upsert_document([document])
+
+    point = client.upsert.call_args.kwargs["points"][0]
+    assert point.payload["id"] == "source-document-id"
+    restored = store.to_documents([
+        Mock(id=point.id, payload=point.payload, vector=point.vector)
+    ])
+    assert restored[0].id == "source-document-id"
+
+    store.delete_document("source-document-id")
+    assert client.delete.call_args.kwargs["points_selector"] == [point.id]


### PR DESCRIPTION
## What changed
- persist the original document ID in each Qdrant payload
- restore that ID when converting search results back to documents
- centralize deterministic Qdrant point-ID conversion and reuse it during deletion
- add a regression test for non-UUID ID round trips and deletion

## Why
Qdrant point IDs must be UUID-compatible, so non-UUID document IDs are transformed before upsert. The original ID was not retained, and deletion used the untransformed value, causing returned identities to change and deletes to miss their stored point.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/agent/action/knowledge/store/test_qdrant_document_ids.py`
- `git diff --check`
