### PR TITLE
fix(memory): accept decoded Chroma additional arguments

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -23,6 +23,13 @@ from agentuniverse.agent.memory.memory_storage.memory_storage import MemoryStora
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
 
 
+def _decode_additional_args(value: Any) -> dict:
+    """Normalize Chroma metadata serialized by old and new clients."""
+    if isinstance(value, str):
+        return json.loads(value) if value else {}
+    return value or {}
+
+
 class ChromaConversationMemoryStorage(MemoryStorage):
     """The chroma memory storage class.
 
@@ -241,7 +248,7 @@ class ChromaConversationMemoryStorage(MemoryStorage):
                         target_type=metadatas[0][i].get('target_type', '') if metadatas[0] else '',
                         trace_id=metadatas[0][i].get('trace_id', '') if metadatas[0] else '',
                         type=metadatas[0][i].get('type', '') if metadatas[0] else '',
-                        additional_args=json.loads(metadatas[0][i].get('additional_args', "{}"))
+                        additional_args=_decode_additional_args(metadatas[0][i].get('additional_args'))
                     )
                     for i in range(len(result['ids'][0]))
                 ]
@@ -261,7 +268,7 @@ class ChromaConversationMemoryStorage(MemoryStorage):
                         content=documents[i],
                         metadata=metadatas[i] if metadatas[i] else None,
                         type=metadatas[i].get('type', '') if metadatas[i] else '',
-                        additional_args=json.loads(metadatas[i].get('additional_args', "{}"))
+                        additional_args=_decode_additional_args(metadatas[i].get('additional_args'))
                     )
                     for i in range(len(result['ids']))
                 ]


### PR DESCRIPTION
## Summary

Normalize `additional_args` from either JSON text or an already-decoded mapping. This supports Chroma clients that materialize object metadata without dropping the whole result set.

## Tests

 targeted regression test.