### PR TITLE
fix(context): preserve Chroma sessions on empty deletes

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -339,7 +339,9 @@ class ChromaContextStore(ContextStore):
         if not self._collection:
             return
 
-        if segment_ids:
+        if segment_ids is not None:
+            if not segment_ids:
+                return
             # Delete specific segments
             ids_to_delete = [f"{session_id}:{seg_id}" for seg_id in segment_ids]
             self._collection.delete(ids=ids_to_delete)

--- a/tests/test_agentuniverse/unit/regressions/test_chroma_context_empty_delete.py
+++ b/tests/test_agentuniverse/unit/regressions/test_chroma_context_empty_delete.py
@@ -1,0 +1,21 @@
+"""Regression tests for Chroma context-store deletion."""
+
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+class RecordingCollection:
+    def __init__(self):
+        self.calls = []
+
+    def delete(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_empty_segment_id_list_does_not_delete_session():
+    store = ChromaContextStore(name="chroma")
+    collection = RecordingCollection()
+    store._collection = collection
+
+    store.delete("session", segment_ids=[])
+
+    assert collection.calls == []


### PR DESCRIPTION
## Summary
- distinguish an empty segment ID list from the `None` sentinel for session deletion
- make empty targeted deletes a no-op instead of deleting the entire Chroma session
- add a regression test that records collection delete calls

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_chroma_context_empty_delete.py`
