### PR TITLE
fix(context): initialize store metrics centrally

### DIFF
--- a/agentuniverse/agent/context/context_store.py
+++ b/agentuniverse/agent/context/context_store.py
@@ -33,6 +33,11 @@ class ContextStore(ComponentBase):
     enable_metrics: bool = False
     _metrics: Dict[str, Any] = {}
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.enable_metrics:
+            self.initialize_metrics()
+
     def initialize_metrics(self) -> None:
         """Initialize performance metrics tracking."""
         self._metrics = {

--- a/tests/test_agentuniverse/unit/regressions/test_context_store_metrics_init.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_store_metrics_init.py
@@ -1,0 +1,11 @@
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+def test_enabling_metrics_initializes_non_ram_stores():
+    store = RedisContextStore(name="redis", enable_metrics=True)
+
+    metrics = store.get_metrics()
+
+    assert metrics["add_count"] == 0
+    assert metrics["get_count"] == 0
+    assert metrics["search_count"] == 0


### PR DESCRIPTION
## Summary
- initialize context-store metric counters in the shared base class
- make metrics work for Redis and Chroma stores, not only RAM
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_store_metrics_init.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
