### PR TITLE
fix(memory): refuse unscoped Elasticsearch deletes

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
@@ -107,6 +107,8 @@ class ElasticsearchMemoryStorage(MemoryStorage):
             session_id (str): The session id of the memory to delete.
             agent_id (str): The agent id of the memory to delete.
         """
+        if session_id is None and agent_id is None and trace_id is None:
+            return
         url = f'{self.es_url}/{self.index_name}/_delete_by_query'
         query = {
             "query": {


### PR DESCRIPTION
## Summary

Make `delete()` a no-op when no session, agent, or trace filter is supplied. An empty bool query otherwise matches every document in the memory index.

## Tests

 targeted regression test.