### PR TITLE
fix(context): handle zero-token selective loss estimates

### DIFF
--- a/agentuniverse/agent/context/compressor/selective_compressor.py
+++ b/agentuniverse/agent/context/compressor/selective_compressor.py
@@ -511,7 +511,11 @@ class SelectiveCompressor(ContextCompressor):
         # Token loss penalty (minor factor)
         original_tokens = self.calculate_total_tokens(original_segments)
         compressed_tokens = self.calculate_total_tokens(compressed_segments)
-        token_loss_penalty = (1.0 - (compressed_tokens / original_tokens)) * 0.1
+        token_loss_penalty = (
+            (1.0 - (compressed_tokens / original_tokens)) * 0.1
+            if original_tokens > 0
+            else 0.0
+        )
 
         total_loss = min(1.0, segment_loss + token_loss_penalty)
 

--- a/tests/test_agentuniverse/unit/regressions/test_selective_compressor_zero_tokens.py
+++ b/tests/test_agentuniverse/unit/regressions/test_selective_compressor_zero_tokens.py
@@ -1,0 +1,27 @@
+"""Regression tests for selective-compressor loss estimates."""
+
+import pytest
+
+from agentuniverse.agent.context.compressor.selective_compressor import (
+    SelectiveCompressor,
+)
+from agentuniverse.agent.context.context_model import (
+    ContextPriority,
+    ContextSegment,
+    ContextType,
+)
+
+
+def test_information_loss_handles_zero_token_segments():
+    compressor = SelectiveCompressor(name="selective")
+    segment = ContextSegment(
+        id="empty",
+        type=ContextType.CONVERSATION,
+        priority=ContextPriority.MEDIUM,
+        content="",
+        tokens=0,
+    )
+
+    loss = compressor.estimate_information_loss([segment], [])
+
+    assert loss == pytest.approx(0.1)


### PR DESCRIPTION
## Summary
- avoid dividing by zero when selective compression evaluates zero-token segments
- retain priority-based segment loss while applying no token penalty to an empty token baseline
- add a regression test for removal of a zero-token segment

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_selective_compressor_zero_tokens.py`
