### PR TITLE
fix(memory): honor zero SQLAlchemy retrieval limits

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/sql_alchemy_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/sql_alchemy_memory_storage.py
@@ -246,6 +246,8 @@ class SqlAlchemyMemoryStorage(MemoryStorage):
             # Execute the query and fetch the results
             records = query.all()
 
+            if top_k <= 0:
+                return []
             records = records[-top_k:]
 
             messages = []


### PR DESCRIPTION
## Summary

Return no records for non-positive `top_k` values. The previous `records[-0:]` slice exposed the entire stored history.

## Tests

 targeted regression test.