### PR TITLE
fix(tool): align MockSearchTool async input handling

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/mock_search_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/mock_search_tool.py
@@ -6,20 +6,19 @@
 # @Email   :
 # @FileName: mock_search_tool.py
 
-from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from agentuniverse.agent.action.tool.tool import Tool
 
 
 class MockSearchTool(Tool):
     """The demo google search mock tool.
     """
 
-    def execute(self, input: str):
+    def execute(self, **kwargs):
         # get top10 results from mock search.
         res = self.mock_api_res()
         return res
 
-    async def async_execute(self, tool_input: ToolInput):
-        input = tool_input.get_data("input")
+    async def async_execute(self, **kwargs):
         # get top10 results from mock search.
         res = self.mock_api_res()
         return res

--- a/tests/test_agentuniverse/unit/regressions/test_mock_search_tool_async_input.py
+++ b/tests/test_agentuniverse/unit/regressions/test_mock_search_tool_async_input.py
@@ -1,0 +1,22 @@
+"""Regression tests for MockSearchTool async input handling."""
+
+import asyncio
+
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.mock_search_tool import MockSearchTool
+
+
+def test_execute_accepts_keyword_args():
+    tool = MockSearchTool(input_keys=["input"])
+    result = tool.execute(input="hello")
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_async_run_uses_keyword_args():
+    tool = MockSearchTool(input_keys=["input"])
+    result = await tool.async_run(input="hello")
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
## Summary
- MockSearchTool.execute() already used the keyword-argument signature, so the base Tool treated it as non-deprecated and routed async_run() through async_execute(**kwargs)
- the async implementation still expected a legacy ToolInput positional argument, so every standard async invocation failed with TypeError
- both execute() and async_execute() now accept keyword arguments consistently

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_mock_search_tool_async_input.py