### PR TITLE
fix(benchmark): reject empty compression workloads

### DIFF
--- a/agentuniverse/agent/context/benchmark/benchmark_suite.py
+++ b/agentuniverse/agent/context/benchmark/benchmark_suite.py
@@ -318,6 +318,9 @@ class ContextBenchmarkSuite:
         Returns:
             Tuple of (compression_ratio, information_loss)
         """
+        if num_segments <= 0:
+            raise ValueError("num_segments must be positive")
+
         session_id = f"benchmark_compression_{datetime.now().timestamp()}"
         window = self.context_manager.create_context_window(
             session_id,

--- a/tests/test_agentuniverse/unit/regressions/test_benchmark_zero_compression.py
+++ b/tests/test_agentuniverse/unit/regressions/test_benchmark_zero_compression.py
@@ -1,0 +1,10 @@
+import pytest
+
+from agentuniverse.agent.context.benchmark.benchmark_suite import ContextBenchmarkSuite
+
+
+def test_compression_benchmark_rejects_empty_workload():
+    suite = ContextBenchmarkSuite(object())
+
+    with pytest.raises(ValueError, match="num_segments must be positive"):
+        suite._test_compression_quality(0)


### PR DESCRIPTION
## Summary
- validate compression benchmark workload sizes before setup
- replace a divide-by-zero failure with a descriptive input error
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_benchmark_zero_compression.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
