### PR TITLE
fix(context): reject negative token deltas

### DIFF
--- a/agentuniverse/agent/context/context_model.py
+++ b/agentuniverse/agent/context/context_model.py
@@ -210,6 +210,8 @@ class ContextWindow(BaseModel):
             segment_tokens: Number of tokens to add/remove
             operation: "add" or "remove"
         """
+        if segment_tokens < 0:
+            raise ValueError("segment_tokens must be non-negative")
         if operation == "add":
             self.total_tokens += segment_tokens
         elif operation == "remove":


### PR DESCRIPTION
## Summary

Validate token deltas before context-window accounting. Negative additions previously bypassed Pydantic constraints and reduced `total_tokens` unexpectedly.

## Tests

 targeted regression test.