### PR TITLE
fix(workflow): apply configured model overrides in llm nodes

### DIFF
--- a/agentuniverse/workflow/node/llm_node.py
+++ b/agentuniverse/workflow/node/llm_node.py
@@ -59,9 +59,9 @@ class LLMNode(Node):
 
         input_variables = re.findall(r'\{\{(.*?)\}\}', prompt)
         if model_name:
-            llm.set_by_agent_model(model_name=model_name, temperature=temperature)
+            llm = llm.set_by_agent_model(model_name=model_name, temperature=temperature)
         else:
-            llm.set_by_agent_model(temperature=temperature)
+            llm = llm.set_by_agent_model(temperature=temperature)
 
         llm_input_params = self._resolve_input_params(inputs.input_param, workflow_output)
         for variable in input_variables:

--- a/tests/test_agentuniverse/unit/regressions/test_llm_node_model_override.py
+++ b/tests/test_agentuniverse/unit/regressions/test_llm_node_model_override.py
@@ -1,0 +1,51 @@
+"""Regression tests for workflow LLM node model overrides."""
+
+from agentuniverse.workflow.node.llm_node import LLMNode
+from agentuniverse.workflow.node.node_config import (
+    LLMNodeInputParams,
+    NodeInfoParams,
+)
+from agentuniverse.workflow.workflow_output import WorkflowOutput
+
+
+class StubLLM:
+    def __init__(self):
+        self.model_name = "base"
+        self.temperature = 0.9
+        self.called_model_name = None
+
+    def set_by_agent_model(self, **kwargs):
+        copied = StubLLM()
+        copied.model_name = kwargs.get("model_name", self.model_name)
+        copied.temperature = kwargs.get("temperature", self.temperature)
+        return copied
+
+    def call(self, messages=None, streaming=False):
+        return type("O", (), {"text": f"used:{self.model_name}"})()
+
+
+def _build_llm_node(model_name, temperature):
+    node = LLMNode(id="llm", type="llm")
+    node._data.inputs = LLMNodeInputParams(
+        llm_param=[
+            NodeInfoParams(name="model_name", type="str", value={"content": model_name}),
+            NodeInfoParams(name="temperature", type="str", value={"content": str(temperature)}),
+            NodeInfoParams(name="prompt", type="str", value={"content": "say hi"}),
+            NodeInfoParams(name="id", type="str", value={"content": "stub"}),
+        ],
+        input_param=[],
+    )
+    node._data.outputs = [type("P", (), {"name": "out", "value": None})()]
+    return node
+
+
+def test_llm_node_uses_configured_model_override():
+    from agentuniverse.llm.llm_manager import LLMManager
+
+    stub = StubLLM()
+    LLMManager().get_instance_obj = lambda llm_id: stub
+
+    node = _build_llm_node("override", 0.2)
+    workflow_output = WorkflowOutput()
+    result = node._run(workflow_output)
+    assert result.result[0].value == "used:override"


### PR DESCRIPTION
## Summary
- LLMNode called set_by_agent_model() but discarded the returned configured copy, so the registered model settings were always used
- the node now keeps the returned copy and calls the configured model name and temperature

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_llm_node_model_override.py