### PR TITLE
fix(context): handle blank router queries

### DIFF
--- a/agentuniverse/agent/context/router/context_router.py
+++ b/agentuniverse/agent/context/router/context_router.py
@@ -292,6 +292,8 @@ class ContextRouter(ComponentBase):
             Optimized list of storage tiers to search
         """
         tiers = self.route_read(task_type, context_type, **kwargs)
+        if not isinstance(query, str) or not query.strip():
+            return tiers
 
         # Keyword-based optimization
         query_lower = query.lower()

--- a/tests/test_agentuniverse/unit/regressions/test_context_router_blank_query.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_router_blank_query.py
@@ -1,0 +1,13 @@
+import pytest
+
+from agentuniverse.agent.context.router.context_router import ContextRouter
+
+
+@pytest.mark.parametrize("query", [None, "", "   "])
+def test_blank_query_keeps_default_search_order(query):
+    router = ContextRouter(name="router", enable_warm_tier=True)
+
+    assert router.optimize_search_order(query, task_type="code_generation") == [
+        "hot",
+        "warm",
+    ]


### PR DESCRIPTION
## Summary
- return the normal tier order for null or whitespace-only router queries
- avoid calling string operations on missing query values
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_router_blank_query.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
