### PR TITLE
feat(tool): add Pydantic input contracts

### DIFF
--- a/agentuniverse/agent/action/tool/tool.py
+++ b/agentuniverse/agent/action/tool/tool.py
@@ -73,7 +73,7 @@ class Tool(ComponentBase):
     @trace_tool
     def run(self, **kwargs):
         """The callable method that runs the tool."""
-        self.input_check(kwargs)
+        kwargs = self.validate_input(kwargs)
         if self.check_execute_signature_deprecated():
             return self.execute(ToolInput(kwargs))
         return self.execute(**kwargs)
@@ -81,10 +81,25 @@ class Tool(ComponentBase):
     @trace_tool
     async def async_run(self, **kwargs):
         """The callable method that runs the tool."""
-        self.input_check(kwargs)
+        kwargs = self.validate_input(kwargs)
         if self.check_execute_signature_deprecated():
             return await asyncio.to_thread(self.execute, ToolInput(kwargs))
         return await self.async_execute(**kwargs)
+
+    def validate_input(self, kwargs: dict) -> dict:
+        """Validate and normalize tool keyword arguments.
+
+        ``input_keys`` remains the lightweight compatibility contract. Tools
+        that set ``args_model`` to a Pydantic model additionally receive type
+        coercion, defaults, and nested validation through one shared sync and
+        async path.
+        """
+        self.input_check(kwargs)
+        if self.args_model is None:
+            return kwargs
+        if not isinstance(self.args_model, type) or not issubclass(self.args_model, BaseModel):
+            raise TypeError('Tool.args_model must be a Pydantic BaseModel subclass.')
+        return self.args_model.model_validate(kwargs).model_dump()
 
     def input_check(self, kwargs: dict) -> None:
         """Check whether the input parameters of the tool contain input keys of the tool"""
@@ -98,10 +113,9 @@ class Tool(ComponentBase):
         """The callable method that runs the tool."""
         if self.check_execute_signature_deprecated():
             """Deprecated in future, use kwargs as tool input instead of ToolInput."""
-            tool_input = ToolInput(kwargs)
             parse_result = self.parse_react_input(args[0])
-            for key in self.input_keys:
-                tool_input.add_data(key, parse_result[key])
+            validated_input = self.validate_input({**kwargs, **parse_result})
+            tool_input = ToolInput(validated_input)
             return self.execute(tool_input)
         else:
             try:
@@ -109,20 +123,21 @@ class Tool(ComponentBase):
                                                             self.input_keys)
             except Exception as e:
                 return str(e)
+            parse_result = self.validate_input(parse_result)
             return self.execute(**parse_result)
 
     @trace_tool
     async def async_langchain_run(self, *args, callbacks=None, **kwargs):
         if self.check_execute_signature_deprecated():
-            tool_input = ToolInput(kwargs)
             parse_result = self.parse_react_input(args[0])
-            for key in self.input_keys:
-                tool_input.add_data(key, parse_result[key])
+            validated_input = self.validate_input({**kwargs, **parse_result})
+            tool_input = ToolInput(validated_input)
             return await asyncio.to_thread(self.execute, tool_input)
         try:
             parse_result = parse_and_check_json_markdown(args[0], self.input_keys)
         except Exception as e:
             return str(e)
