### PR TITLE
fix(context): honor non-positive RAM get limits

### DIFF
--- a/agentuniverse/agent/context/store/ram_context_store.py
+++ b/agentuniverse/agent/context/store/ram_context_store.py
@@ -99,6 +99,7 @@ class RamContextStore(ContextStore):
             List[ContextSegment]: Retrieved segments (sorted by last_accessed desc)
         """
         start_time = time.time() if self.enable_metrics else None
+        limit = max(0, limit)
 
         if session_id not in self._storage:
             return []

--- a/tests/test_agentuniverse/unit/regressions/test_ram_context_nonpositive_limit.py
+++ b/tests/test_agentuniverse/unit/regressions/test_ram_context_nonpositive_limit.py
@@ -1,0 +1,12 @@
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+def test_get_with_negative_limit_returns_no_segments():
+    store = RamContextStore(name="ram")
+    store.add([
+        ContextSegment(type=ContextType.CONVERSATION, content="one", tokens=1),
+        ContextSegment(type=ContextType.CONVERSATION, content="two", tokens=1),
+    ], session_id="session")
+
+    assert store.get("session", limit=-1) == []


### PR DESCRIPTION
## Summary
- normalize negative RAM get limits to an empty result window
- prevent Python negative slicing from returning all but the final segment
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_ram_context_nonpositive_limit.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
