### PR TITLE
fix(benchmark): reject empty performance workloads

### DIFF
--- a/agentuniverse/agent/context/benchmark/benchmark_suite.py
+++ b/agentuniverse/agent/context/benchmark/benchmark_suite.py
@@ -402,6 +402,9 @@ class ContextBenchmarkSuite:
         Returns:
             Dictionary with latency statistics
         """
+        if num_operations <= 0:
+            raise ValueError("num_operations must be positive")
+
         session_id = f"benchmark_perf_{datetime.now().timestamp()}"
         self.context_manager.create_context_window(session_id)
 

--- a/tests/test_agentuniverse/unit/regressions/test_benchmark_zero_operations.py
+++ b/tests/test_agentuniverse/unit/regressions/test_benchmark_zero_operations.py
@@ -1,0 +1,10 @@
+import pytest
+
+from agentuniverse.agent.context.benchmark.benchmark_suite import ContextBenchmarkSuite
+
+
+def test_performance_benchmark_rejects_empty_workload():
+    suite = ContextBenchmarkSuite(object())
+
+    with pytest.raises(ValueError, match="num_operations must be positive"):
+        suite._test_performance(0)


### PR DESCRIPTION
## Summary
- reject zero-operation performance benchmark runs
- avoid empty latency percentile indexing and division by zero
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_benchmark_zero_operations.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
