### PR TITLE
fix(context): reject oversized context segments

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -240,8 +240,15 @@ class ContextManager(ComponentBase):
         # Count tokens for new content
         tokens = self._count_tokens(content)
 
+        input_budget = window.calculate_input_tokens()
+        if tokens > input_budget:
+            raise ValueError(
+                f"Context segment requires {tokens} tokens, exceeding the "
+                f"window input budget of {input_budget}"
+            )
+
         # Proactive budget check - make room BEFORE adding
-        if window.total_tokens + tokens > window.calculate_input_tokens():
+        if window.total_tokens + tokens > input_budget:
             self._make_room(window, tokens)
 
         # Create segment

--- a/tests/test_agentuniverse/unit/regressions/test_context_manager_oversized_segment.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_manager_oversized_segment.py
@@ -1,0 +1,17 @@
+import pytest
+
+from agentuniverse.agent.context.context_manager import ContextManager
+from agentuniverse.agent.context.context_model import ContextType
+
+
+def test_context_manager_rejects_segment_larger_than_window_budget():
+    manager = ContextManager()
+    window = manager.create_context_window(
+        "session", max_tokens=10, reserved_tokens=2
+    )
+
+    with pytest.raises(ValueError, match="exceeding the window input budget of 8"):
+        manager.add_context("session", "x" * 36, ContextType.TASK)
+
+    assert window.total_tokens == 0
+    assert window.segment_ids == []


### PR DESCRIPTION
## Summary
- reject oversized context segments
- add focused regression coverage for the corrected behavior

## Root cause
A segment larger than the entire input budget could be stored even after eviction, leaving the context window permanently over budget.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_manager_oversized_segment.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
