### PR TITLE
fix(knowledge): normalize threshold metadata scores

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/threshold_filter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/threshold_filter.py
@@ -215,9 +215,13 @@ class ThresholdFilter(DocProcessor):
             float: Document score or default_score if not found.
         """
         if not doc.metadata:
-            return self.default_score
+            return float(self.default_score)
 
-        return doc.metadata.get(self.score_field, self.default_score)
+        value = doc.metadata.get(self.score_field, self.default_score)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return float(self.default_score)
 
     def _combine_results(self, results: List[List[Document]], logic: str) -> List[Document]:
         """Combine filter results using AND/OR logic.


### PR DESCRIPTION
## Summary

Convert numeric metadata scores to floats and fall back for null or malformed values, preventing comparison and sorting errors in threshold filters.

## Tests

 targeted regression test.