### PR TITLE
fix(workflow): reject duplicate graph node ids

### DIFF
--- a/agentuniverse/workflow/graph/graph.py
+++ b/agentuniverse/workflow/graph/graph.py
@@ -46,7 +46,7 @@ class Graph(nx.DiGraph):
             raise ValueError('The node type is not supported')
         node_id = node_config.get('id')
         if self.has_node(node_id):
-            return
+            raise ValueError(f"The node id '{node_id}' is duplicated in the workflow configuration.")
         node_cls = NODE_CLS_MAPPING[node_config.get('type')]
         node_type = node_config.pop('type')
         node_instance = node_cls(type=NodeEnum.from_value(node_type), workflow_id=workflow_id,

--- a/tests/test_agentuniverse/unit/regressions/test_graph_duplicate_node_id.py
+++ b/tests/test_agentuniverse/unit/regressions/test_graph_duplicate_node_id.py
@@ -1,0 +1,32 @@
+"""Regression tests for duplicate workflow node ids."""
+
+import pytest
+
+from agentuniverse.workflow.graph.graph import Graph
+
+
+def test_duplicate_node_id_raises_value_error():
+    graph = Graph()
+    config = {
+        "nodes": [
+            {"id": "same", "type": "start", "name": "first"},
+            {"id": "same", "type": "end", "name": "second"},
+        ],
+        "edges": [{"source_node_id": "same", "target_node_id": "same"}],
+    }
+    with pytest.raises(ValueError):
+        graph.build(workflow_id="wf_duplicate", config=config)
+
+
+def test_unique_node_ids_build_successfully():
+    graph = Graph()
+    config = {
+        "nodes": [
+            {"id": "start", "type": "start", "name": "first"},
+            {"id": "end", "type": "end", "name": "second"},
+        ],
+        "edges": [{"source_node_id": "start", "target_node_id": "end"}],
+    }
+    graph.build(workflow_id="wf_unique", config=config)
+    assert graph.has_node("start")
+    assert graph.has_node("end")


### PR DESCRIPTION
## Summary
- raise a clear error when a workflow graph defines two nodes with the same id instead of silently keeping the first definition
- the old behavior hid copy/paste mistakes and merge conflicts behind a successful build

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_graph_duplicate_node_id.py