### PR TITLE
fix(context): isolate batch session identifiers

### DIFF
--- a/agentuniverse/agent/context/context_store.py
+++ b/agentuniverse/agent/context/context_store.py
@@ -166,8 +166,10 @@ class ContextStore(ComponentBase):
             segments_by_session: Dict mapping session_id to segment list
             **kwargs: Additional parameters
         """
+        add_kwargs = dict(kwargs)
+        add_kwargs.pop("session_id", None)
         for session_id, segments in segments_by_session.items():
-            self.add(segments, session_id=session_id, **kwargs)
+            self.add(segments, session_id=session_id, **add_kwargs)
 
     def count(self, session_id: str, **kwargs) -> int:
         """Count total segments for session.

--- a/tests/test_agentuniverse/unit/regressions/test_context_store_batch_session_override.py
+++ b/tests/test_agentuniverse/unit/regressions/test_context_store_batch_session_override.py
@@ -1,0 +1,29 @@
+from agentuniverse.agent.context.context_store import ContextStore
+
+
+class RecordingStore(ContextStore):
+    calls: list = []
+
+    def add(self, segments, **kwargs):
+        self.calls.append((segments, kwargs))
+
+    def get(self, session_id, context_type=None, limit=100, **kwargs):
+        return []
+
+    def search(self, query, session_id, top_k=10, **kwargs):
+        return []
+
+    def delete(self, session_id, segment_ids=None, **kwargs):
+        return None
+
+    def prune(self, session_id, **kwargs):
+        return 0
+
+
+def test_batch_add_uses_mapping_session_ids_over_shared_kwargs():
+    store = RecordingStore()
+
+    store.batch_add({"first": [1], "second": [2]}, session_id="wrong", ttl=30)
+
+    assert [call[1]["session_id"] for call in store.calls] == ["first", "second"]
+    assert all(call[1]["ttl"] == 30 for call in store.calls)


### PR DESCRIPTION
## Summary
- isolate batch session identifiers
- add focused regression coverage for the corrected behavior

## Root cause
Passing a shared session_id through batch kwargs collided with the per-entry session_id and raised a duplicate-keyword TypeError.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_context_store_batch_session_override.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
