### PR TITLE
fix(context): reserve room in compression targets

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -426,7 +426,9 @@ class ContextManager(ComponentBase):
                 return  # Nothing to compress
 
             # Calculate target tokens for compression
-            target_tokens = window.calculate_input_tokens()
+            target_tokens = max(
+                0, window.calculate_input_tokens() - needed_tokens
+            )
 
             try:
                 # Use compressor to intelligently compress segments

--- a/tests/test_agentuniverse/unit/regressions/test_context_manager_compression_target.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_manager_compression_target.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from agentuniverse.agent.context.context_manager import ContextManager
+from agentuniverse.agent.context.context_model import (
+    ContextSegment,
+    ContextType,
+    ContextWindow,
+)
+
+
+class RecordingCompressor:
+    def __init__(self):
+        self.target_tokens = None
+
+    def compress(self, segments, target_tokens, **kwargs):
+        self.target_tokens = target_tokens
+        compressed = segments[0].model_copy(update={"tokens": target_tokens})
+        return [compressed], SimpleNamespace()
+
+
+class StubStore:
+    def __init__(self, segment):
+        self.segments = [segment]
+
+    def prune(self, session_id, **kwargs):
+        return 0
+
+    def get(self, session_id, **kwargs):
+        return self.segments
+
+    def delete(self, session_id, **kwargs):
+        self.segments = []
+
+    def add(self, segments, **kwargs):
+        self.segments = list(segments)
+
+
+def test_compression_target_reserves_tokens_for_incoming_context():
+    segment = ContextSegment(
+        type=ContextType.CONVERSATION,
+        content="existing",
+        tokens=80,
+        session_id="session",
+    )
+    window = ContextWindow(
+        session_id="session",
+        max_tokens=100,
+        reserved_tokens=0,
+        total_tokens=80,
+        segment_ids=[segment.id],
+    )
+    compressor = RecordingCompressor()
+    manager = ContextManager(name="manager")
+    manager._hot_store = StubStore(segment)
+    manager._compressor = compressor
+
+    manager._make_room(window, needed_tokens=30)
+
+    assert compressor.target_tokens == 70
+    assert window.total_tokens == 70


### PR DESCRIPTION
## Summary
- reserve the incoming segment budget when selecting a compression target
- prevent successful no-op compression from leaving the context window over budget
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_manager_compression_target.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
