### PR TITLE
feat(knowledge): expose per-store query diagnostics

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -9,6 +9,7 @@ import os
 import re
 import traceback
 from copy import deepcopy
+from time import perf_counter
 from typing import Optional, Dict, List, Any
 from concurrent.futures import wait, ALL_COMPLETED
 
@@ -18,6 +19,10 @@ from langchain.tools import Tool as LangchainTool
 from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.knowledge.store.query import Query
+from agentuniverse.agent.action.knowledge.store.query_result import (
+    KnowledgeQueryResult,
+    StoreQueryDiagnostic,
+)
 from agentuniverse.agent.action.knowledge.store.store_manager import StoreManager
 from agentuniverse.agent.action.knowledge.doc_processor.doc_processor import DocProcessor
 from agentuniverse.agent.action.knowledge.doc_processor.doc_processor_manager import DocProcessorManager
@@ -233,17 +238,28 @@ class Knowledge(ComponentBase):
 
         Query documents from the store and return the results.
         """
+        return self._query_knowledge_with_diagnostics(**kwargs).documents
+
+    @trace_knowledge
+    def query_knowledge_with_diagnostics(self, **kwargs) -> KnowledgeQueryResult:
+        """Query knowledge and expose the outcome of every routed store."""
+        return self._query_knowledge_with_diagnostics(**kwargs)
+
+    def _query_knowledge_with_diagnostics(self, **kwargs) -> KnowledgeQueryResult:
         query = Query(**kwargs)
         query = self._paraphrase_query(query)
         query_tasks = self._route_rag(query)
 
         futures = []
-        for query_task in query_tasks:
+        for store_query, store_code in query_tasks:
+            store = StoreManager().get_instance_obj(store_code, strict=True)
             futures.append((
                 self.query_executor.submit(
-                    StoreManager().get_instance_obj(query_task[1], strict=True).query,
-                    query_task[0]),
-                query_task[1],
+                    self._execute_store_query,
+                    store,
+                    store_query,
+                ),
+                store_code,
             ))
         wait([future for future, _ in futures], return_when=ALL_COMPLETED)
         # Channel-aware recall is opt-in: only when a configured post-processor
@@ -255,32 +271,60 @@ class Knowledge(ComponentBase):
         # changes the output of pipelines that do not use it.
         preserve_channels = self._channel_fusion_enabled()
         retrieved_docs = {}
+        diagnostics = []
         for future, store_code in futures:
-            try:
-                task_result = future.result()
-                for _doc in task_result:
-                    if preserve_channels:
-                        # Stamp the store code that recalled this document and
-                        # de-duplicate per channel (id + channel): a document
-                        # recalled by several stores is kept once per store,
-                        # while a duplicate within the same store is dropped.
-                        metadata = dict(_doc.metadata or {})
-                        metadata[RECALL_CHANNEL_KEY] = store_code
-                        _doc.metadata = metadata
-                        dedup_identity = (_doc.id, store_code)
-                    else:
-                        # Default contract: collapse cross-store duplicates to
-                        # a single document (first recall wins) and stamp no
-                        # extra metadata, so the output matches master.
-                        dedup_identity = _doc.id
-                    if dedup_identity not in retrieved_docs:
-                        retrieved_docs[dedup_identity] = _doc
-            except Exception as e:
-                traceback.print_exc()
-                LOGGER.error(f"Exception occurred in knowledge query: {e}")
+            task_result, duration_ms, error = future.result()
+            diagnostics.append(StoreQueryDiagnostic(
+                store_code=store_code,
+                succeeded=error is None,
+                duration_ms=duration_ms,
+                document_count=len(task_result),
+                error=(f'{type(error).__name__}: {error}' if error else None),
+            ))
+            if error:
+                LOGGER.error(f"Exception occurred in knowledge query: {error}")
+                continue
+            for _doc in task_result:
+                if preserve_channels:
+                    # Stamp the store code that recalled this document and
+                    # de-duplicate per channel (id + channel): a document
+                    # recalled by several stores is kept once per store,
+                    # while a duplicate within the same store is dropped.
+                    metadata = dict(_doc.metadata or {})
+                    metadata[RECALL_CHANNEL_KEY] = store_code
+                    _doc.metadata = metadata
+                    dedup_identity = (_doc.id, store_code)
+                else:
+                    # Default contract: collapse cross-store duplicates to
+                    # a single document (first recall wins) and stamp no
+                    # extra metadata, so the output matches master.
+                    dedup_identity = _doc.id
+                if dedup_identity not in retrieved_docs:
+                    retrieved_docs[dedup_identity] = _doc
         retrieved_docs = list(retrieved_docs.values())
         retrieved_docs = self._rag_post_process(retrieved_docs, query)
-        return retrieved_docs
+        return KnowledgeQueryResult(
+            documents=retrieved_docs,
+            diagnostics=diagnostics,
+        )
+
+    @staticmethod
+    def _execute_store_query(store, query: Query):
+        """Execute one store query and retain timing for success or failure."""
+        started_at = perf_counter()
+        try:
+            documents = store.query(query)
+            if documents is None:
+                documents = []
+                error = TypeError('Knowledge stores must return an iterable of documents.')
+            else:
+                documents = list(documents)
+                error = None
+        except Exception as query_error:  # noqa: BLE001 - reported as a diagnostic
+            documents = []
+            error = query_error
+        duration_ms = max(0.0, (perf_counter() - started_at) * 1000)
+        return documents, duration_ms, error
 
     def to_llm(self, retrieved_docs: List[Document]) -> Any:
         """Transfer list docs to llm input"""

--- a/agentuniverse/agent/action/knowledge/store/query_result.py
+++ b/agentuniverse/agent/action/knowledge/store/query_result.py
@@ -1,0 +1,22 @@
+"""Structured result models for observable knowledge queries."""
+
+from pydantic import BaseModel, Field
+
+from agentuniverse.agent.action.knowledge.store.document import Document
+
+
+class StoreQueryDiagnostic(BaseModel):
+    """Outcome and timing for one routed store query."""
+
+    store_code: str
+    succeeded: bool
+    duration_ms: float = Field(ge=0)
+    document_count: int = Field(default=0, ge=0)
+    error: str | None = None
+
+
+class KnowledgeQueryResult(BaseModel):
+    """Post-processed documents and their per-store diagnostics."""
+
+    documents: list[Document] = Field(default_factory=list)
+    diagnostics: list[StoreQueryDiagnostic] = Field(default_factory=list)

--- a/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Knowledge_Query_Diagnostics.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tutorials/Knowledge/Knowledge_Query_Diagnostics.md
@@ -1,0 +1,29 @@
+# Knowledge query diagnostics
+
+`Knowledge.query_knowledge()` intentionally tolerates failures from individual
+stores so healthy retrieval channels can still answer. Applications that need
+to observe those partial failures can use the opt-in diagnostics API:
+
+```python
+result = knowledge.query_knowledge_with_diagnostics(
+    query_str="agent orchestration",
+    similarity_top_k=5,
+)
+
+for diagnostic in result.diagnostics:
+    print(
+        diagnostic.store_code,
+        diagnostic.succeeded,
+        diagnostic.duration_ms,
+        diagnostic.document_count,
+        diagnostic.error,
+    )
+
+documents = result.documents
+```
+
+Every routed store produces one diagnostic with success state, elapsed
+milliseconds, returned document count, and a concise error when applicable.
+`documents` uses the same de-duplication and post-processing path as
+`query_knowledge()`. Missing component registrations still raise immediately;
+runtime failures from one store remain non-fatal.

--- a/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/知识查询诊断.md
+++ b/docs/guidebook/zh/In-Depth_Guides/原理介绍/知识/知识查询诊断.md
@@ -1,0 +1,26 @@
+# 知识查询诊断
+
+`Knowledge.query_knowledge()` 会容忍单个存储的运行时失败，使健康的检索
+通道仍可返回结果。需要观察部分失败的应用可以使用可选诊断接口：
+
+```python
+result = knowledge.query_knowledge_with_diagnostics(
+    query_str="智能体编排",
+    similarity_top_k=5,
+)
+
+for diagnostic in result.diagnostics:
+    print(
+        diagnostic.store_code,
+        diagnostic.succeeded,
+        diagnostic.duration_ms,
+        diagnostic.document_count,
+        diagnostic.error,
+    )
+
+documents = result.documents
+```
+
+每个路由到的存储都会产生一条诊断，包含成功状态、耗时毫秒数、返回文档数和
+简洁错误信息。`documents` 与 `query_knowledge()` 使用相同的去重和后处理
+流程。组件未注册仍会立即报错；单个存储的运行时失败保持非致命。

--- a/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_query_diagnostics.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_query_diagnostics.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch
+
+from agentuniverse.agent.action.knowledge.knowledge import Knowledge
+from agentuniverse.agent.action.knowledge.store.document import Document
+from agentuniverse.agent.action.knowledge.store.query import Query
+
+
+class SuccessfulStore:
+    def query(self, query):
+        return [Document(id="doc-1", text=f"result for {query.query_str}")]
+
+
+class FailingStore:
+    def query(self, query):
+        raise RuntimeError(f"{query.query_str} store is offline")  # noqa: TRY003
+
+
+def make_knowledge():
+    return Knowledge(name="diagnostic_knowledge", stores=["ok", "offline"])
+
+
+def test_query_diagnostics_report_success_and_partial_failure():
+    knowledge = make_knowledge()
+    routes = [(Query(query_str="q"), "ok"), (Query(query_str="q"), "offline")]
+    stores = {"ok": SuccessfulStore(), "offline": FailingStore()}
+
+    with (
+        patch.object(knowledge, "_route_rag", return_value=routes),
+        patch.object(knowledge, "_channel_fusion_enabled", return_value=False),
+        patch.object(knowledge, "_rag_post_process", side_effect=lambda docs, _: docs),
+        patch("agentuniverse.agent.action.knowledge.knowledge.StoreManager") as store_manager,
+    ):
+        store_manager.return_value.get_instance_obj.side_effect = lambda code, **_: stores[code]
+        result = Knowledge.query_knowledge_with_diagnostics.__wrapped__(
+            knowledge,
+            query_str="q",
+        )
+
+    assert [document.id for document in result.documents] == ["doc-1"]
+    assert [item.store_code for item in result.diagnostics] == ["ok", "offline"]
+    assert result.diagnostics[0].succeeded is True
+    assert result.diagnostics[0].document_count == 1
+    assert result.diagnostics[0].duration_ms >= 0
+    assert result.diagnostics[0].error is None
+    assert result.diagnostics[1].succeeded is False
+    assert result.diagnostics[1].document_count == 0
+    assert result.diagnostics[1].duration_ms >= 0
+    assert result.diagnostics[1].error == "RuntimeError: q store is offline"
+
+
+def test_existing_query_api_still_returns_only_documents():
+    knowledge = make_knowledge()
+    expected = [Document(id="doc-1", text="result")]
+
+    with patch.object(
+        knowledge,
+        "_query_knowledge_with_diagnostics",
+    ) as query_with_diagnostics:
+        query_with_diagnostics.return_value.documents = expected
+        result = Knowledge.query_knowledge.__wrapped__(knowledge, query_str="q")
+
+    assert result == expected


### PR DESCRIPTION
## Summary

- add `query_knowledge_with_diagnostics()` without changing the existing document-only API
- report success, elapsed time, document count, and concise errors for every routed store
- preserve strict missing-component errors, partial-failure tolerance, de-duplication, channel fusion, and post-processing
- add focused regression tests and bilingual documentation

Closes #1124

## Validation

- diagnostics, registration-error, and RRF integration tests: 13 passed
- targeted Ruff and Black checks passed
- `git diff --check` passed

## Checklist

- [x] `query_knowledge()` remains backward compatible
- [x] Partial store failures remain non-fatal
- [x] Tests and English/Chinese docs included
- [x] No new dependency
