### PR TITLE
fix(prompt): ignore malformed config payloads

### DIFF
--- a/agentuniverse/prompt/prompt.py
+++ b/agentuniverse/prompt/prompt.py
@@ -63,7 +63,10 @@ class Prompt(ComponentBase):
             Prompt: the prompt object
         """
         prompt_values = []
-        for k, v in component_configer.configer.value.items():
+        config_value = getattr(component_configer.configer, "value", {})
+        if not isinstance(config_value, dict):
+            config_value = {}
+        for k, v in config_value.items():
             # ignore metadata values
             if k == 'metadata':
                 continue

--- a/tests/test_agentuniverse/unit/prompt/test_prompt_config_payload.py
+++ b/tests/test_agentuniverse/unit/prompt/test_prompt_config_payload.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+SOURCE = Path(
+    "agentuniverse/prompt/prompt.py"
+).read_text(encoding="utf-8")
+
+
+def test_prompt_ignores_non_mapping_configuration_payloads():
+    assert 'config_value = getattr(component_configer.configer, "value", {})' in SOURCE
+    assert "if not isinstance(config_value, dict):" in SOURCE
+    assert "for k, v in config_value.items():" in SOURCE


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Load prompt values safely when the component configuration is missing or non-mapping.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/prompt/test_prompt_config_payload.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`