### PR TITLE
fix(tool): reject invalid configured tool types

### DIFF
--- a/agentuniverse/agent/action/tool/tool.py
+++ b/agentuniverse/agent/action/tool/tool.py
@@ -176,8 +176,12 @@ class Tool(ComponentBase):
         self.name = component_configer.name
         self.description = component_configer.description
         if component_configer.tool_type:
-            self.tool_type = next((member for member in ToolTypeEnum if
-                                   member.value == component_configer.tool_type))
+            try:
+                self.tool_type = ToolTypeEnum(component_configer.tool_type)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Unsupported tool_type: {component_configer.tool_type}"
+                ) from exc
         self.input_keys = component_configer.input_keys
         if hasattr(component_configer, "tracing"):
             self.tracing = component_configer.tracing

--- a/tests/test_agentuniverse/unit/regressions/test_invalid_tool_type.py
+++ b/tests/test_agentuniverse/unit/regressions/test_invalid_tool_type.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agentuniverse.agent.action.tool.tool import Tool
+
+
+class StubTool(Tool):
+    def execute(self, **kwargs):
+        return None
+
+
+def test_invalid_tool_type_raises_descriptive_value_error():
+    configer = SimpleNamespace(
+        configer=SimpleNamespace(value={}),
+        name="tool",
+        description="tool",
+        tool_type="invalid",
+        input_keys=[],
+    )
+
+    with pytest.raises(ValueError, match="Unsupported tool_type: invalid"):
+        StubTool().initialize_by_component_configer(configer)


### PR DESCRIPTION
## Summary
- validate configured tool types with the ToolTypeEnum constructor
- replace an opaque StopIteration with a descriptive ValueError
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_invalid_tool_type.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
