### PR TITLE
fix(context): normalize RAM segment session scope

### DIFF
--- a/agentuniverse/agent/context/store/ram_context_store.py
+++ b/agentuniverse/agent/context/store/ram_context_store.py
@@ -61,9 +61,9 @@ class RamContextStore(ContextStore):
         session_storage = self._storage[session_id]
 
         for segment in segments:
-            # Update session_id if not set
-            if not segment.session_id:
-                segment.session_id = session_id
+            # The explicit storage scope is authoritative. Keeping a stale
+            # segment scope would make cross-session reads inconsistent.
+            segment.session_id = session_id
 
             # Add or update segment (move to end for LRU)
             if segment.id in session_storage:

--- a/tests/test_agentuniverse/unit/regressions/test_ram_context_session_scope.py
+++ b/tests/test_agentuniverse/unit/regressions/test_ram_context_session_scope.py
@@ -1,0 +1,17 @@
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.ram_context_store import RamContextStore
+
+
+def test_add_normalizes_segment_to_storage_session():
+    segment = ContextSegment(
+        type=ContextType.CONVERSATION,
+        content="context",
+        tokens=1,
+        session_id="stale-session",
+    )
+    store = RamContextStore(name="ram")
+
+    store.add([segment], session_id="current-session")
+
+    assert segment.session_id == "current-session"
+    assert store.get("current-session")[0].session_id == "current-session"


### PR DESCRIPTION
## Summary
- make the explicit RAM storage session authoritative for added segments
- prevent a segment stored under one session from retaining a stale session identifier
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_ram_context_session_scope.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
