### PR TITLE
fix(product): persist plugin OpenAPI descriptions

### DIFF
--- a/agentuniverse_product/service/util/plugin_util.py
+++ b/agentuniverse_product/service/util/plugin_util.py
@@ -51,7 +51,7 @@ def assemble_plugin_product_config_data(plugin_dto: PluginDTO, tool_id_list: Lis
             'module': 'agentuniverse_product.base.plugin_product',
             'type': 'PRODUCT'
         },
-        'openapi_desc': ''
+        'openapi_desc': plugin_dto.openapi_desc or ''
     }
 
 

--- a/tests/test_agentuniverse/unit/regressions/test_plugin_openapi_desc.py
+++ b/tests/test_agentuniverse/unit/regressions/test_plugin_openapi_desc.py
@@ -1,0 +1,22 @@
+"""Regression tests for plugin OpenAPI description persistence."""
+
+from agentuniverse_product.service.model.plugin_dto import PluginDTO
+from agentuniverse_product.service.util.plugin_util import assemble_plugin_product_config_data
+
+
+def test_openapi_desc_is_persisted_in_product_config():
+    dto = PluginDTO(
+        id="plugin_id",
+        nickname="nick",
+        avatar="avatar",
+        description="desc",
+        openapi_desc="openapi: 3.0.0\ninfo: {}\npaths: {}",
+    )
+    config = assemble_plugin_product_config_data(dto, tool_id_list=["t1"])
+    assert config["openapi_desc"] == dto.openapi_desc
+
+
+def test_openapi_desc_none_falls_back_to_empty():
+    dto = PluginDTO(id="plugin_id", nickname="nick", avatar="avatar", description="desc", openapi_desc=None)
+    config = assemble_plugin_product_config_data(dto, tool_id_list=["t1"])
+    assert config["openapi_desc"] == ""


### PR DESCRIPTION
## Summary
- plugin creation parsed the caller openapi_desc, but assemble_plugin_product_config_data() wrote an empty string to the product configuration
- get_plugin_list() later read that persisted field, so the original schema was permanently lost from the product model
- the persisted config now carries the real openapi_desc (falling back to an empty string when absent)

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_plugin_openapi_desc.py