### PR TITLE
feat(prompt): add reusable partial bindings

### DIFF
--- a/agentuniverse/prompt/prompt.py
+++ b/agentuniverse/prompt/prompt.py
@@ -5,10 +5,10 @@
 # @Email   : lc299034@antgroup.com
 # @FileName: prompt.py
 """Prompt base module."""
-import re
-from typing import Optional
+from typing import Any, Optional
 
 from langchain_core.prompts import PromptTemplate
+from pydantic import Field
 
 from agentuniverse.base.component.component_base import ComponentBase
 from agentuniverse.base.component.component_enum import ComponentEnum
@@ -23,6 +23,7 @@ class Prompt(ComponentBase):
     prompt_version: Optional[str] = None
     prompt_template: Optional[str] = None
     input_variables: Optional[list[str]] = None
+    partial_variables: dict[str, Any] = Field(default_factory=dict)
 
     def __init__(self, **kwargs):
         super().__init__(component_type=ComponentEnum.PROMPT, **kwargs)
@@ -34,7 +35,39 @@ class Prompt(ComponentBase):
             PromptTemplate: The prompt template.
         """
         return PromptTemplate(template=self.prompt_template,
-                              input_variables=self.input_variables)
+                              input_variables=self.input_variables,
+                              partial_variables=self.partial_variables)
+
+    def partial(self, **values: Any) -> 'Prompt':
+        """Return an independent prompt with reusable variables bound.
+
+        Values may be constants or zero-argument callables, matching LangChain
+        partial prompt semantics.
+        """
+        template_variables = set(self._extract_input_variables())
+        unknown_variables = sorted(set(values) - template_variables)
+        if unknown_variables:
+            raise ValueError(
+                f'Cannot bind variables not present in the prompt template: '
+                f'{", ".join(unknown_variables)}.'
+            )
+        copied = self.model_copy(deep=True)
+        copied.partial_variables.update(values)
+        copied.input_variables = [
+            variable for variable in self._extract_input_variables()
+            if variable not in copied.partial_variables
+        ]
+        return copied
+
+    def format(self, **values: Any) -> str:
+        """Render this prompt using its partial and invocation variables."""
+        return self.as_langchain().format(**values)
+
+    def _extract_input_variables(self) -> list[str]:
+        """Return variables declared by the current f-string template."""
+        if not self.prompt_template:
+            return []
+        return PromptTemplate.from_template(self.prompt_template).input_variables
 
     def build_prompt(self, agent_prompt_model: AgentPromptModel, prompt_assemble_order: list[str]) -> 'Prompt':
         """Build the prompt class.
