### PR TITLE
fix(context): skip blank RAM context searches

### DIFF
--- a/agentuniverse/agent/context/store/ram_context_store.py
+++ b/agentuniverse/agent/context/store/ram_context_store.py
@@ -160,6 +160,8 @@ class RamContextStore(ContextStore):
         """
         start_time = time.time() if self.enable_metrics else None
 
+        if not isinstance(query, str) or not query.strip():
+            return []
         if session_id not in self._storage:
             return []
 

--- a/tests/test_agentuniverse/unit/regressions/test_ram_context_blank_search.py
+++ b/tests/test_agentuniverse/unit/regressions/test_ram_context_blank_search.py
@@ -1,0 +1,14 @@
+import pytest
+
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+@pytest.mark.parametrize("query", [None, "", "   "])
+def test_blank_search_does_not_match_every_segment(query):
+    store = RamContextStore(name="ram")
+    store.add([
+        ContextSegment(type=ContextType.CONVERSATION, content="context", tokens=1)
+    ], session_id="session")
+
+    assert store.search(query, "session") == []


### PR DESCRIPTION
## Summary
- treat null and whitespace-only RAM search queries as empty
- prevent the empty string from matching every stored segment
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_ram_context_blank_search.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
