### PR TITLE
fix(knowledge): invalidate cached text splitters

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/character_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/character_text_splitter.py
@@ -76,4 +76,5 @@ class CharacterTextSplitter(DocProcessor):
             self.chunk_overlap = doc_processor_configer.chunk_overlap
         if hasattr(doc_processor_configer, "separator"):
             self.separator = doc_processor_configer.separator
+        self.__splitter = None
         return self

--- a/agentuniverse/agent/action/knowledge/doc_processor/recursive_character_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/recursive_character_text_splitter.py
@@ -65,6 +65,7 @@ class RecursiveCharacterTextSplitter(DocProcessor):
             self.chunk_overlap = doc_processor_configer.chunk_overlap
         if hasattr(doc_processor_configer, "separators"):
             self.separators = doc_processor_configer.separators
+        self.__splitter = None
         return self
 
 

--- a/agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py
@@ -70,4 +70,5 @@ class TokenTextSplitter(DocProcessor):
             self.encoding_name = doc_processor_configer.encoding_name
         if hasattr(doc_processor_configer, "model_name"):
             self.model_name = doc_processor_configer.model_name
+        self.__splitter = None
         return self


### PR DESCRIPTION
## Summary

Clear cached LangChain splitter instances after component reconfiguration across character, recursive-character, and token splitters. Updated chunk settings now take effect.

## Tests

 targeted regression test.