### PR TITLE
fix(memory): skip empty Elasticsearch bulk writes

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
@@ -143,6 +143,8 @@ class ElasticsearchMemoryStorage(MemoryStorage):
             agent_id (str): The agent id of the memory to add.
         """
         message_list = ConversationMessage.check_and_convert_message(message_list, session_id)
+        if not message_list:
+            return
         actions = []
         for message in message_list:
             action = self.memory_converter.to_es_action(message, session_id=session_id, agent_id=agent_id, **kwargs)


### PR DESCRIPTION
## Summary

Return before issuing a bulk request when there are no conversation messages. This avoids sending a lone newline as an invalid Elasticsearch bulk payload.

## Tests

 targeted regression test.