### PR TITLE
fix(context): preserve windows on empty ID deletes

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -365,7 +365,7 @@ class ContextManager(ComponentBase):
         # Get window to update token count
         window = self._windows.get(session_id)
 
-        if segment_ids and window:
+        if segment_ids is not None and window:
             # Calculate tokens to remove
             segments = self._hot_store.get_by_ids(session_id, segment_ids)
             tokens_removed = sum(seg.tokens for seg in segments)

--- a/tests/test_agentuniverse/unit/regressions/test_context_manager_empty_id_delete.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_manager_empty_id_delete.py
@@ -1,0 +1,17 @@
+from agentuniverse.agent.context.context_manager import ContextManager
+from agentuniverse.agent.context.context_model import ContextType
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+def test_empty_id_delete_preserves_window_and_storage():
+    manager = ContextManager(name="manager")
+    manager._hot_store = RamContextStore(name="ram")
+    window = manager.create_context_window("session")
+    segment = manager.add_context("session", "retained context", ContextType.CONVERSATION)
+    tokens_before = window.total_tokens
+
+    manager.delete_context("session", segment_ids=[])
+
+    assert window.total_tokens == tokens_before
+    assert window.segment_ids == [segment.id]
+    assert [item.id for item in manager._hot_store.get("session")] == [segment.id]


### PR DESCRIPTION
## Summary
- distinguish an empty segment-ID list from the sentinel that deletes a whole session
- keep window token and segment tracking synchronized when a targeted delete has no IDs
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_manager_empty_id_delete.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
