### PR TITLE
fix(memory): unwrap Qdrant query responses

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
@@ -199,7 +199,8 @@ class QdrantMemoryStorage(MemoryStorage):
                     with_vectors=False,
                     query_filter=filt,
                 )
-                messages = self.to_messages(results)
+                points = getattr(results, "points", results)
+                messages = self.to_messages(points)
                 messages.reverse()
                 return messages
             else:


### PR DESCRIPTION
## Summary

Convert the `points` carried by Qdrant `QueryResponse` objects rather than iterating the response wrapper itself. Semantic memory lookups now return their matches.

## Tests

 targeted regression test.