### PR TITLE
fix(knowledge): preserve fields on budget truncation

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/context_budget_compressor.py
@@ -109,8 +109,13 @@ class ContextBudgetCompressor(DocProcessor):
             if truncated_text:
                 metadata = dict(doc.metadata or {})
                 metadata["truncated"] = True
-                kept.append(Document(text=truncated_text, metadata=metadata,
-                                     id=doc.id))
+                kept.append(Document(
+                    text=truncated_text,
+                    metadata=metadata,
+                    id=doc.id,
+                    embedding=list(doc.embedding),
+                    keywords=set(doc.keywords),
+                ))
             break  # budget exhausted after the (possibly truncated) boundary doc
         return kept
 


### PR DESCRIPTION
## Summary

Carry embeddings and keywords into the truncated boundary document. Context-budget compression no longer discards retrieval data needed by downstream processors.

## Tests

 targeted regression test.