### PR TITLE
fix(memory): handle non-positive prune budgets

### DIFF
--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -95,7 +95,7 @@ class Memory(ComponentBase):
         return []
 
     def prune(self, memories: List[Message]) -> List[Message]:
-        if not memories:
+        if not memories or self.max_tokens <= 0:
             return []
         new_memories = memories[:]
 


### PR DESCRIPTION
## Summary

Return an empty history for non-positive token budgets instead of popping past the end of the message list and raising `IndexError`.

## Tests

 targeted regression test.