### PR TITLE
fix(workflow): isolate node outputs between executions

### DIFF
--- a/agentuniverse/workflow/node/agent_node.py
+++ b/agentuniverse/workflow/node/agent_node.py
@@ -55,7 +55,7 @@ class AgentNode(Node):
 
         agent_output: OutputObject = agent.run(**agent_input_params)
         agent_output_dict = agent_output.to_dict()
-        output_params: List[NodeOutputParams] = self._data.outputs
+        output_params: List[NodeOutputParams] = [NodeOutputParams(**p.model_dump()) for p in self._data.outputs]
 
         for output_param in output_params:
             output_param.value = agent_output_dict.get(output_param.name, None)

--- a/agentuniverse/workflow/node/end_node.py
+++ b/agentuniverse/workflow/node/end_node.py
@@ -50,7 +50,7 @@ class EndNode(Node):
         except KeyError as e:
             raise ValueError(f"Error processing template variables: {e}")
 
-        output_params: List[NodeOutputParams] = self._data.outputs
+        output_params: List[NodeOutputParams] = [NodeOutputParams(**p.model_dump()) for p in self._data.outputs]
         output_param: NodeOutputParams = output_params[0]
         output_param.value = prompt_val
 

--- a/agentuniverse/workflow/node/knowledge_node.py
+++ b/agentuniverse/workflow/node/knowledge_node.py
@@ -64,7 +64,7 @@ class KnowledgeNode(Node):
         for knowledge in knowledge_list:
             document_texts = [document.text for document in knowledge.query_knowledge(**knowledge_input_params)]
             knowledge_res += '\n'.join(document_texts)
-        output_params: List[NodeOutputParams] = self._data.outputs
+        output_params: List[NodeOutputParams] = [NodeOutputParams(**p.model_dump()) for p in self._data.outputs]
         output_params[0].value = knowledge_res
 
         workflow_output.workflow_parameters[self.id] = output_params

--- a/agentuniverse/workflow/node/llm_node.py
+++ b/agentuniverse/workflow/node/llm_node.py
@@ -73,7 +73,7 @@ class LLMNode(Node):
         llm_output: LLMOutput = llm.call(messages=messages, streaming=False)
 
         # handle output parameters
-        output_params: List[NodeOutputParams] = self._data.outputs
+        output_params: List[NodeOutputParams] = [NodeOutputParams(**p.model_dump()) for p in self._data.outputs]
         output_params[0].value = llm_output.text
         workflow_output.workflow_parameters[self.id] = output_params
 

--- a/agentuniverse/workflow/node/start_node.py
+++ b/agentuniverse/workflow/node/start_node.py
@@ -24,7 +24,7 @@ class StartNode(Node):
     def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
         start_params: dict = workflow_output.workflow_start_params
         start_val = start_params.get('input', '')
-        output_params: List[NodeOutputParams] = self._data.outputs
+        output_params: List[NodeOutputParams] = [NodeOutputParams(**p.model_dump()) for p in self._data.outputs]
         output_params[0].value = start_val
         workflow_output.workflow_parameters[self.id] = output_params
         return NodeOutput(node_id=self.id, status=NodeStatusEnum.SUCCEEDED, result=output_params)

--- a/agentuniverse/workflow/node/tool_node.py
+++ b/agentuniverse/workflow/node/tool_node.py
@@ -44,7 +44,7 @@ class ToolNode(Node):
 
         tool_input_params = self._resolve_input_params(inputs.input_param, workflow_output)
         tool_output = tool.run(**tool_input_params)
-        output_params: List[NodeOutputParams] = self._data.outputs
+        output_params: List[NodeOutputParams] = [NodeOutputParams(**p.model_dump()) for p in self._data.outputs]
 
         if isinstance(tool_output, str):
             output_params[0].value = tool_output

--- a/tests/test_agentuniverse/unit/regressions/test_workflow_output_isolation.py
+++ b/tests/test_agentuniverse/unit/regressions/test_workflow_output_isolation.py
@@ -1,0 +1,28 @@
+"""Regression tests for workflow node output isolation across executions."""
+
+from agentuniverse.workflow.node.node_config import NodeOutputParams
+from agentuniverse.workflow.node.start_node import StartNode
+from agentuniverse.workflow.workflow_output import WorkflowOutput
+
+
+def _build_start_node():
+    node = StartNode(id="start", type="start")
+    node._data.outputs = [NodeOutputParams(name="out", type="str", value=None)]
+    return node
+
+
+def test_reused_workflow_start_node_outputs_are_isolated():
+    node = _build_start_node()
+
+    first = WorkflowOutput()
+    first.workflow_start_params = {"input": "first"}
+    result1 = node._run(first)
+
+    second = WorkflowOutput()
+    second.workflow_start_params = {"input": "second"}
+    result2 = node._run(second)
+
+    assert result1.result[0].value == "first"
+    assert result2.result[0].value == "second"
+    assert result1.result[0] is not result2.result[0]
+    assert node._data.outputs[0].value is None


### PR DESCRIPTION
## Summary
- workflow nodes reused the persistent output objects from their configuration, so a re-run of the same workflow mutated the previously returned outputs
- start/end/llm/tool/knowledge/agent nodes now build a fresh copy of their output params per run

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_workflow_output_isolation.py