### PR TITLE
fix(context): exclude expired RAM segments from counts

### DIFF
--- a/agentuniverse/agent/context/store/ram_context_store.py
+++ b/agentuniverse/agent/context/store/ram_context_store.py
@@ -306,7 +306,7 @@ class RamContextStore(ContextStore):
         return segments
 
     def count(self, session_id: str, **kwargs) -> int:
-        """Count total segments for session (O(1) operation).
+        """Count non-expired segments for a session.
 
         Args:
             session_id: Session identifier
@@ -318,7 +318,10 @@ class RamContextStore(ContextStore):
         if session_id not in self._storage:
             return 0
 
-        return len(self._storage[session_id])
+        return sum(
+            not self._is_expired(segment)
+            for segment in self._storage[session_id].values()
+        )
 
     def get_all_sessions(self) -> List[str]:
         """Get list of all session IDs in storage.

--- a/tests/test_agentuniverse/unit/regressions/test_ram_context_expired_count.py
+++ b/tests/test_agentuniverse/unit/regressions/test_ram_context_expired_count.py
@@ -1,0 +1,33 @@
+"""Regression tests for RAM context-store counts."""
+
+from datetime import datetime, timedelta
+
+from agentuniverse.agent.context.context_model import (
+    ContextMetadata,
+    ContextSegment,
+    ContextType,
+)
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+def test_count_excludes_expired_segments():
+    store = RamContextStore(name="ram", ttl_hours=1)
+    expired = ContextSegment(
+        id="expired",
+        type=ContextType.CONVERSATION,
+        content="old context",
+        tokens=2,
+        metadata=ContextMetadata(
+            created_at=datetime.now() - timedelta(hours=2),
+        ),
+    )
+    current = ContextSegment(
+        id="current",
+        type=ContextType.CONVERSATION,
+        content="current context",
+        tokens=2,
+    )
+
+    store.add([expired, current], session_id="session")
+
+    assert store.count("session") == 1


### PR DESCRIPTION
## Summary
- make RAM context counts follow the same TTL visibility rules as retrieval
- exclude expired segments without mutating the backing store
- add a regression test covering mixed live and expired context

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_ram_context_expired_count.py`
