### PR TITLE
fix(startup): tolerate null sub-config sections

### DIFF
--- a/agentuniverse/base/agentuniverse.py
+++ b/agentuniverse/base/agentuniverse.py
@@ -79,8 +79,11 @@ class AgentUniverse(object):
         configer = Configer(path=config_path).load()
 
         # try to load custom key first
+        sub_config_path = configer.value.get('SUB_CONFIG_PATH')
+        if not isinstance(sub_config_path, dict):
+            sub_config_path = {}
         custom_key_configer_path = self.__parse_sub_config_path(
-            configer.value.get('SUB_CONFIG_PATH', {}).get('custom_key_path'),
+            sub_config_path.get('custom_key_path'),
             config_path)
         CustomKeyConfiger(custom_key_configer_path)
 
@@ -89,9 +92,13 @@ class AgentUniverse(object):
         app_configer = AppConfiger().load_by_configer(configer)
         self.__config_container.app_configer = app_configer
 
+        sub_config_path = configer.value.get('SUB_CONFIG_PATH')
+        if not isinstance(sub_config_path, dict):
+            sub_config_path = {}
+
         # init loguru loggers
         log_config_path = self.__parse_sub_config_path(
-            configer.value.get('SUB_CONFIG_PATH', {}).get('log_config_path'),
+            sub_config_path.get('log_config_path'),
             config_path)
         init_loggers(log_config_path)
 

--- a/tests/test_agentuniverse/unit/base/test_agentuniverse_null_sub_config.py
+++ b/tests/test_agentuniverse/unit/base/test_agentuniverse_null_sub_config.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_startup_normalizes_nullable_sub_config_path_section():
+    source = Path("agentuniverse/base/agentuniverse.py").read_text(encoding="utf-8")
+
+    assert source.count("if not isinstance(sub_config_path, dict):") == 2
+    assert "sub_config_path.get('custom_key_path')" in source
+    assert "sub_config_path.get('log_config_path')" in source


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Treat a null SUB_CONFIG_PATH section as empty configuration during startup and reload.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/base/test_agentuniverse_null_sub_config.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`