### PR TITLE
fix(tool): validate arXiv query inputs

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
@@ -43,6 +43,9 @@ class ArxivTool(Tool):
         if mode not in [m.value for m in SearchMode]:
             raise ValueError(f"Invalid mode: {mode}. Must be one of {[m.value for m in SearchMode]}")
 
+        if not isinstance(input, str) or not input.strip():
+            raise ValueError("input must be a non-empty string")
+
         try:
             import arxiv
         except ImportError:

--- a/tests/test_agentuniverse/unit/regressions/test_arxiv_tool_empty_input.py
+++ b/tests/test_agentuniverse/unit/regressions/test_arxiv_tool_empty_input.py
@@ -1,0 +1,13 @@
+"""Regression tests for arXiv tool input validation."""
+
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.arxiv_tool import ArxivTool
+
+
+@pytest.mark.parametrize("query", [None, "", "   "])
+def test_execute_rejects_empty_input_before_loading_dependencies(query):
+    tool = ArxivTool(name="arxiv")
+
+    with pytest.raises(ValueError, match="input must be a non-empty string"):
+        tool.execute(query, mode="search")


### PR DESCRIPTION
## Summary
- reject missing and blank arXiv queries with a clear validation error
- validate before loading optional arXiv dependencies or creating a client
- add regression coverage for null, empty, and whitespace-only inputs

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_arxiv_tool_empty_input.py`
