### PR TITLE
fix(knowledge): clamp negative top-k filters

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/threshold_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/threshold_filter.py
@@ -163,7 +163,7 @@ class ThresholdFilter(DocProcessor):
         Returns:
             List[Document]: Top K documents by score.
         """
-        k = config.get("k", len(docs))
+        k = max(0, config.get("k", len(docs)))
 
         # Score each document
         scored_docs = [(doc, self._get_score(doc)) for doc in docs]


### PR DESCRIPTION
## Summary

Clamp negative top-k filter values to zero. Python negative slicing previously kept all but the last document, which is not a meaningful top-k result.

## Tests

 targeted regression test.