### PR TITLE
fix(knowledge): reject mismatched embedding dimensions

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/semantic_deduplicator.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/semantic_deduplicator.py
@@ -211,6 +211,9 @@ class SemanticDeduplicator(DocProcessor):
         Returns:
             Cosine similarity score (0.0-1.0).
         """
+        if len(embedding1) != len(embedding2):
+            return 0.0
+
         # Compute dot product
         dot_product = sum(a * b for a, b in zip(embedding1, embedding2))
 


### PR DESCRIPTION
## Summary

Return zero similarity for embeddings with different dimensions. `zip()` previously truncated vectors and could incorrectly collapse unrelated documents as duplicates.

## Tests

 targeted regression test.