### PR TITLE
fix(agent): honor explicit empty knowledge selections

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -430,7 +430,9 @@ class Agent(ComponentBase, ABC):
         return "\n\n".join(tool_results)
 
     def invoke_knowledge(self, query_str: str, input_object: InputObject, **kwargs) -> str:
-        knowledge_names = kwargs.get('knowledge_names') or self.agent_model.action.get('knowledge', [])
+        knowledge_names = kwargs.get('knowledge_names')
+        if knowledge_names is None:
+            knowledge_names = self.agent_model.action.get('knowledge', [])
         if not knowledge_names or not query_str:
             return ''
 

--- a/tests/test_agentuniverse/unit/regressions/test_agent_empty_knowledge_selection.py
+++ b/tests/test_agentuniverse/unit/regressions/test_agent_empty_knowledge_selection.py
@@ -1,0 +1,38 @@
+from agentuniverse.agent.agent import Agent
+from agentuniverse.agent.agent_model import AgentModel
+from agentuniverse.agent.input_object import InputObject
+
+
+class StubAgent(Agent):
+    def input_keys(self):
+        return []
+
+    def output_keys(self):
+        return []
+
+    def parse_input(self, input_object: InputObject, agent_input: dict):
+        return agent_input
+
+    def parse_result(self, agent_result: dict):
+        return agent_result
+
+
+def test_explicit_empty_knowledge_list_disables_configured_sources(monkeypatch):
+    class UnexpectedKnowledgeManager:
+        def get_instance_obj(self, name):
+            raise AssertionError("configured knowledge should be disabled")
+
+    monkeypatch.setattr(
+        "agentuniverse.agent.agent.KnowledgeManager",
+        UnexpectedKnowledgeManager,
+    )
+    agent = StubAgent()
+    agent.agent_model = AgentModel(action={"knowledge": ["configured"]})
+
+    result = agent.invoke_knowledge(
+        "question",
+        InputObject({}),
+        knowledge_names=[],
+    )
+
+    assert result == ""


### PR DESCRIPTION
## Summary
- distinguish an explicit empty knowledge list from an omitted override
- allow callers to disable configured knowledge sources for one invocation
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_agent_empty_knowledge_selection.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
