### PR TITLE
fix(memory): reject invalid configured memory types

### DIFF
--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -254,7 +254,12 @@ class Memory(ComponentBase):
         if component_configer.description:
             self.description = component_configer.description
         if component_configer.type:
-            self.type = next((member for member in MemoryTypeEnum if member.value == component_configer.type))
+            try:
+                self.type = MemoryTypeEnum(component_configer.type)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Unsupported memory type: {component_configer.type}"
+                ) from exc
         if component_configer.memory_key:
             self.memory_key = component_configer.memory_key
         if component_configer.max_tokens:

--- a/tests/test_agentuniverse/unit/regressions/test_invalid_memory_type.py
+++ b/tests/test_agentuniverse/unit/regressions/test_invalid_memory_type.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agentuniverse.agent.memory.memory import Memory
+
+
+def test_invalid_memory_type_raises_descriptive_value_error():
+    configer = SimpleNamespace(
+        name="memory",
+        description="memory",
+        type="invalid",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported memory type: invalid"):
+        Memory().initialize_by_component_configer(configer)


### PR DESCRIPTION
## Summary
- validate configured memory types with the MemoryTypeEnum constructor
- replace an opaque StopIteration with a descriptive ValueError
- add focused regression coverage for the affected edge case

## Root cause and impact
The previous implementation conflated an edge-case input with a normal execution path, which could produce an incorrect result or an unrelated runtime failure. The change makes the behavior explicit and stable for callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_invalid_memory_type.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
