### PR TITLE
fix(tool): isolate Tavily request overrides

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/tavily_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/tavily_tool.py
@@ -77,27 +77,20 @@ class TavilyTool(Tool):
         Returns:
             Dict: 包含搜索结果或提取内容的字典
         """
-        # 检查API密钥
-        if not self.api_key:
+        def setting(name):
+            value = kwargs.get(name)
+            return getattr(self, name) if value is None else value
+
+        api_key = setting("api_key")
+        if not api_key:
             return {"error": "未提供Tavily API密钥，请设置TAVILY_API_KEY环境变量或在调用时提供api_key参数"}
-            
-        # 更新可选配置（如果提供）
-        possible_params = [
-            "api_key", "search_depth", "include_answer", "mode",
-            "topic", "days", "time_range", "max_results", "include_domains", "exclude_domains",
-            "include_raw_content", "include_images", "include_image_descriptions", "extract_depth"
-        ]
-        
-        for param in possible_params:
-            if kwargs.get(param) is not None:
-                setattr(self, param, kwargs.get(param))
 
         try:
             # 初始化Tavily客户端
-            client = _get_tavily_client_class()(api_key=self.api_key)
+            client = _get_tavily_client_class()(api_key=api_key)
             
             # 根据操作模式执行不同的操作
-            if self.mode == "extract":
+            if setting("mode") == "extract":
                 # 提取模式
                 urls = input
                 if not urls:
@@ -110,8 +103,8 @@ class TavilyTool(Tool):
                 # 提取参数
                 extract_params = {
                     "urls": urls,
-                    "include_images": self.include_images,
-                    "extract_depth": self.extract_depth
+                    "include_images": setting("include_images"),
+                    "extract_depth": setting("extract_depth")
                 }
                 
                 # 执行提取
@@ -129,21 +122,21 @@ class TavilyTool(Tool):
                 # 搜索参数
                 search_params = {
                     "query": query,
-                    "search_depth": self.search_depth
+                    "search_depth": setting("search_depth")
                 }
                 
                 # 添加其他可选参数（如果有设置）
                 for param_name, param_attr in {
-                    "topic": self.topic,
-                    "days": self.days,
-                    "time_range": self.time_range,
-                    "max_results": self.max_results,
-                    "include_domains": self.include_domains,
-                    "exclude_domains": self.exclude_domains,
-                    "include_answer": self.include_answer,
-                    "include_raw_content": self.include_raw_content,
-                    "include_images": self.include_images,
-                    "include_image_descriptions": self.include_image_descriptions
+                    "topic": setting("topic"),
+                    "days": setting("days"),
+                    "time_range": setting("time_range"),
+                    "max_results": setting("max_results"),
+                    "include_domains": setting("include_domains"),
+                    "exclude_domains": setting("exclude_domains"),
+                    "include_answer": setting("include_answer"),
+                    "include_raw_content": setting("include_raw_content"),
+                    "include_images": setting("include_images"),
+                    "include_image_descriptions": setting("include_image_descriptions")
                 }.items():
                     if param_attr is not None:
                         search_params[param_name] = param_attr

--- a/tests/test_agentuniverse/unit/regressions/test_tavily_request_overrides.py
+++ b/tests/test_agentuniverse/unit/regressions/test_tavily_request_overrides.py
@@ -1,0 +1,24 @@
+from agentuniverse.agent.action.tool.common_tool import tavily_tool
+
+
+class RecordingClient:
+    searches = []
+
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def search(self, **kwargs):
+        self.searches.append(kwargs)
+        return kwargs
+
+
+def test_request_override_does_not_leak_to_later_calls(monkeypatch):
+    RecordingClient.searches = []
+    monkeypatch.setattr(tavily_tool, "_get_tavily_client_class", lambda: RecordingClient)
+    tool = tavily_tool.TavilyTool(api_key="key", max_results=5)
+
+    tool.execute("first", max_results=1)
+    tool.execute("second")
+
+    assert [call["max_results"] for call in RecordingClient.searches] == [1, 5]
+    assert tool.max_results == 5


### PR DESCRIPTION
## Summary
- apply Tavily keyword overrides as request-local settings
- prevent one invocation from mutating defaults observed by later requests
- add focused regression coverage for the affected behavior

## Root cause and impact
The previous path treated an edge-case input as a normal operation, producing inconsistent state, an unrelated exception, or settings that leaked beyond one call. This change makes the contract explicit while preserving existing behavior for valid inputs.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.11 -m pytest -q tests/test_agentuniverse/unit/regressions/test_tavily_request_overrides.py`
- `python3.11 -m py_compile` on the changed source and regression test
- `git diff --check`
