### PR TITLE
feat(memory): add JSONL transcript import and export

### DIFF
--- a/agentuniverse/agent/memory/transcript.py
+++ b/agentuniverse/agent/memory/transcript.py
@@ -1,0 +1,71 @@
+"""Portable JSON Lines serialization for memory messages."""
+
+# Dynamic, line-specific import errors are the public API of this module.
+# ruff: noqa: TRY003
+
+import json
+from collections.abc import Iterable
+
+from pydantic import ValidationError
+
+from agentuniverse.agent.memory.message import Message
+
+
+class TranscriptFormatError(ValueError):
+    """Raised when transcript text cannot be decoded or parsed."""
+
+
+class TranscriptTypeError(TypeError):
+    """Raised when transcript APIs receive unsupported object types."""
+
+
+def messages_to_jsonl(messages: Iterable[Message]) -> str:
+    """Serialize an ordered message sequence as newline-delimited JSON.
+
+    Every Pydantic field is preserved, including message identifiers. A final
+    newline is emitted for non-empty transcripts so the result can be safely
+    appended to JSONL files and streams.
+    """
+    records = []
+    for index, message in enumerate(messages, start=1):
+        if not isinstance(message, Message):
+            raise TranscriptTypeError(f"Transcript item {index} must be a Message.")
+        records.append(
+            json.dumps(
+                message.model_dump(mode="json"),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+    if not records:
+        return ""
+    return "\n".join(records) + "\n"
+
+
+def messages_from_jsonl(transcript: str | bytes) -> list[Message]:
+    """Load messages from JSONL text or UTF-8 bytes.
+
+    Empty lines are ignored. Parse and validation failures include the source
+    line number so imported transcripts can be repaired efficiently.
+    """
+    if isinstance(transcript, bytes):
+        try:
+            transcript = transcript.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise TranscriptFormatError("Transcript bytes must contain valid UTF-8.") from error
+    if not isinstance(transcript, str):
+        raise TranscriptTypeError("Transcript must be str or bytes.")
+
+    messages = []
+    for line_number, line in enumerate(transcript.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise TranscriptFormatError(f"Invalid JSON on transcript line {line_number}: {error.msg}.") from error
+        try:
+            messages.append(Message.model_validate(record))
+        except ValidationError as error:
+            raise TranscriptFormatError(f"Invalid message on transcript line {line_number}: {error}") from error
+    return messages

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Memory/Memory_Transcripts.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Memory/Memory_Transcripts.md
@@ -1,0 +1,23 @@
+# Portable memory transcripts
+
+Conversation history can be exported to JSON Lines without depending on a
+particular memory storage backend:
+
+```python
+from agentuniverse.agent.memory.transcript import (
+    messages_from_jsonl,
+    messages_to_jsonl,
+)
+
+payload = messages_to_jsonl(messages)
+restored_messages = messages_from_jsonl(payload)
+```
+
+Each line is one complete `Message`. IDs, roles, text or multimodal content,
+sources, and metadata are preserved. The loader accepts `str` or UTF-8 bytes
+and ignores empty lines, which makes transcripts convenient for files and
+append-only streams. Malformed JSON and invalid message records report the
+failing line number.
+
+The helpers only transform data; applications remain responsible for access
+control and for removing sensitive content before exporting a transcript.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/记忆/记忆记录导入导出.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/记忆/记忆记录导入导出.md
@@ -1,0 +1,20 @@
+# 可移植的记忆记录
+
+对话历史可以导出为 JSON Lines，而不依赖具体的记忆存储后端：
+
+```python
+from agentuniverse.agent.memory.transcript import (
+    messages_from_jsonl,
+    messages_to_jsonl,
+)
+
+payload = messages_to_jsonl(messages)
+restored_messages = messages_from_jsonl(payload)
+```
+
+每一行保存一个完整的 `Message`，包括 ID、角色、文本或多模态内容、来源和
+元数据。加载器接受字符串或 UTF-8 字节并忽略空行，适合文件和追加写入的
+数据流。JSON 损坏或消息字段不合法时，错误会指出对应行号。
+
+这些辅助函数只负责数据转换；应用仍需自行控制访问权限，并在导出前移除
+敏感内容。

--- a/tests/test_agentuniverse/unit/agent/memory/test_transcript.py
+++ b/tests/test_agentuniverse/unit/agent/memory/test_transcript.py
@@ -1,0 +1,67 @@
+import pytest
+
+from agentuniverse.agent.memory.message import Message
+from agentuniverse.agent.memory.transcript import (
+    messages_from_jsonl,
+    messages_to_jsonl,
+)
+
+
+def test_jsonl_round_trip_preserves_all_message_fields():
+    messages = [
+        Message(
+            id="message-1",
+            type="human",
+            content="hello",
+            source="user",
+            metadata={"locale": "zh-CN"},
+        ),
+        Message(
+            id="message-2",
+            type="ai",
+            content=["caption", {"type": "image_url", "url": "image.png"}],
+            source="assistant",
+            metadata={"model": "example"},
+        ),
+    ]
+
+    transcript = messages_to_jsonl(messages)
+
+    assert transcript.endswith("\n")
+    assert messages_from_jsonl(transcript) == messages
+    assert messages_from_jsonl(transcript.encode()) == messages
+
+
+def test_blank_lines_are_ignored():
+    transcript = '\n{"id":"1","type":"human","content":"hello"}\n\n'
+
+    messages = messages_from_jsonl(transcript)
+
+    assert messages == [Message(id="1", type="human", content="hello")]
+
+
+def test_invalid_json_reports_the_source_line():
+    with pytest.raises(ValueError, match="Invalid JSON.*line 3"):
+        messages_from_jsonl('\n{"content":"ok"}\nnot-json')
+
+
+def test_invalid_message_reports_the_source_line():
+    with pytest.raises(ValueError, match="Invalid message.*line 2"):
+        messages_from_jsonl("\n[]")
+
+
+def test_invalid_utf8_and_input_type_are_rejected():
+    with pytest.raises(ValueError, match="valid UTF-8"):
+        messages_from_jsonl(b"\xff")
+    with pytest.raises(TypeError, match="str or bytes"):
+        messages_from_jsonl(None)
+
+
+def test_serializer_requires_message_objects():
+    with pytest.raises(TypeError, match="item 2"):
+        messages_to_jsonl([Message(content="ok"), {"content": "invalid"}])
+
+
+def test_empty_transcript_round_trip():
+    assert messages_to_jsonl([]) == ""
+    assert messages_from_jsonl("") == []


### PR DESCRIPTION
## Summary

- add backend-independent JSONL serialization for ordered memory messages
- preserve IDs, roles, multimodal content, sources, and metadata
- accept UTF-8 text or bytes, tolerate blank lines, and report malformed records with line numbers
- add typed format errors, unit tests, and bilingual documentation

Closes #1123

## Validation

- memory transcript tests: 7 passed
- targeted Ruff and Black checks passed
- `git diff --check` passed

## Checklist

- [x] No storage backend dependency
- [x] Empty and multimodal transcripts covered
- [x] Tests and English/Chinese docs included
- [x] No new dependency
