### PR TITLE
fix(memory): read context roles from custom metadata

### DIFF
--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -168,7 +168,7 @@ class Memory(ComponentBase):
                     messages = []
                     for seg in segments:
                         # Parse role from metadata if available
-                        role = seg.metadata.extra_data.get('role', 'assistant') if hasattr(seg.metadata, 'extra_data') else 'assistant'
+                        role = seg.metadata.custom.get('role', 'assistant')
                         messages.append(Message(
                             content=seg.content,
                             type=role


### PR DESCRIPTION
## Summary

Read conversation roles from `ContextMetadata.custom`, the field defined by the context model. The previous nonexistent `extra_data` lookup silently converted every segment to an assistant message.

## Tests

 targeted regression test.