### PR TITLE
fix(embedding): preserve zero Doubao vectors

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
@@ -58,8 +58,11 @@ class DoubaoEmbedding(Embedding):
                     f"Supported dimensions are: {', '.join(SUPPORTED_DIMENSIONS)}"
                 )
             import numpy as np
-            norm = float(np.linalg.norm(vec[:self.embedding_dims]))
-            return [v / norm for v in vec[:self.embedding_dims]]
+            sliced = vec[:self.embedding_dims]
+            norm = float(np.linalg.norm(sliced))
+            if norm == 0.0:
+                return [0.0 for _ in sliced]
+            return [v / norm for v in sliced]
 
         try:
             response = self.client.embeddings.create(model=self.endpoint_id,

--- a/tests/test_agentuniverse/unit/regressions/test_doubao_zero_vector.py
+++ b/tests/test_agentuniverse/unit/regressions/test_doubao_zero_vector.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from agentuniverse.agent.action.knowledge.embedding.doubao_embedding import DoubaoEmbedding
+
+
+class FakeEmbeddings:
+    def create(self, **kwargs):
+        return SimpleNamespace(
+            data=[SimpleNamespace(embedding=[0.0] * 512)],
+        )
+
+
+def test_zero_vector_normalization_remains_finite():
+    embedding = DoubaoEmbedding(
+        client=SimpleNamespace(embeddings=FakeEmbeddings()),
+        endpoint_id="endpoint",
+        embedding_dims=512,
+    )
+
+    result = embedding.get_embeddings(["text"])
+
+    assert result == [[0.0] * 512]


### PR DESCRIPTION
## Summary
- preserve zero Doubao embedding vectors during optional normalization
- avoid division by zero and non-finite embedding values
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_doubao_zero_vector.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
