### PR TITLE
fix(context): skip blank Redis context searches

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -195,6 +195,9 @@ class RedisContextStore(ContextStore):
         Returns:
             List of matching segments ranked by relevance
         """
+        if not isinstance(query, str) or not query.strip():
+            return []
+
         # Get all segments and do in-memory search
         # For production, consider Redis full-text search module
         segments = self.get(session_id, limit=1000)

--- a/tests/test_agentuniverse/unit/regressions/test_redis_context_blank_search.py
+++ b/tests/test_agentuniverse/unit/regressions/test_redis_context_blank_search.py
@@ -1,0 +1,16 @@
+import pytest
+
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+class UnexpectedRedisAccess:
+    def hgetall(self, key):
+        raise AssertionError("Redis should not be queried for a blank search")
+
+
+@pytest.mark.parametrize("query", [None, "", "   "])
+def test_blank_search_skips_redis(query):
+    store = RedisContextStore(name="redis")
+    store._redis = UnexpectedRedisAccess()
+
+    assert store.search(query, "session") == []


### PR DESCRIPTION
## Summary
- short-circuit null and whitespace-only Redis context searches
- avoid loading the full session for a query with no searchable terms
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_redis_context_blank_search.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
