### PR TITLE
fix(context): normalize Redis segment session scope

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -108,6 +108,9 @@ class RedisContextStore(ContextStore):
         ttl_seconds = kwargs.get("ttl_seconds", self.default_ttl_seconds)
 
         for segment in segments:
+            # The Redis key scope is authoritative for serialized segments.
+            segment.session_id = session_id
+
             # Serialize segment to JSON
             segment_data = self._serialize_segment(segment)
 

--- a/tests/test_agentuniverse/unit/regressions/test_redis_context_session_scope.py
+++ b/tests/test_agentuniverse/unit/regressions/test_redis_context_session_scope.py
@@ -1,0 +1,35 @@
+import json
+
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+class RecordingRedis:
+    def __init__(self):
+        self.payload = None
+
+    def hset(self, key, segment_id, payload):
+        self.payload = payload
+
+    def expire(self, key, ttl):
+        pass
+
+    def zadd(self, key, values):
+        pass
+
+
+def test_add_serializes_the_redis_session_scope():
+    segment = ContextSegment(
+        type=ContextType.CONVERSATION,
+        content="context",
+        tokens=1,
+        session_id="stale-session",
+    )
+    redis = RecordingRedis()
+    store = RedisContextStore(name="redis")
+    store._redis = redis
+
+    store.add([segment], session_id="current-session")
+
+    assert segment.session_id == "current-session"
+    assert json.loads(redis.payload.decode("utf-8"))["session_id"] == "current-session"


### PR DESCRIPTION
## Summary
- normalize segment session IDs before Redis serialization
- keep the serialized payload consistent with the Redis session key
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_redis_context_session_scope.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