+        parse_result = self.validate_input(parse_result)
         return await self.async_execute(**parse_result)
 
     def parse_react_input(self, input_str: str):

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Tool/Typed_Tool_Inputs.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Tool/Typed_Tool_Inputs.md
@@ -1,0 +1,30 @@
+# Typed tool inputs
+
+Tools can attach a Pydantic model to `args_model` when key-presence checks are
+not enough. The model is applied by both `run()` and `async_run()` before the
+tool implementation is called.
+
+```python
+from pydantic import BaseModel, Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class SearchArgs(BaseModel):
+    query: str
+    limit: int = Field(default=5, ge=1, le=20)
+
+
+class SearchTool(Tool):
+    name: str = "search"
+    input_keys: list[str] = ["query"]
+    args_model: object = SearchArgs
+
+    def execute(self, query: str, limit: int):
+        return search(query, limit=limit)
+```
+
+Pydantic coercions and defaults are passed to `execute`. Invalid input raises
+the normal Pydantic `ValidationError`. Existing tools that leave `args_model`
+unset keep their current behavior, including tools that still receive a
+`ToolInput` object.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/工具/工具参数类型契约.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/工具/工具参数类型契约.md
@@ -1,0 +1,29 @@
+# 工具参数类型契约
+
+当 `input_keys` 的键存在性检查不足以描述参数时，工具可以通过
+`args_model` 绑定 Pydantic 模型。`run()` 与 `async_run()` 会在执行工具前
+使用同一模型完成校验和规范化。
+
+```python
+from pydantic import BaseModel, Field
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class SearchArgs(BaseModel):
+    query: str
+    limit: int = Field(default=5, ge=1, le=20)
+
+
+class SearchTool(Tool):
+    name: str = "search"
+    input_keys: list[str] = ["query"]
+    args_model: object = SearchArgs
+
+    def execute(self, query: str, limit: int):
+        return search(query, limit=limit)
+```
+
+Pydantic 的类型转换和默认值会传给 `execute`。非法输入保持标准
+`ValidationError`。未设置 `args_model` 的现有工具以及仍接收
+`ToolInput` 的旧工具保持兼容。

--- a/tests/test_agentuniverse/unit/agent/action/tool/test_tool_input_contract.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_tool_input_contract.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+
+
+class SearchArgs(BaseModel):
+    query: str
+    limit: int = Field(default=5, ge=1, le=20)
+
+
+class TypedTool(Tool):
+    name: str = "typed_tool"
+
+    def execute(self, **kwargs):
+        return kwargs
+
+
+class AsyncTypedTool(TypedTool):
+    async def async_execute(self, **kwargs):
+        return kwargs
+
+
+class LegacyTypedTool(Tool):
+    name: str = "legacy_typed_tool"
+
+    def execute(self, tool_input: ToolInput):
+        return tool_input.to_dict()
+
+
+def typed_tool(**kwargs):
+    return TypedTool(input_keys=["query"], args_model=SearchArgs, **kwargs)
+
+
+def test_run_applies_pydantic_coercion_and_defaults():
+    result = Tool.run.__wrapped__(typed_tool(), query="agents", limit="3")
+
+    assert result == {"query": "agents", "limit": 3}
+
+
+def test_async_run_uses_the_same_input_contract():
+    result = asyncio.run(
+        Tool.async_run.__wrapped__(
+            AsyncTypedTool(input_keys=["query"], args_model=SearchArgs),
+            query="agents",
+        )
+    )
+
+    assert result == {"query": "agents", "limit": 5}
+
+
+def test_validation_error_is_preserved():
+    with pytest.raises(ValidationError):
+        Tool.run.__wrapped__(typed_tool(), query="agents", limit=0)
+
+
+def test_invalid_args_model_has_an_actionable_error():
+    tool = TypedTool(input_keys=["query"], args_model=dict)
+
+    with pytest.raises(TypeError, match="Pydantic BaseModel subclass"):
+        Tool.run.__wrapped__(tool, query="agents")
+
+
+def test_typed_contract_supports_legacy_tool_input_signature():
+    tool = LegacyTypedTool(input_keys=["query"], args_model=SearchArgs)
+
+    result = Tool.run.__wrapped__(tool, query="agents", limit="2")
+
+    assert result == {"query": "agents", "limit": 2}
+
+
+def test_tools_without_args_model_keep_existing_behavior():
+    tool = TypedTool(input_keys=["query"], args_model=None)
+
+    result = Tool.run.__wrapped__(tool, query="agents", extra=True)
+
+    assert result == {"query": "agents", "extra": True}


### PR DESCRIPTION
## Summary

- validate tool keyword arguments with the existing `args_model` hook
- apply Pydantic coercions, defaults, and nested validation consistently in sync, async, and LangChain entry points
- preserve `input_keys`, untyped tools, and deprecated `ToolInput` compatibility
- add regression tests and bilingual documentation

Closes #1121

## Validation

- `pytest test_tool_input_contract.py test_tool_async_compatibility.py -q` (8 passed)
- targeted Ruff and Black checks passed
- `git diff --check` passed

## Checklist

- [x] Existing untyped tool behavior is unchanged
- [x] Sync and async paths share one validation contract
- [x] Tests and English/Chinese docs included
- [x] No new dependency
