### PR TITLE
fix(tool): validate request URLs before dispatch

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/request_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/request_tool.py
@@ -25,8 +25,13 @@ class RequestTool(Tool):
 
     @staticmethod
     def _clean_url(url: str) -> str:
-        """Strips quotes from the url."""
-        return url.strip("\"'")
+        """Validate a URL value and strip surrounding whitespace/quotes."""
+        if not isinstance(url, str):
+            raise ValueError("url must be a non-empty string")
+        cleaned = url.strip().strip("\"'").strip()
+        if not cleaned:
+            raise ValueError("url must be a non-empty string")
+        return cleaned
 
     def _normalized_method(self) -> str:
         if not isinstance(self.method, str):

--- a/tests/test_agentuniverse/unit/regressions/test_request_tool_url_validation.py
+++ b/tests/test_agentuniverse/unit/regressions/test_request_tool_url_validation.py
@@ -1,0 +1,13 @@
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.request_tool import RequestTool
+
+
+@pytest.mark.parametrize("url", [None, "", "   ", "  ''  "])
+def test_clean_url_rejects_empty_values(url):
+    with pytest.raises(ValueError, match="url must be a non-empty string"):
+        RequestTool._clean_url(url)
+
+
+def test_clean_url_removes_whitespace_and_quotes():
+    assert RequestTool._clean_url('  "https://example.com"  ') == "https://example.com"


### PR DESCRIPTION
## Summary
- validate request URLs before sync or async dispatch
- strip surrounding whitespace and quotes while rejecting empty or non-string values
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_request_tool_url_validation.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
