### PR TITLE
fix(tool): validate EAST input dimensions

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/readimage_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/readimage_tool.py
@@ -58,6 +58,17 @@ def detect_text_regions(image, east_model='frozen_east_text_detection.pb', min_c
     """
     _require_dependency(cv2, "opencv-python")
     _require_dependency(np, "numpy")
+    if (
+        isinstance(width, bool)
+        or isinstance(height, bool)
+        or not isinstance(width, int)
+        or not isinstance(height, int)
+        or width <= 0
+        or height <= 0
+        or width % 32 != 0
+        or height % 32 != 0
+    ):
+        raise ValueError("width and height must be positive multiples of 32")
     # Load the EAST model
     net = cv2.dnn.readNet(east_model)
     orig = image.copy()

--- a/tests/test_agentuniverse/unit/regressions/test_east_input_dimensions.py
+++ b/tests/test_agentuniverse/unit/regressions/test_east_input_dimensions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool import readimage_tool
+
+
+@pytest.mark.parametrize(
+    ("width", "height"),
+    [(0, 320), (-32, 320), (321, 320), (320, True)],
+)
+def test_east_dimensions_are_validated_before_loading_model(monkeypatch, width, height):
+    monkeypatch.setattr(readimage_tool, "cv2", object())
+    monkeypatch.setattr(readimage_tool, "np", object())
+
+    with pytest.raises(ValueError, match="positive multiples of 32"):
+        readimage_tool.detect_text_regions(object(), width=width, height=height)


### PR DESCRIPTION
## Summary
- validate EAST detector width and height before model loading
- enforce positive integer dimensions aligned to the required 32-pixel grid
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_east_input_dimensions.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
