### PR TITLE
fix(context): skip malformed Chroma session metadata

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -486,7 +486,11 @@ class ChromaContextStore(ContextStore):
             # Extract unique session IDs
             session_ids = set()
             for metadata in results["metadatas"]:
-                session_ids.add(metadata["session_id"])
+                if not isinstance(metadata, dict):
+                    continue
+                session_id = metadata.get("session_id")
+                if isinstance(session_id, str) and session_id:
+                    session_ids.add(session_id)
 
             return list(session_ids)
 

--- a/tests/test_agentuniverse/unit/regressions/test_chroma_context_malformed_sessions.py
+++ b/tests/test_agentuniverse/unit/regressions/test_chroma_context_malformed_sessions.py
@@ -1,0 +1,21 @@
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+class FakeCollection:
+    def get(self):
+        return {
+            "metadatas": [
+                {"session_id": "valid"},
+                None,
+                {},
+                {"session_id": ""},
+                {"session_id": 123},
+            ]
+        }
+
+
+def test_chroma_session_listing_skips_malformed_metadata():
+    store = ChromaContextStore()
+    store._collection = FakeCollection()
+
+    assert store.get_all_sessions() == ["valid"]


### PR DESCRIPTION
## Summary
- skip malformed Chroma session metadata
- add focused regression coverage for the corrected behavior

## Root cause
One malformed Chroma metadata record caused session enumeration to discard every otherwise valid session.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_chroma_context_malformed_sessions.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
