### PR TITLE
fix(server): normalize malformed service config

### DIFF
--- a/agentuniverse/agent_serve/service_configer.py
+++ b/agentuniverse/agent_serve/service_configer.py
@@ -71,14 +71,17 @@ class ServiceConfiger(ComponentConfiger):
         Returns:
             ServiceConfiger: A ServiceConfiger instance.
         """
+        if not isinstance(configer.value, dict):
+            configer.value = {}
         super().load_by_configer(configer)
-        agent_code = configer.value.get('agent')
-        service_name = configer.value.get('name') or '<unnamed>'
+        config_value = configer.value
+        agent_code = config_value.get('agent')
+        service_name = config_value.get('name') or '<unnamed>'
         config_path = configer.path or '<unknown>'
         self.__set_default_meta_info()
         try:
-            self.__name = configer.value.get('name')
-            self.__description = configer.value.get('description')
+            self.__name = config_value.get('name')
+            self.__description = config_value.get('description')
             if not agent_code:
                 raise ValueError(
                     f"Service '{service_name}' in config '{config_path}' must define a non-empty 'agent'."

--- a/tests/test_agentuniverse/unit/agent_serve/test_service_config_payload.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_service_config_payload.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+SOURCE = Path(
+    "agentuniverse/agent_serve/service_configer.py"
+).read_text(encoding="utf-8")
+
+
+def test_service_configer_normalizes_non_mapping_values():
+    assert "if not isinstance(configer.value, dict):" in SOURCE
+    assert "configer.value = {}" in SOURCE
+    assert "config_value = configer.value" in SOURCE


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Normalize non-mapping service configuration payloads before component parsing.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/agent_serve/test_service_config_payload.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`