### PR TITLE
fix(context): lift default count cap

### DIFF
--- a/agentuniverse/agent/context/context_store.py
+++ b/agentuniverse/agent/context/context_store.py
@@ -181,7 +181,9 @@ class ContextStore(ComponentBase):
         Returns:
             int: Number of segments
         """
-        return len(self.get(session_id, **kwargs))
+        count_kwargs = kwargs.copy()
+        count_kwargs.setdefault("limit", self.max_segments)
+        return len(self.get(session_id, **count_kwargs))
 
     def get_metrics(self) -> Dict[str, Any]:
         """Get performance metrics.

--- a/tests/test_agentuniverse/unit/regressions/test_context_store_default_count_limit.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_store_default_count_limit.py
@@ -1,0 +1,33 @@
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.context_store import ContextStore
+
+
+class ListContextStore(ContextStore):
+    def __init__(self, segments):
+        super().__init__(name="list", max_segments=200)
+        self._segments = segments
+
+    def add(self, segments, **kwargs):
+        self._segments.extend(segments)
+
+    def get(self, session_id, context_type=None, limit=100, **kwargs):
+        return self._segments[:limit]
+
+    def search(self, query, session_id, top_k=10, **kwargs):
+        return []
+
+    def delete(self, session_id, segment_ids=None, **kwargs):
+        pass
+
+    def prune(self, session_id, **kwargs):
+        return 0
+
+
+def test_default_count_is_not_capped_by_get_default():
+    segments = [
+        ContextSegment(id=str(index), type=ContextType.REFERENCE, content=str(index), tokens=1)
+        for index in range(101)
+    ]
+    store = ListContextStore(segments)
+
+    assert store.count("session") == 101


### PR DESCRIPTION
## Summary
- let the default count implementation use the configured store capacity
- prevent counts from being silently capped by the default 100-item get window
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_store_default_count_limit.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
