### PR TITLE
fix(config): ignore non-mapping custom key lists

### DIFF
--- a/agentuniverse/base/config/custom_configer/custom_key_configer.py
+++ b/agentuniverse/base/config/custom_configer/custom_key_configer.py
@@ -24,6 +24,7 @@ class CustomKeyConfiger(Configer):
             except FileNotFoundError as e:
                 print(f"Custom key file {config_path} read error, "
                       f"skip load custom key.")
-        if self._Configer__value.get("KEY_LIST"):
-            for key, value in self._Configer__value.get("KEY_LIST").items():
+        key_list = self._Configer__value.get("KEY_LIST")
+        if isinstance(key_list, dict):
+            for key, value in key_list.items():
                 os.environ[key] = str(value)

--- a/tests/test_agentuniverse/unit/base/config/test_custom_key_configer_shape.py
+++ b/tests/test_agentuniverse/unit/base/config/test_custom_key_configer_shape.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from agentuniverse.base.config.custom_configer.custom_key_configer import CustomKeyConfiger
+
+
+def test_non_mapping_key_list_is_ignored(tmp_path: Path):
+    config_path = tmp_path / "custom_key.yaml"
+    config_path.write_text("KEY_LIST: []\n", encoding="utf-8")
+
+    # The singleton is initialized once in this test process; an empty list
+    # must not make initialization call .items() on a non-mapping value.
+    CustomKeyConfiger(str(config_path))


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Guard custom key configuration when a truthy non-mapping value is supplied, preventing .items() crashes.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/base/config/test_custom_key_configer_shape.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`