### PR TITLE
fix(knowledge): generate IDs for nullable document text

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/document.py
+++ b/agentuniverse/agent/action/knowledge/store/document.py
@@ -31,7 +31,7 @@ class Document(BaseModel):
 
     @model_validator(mode='before')
     def create_id(cls, values):
-        text: str = values.get('text', '')
+        text: str = values.get('text') or ''
         if not values.get('id'):
             values['id'] = str(uuid.uuid5(uuid.NAMESPACE_URL, text))
         return values


### PR DESCRIPTION
## Summary

Normalize `None` to an empty string only for UUID generation, allowing the model's declared nullable text field without raising inside `uuid5`.

## Tests

 targeted regression test.