### PR TITLE
fix(tool): avoid masking missing APITool body parameters

### DIFF
--- a/agentuniverse/agent/action/tool/api_tool.py
+++ b/agentuniverse/agent/action/tool/api_tool.py
@@ -177,8 +177,9 @@ class APITool(Tool):
                             body[name] = self.convert_body_property_type(
                                 property, parameters[name])
                         elif name in required:
+                            operation_id = self.openapi_spec.get('operation', {}).get('operationId')
                             raise Exception(
-                                f"Missing required parameter {name} in operation {self.plugin_api_model.operation_id}"
+                                f"Missing required parameter {name} in operation {operation_id or self.name}"
                             )
                         elif 'default' in property:
                             body[name] = property['default']

--- a/tests/test_agentuniverse/unit/regressions/test_api_tool_missing_body_param.py
+++ b/tests/test_agentuniverse/unit/regressions/test_api_tool_missing_body_param.py
@@ -1,0 +1,38 @@
+"""Regression tests for APITool missing body parameter errors."""
+
+import pytest
+
+from agentuniverse.agent.action.tool.api_tool import APITool
+
+
+def _make_api_tool(operation_id="op1"):
+    tool = APITool(name="api_tool")
+    tool.openapi_spec = {
+        "operation": {
+            "operationId": operation_id,
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "required": ["name"],
+                            "properties": {"name": {"type": "string"}},
+                        }
+                    }
+                }
+            },
+            "parameters": [],
+        }
+    }
+    return tool
+
+
+def test_missing_required_body_parameter_raises_validation_error():
+    tool = _make_api_tool(operation_id="createUser")
+    with pytest.raises(Exception, match="Missing required parameter name in operation createUser"):
+        tool.do_http_request("https://api.example.com/users", "post", {}, {})
+
+
+def test_missing_required_body_parameter_falls_back_to_tool_name():
+    tool = _make_api_tool(operation_id="")
+    with pytest.raises(Exception, match="Missing required parameter name in operation api_tool"):
+        tool.do_http_request("https://api.example.com/users", "post", {}, {})


### PR DESCRIPTION
## Summary
- when a required OpenAPI request-body property is absent, APITool.do_http_request() tried to include self.plugin_api_model.operation_id in the error message
- APITool does not define plugin_api_model, so the missing-parameter path raised AttributeError instead of the intended validation exception
- the error now uses the operationId from the openapi spec and falls back to the tool name

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest tests/test_agentuniverse/unit/regressions/test_api_tool_missing_body_param.py
