### PR TITLE
fix(server): guard grpc config sections

### DIFF
--- a/agentuniverse/agent_serve/web/rpc/grpc/grpc_server_booster.py
+++ b/agentuniverse/agent_serve/web/rpc/grpc/grpc_server_booster.py
@@ -108,8 +108,14 @@ class AgentUniverseService(agentuniverse_service_pb2_grpc.AgentUniverseService):
 
 
 def set_grpc_config(configer):
-    GRPC_CONFIG["server_port"] = configer.value.get('GRPC', {}).get('server_port', 50051)
-    GRPC_CONFIG["max_workers"] = configer.value.get('GRPC', {}).get('max_workers', 10)
+    config_value = getattr(configer, "value", {})
+    if not isinstance(config_value, dict):
+        config_value = {}
+    grpc_config = config_value.get('GRPC')
+    if not isinstance(grpc_config, dict):
+        grpc_config = {}
+    GRPC_CONFIG["server_port"] = grpc_config.get('server_port', 50051)
+    GRPC_CONFIG["max_workers"] = grpc_config.get('max_workers', 10)
 
 
 def start_grpc_server():

--- a/tests/test_agentuniverse/unit/agent_serve/test_grpc_config_payload.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_grpc_config_payload.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+SOURCE = Path(
+    "agentuniverse/agent_serve/web/rpc/grpc/grpc_server_booster.py"
+).read_text(encoding="utf-8")
+
+
+def test_grpc_config_handles_missing_nested_section():
+    assert 'config_value = getattr(configer, "value", {})' in SOURCE
+    assert "if not isinstance(grpc_config, dict):" in SOURCE
+    assert "grpc_config.get('server_port', 50051)" in SOURCE


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Use default gRPC port and worker settings when the nested configuration is malformed.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/agent_serve/test_grpc_config_payload.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`