### PR TITLE
fix(context): honor disabled Chroma prune TTL

### DIFF
--- a/agentuniverse/agent/context/store/chroma_context_store.py
+++ b/agentuniverse/agent/context/store/chroma_context_store.py
@@ -391,9 +391,10 @@ class ChromaContextStore(ContextStore):
                 to_remove.append(segment.id)
                 continue
 
-            # Remove if too old
+            # Remove if too old. Nonpositive TTL disables age pruning,
+            # matching ContextStore._is_expired().
             age_hours = (now - segment.metadata.created_at).total_seconds() / 3600
-            if age_hours > max_age_hours:
+            if max_age_hours is not None and max_age_hours > 0 and age_hours > max_age_hours:
                 to_remove.append(segment.id)
 
         if to_remove:

--- a/tests/test_agentuniverse/unit/regressions/test_chroma_context_disabled_prune_ttl.py
+++ b/tests/test_agentuniverse/unit/regressions/test_chroma_context_disabled_prune_ttl.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.chroma_context_store import ChromaContextStore
+
+
+def test_chroma_prune_disables_age_filter_for_nonpositive_ttl(monkeypatch):
+    store = ChromaContextStore(ttl_hours=0)
+    store._collection = object()
+    segment = ContextSegment(type=ContextType.TASK, content="old", tokens=1)
+    segment.metadata.created_at = datetime.now() - timedelta(days=30)
+    deleted = []
+    monkeypatch.setattr(ChromaContextStore, "get", lambda *args, **kwargs: [segment])
+    monkeypatch.setattr(ChromaContextStore, "delete", lambda *args, **kwargs: deleted.append(args))
+
+    assert store.prune("session") == 0
+    assert deleted == []


### PR DESCRIPTION
## Summary
- honor disabled Chroma prune TTL
- add focused regression coverage for the corrected behavior

## Root cause
Chroma pruning treated a nonpositive TTL as an immediate expiration even though the base store defines it as disabled.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_chroma_context_disabled_prune_ttl.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
