### PR TITLE
fix: register coroutines in async langchain tool conversions

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -377,7 +377,8 @@ class Knowledge(ComponentBase):
         return LangchainTool(
             name=self.name,
             description=self.description or '' + args_description,
-            func=self.async_langchain_query,
+            func=self.langchain_query,
+            coroutine=self.async_langchain_query,
         )
 
     def create_copy(self):

--- a/agentuniverse/agent/action/tool/tool.py
+++ b/agentuniverse/agent/action/tool/tool.py
@@ -150,7 +150,7 @@ class Tool(ComponentBase):
 
     async def async_as_langchain(self) -> LangchainTool:
         return LangchainTool(name=self.name,
-                             func=self.run,
+                             func=self.langchain_run,
                              coroutine=self.async_langchain_run,
                              description=self.description)
 

--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -284,7 +284,8 @@ class Agent(ComponentBase, ABC):
         """
         return LangchainTool(
             name=self.agent_model.info.get("name"),
-            func=self.async_langchain_run,
+            func=self.langchain_run,
+            coroutine=self.async_langchain_run,
             description=self.agent_model.info.get("description") + args_description
         )
 

--- a/tests/test_agentuniverse/unit/regressions/test_async_langchain_tool_coroutine.py
+++ b/tests/test_agentuniverse/unit/regressions/test_async_langchain_tool_coroutine.py
@@ -1,0 +1,16 @@
+"""Regression tests for async LangChain tool coroutine registration."""
+
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.mock_search_tool import MockSearchTool
+
+
+@pytest.mark.asyncio
+async def test_async_as_langchain_registers_coroutine_and_sync_adapter():
+    tool = MockSearchTool(input_keys=["input"])
+    lc_tool = await tool.async_as_langchain()
+
+    assert lc_tool.coroutine is not None
+    assert lc_tool.func is not None
+    assert callable(lc_tool.coroutine)
+    assert callable(lc_tool.func)


### PR DESCRIPTION
## Summary
- Agent and Knowledge async conversions only set func, so ainvoke() ran the sync fallback in a thread and returned an unawaited coroutine
- Tool async conversion set coroutine but pointed func at run(), which fails when LangChain passes a positional JSON string
- all three now register the JSON-string sync adapter as func and the async adapter as coroutine

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_async_langchain_tool_coroutine.py