### PR TITLE
fix(context): reset saved state when context is reused

### DIFF
--- a/agentuniverse/base/context/framework_context.py
+++ b/agentuniverse/base/context/framework_context.py
@@ -26,10 +26,14 @@ class FrameworkContext:
 
     def __enter__(self):
         """Preserve the prior context and set a new one."""
+        # A FrameworkContext instance may be reused. Do not let values captured
+        # by an earlier entry leak into a later restoration.
+        self.old_state = {}
         for key, value in self.context.items():
             if FrameworkContextManager().is_context_exist(key):
                 self.old_state[key] = FrameworkContextManager().get_context(key)
             FrameworkContextManager().set_context(key, value)
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Clear the current context and revert to the prior context."""


### PR DESCRIPTION
## Summary

Reset the saved state on every entry and return the context manager from `__enter__`. Reusing one instance can no longer restore values captured by an earlier `with` block.

## Tests

 targeted regression test.