### PR TITLE
fix(benchmark): reject empty resource workloads

### DIFF
--- a/agentuniverse/agent/context/benchmark/benchmark_suite.py
+++ b/agentuniverse/agent/context/benchmark/benchmark_suite.py
@@ -455,6 +455,9 @@ class ContextBenchmarkSuite:
         """
         import sys
 
+        if num_turns <= 0:
+            raise ValueError("num_turns must be positive")
+
         session_id = f"benchmark_resource_{datetime.now().timestamp()}"
         self.context_manager.create_context_window(session_id)
 

--- a/tests/test_agentuniverse/unit/regressions/test_benchmark_zero_turns.py
+++ b/tests/test_agentuniverse/unit/regressions/test_benchmark_zero_turns.py
@@ -1,0 +1,10 @@
+import pytest
+
+from agentuniverse.agent.context.benchmark.benchmark_suite import ContextBenchmarkSuite
+
+
+def test_resource_benchmark_rejects_empty_workload():
+    suite = ContextBenchmarkSuite(object())
+
+    with pytest.raises(ValueError, match="num_turns must be positive"):
+        suite._test_resource_usage(0)


### PR DESCRIPTION
## Summary
- reject zero-turn resource benchmark runs
- avoid dividing the measured token total by an empty workload
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_benchmark_zero_turns.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
