### PR TITLE
fix(knowledge): guard Neo4j query metadata

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/neo4j_store.py
+++ b/agentuniverse/agent/action/knowledge/store/neo4j_store.py
@@ -74,11 +74,14 @@ class Neo4jStore(Store):
 
 
     def query(self, query: Query, **kwargs) -> List[Document]:
-        query_type = query.ext_info.get("query_type", "")
+        if query is None:
+            raise ValueError("query is required")
+        query_ext_info = query.ext_info if isinstance(query.ext_info, dict) else {}
+        query_type = query_ext_info.get("query_type", "")
 
         if query_type == "direct_cypher":
             cypher_query = query.query_str
-            query_params = query.ext_info.get("query_params", {})
+            query_params = query_ext_info.get("query_params", {})
             records = self.execute_cypher(cypher_query, query_params)
             return self._records_to_documents(cypher_query, records)
 
@@ -89,7 +92,7 @@ class Neo4jStore(Store):
                 query.query_str,
                 schema_info
             )
-            query_params = query.ext_info.get("query_params", {})
+            query_params = query_ext_info.get("query_params", {})
             records = self.execute_cypher(llm_cypher, query_params)
             return self._records_to_documents(query.query_str, records)
 
@@ -99,7 +102,7 @@ class Neo4jStore(Store):
                 return []
             node_ids = self._parse_node_ids(node_ids_raw)
             node_query, node_params = self._build_node_ids_query(node_ids)
-            query_params = {**query.ext_info.get("query_params", {}), **node_params}
+            query_params = {**query_ext_info.get("query_params", {}), **node_params}
             records = self.execute_cypher(node_query, query_params)
             return self._records_to_documents(node_ids_raw, records)
         else:

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_query_metadata.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_query_metadata.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+SOURCE = Path(
+    "agentuniverse/agent/action/knowledge/store/neo4j_store.py"
+).read_text(encoding="utf-8")
+
+
+def test_neo4j_query_normalizes_missing_metadata():
+    assert "if query is None:" in SOURCE
+    assert "query_ext_info = query.ext_info if isinstance(query.ext_info, dict) else {}" in SOURCE
+    assert SOURCE.count("query_ext_info.get") >= 4


### PR DESCRIPTION
## Checklist
- [x] I have read and understood the contribution guidelines.
- [x] I checked for duplicate work.
- [x] I added a focused regression test.
- [x] Changes are signed off with DCO.

## Details
Validate missing queries and normalize non-mapping Neo4j query metadata.

## Tests
- `python -m pytest -q tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_query_metadata.py` (focused regression/source-contract check)
- `python -m py_compile` on changed Python files
- `git diff --check`