### PR TITLE
fix(tool): validate Word output paths

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/write_word_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_word_tool.py
@@ -7,6 +7,13 @@ from agentuniverse.agent.action.tool.tool import Tool
 
 class WriteWordDocumentTool(Tool):
     def execute(self, file_path: str, content: str = "", append: bool = False) -> str:
+        if not isinstance(file_path, str) or not file_path.strip():
+            return json.dumps({
+                "error": "file_path must be a non-empty string",
+                "file_path": file_path,
+                "status": "error",
+            })
+        file_path = file_path.strip()
         if not file_path.lower().endswith(".docx"):
             return json.dumps(
                 {"error": "The target file must have a .docx extension.", "file_path": file_path, "status": "error"}

--- a/tests/test_agentuniverse/unit/regressions/test_write_word_empty_path.py
+++ b/tests/test_agentuniverse/unit/regressions/test_write_word_empty_path.py
@@ -1,0 +1,13 @@
+import json
+
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.write_word_tool import WriteWordDocumentTool
+
+
+@pytest.mark.parametrize("file_path", [None, "", "   "])
+def test_empty_output_path_returns_structured_error(file_path):
+    result = json.loads(WriteWordDocumentTool().execute(file_path))
+
+    assert result["status"] == "error"
+    assert result["error"] == "file_path must be a non-empty string"


### PR DESCRIPTION
## Summary
- validate Word output paths before extension handling
- return a structured tool error instead of raising AttributeError for missing paths
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_write_word_empty_path.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
