### PR TITLE
feat(core): add component registration aliases

### DIFF
--- a/agentuniverse/base/component/component_manager_base.py
+++ b/agentuniverse/base/component/component_manager_base.py
@@ -26,10 +26,17 @@ class ComponentManagerBase(Generic[ComponentTypeVar]):
         # The component pool map, which is used to store the component instance.
         # _instance_obj_map - Format: {component_instance_name: component_instance_obj}.
         self._instance_obj_map: dict[str, ComponentTypeVar] = {}
+        # Alias and target values use the same fully-qualified codes as the
+        # component pool. Targets are canonicalized when aliases are added.
+        self._alias_map: dict[str, str] = {}
         self._component_type: ComponentEnum = component_type
 
     def register(self, component_instance_name: str, component_instance_obj: ComponentTypeVar):
         """Register the component instance."""
+        if component_instance_name in self._alias_map:
+            LOGGER.warn(f"{self._component_type.value} component name "
+                        f"'{component_instance_name}' is already registered as an alias.")
+            return
         if component_instance_name in self._instance_obj_map.keys():
             if is_system_builtin(component_instance_obj):
                 LOGGER.info(f"Component name '{component_instance_name}' is already registered. "
@@ -66,7 +73,8 @@ class ComponentManagerBase(Generic[ComponentTypeVar]):
         if component_instance_name == "__default_instance__":
             return self.get_default_instance(new_instance)
         appname = appname or ApplicationConfigManager().app_configer.base_info_appname
-        instance_code = f'{appname}.{self._component_type.value.lower()}.{component_instance_name}'
+        instance_code = self._build_instance_code(component_instance_name, appname)
+        instance_code = self._alias_map.get(instance_code, instance_code)
         instance = self._instance_obj_map.get(instance_code)
         if instance is None:
             if strict:
@@ -81,6 +89,51 @@ class ComponentManagerBase(Generic[ComponentTypeVar]):
         if new_instance:
             return instance.create_copy()
         return instance
+
+    def register_alias(self, alias_name: str, target_name: str,
+                       appname: str = None) -> None:
+        """Register an alternative name for an existing component.
+
+        Alias targets are resolved to canonical component codes immediately.
+        This permits alias chains without leaving cycles or dependencies
+        between aliases.
+
+        Args:
+            alias_name: New bare component name used by callers.
+            target_name: Existing bare component name or alias.
+            appname: Application name; defaults to the configured app.
+
+        Raises:
+            ValueError: If the alias collides or the target is not registered.
+        """
+        appname = appname or ApplicationConfigManager().app_configer.base_info_appname
+        alias_code = self._build_instance_code(alias_name, appname)
+        target_code = self._build_instance_code(target_name, appname)
+        canonical_target = self._alias_map.get(target_code, target_code)
+
+        if alias_code in self._instance_obj_map or alias_code in self._alias_map:
+            raise ValueError(
+                f"Cannot register alias '{alias_name}': the name is already in use."
+            )
+        if canonical_target not in self._instance_obj_map:
+            raise ValueError(
+                f"Cannot register alias '{alias_name}': target component "
+                f"'{target_name}' is not registered."
+            )
+        self._alias_map[alias_code] = canonical_target
+
+    def unregister_alias(self, alias_name: str, appname: str = None) -> None:
+        """Remove an alias without unregistering its target component."""
+        appname = appname or ApplicationConfigManager().app_configer.base_info_appname
+        self._alias_map.pop(self._build_instance_code(alias_name, appname))
+
+    def get_alias_map(self) -> dict[str, str]:
+        """Return an isolated alias-to-canonical-code mapping."""
+        return self._alias_map.copy()
+
+    def _build_instance_code(self, component_name: str, appname: str) -> str:
+        """Build the registry key for a bare component name."""
+        return f'{appname}.{self._component_type.value.lower()}.{component_name}'
 
     def get_default_instance(self, new_instance: bool = False) -> ComponentTypeVar:
         """Return the default instance of component."""

--- a/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Others/Component_Aliases.md
+++ b/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Others/Component_Aliases.md
@@ -1,0 +1,23 @@
+# Component registration aliases
+
+Component aliases provide a migration window when an agent, tool, model, or
+other configured component is renamed. Register the canonical component first,
+then add an alternative bare name through its manager:
+
+```python
+manager.register_alias(
+    alias_name="legacy_search",
+    target_name="web_search",
+)
+
+tool = manager.get_instance_obj("legacy_search")
+```
+
+Alias lookups preserve normal manager behavior, including defensive copies and
+strict lookup errors. Targets may themselves be aliases; the manager stores the
+resolved canonical code so alias chains cannot form cycles. Collisions and
+missing targets are rejected.
+
+Use `get_alias_map()` for introspection. `unregister_alias()` removes only the
+alternative name and never unregisters the canonical component. Alias and
+target names belong to the same application and component manager.

--- a/docs/guidebook/zh/In-Depth_Guides/技术组件/其他/组件别名.md
+++ b/docs/guidebook/zh/In-Depth_Guides/技术组件/其他/组件别名.md
@@ -1,0 +1,20 @@
+# 组件注册别名
+
+当智能体、工具、模型或其他配置组件改名时，组件别名可以提供平滑迁移窗口。
+先注册正式组件，再通过对应 Manager 添加备用短名称：
+
+```python
+manager.register_alias(
+    alias_name="legacy_search",
+    target_name="web_search",
+)
+
+tool = manager.get_instance_obj("legacy_search")
+```
+
+通过别名获取组件时仍遵守 Manager 的防御性复制和严格查询错误等现有行为。
+目标也可以是已有别名；Manager 会立即保存解析后的正式组件编码，因此别名链
+不会形成循环。名称碰撞和不存在的目标会被拒绝。
+
+可以使用 `get_alias_map()` 查看别名，`unregister_alias()` 只删除备用名称，
+不会注销正式组件。别名和目标必须属于同一个应用及同一种组件 Manager。

--- a/tests/test_agentuniverse/unit/base/component/test_component_manager_aliases.py
+++ b/tests/test_agentuniverse/unit/base/component/test_component_manager_aliases.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.component.component_manager_base import ComponentManagerBase
+
+APP_NAME = "test_app"
+TARGET_CODE = "test_app.tool.current"
+
+
+def make_manager():
+    manager = ComponentManagerBase(ComponentEnum.TOOL)
+    component = MagicMock()
+    component.default_symbol = False
+    component.create_copy.return_value = "component-copy"
+    manager.register(TARGET_CODE, component)
+    return manager, component
+
+
+def test_alias_uses_normal_copy_and_raw_lookup_behavior():
+    manager, component = make_manager()
+    manager.register_alias("legacy", "current", appname=APP_NAME)
+
+    assert manager.get_instance_obj("legacy", appname=APP_NAME) == "component-copy"
+    assert manager.get_instance_obj("legacy", appname=APP_NAME, new_instance=False) is component
+
+
+def test_aliases_are_canonicalized_and_introspectable():
+    manager, _ = make_manager()
+    manager.register_alias("legacy", "current", appname=APP_NAME)
+    manager.register_alias("older", "legacy", appname=APP_NAME)
+
+    aliases = manager.get_alias_map()
+
+    assert aliases == {
+        "test_app.tool.legacy": TARGET_CODE,
+        "test_app.tool.older": TARGET_CODE,
+    }
+    aliases.clear()
+    assert len(manager.get_alias_map()) == 2
+
+
+def test_alias_collisions_and_missing_targets_are_rejected():
+    manager, _ = make_manager()
+
+    with pytest.raises(ValueError, match="name is already in use"):
+        manager.register_alias("current", "current", appname=APP_NAME)
+    with pytest.raises(ValueError, match="target component.*missing"):
+        manager.register_alias("legacy", "missing", appname=APP_NAME)
+
+
+def test_alias_cycle_attempt_collides_with_canonical_component():
+    manager, _ = make_manager()
+    manager.register_alias("legacy", "current", appname=APP_NAME)
+
+    with pytest.raises(ValueError, match="name is already in use"):
+        manager.register_alias("current", "legacy", appname=APP_NAME)
+
+
+def test_unregister_alias_keeps_target_component():
+    manager, component = make_manager()
+    manager.register_alias("legacy", "current", appname=APP_NAME)
+
+    manager.unregister_alias("legacy", appname=APP_NAME)
+
+    assert manager.get_alias_map() == {}
+    assert manager.get_instance_obj("current", appname=APP_NAME, new_instance=False) is component
+    assert manager.get_instance_obj("legacy", appname=APP_NAME) is None
+
+
+def test_strict_alias_lookup_preserves_strict_behavior():
+    manager, _ = make_manager()
+    manager.register_alias("legacy", "current", appname=APP_NAME)
+    manager._instance_obj_map.pop(TARGET_CODE)
+
+    with pytest.raises(ValueError, match="legacy.*not registered"):
+        manager.get_instance_obj("legacy", appname=APP_NAME, strict=True)


### PR DESCRIPTION
## Summary

- add explicit aliases to every `ComponentManagerBase` specialization
- canonicalize alias chains while preserving copy, raw, and strict lookup behavior
- reject missing targets, name collisions, and cycle attempts
- expose isolated alias introspection and safe alias removal
- add regression tests and bilingual documentation

Closes #1125

## Validation

- alias and strict component-lookup tests: 12 passed
- targeted Ruff and Black checks passed
- `git diff --check` passed

## Checklist

- [x] Removing an alias never removes its target
- [x] Canonical component lookups remain compatible
- [x] Tests and English/Chinese docs included
- [x] No new dependency
