### PR TITLE
fix(tool): report missing arXiv papers clearly

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/arxiv_tool.py
@@ -105,7 +105,9 @@ class ArxivTool(Tool):
         except ImportError:
             raise ImportError("arxiv is required. Install with: pip install arxiv")
         search = arxiv.Search(id_list=[paper_id])
-        paper = next(self.sch_engine.results(search))
+        paper = next(self.sch_engine.results(search), None)
+        if paper is None:
+            raise ValueError(f"No arXiv paper found for ID: {paper_id}")
         paper.download_pdf(filename="downloaded-paper.pdf") 
         
         try:

--- a/tests/test_agentuniverse/unit/regressions/test_arxiv_missing_paper.py
+++ b/tests/test_agentuniverse/unit/regressions/test_arxiv_missing_paper.py
@@ -1,0 +1,23 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.arxiv_tool import ArxivTool
+
+
+class EmptySearchEngine:
+    def results(self, search):
+        return iter(())
+
+
+def test_missing_paper_raises_descriptive_error(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "arxiv",
+        SimpleNamespace(Search=lambda **kwargs: kwargs),
+    )
+    tool = ArxivTool(name="arxiv", sch_engine=EmptySearchEngine())
+
+    with pytest.raises(ValueError, match="No arXiv paper found for ID: missing"):
+        ArxivTool.retrieve_full_paper_text.__wrapped__(tool, "missing")


### PR DESCRIPTION
## Summary
- detect an empty arXiv ID lookup result before attempting a download
- raise a descriptive error instead of leaking StopIteration
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_arxiv_missing_paper.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
