### PR TITLE
fix(context): honor non-positive Chroma get limits

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -207,7 +207,7 @@ class ChromaContextStore(ContextStore):
         Returns:
             List of matching segments
         """
-        if not self._collection:
+        if limit <= 0 or not self._collection:
             return []
 
         # Build where clause for filtering

--- a/tests/test_agentuniverse/unit/regressions/test_chroma_context_nonpositive_limit.py
+++ b/tests/test_agentuniverse/unit/regressions/test_chroma_context_nonpositive_limit.py
@@ -1,0 +1,14 @@
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+class UnexpectedCollectionAccess:
+    def get(self, **kwargs):
+        raise AssertionError("Chroma should not be queried for an empty result window")
+
+
+def test_get_with_nonpositive_limit_skips_chroma():
+    store = ChromaContextStore(name="chroma")
+    store._collection = UnexpectedCollectionAccess()
+
+    assert store.get("session", limit=-1) == []
+    assert store.get("session", limit=0) == []


### PR DESCRIPTION
## Summary
- return an empty result for zero or negative Chroma get limits
- avoid passing invalid result limits to the Chroma collection
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_chroma_context_nonpositive_limit.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
