### PR TITLE
fix(workflow): render falsey values in end node templates

### DIFF
--- a/agentuniverse/workflow/node/end_node.py
+++ b/agentuniverse/workflow/node/end_node.py
@@ -46,7 +46,7 @@ class EndNode(Node):
                 if var not in end_node_input_params:
                     raise KeyError(f"The variable '{var}' is not found in the input params.")
                 prompt_val = prompt_val.replace(f'{{{{{var}}}}}',
-                                                str(end_node_input_params[var]) if end_node_input_params[var] else '')
+                                                str(end_node_input_params[var]) if end_node_input_params[var] is not None else '')
         except KeyError as e:
             raise ValueError(f"Error processing template variables: {e}")
 

--- a/tests/test_agentuniverse/unit/regressions/test_end_node_falsey_values.py
+++ b/tests/test_agentuniverse/unit/regressions/test_end_node_falsey_values.py
@@ -1,0 +1,29 @@
+"""Regression tests for end-node template rendering of falsey values."""
+
+from agentuniverse.workflow.node.end_node import EndNode
+from agentuniverse.workflow.node.node_config import EndNodeInputParams, NodeInfoParams
+from agentuniverse.workflow.workflow_output import WorkflowOutput
+
+
+def _run_end_node(value):
+    node = EndNode(id="end", type="end")
+    node._data.inputs = EndNodeInputParams(
+        prompt=NodeInfoParams(name="prompt", type="str", value={"content": "result={{value}}"}),
+        input_param=[],
+    )
+    node._resolve_input_params = lambda inputs, wf: {"value": value}
+    workflow_output = WorkflowOutput()
+    result = node._run(workflow_output)
+    return result.result[0].value
+
+
+def test_zero_value_is_rendered():
+    assert _run_end_node(0) == "result=0"
+
+
+def test_false_value_is_rendered():
+    assert _run_end_node(False) == "result=False"
+
+
+def test_none_value_is_rendered_as_empty():
+    assert _run_end_node(None) == "result="


### PR DESCRIPTION
## Summary
- keep numeric 0 and boolean False in rendered end-node templates instead of dropping them to an empty string
- None is still rendered as an empty string, preserving the previous intent for missing values

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_end_node_falsey_values.py