### PR TITLE
fix(tool): reject reversed file line ranges

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
@@ -55,6 +55,13 @@ class ViewFileTool(Tool):
                 "status": "error"
             })
 
+        if end_line is not None and start_line > end_line:
+            return json.dumps({
+                "error": "start_line must be less than or equal to end_line",
+                "file_path": file_path,
+                "status": "error"
+            })
+
         try:
             safe_file_path = resolve_safe_path(file_path, self.base_dir)
         except ValueError as e:

--- a/tests/test_agentuniverse/unit/regressions/test_view_file_reversed_range.py
+++ b/tests/test_agentuniverse/unit/regressions/test_view_file_reversed_range.py
@@ -1,0 +1,14 @@
+import json
+
+from agentuniverse.agent.action.tool.common_tool.view_file_tool import ViewFileTool
+
+
+def test_view_file_rejects_reversed_line_range(tmp_path):
+    source = tmp_path / "sample.txt"
+    source.write_text("one\ntwo\nthree\n")
+    tool = ViewFileTool(base_dir=str(tmp_path))
+
+    result = json.loads(tool.execute("sample.txt", start_line=2, end_line=1))
+
+    assert result["status"] == "error"
+    assert result["error"] == "start_line must be less than or equal to end_line"


### PR DESCRIPTION
## Summary
- reject reversed file line ranges
- add focused regression coverage for the corrected behavior

## Root cause
A reversed start/end range was accepted as a successful empty read, hiding an invalid tool request.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_view_file_reversed_range.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
