### PR TITLE
fix(context): honor non-positive Redis get limits

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -145,7 +145,7 @@ class RedisContextStore(ContextStore):
         Returns:
             List of matching segments
         """
-        if not self._redis:
+        if limit <= 0 or not self._redis:
             return []
 
         key = self._make_session_key(session_id)

--- a/tests/test_agentuniverse/unit/regressions/test_redis_context_nonpositive_limit.py
+++ b/tests/test_agentuniverse/unit/regressions/test_redis_context_nonpositive_limit.py
@@ -1,0 +1,14 @@
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+class UnexpectedRedisAccess:
+    def hgetall(self, key):
+        raise AssertionError("Redis should not be queried for an empty result window")
+
+
+def test_get_with_nonpositive_limit_skips_redis():
+    store = RedisContextStore(name="redis")
+    store._redis = UnexpectedRedisAccess()
+
+    assert store.get("session", limit=-1) == []
+    assert store.get("session", limit=0) == []


### PR DESCRIPTION
## Summary
- return an empty result for zero or negative Redis get limits
- avoid an unnecessary Redis request when no results can be returned
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_redis_context_nonpositive_limit.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
