### PR TITLE
fix(memory): return the most recent Chroma memory window

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/chroma_memory_storage.py
@@ -171,7 +171,6 @@ class ChromaMemoryStorage(MemoryStorage):
         else:
             results = self._collection.get(where=filters)
             messages = self.to_messages(result=results, sort_by_time=True)
-            messages.reverse()
             return messages[-top_k:]
 
     def to_messages(self, result: dict, sort_by_time: bool = False) -> List[Message]:

--- a/tests/test_agentuniverse/unit/regressions/test_chroma_memory_window.py
+++ b/tests/test_agentuniverse/unit/regressions/test_chroma_memory_window.py
@@ -1,0 +1,29 @@
+"""Regression tests for the non-semantic Chroma memory window."""
+
+from agentuniverse.agent.memory.memory_storage.chroma_memory_storage import ChromaMemoryStorage
+from agentuniverse.message.message import Message
+
+
+class RecordingCollection:
+    def __init__(self, messages):
+        self.messages = messages
+
+    def get(self, where=None):
+        return {"ids": [str(i) for i in range(len(self.messages))], "documents": self.messages}
+
+
+def test_get_returns_most_recent_window_in_time_order():
+    messages = [Message(content=f"m{i}", gmt_created=i) for i in range(1, 5)]
+    store = ChromaMemoryStorage(name="chroma")
+    store._collection = RecordingCollection([m.content for m in messages])
+
+    def fake_to_messages(result, sort_by_time=False):
+        docs = result["documents"]
+        pairs = sorted(zip(docs, range(len(docs))), key=lambda x: x[1])
+        return [Message(content=content, gmt_created=i) for content, i in pairs]
+
+    store.to_messages = fake_to_messages
+
+    result = store.get(key="session", top_k=2)
+    contents = [m.content for m in result]
+    assert contents == ["m3", "m4"]


### PR DESCRIPTION
## Summary
- the non-semantic ChromaMemoryStorage.get() path sorted messages oldest to newest, reversed the list, and returned its final top_k entries
- that picked the oldest messages instead of the recent history window and returned them in reverse chronological order
- it now returns the newest top_k messages in time order

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_chroma_memory_window.py