### PR TITLE
fix(chroma): infer ports for remote URLs

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -50,7 +50,7 @@ class ChromaStore(Store):
             settings = Settings(
                 chroma_api_impl="chromadb.api.fastapi.FastAPI",
                 chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
+                chroma_server_http_port=str(parsed_url.port or (443 if parsed_url.scheme == 'https' else 80))
             )
         elif self.persist_path:
             # Local persistent database

--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -62,7 +62,7 @@ class ChromaConversationMemoryStorage(MemoryStorage):
             settings = Settings(
                 chroma_api_impl="chromadb.api.fastapi.FastAPI",
                 chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
+                chroma_server_http_port=str(parsed_url.port or (443 if parsed_url.scheme == 'https' else 80))
             )
         else:
             settings = Settings(

--- a/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
@@ -60,7 +60,7 @@ class ChromaMemoryStorage(MemoryStorage):
             settings = Settings(
                 chroma_api_impl="chromadb.api.fastapi.FastAPI",
                 chroma_server_host=parsed_url.hostname,
-                chroma_server_http_port=str(parsed_url.port)
+                chroma_server_http_port=str(parsed_url.port or (443 if parsed_url.scheme == 'https' else 80))
             )
         else:
             settings = Settings(


### PR DESCRIPTION
## Summary

Infer port 443 for HTTPS and 80 for HTTP when remote Chroma URLs omit an explicit port. This avoids passing the literal string `None` to Chroma settings across stores.

## Tests

 targeted regression test.