### PR TITLE
fix(config): avoid prompt path crash without metadata

### DIFF
--- a/agentuniverse/base/config/component_configer/configers/prompt_configer.py
+++ b/agentuniverse/base/config/component_configer/configers/prompt_configer.py
@@ -41,9 +41,10 @@ class PromptConfiger(ComponentConfiger):
         """
         super().load_by_configer(configer)
         try:
-            if configer.value.get('metadata'):
-                self.__metadata_version = configer.value.get('metadata').get('version')
-            else:
+            metadata = configer.value.get('metadata')
+            if isinstance(metadata, dict) and metadata:
+                self.__metadata_version = metadata.get('version')
+            elif configer.path:
                 path = Path(configer.path)
                 self.__metadata_version = f"{path.parent.name}.{path.stem}"
             # set the prompt default module and class

--- a/tests/test_agentuniverse/unit/base/config/test_prompt_config_path.py
+++ b/tests/test_agentuniverse/unit/base/config/test_prompt_config_path.py
@@ -1,0 +1,11 @@
+from agentuniverse.base.config.component_configer.configers.prompt_configer import PromptConfiger
+from agentuniverse.base.config.configer import Configer
+
+
+def test_prompt_config_without_metadata_or_path_keeps_version_unset():
+    configer = Configer()
+    configer.value = {"name": "example_prompt"}
+
+    loaded = PromptConfiger(configer).load()
+
+    assert loaded.metadata_version is None


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Handle missing or malformed prompt metadata and avoid constructing a Path from a null value.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/base/config/test_prompt_config_path.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`