### PR TITLE
fix(context): isolate returned priority type lists

### DIFF
--- a/agentuniverse/agent/context/router/context_router.py
+++ b/agentuniverse/agent/context/router/context_router.py
@@ -271,7 +271,7 @@ class ContextRouter(ComponentBase):
             List of context types to prioritize
         """
         rule = self.get_routing_rule(task_type)
-        return rule.priority_types
+        return rule.priority_types.copy()
 
     def optimize_search_order(
         self,


### PR DESCRIPTION
## Summary

Return a copy of routing-rule priority types so callers cannot mutate the router's shared task configuration through the accessor.

## Tests

 targeted regression test.