### PR TITLE
fix(memory): make Chroma memory types optional

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -169,7 +169,7 @@ class ChromaConversationMemoryStorage(MemoryStorage):
                     {'target_type': ConversationMessageSourceType.AGENT.value}
                 ]
             }
-            if kwargs['memory_types'] and len(kwargs["memory_types"]) > 0:
+            if kwargs.get('memory_types'):
                 condition = {
                     "$or": [
                         condition,


### PR DESCRIPTION
## Summary

Use an optional lookup for `memory_types` when an `agent_id` is supplied. Callers no longer get a `KeyError` when they rely on the documented defaults.

## Tests

 targeted regression test.