### PR TITLE
fix(product): resolve OpenAPI parameter references

### DIFF
--- a/agentuniverse_product/service/util/plugin_util.py
+++ b/agentuniverse_product/service/util/plugin_util.py
@@ -51,7 +51,7 @@ def assemble_plugin_product_config_data(plugin_dto: PluginDTO, tool_id_list: Lis
             'module': 'agentuniverse_product.base.plugin_product',
             'type': 'PRODUCT'
         },
-        'openapi_desc': ''
+        'openapi_desc': plugin_dto.openapi_desc or ''
     }
 
 

--- a/agentuniverse_product/service/util/plugin_util.py
+++ b/agentuniverse_product/service/util/plugin_util.py
@@ -79,12 +79,17 @@ def parse_openapi_yaml_to_tool_bundle(yaml: str) -> list:
     for path, path_item in openapi['paths'].items():
         methods = ['get', 'post', 'put', 'delete',
                    'patch', 'head', 'options', 'trace']
+        path_parameters = path_item.get('parameters', [])
         for method in methods:
             if method in path_item:
+                operation = dict(path_item[method])
+                operation_parameters = operation.get('parameters', [])
+                merged = _merge_parameters(path_parameters, operation_parameters)
+                operation['parameters'] = _resolve_parameter_refs(openapi, merged)
                 interfaces.append({
                     'path': path,
                     'method': method,
-                    'operation': path_item[method],
+                    'operation': operation,
                     'url': server_url + path,
                 })
     # create tool bundle
@@ -120,3 +125,58 @@ def parse_openapi_yaml_to_tool_bundle(yaml: str) -> list:
             interface['operation']['operationId'] = f'{path}_{interface["method"]}'
 
     return interfaces
+
+
+def _resolve_ref(openapi: dict, ref: str) -> dict:
+    """Resolve a local OpenAPI $ref against the document root.
+
+    Args:
+        openapi (dict): The OpenAPI document root.
+        ref (str): The $ref string, expected to start with '#/'.
+
+    Returns:
+        dict: The referenced object.
+
+    Raises:
+        Exception: If the reference is malformed or points to a missing node.
+    """
+    if not ref.startswith('#/'):
+        raise Exception(f'Only local OpenAPI references are supported: {ref}')
+    root = openapi
+    for part in ref[2:].split('/'):
+        if part not in root:
+            raise Exception(f'Unresolved OpenAPI reference: {ref}')
+        root = root[part]
+    return root
+
+
+def _resolve_parameter_refs(openapi: dict, parameters: list) -> list:
+    """Resolve $ref entries inside an OpenAPI parameter list.
+
+    Args:
+        openapi (dict): The OpenAPI document root.
+        parameters (list): The parameter list.
+
+    Returns:
+        list: A new list with references resolved to concrete parameter objects.
+    """
+    resolved = []
+    for parameter in parameters:
+        if '$ref' in parameter:
+            resolved.append(_resolve_ref(openapi, parameter['$ref']))
+        else:
+            resolved.append(parameter)
+    return resolved
+
+
+def _merge_parameters(path_parameters: list, operation_parameters: list) -> list:
+    """Merge Path Item parameters with operation parameters without mutating inputs.
+
+    Args:
+        path_parameters (list): Parameters declared at the Path Item level.
+        operation_parameters (list): Parameters declared at the operation level.
+
+    Returns:
+        list: The merged parameter list.
+    """
+    return list(path_parameters) + list(operation_parameters)

--- a/tests/test_agentuniverse/unit/regressions/test_openapi_parameter_refs.py
+++ b/tests/test_agentuniverse/unit/regressions/test_openapi_parameter_refs.py
@@ -1,0 +1,61 @@
+"""Regression tests for OpenAPI parameter reference resolution."""
+
+import pytest
+
+from agentuniverse_product.service.util.plugin_util import parse_openapi_yaml_to_tool_bundle
+
+OPENAPI_YAML = """
+openapi: 3.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users/{userId}:
+    parameters:
+      - $ref: '#/components/parameters/UserId'
+    get:
+      operationId: getUser
+      parameters:
+        - name: verbose
+          in: query
+          required: true
+          schema:
+            type: boolean
+components:
+  parameters:
+    UserId:
+      name: userId
+      in: path
+      required: true
+      schema:
+        type: string
+"""
+
+
+def test_parameter_refs_are_resolved():
+    bundles = parse_openapi_yaml_to_tool_bundle(OPENAPI_YAML)
+    assert len(bundles) == 1
+    parameters = bundles[0]["operation"]["parameters"]
+    names = [p.get("name") for p in parameters]
+    assert "userId" in names
+    assert "verbose" in names
+    user_id = next(p for p in parameters if p.get("name") == "userId")
+    assert user_id["in"] == "path"
+    assert user_id["required"] is True
+
+
+def test_malformed_ref_raises_clear_error():
+    yaml = """
+openapi: 3.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /x:
+    get:
+      operationId: getX
+      parameters:
+        - $ref: '#/components/parameters/Missing'
+components:
+  parameters: {}
+"""
+    with pytest.raises(Exception, match="Unresolved OpenAPI reference"):
+        parse_openapi_yaml_to_tool_bundle(yaml)

--- a/tests/test_agentuniverse/unit/regressions/test_plugin_openapi_desc.py
+++ b/tests/test_agentuniverse/unit/regressions/test_plugin_openapi_desc.py
@@ -1,0 +1,22 @@
+"""Regression tests for plugin OpenAPI description persistence."""
+
+from agentuniverse_product.service.model.plugin_dto import PluginDTO
+from agentuniverse_product.service.util.plugin_util import assemble_plugin_product_config_data
+
+
+def test_openapi_desc_is_persisted_in_product_config():
+    dto = PluginDTO(
+        id="plugin_id",
+        nickname="nick",
+        avatar="avatar",
+        description="desc",
+        openapi_desc="openapi: 3.0.0\ninfo: {}\npaths: {}",
+    )
+    config = assemble_plugin_product_config_data(dto, tool_id_list=["t1"])
+    assert config["openapi_desc"] == dto.openapi_desc
+
+
+def test_openapi_desc_none_falls_back_to_empty():
+    dto = PluginDTO(id="plugin_id", nickname="nick", avatar="avatar", description="desc", openapi_desc=None)
+    config = assemble_plugin_product_config_data(dto, tool_id_list=["t1"])
+    assert config["openapi_desc"] == ""


### PR DESCRIPTION
## Summary
- the product OpenAPI parser resolved local $ref values inside request-body schemas but left parameter references untouched
- a parameter entry such as {"$ref": "#/components/parameters/UserId"} reached parse_tool_input() and APITool without name, in, or required fields, breaking the generated tool inputs
- parameters are now merged from Path Item and operation levels and local $refs are resolved against the document root, with a clear error for malformed references

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest tests/test_agentuniverse/unit/regressions/test_openapi_parameter_refs.py
