### PR TITLE
fix(memory): apply SQLite conversation delete filters

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/sqlite_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/sqlite_conversation_memory_storage.py
@@ -231,9 +231,9 @@ class SqliteMemoryStorage(MemoryStorage):
                                         target_type_col == ConversationMessageSourceType.AGENT.value)
                 agent_id_col = or_(source_condition, target_condition)
 
-                query.filter(agent_id_col)
+                query = query.filter(agent_id_col)
             if trace_id is not None:
-                query.filter(getattr(model_class, 'trace_id') == trace_id)
+                query = query.filter(model_class.trace_id == trace_id)
 
             # execute delete and commit the session
             query.delete(synchronize_session=False)


### PR DESCRIPTION
## Summary

Assign the SQLAlchemy query returned by agent and trace filters before deleting. Previously those filters were discarded, allowing a scoped delete to remove every message in the session.

## Tests

 targeted regression test.