### PR TITLE
test(context): fix RAM store keyword invocation

### DIFF
--- a/tests/test_agentuniverse/unit/agent/context/test_ram_context_store.py
+++ b/tests/test_agentuniverse/unit/agent/context/test_ram_context_store.py
@@ -85,7 +85,7 @@ class TestRamContextStore:
         store.add(sample_segments, session_id="session_1")
 
         # Get all segments
-        segments = store.get("session_id"="session_1")
+        segments = store.get(session_id="session_1")
         assert len(segments) == 4
 
     def test_get_with_type_filter(self, store, sample_segments):


### PR DESCRIPTION
## Summary

Fixes a syntax error in the RAM context-store test so the module can be collected and the intended lookup assertion can run.

## Tests

 `python -m py_compile tests/test_agentuniverse/unit/agent/context/test_ram_context_store.py`