@@ -47,7 +80,7 @@ class Prompt(ComponentBase):
             Prompt: The prompt object.
         """
         self.prompt_template = generate_template(agent_prompt_model, prompt_assemble_order)
-        self.input_variables = re.findall(r'\{(.*?)}', self.prompt_template)
+        self.input_variables = self._extract_input_variables()
         return self
 
     def get_instance_code(self) -> str:
@@ -76,5 +109,5 @@ class Prompt(ComponentBase):
 
         self.prompt_template = '\n'.join(prompt_values)
 
-        self.input_variables = re.findall(r'\{(.*?)}', self.prompt_template)
+        self.input_variables = self._extract_input_variables()
         return self

--- a/docs/guidebook/en/Get_Start/8.Advanced_Techniques-Prompt_Manager.md
+++ b/docs/guidebook/en/Get_Start/8.Advanced_Techniques-Prompt_Manager.md
@@ -15,3 +15,24 @@ Taking the `demo_agent.yaml` in the `sample_standard_app` project as an example,
 ![prompt_version](../../_picture/prompt_version.png)
 
 By doing so, we can manage and use a large number of prompts in an orderly and flexible manner by simply modifying the `prompt_version` in the agent YAML file.
+# Reusable partial prompt variables
+
+Values shared by many invocations can be bound once without mutating the
+registered prompt:
+
+```python
+prompt = Prompt(
+    prompt_template="{product}: answer {question} in {language}",
+    input_variables=["product", "question", "language"],
+)
+
+english_prompt = prompt.partial(
+    product="agentUniverse",
+    language="English",
+)
+text = english_prompt.format(question="What is an agent?")
+```
+
+`partial()` returns an independent copy. Constants and zero-argument callables
+are supported, bindings can be chained, and bound names are removed from
+`input_variables`. The same bindings are forwarded by `as_langchain()`.

--- a/docs/guidebook/zh/开始使用/8.进阶技巧-prompt管理.md
+++ b/docs/guidebook/zh/开始使用/8.进阶技巧-prompt管理.md
@@ -16,3 +16,22 @@
 ![prompt_version](../../_picture/prompt_version.png)
 
 通过这种方式，我们可以通过修改agent yaml中的prompt_version（prompt版本号）将大量prompt有序管理并灵活使用起来。
+# 可复用的 Prompt 部分变量
+
+多个调用共享的固定值可以预先绑定，同时不会修改已注册的 Prompt：
+
+```python
+prompt = Prompt(
+    prompt_template="{product}：请用{language}回答{question}",
+    input_variables=["product", "question", "language"],
+)
+
+chinese_prompt = prompt.partial(
+    product="agentUniverse",
+    language="中文",
+)
+text = chinese_prompt.format(question="什么是智能体？")
+```
+
+`partial()` 返回独立副本，支持常量和无参数可调用对象，也可以链式绑定。
+已绑定变量会从 `input_variables` 中移除，并由 `as_langchain()` 原样传递。

--- a/tests/test_agentuniverse/unit/prompt/test_prompt_partial.py
+++ b/tests/test_agentuniverse/unit/prompt/test_prompt_partial.py
@@ -1,0 +1,53 @@
+import pytest
+
+from agentuniverse.prompt.prompt import Prompt
+
+
+def make_prompt() -> Prompt:
+    return Prompt(
+        prompt_template="{product}: Hello {name} from {locale}",
+        input_variables=["product", "name", "locale"],
+    )
+
+
+def test_partial_returns_an_independent_prompt():
+    prompt = make_prompt()
+
+    bound = prompt.partial(product="agentUniverse", locale="Shanghai")
+
+    assert prompt.partial_variables == {}
+    assert prompt.input_variables == ["product", "name", "locale"]
+    assert bound.input_variables == ["name"]
+    assert bound.format(name="Ada") == "agentUniverse: Hello Ada from Shanghai"
+
+
+def test_partial_bindings_can_be_chained_and_rebound():
+    prompt = make_prompt().partial(product="old").partial(product="new")
+
+    prompt = prompt.partial(locale="Hangzhou")
+
+    assert prompt.input_variables == ["name"]
+    assert prompt.format(name="Lin") == "new: Hello Lin from Hangzhou"
+
+
+def test_callable_partial_is_resolved_at_format_time():
+    prompt = make_prompt().partial(
+        product="agentUniverse",
+        locale=lambda: "runtime locale",
+    )
+
+    assert prompt.format(name="Ada") == ("agentUniverse: Hello Ada from runtime locale")
+
+
+def test_unknown_partial_variable_is_rejected():
+    with pytest.raises(ValueError, match="not present.*missing"):
+        make_prompt().partial(missing="value")
+
+
+def test_as_langchain_preserves_partial_variables():
+    prompt = make_prompt().partial(product="agentUniverse")
+
+    langchain_prompt = prompt.as_langchain()
+
+    assert langchain_prompt.partial_variables == {"product": "agentUniverse"}
+    assert langchain_prompt.input_variables == ["locale", "name"]


### PR DESCRIPTION
## Summary

- add immutable-style `Prompt.partial()` bindings for constants and callables
- remove bound names from remaining `input_variables`
- add direct `Prompt.format()` rendering and preserve bindings in LangChain conversion
- improve template-variable extraction and add regression tests plus bilingual docs

Closes #1122

## Validation

- prompt partial-binding tests: 5 passed
- targeted Ruff and Black checks passed
- `git diff --check` passed

## Checklist

- [x] Registered prompts are not mutated
- [x] Existing prompt construction remains compatible
- [x] Tests and English/Chinese docs included
- [x] No new dependency
