### PR TITLE
fix(memory): build SQLAlchemy type filters correctly

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/sql_alchemy_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/sql_alchemy_memory_storage.py
@@ -232,10 +232,14 @@ class SqlAlchemyMemoryStorage(MemoryStorage):
             if kwargs.get('type'):
                 if isinstance(kwargs['type'], list):
                     types = kwargs['type']
-                if not isinstance(kwargs['type'], str):
+                elif isinstance(kwargs['type'], str):
                     types = [kwargs['type']]
-                type_col = getattr(model_class, 'type')
-                conditions.append(conditions.append(type_col.in_(types)))
+                else:
+                    raise ValueError("type must be a list or str")
+                type_col = getattr(model_class, 'type', None)
+                if type_col is None:
+                    raise ValueError("the configured memory model does not support type filtering")
+                conditions.append(type_col.in_(types))
 
             # build the query with dynamic conditions
             query = session.query(self.memory_converter.model_class)


### PR DESCRIPTION
## Summary

Normalize string/list type filters, append the SQL condition only once, and report a clear error when a custom memory model has no type column. This replaces the previous nested-list and `None` condition bug.

## Tests

 targeted regression test.