### PR TITLE
fix(memory): enable Chroma conversation semantic search

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -191,7 +191,6 @@ class ChromaConversationMemoryStorage(MemoryStorage):
 
         if len(filters["$and"]) < 2:
             filters = filters["$and"][0] if len(filters["$and"]) == 1 else {}
-        input = None
         if input:
             embedding = []
             if self.embedding_model:


### PR DESCRIPTION
## Summary

Stop overwriting the caller's search input with `None`. Non-empty conversation queries now use Chroma semantic retrieval rather than returning an unfiltered collection slice.

## Tests

 targeted regression test.