### PR TITLE
fix(knowledge): reject negative RRF constants

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/reciprocal_rank_fusion_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/reciprocal_rank_fusion_processor.py
@@ -88,6 +88,8 @@ class ReciprocalRankFusionProcessor(DocProcessor):
             (descending), each carrying ``metadata[score_field]``. An empty
             input yields an empty list.
         """
+        if self.k < 0:
+            raise ValueError("k must be non-negative")
         if not origin_docs:
             return []
 


### PR DESCRIPTION
## Summary

Validate the reciprocal-rank constant before scoring so `k=-1` cannot divide by zero on the first result.

## Tests

 targeted regression test.