### PR TITLE
fix(context): lift default ID lookup cap

### DIFF
--- a/agentuniverse/agent/context/context_store.py
+++ b/agentuniverse/agent/context/context_store.py
@@ -149,7 +149,9 @@ class ContextStore(ComponentBase):
         Returns:
             List[ContextSegment]: Retrieved segments
         """
-        all_segments = self.get(session_id, **kwargs)
+        lookup_kwargs = kwargs.copy()
+        lookup_kwargs.setdefault("limit", self.max_segments)
+        all_segments = self.get(session_id, **lookup_kwargs)
         segment_id_set = set(segment_ids)
         return [s for s in all_segments if s.id in segment_id_set]
 

--- a/tests/test_agentuniverse/unit/regressions/test_context_store_default_id_limit.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_store_default_id_limit.py
@@ -1,0 +1,37 @@
+from typing import List
+
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.context_store import ContextStore
+
+
+class ListContextStore(ContextStore):
+    def __init__(self, segments):
+        super().__init__(name="list", max_segments=200)
+        self._segments = segments
+
+    def add(self, segments, **kwargs):
+        self._segments.extend(segments)
+
+    def get(self, session_id, context_type=None, limit=100, **kwargs):
+        return self._segments[:limit]
+
+    def search(self, query, session_id, top_k=10, **kwargs):
+        return []
+
+    def delete(self, session_id, segment_ids=None, **kwargs):
+        pass
+
+    def prune(self, session_id, **kwargs):
+        return 0
+
+
+def test_default_id_lookup_searches_beyond_get_default():
+    segments: List[ContextSegment] = [
+        ContextSegment(id=str(index), type=ContextType.REFERENCE, content=str(index), tokens=1)
+        for index in range(101)
+    ]
+    store = ListContextStore(segments)
+
+    result = store.get_by_ids("session", ["100"])
+
+    assert [segment.id for segment in result] == ["100"]


### PR DESCRIPTION
## Summary
- let the default ID lookup inspect the configured store capacity
- prevent requested IDs after the first 100 segments from being invisible
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_store_default_id_limit.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
