### PR TITLE
fix(knowledge): tolerate empty keyword extraction

### DIFF
--- a/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
+++ b/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
@@ -24,10 +24,15 @@ class QueryKeywordExtractor(QueryParaphraser):
 
         keyword_extractor_instance = DocProcessorManager().get_instance_obj(self.keyword_extractor)
 
-        keywords = keyword_extractor_instance.process_docs(
+        processed_docs = keyword_extractor_instance.process_docs(
             [Document(text=origin_query.query_str)]
-        )[0].keywords
+        )
+        if not processed_docs:
+            return origin_query
+        keywords = processed_docs[0].keywords or set()
 
+        if origin_query.keywords is None:
+            origin_query.keywords = set()
         origin_query.keywords.update(keywords)
         return origin_query
 

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/test_query_keyword_empty_results.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/test_query_keyword_empty_results.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+SOURCE = Path(
+    "agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py"
+).read_text(encoding="utf-8")
+
+
+def test_keyword_extractor_tolerates_empty_processor_results():
+    assert "processed_docs = keyword_extractor_instance.process_docs(" in SOURCE
+    assert "if not processed_docs:" in SOURCE
+    assert "keywords = processed_docs[0].keywords or set()" in SOURCE


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Leave the original query unchanged when the keyword processor returns no documents.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/agent/action/knowledge/test_query_keyword_empty_results.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`