### PR TITLE
fix(context): skip blank Chroma context searches

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -270,6 +270,8 @@ class ChromaContextStore(ContextStore):
         Returns:
             List of matching segments ranked by semantic similarity
         """
+        if not isinstance(query, str) or not query.strip():
+            return []
         if not self._collection:
             return []
 

--- a/tests/test_agentuniverse/unit/regressions/test_chroma_context_blank_search.py
+++ b/tests/test_agentuniverse/unit/regressions/test_chroma_context_blank_search.py
@@ -1,0 +1,16 @@
+import pytest
+
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+class UnexpectedCollectionAccess:
+    def query(self, **kwargs):
+        raise AssertionError("Chroma should not be queried for a blank search")
+
+
+@pytest.mark.parametrize("query", [None, "", "   "])
+def test_blank_search_skips_chroma(query):
+    store = ChromaContextStore(name="chroma")
+    store._collection = UnexpectedCollectionAccess()
+
+    assert store.search(query, "session") == []


### PR DESCRIPTION
## Summary
- short-circuit null and whitespace-only Chroma context searches
- avoid embedding and querying empty text
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_chroma_context_blank_search.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
