### PR TITLE
fix(context): validate updated segment token counts

### DIFF
--- a/agentuniverse/agent/context/context_model.py
+++ b/agentuniverse/agent/context/context_model.py
@@ -138,6 +138,8 @@ class ContextSegment(BaseModel):
         Returns:
             bool: True if content changed
         """
+        if new_tokens < 0:
+            raise ValueError("new_tokens must be non-negative")
         new_hash = hashlib.md5(new_content.encode('utf-8')).hexdigest()
 
         if new_hash != self._content_hash:


### PR DESCRIPTION
## Summary

Reject negative token counts before mutating a context segment. Direct assignment inside `update_content` bypassed Pydantic field constraints and could corrupt budget accounting.

## Tests

 targeted regression test.