### PR TITLE
fix(agent): tolerate reasoning-only stream chunks

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -367,8 +367,8 @@ class Agent(ComponentBase, ABC):
             return ""
         if isinstance(data[0], str):
             return "".join(data)
-        text = [val.get('text') for val in data]
-        reasoning_content = [val.get('reasoning_content', "") for val in data]
+        text = [val.get('text') or '' for val in data]
+        reasoning_content = [val.get('reasoning_content') or '' for val in data]
         return {
             'text': "".join(text),
             'reasoning_content': "".join(reasoning_content)

--- a/tests/test_agentuniverse/unit/regressions/test_agent_reasoning_only_chunks.py
+++ b/tests/test_agentuniverse/unit/regressions/test_agent_reasoning_only_chunks.py
@@ -1,0 +1,27 @@
+from agentuniverse.agent.agent import Agent
+from agentuniverse.agent.input_object import InputObject
+
+
+class StubAgent(Agent):
+    def input_keys(self):
+        return []
+
+    def output_keys(self):
+        return []
+
+    def parse_input(self, input_object: InputObject, agent_input: dict):
+        return agent_input
+
+    def parse_result(self, agent_result: dict):
+        return agent_result
+
+
+def test_generate_result_accepts_reasoning_only_chunks():
+    agent = StubAgent()
+
+    result = agent.generate_result([
+        {"reasoning_content": "step"},
+        {"text": "answer", "reasoning_content": None},
+    ])
+
+    assert result == {"text": "answer", "reasoning_content": "step"}


### PR DESCRIPTION
## Summary
- normalize absent stream text and reasoning fields to empty strings
- support reasoning-only chunks without failing during result concatenation
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_agent_reasoning_only_chunks.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
