### PR TITLE
fix(memory): honor zero SQLite conversation limits

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/sqlite_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/sqlite_conversation_memory_storage.py
@@ -326,6 +326,8 @@ class SqliteMemoryStorage(MemoryStorage):
             # Execute the query and fetch the results
             records = query.all()
 
+            if top_k <= 0:
+                return []
             records = records[-top_k:]
 
             messages = []


### PR DESCRIPTION
## Summary

Treat non-positive `top_k` values as an empty result instead of using the `[-0:]` slice that returns all conversation rows.

## Tests

 targeted regression test.