### PR TITLE
fix(memory): honor zero RAM retrieval limits

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/ram_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/ram_memory_storage.py
@@ -59,5 +59,7 @@ class RamMemoryStorage(MemoryStorage):
         Returns:
             List[Message]: The list of aU messages.
         """
+        if top_k <= 0:
+            return []
         memories = self.messages.get(session_id, {}).get(agent_id, [])
         return memories[-top_k:]


### PR DESCRIPTION
## Summary

Treat non-positive `top_k` as an empty result. Python's `[-0:]` slice otherwise returns the entire RAM history.

## Tests

 targeted regression test.