### PR TITLE
fix(context): preserve Redis sessions on empty deletes

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -257,7 +257,9 @@ class RedisContextStore(ContextStore):
         key = self._make_session_key(session_id)
         index_key = self._make_index_key(session_id)
 
-        if segment_ids:
+        if segment_ids is not None:
+            if not segment_ids:
+                return
             # Delete specific segments
             self._redis.hdel(key, *segment_ids)
             self._redis.zrem(index_key, *segment_ids)

--- a/tests/test_agentuniverse/unit/regressions/test_redis_context_empty_delete.py
+++ b/tests/test_agentuniverse/unit/regressions/test_redis_context_empty_delete.py
@@ -1,0 +1,27 @@
+"""Regression tests for Redis context-store deletion."""
+
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+class RecordingRedis:
+    def __init__(self):
+        self.calls = []
+
+    def hdel(self, *args):
+        self.calls.append(("hdel", args))
+
+    def zrem(self, *args):
+        self.calls.append(("zrem", args))
+
+    def delete(self, *args):
+        self.calls.append(("delete", args))
+
+
+def test_empty_segment_id_list_does_not_delete_session():
+    store = RedisContextStore(name="redis")
+    redis = RecordingRedis()
+    store._redis = redis
+
+    store.delete("session", segment_ids=[])
+
+    assert redis.calls == []


### PR DESCRIPTION
## Summary
- distinguish an empty segment ID list from the `None` sentinel for session deletion
- make empty targeted deletes a no-op instead of deleting the entire Redis session
- add a regression test that records backend delete calls

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_redis_context_empty_delete.py`
