### PR TITLE
fix(context): handle nonpositive search limits

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -321,7 +321,7 @@ class ContextManager(ComponentBase):
         Returns:
             List of matching ContextSegments ranked by relevance
         """
-        if not self._hot_store:
+        if not self._hot_store or top_k <= 0:
             return []
 
         results = self._hot_store.search(

--- a/tests/test_agentuniverse/unit/regressions/test_context_manager_search_top_k.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_manager_search_top_k.py
@@ -1,0 +1,20 @@
+from agentuniverse.agent.context.context_manager import ContextManager
+
+
+class SearchStore:
+    def __init__(self):
+        self.calls = 0
+
+    def search(self, **kwargs):
+        self.calls += 1
+        return [object()]
+
+
+def test_context_manager_skips_nonpositive_search_limits():
+    manager = ContextManager()
+    store = SearchStore()
+    manager._hot_store = store
+
+    assert manager.search_context("session", "query", top_k=0) == []
+    assert manager.search_context("session", "query", top_k=-3) == []
+    assert store.calls == 0


### PR DESCRIPTION
## Summary
- handle nonpositive search limits
- add focused regression coverage for the corrected behavior

## Root cause
Negative Python slices could turn an invalid context search limit into unexpected results, while zero still invoked the backend.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_manager_search_top_k.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
