### PR TITLE
fix(embedding): format Doubao dimension errors

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
@@ -55,7 +55,8 @@ class DoubaoEmbedding(Embedding):
             if self.embedding_dims not in SUPPORTED_DIMENSIONS:
                 raise ValueError(
                     f"Unsupported embedding dimension: {self.embedding_dims}. "
-                    f"Supported dimensions are: {', '.join(SUPPORTED_DIMENSIONS)}"
+                    "Supported dimensions are: "
+                    f"{', '.join(str(value) for value in sorted(SUPPORTED_DIMENSIONS))}"
                 )
             import numpy as np
             norm = float(np.linalg.norm(vec[:self.embedding_dims]))

--- a/tests/test_agentuniverse/unit/regressions/test_doubao_dimension_message.py
+++ b/tests/test_agentuniverse/unit/regressions/test_doubao_dimension_message.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agentuniverse.agent.action.knowledge.embedding.doubao_embedding import DoubaoEmbedding
+
+
+class FakeEmbeddings:
+    def create(self, **kwargs):
+        return SimpleNamespace(data=[SimpleNamespace(embedding=[1.0] * 8)])
+
+
+def test_unsupported_dimension_error_lists_supported_values():
+    embedding = DoubaoEmbedding(
+        client=SimpleNamespace(embeddings=FakeEmbeddings()),
+        endpoint_id="endpoint",
+        embedding_dims=8,
+    )
+
+    with pytest.raises(
+        Exception,
+        match="Supported dimensions are: 512, 1024, 2048",
+    ):
+        embedding.get_embeddings(["text"])


### PR DESCRIPTION
## Summary
- format supported Doubao dimensions as strings in validation errors
- surface the intended configuration message instead of a join TypeError
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_doubao_dimension_message.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
