### PR TITLE
fix(config): tolerate malformed component metadata

### DIFF
--- a/agentuniverse/base/config/component_configer/component_configer.py
+++ b/agentuniverse/base/config/component_configer/component_configer.py
@@ -93,10 +93,11 @@ class ComponentConfiger(object):
         try:
             for k, v in configer.value.items():
                 self.__dict__[k] = v
-            if configer.value.get('metadata'):
-                self.__metadata_type = configer.value.get('metadata').get('type')
-                self.__metadata_module = configer.value.get('metadata').get('module')
-                self.__metadata_class = configer.value.get('metadata').get('class')
+            metadata = configer.value.get('metadata')
+            if isinstance(metadata, dict) and metadata:
+                self.__metadata_type = metadata.get('type')
+                self.__metadata_module = metadata.get('module')
+                self.__metadata_class = metadata.get('class')
             elif configer.path and 'prompt' in configer.path:
                 self.__metadata_type = ComponentEnum.PROMPT.value
             self.__meta_class = configer.value.get('meta_class')

--- a/tests/test_agentuniverse/unit/base/config/test_component_metadata_shape.py
+++ b/tests/test_agentuniverse/unit/base/config/test_component_metadata_shape.py
@@ -1,0 +1,12 @@
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+def test_non_mapping_metadata_does_not_abort_component_loading():
+    configer = Configer()
+    configer.value = {"name": "example", "metadata": []}
+
+    loaded = ComponentConfiger(configer).load()
+
+    assert loaded.metadata_type is None
+    assert loaded.configer is configer


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Ignore malformed component metadata instead of calling mapping methods on non-dict values.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/base/config/test_component_metadata_shape.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`