### PR TITLE
fix(knowledge): handle zero summarization input limits

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/summarization_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/summarization_processor.py
@@ -103,7 +103,7 @@ class SummarizationProcessor(DocProcessor):
             List[Document]: A one-element list containing the summary document.
             An empty input yields an empty list.
         """
-        if not origin_docs:
+        if not origin_docs or self.max_input_docs <= 0:
             return []
 
         # Bound the input size; recall results are typically relevance-ordered


### PR DESCRIPTION
## Summary

Return an empty result for non-positive `max_input_docs` rather than indexing `source_docs[0]` after slicing the input to an empty list.

## Tests

 targeted regression test.