### PR TITLE
fix(context): honor disabled Redis prune TTL

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -308,9 +308,10 @@ class RedisContextStore(ContextStore):
                     to_remove.append(segment.id)
                     continue
 
-            # Check manual TTL (from metadata)
+            # Check manual TTL (from metadata). Nonpositive TTL disables
+            # age pruning, matching ContextStore._is_expired().
             age_hours = (now - segment.metadata.created_at).total_seconds() / 3600
-            if age_hours > self.ttl_hours:
+            if self.ttl_hours > 0 and age_hours > self.ttl_hours:
                 to_remove.append(segment.id)
 
         if to_remove:

--- a/tests/test_agentuniverse/unit/regressions/test_redis_context_disabled_prune_ttl.py
+++ b/tests/test_agentuniverse/unit/regressions/test_redis_context_disabled_prune_ttl.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+def test_redis_prune_disables_age_filter_for_nonpositive_ttl(monkeypatch):
+    store = RedisContextStore(ttl_hours=0)
+    store._redis = object()
+    segment = ContextSegment(type=ContextType.TASK, content="old", tokens=1)
+    segment.metadata.created_at = datetime.now() - timedelta(days=30)
+    deleted = []
+    monkeypatch.setattr(RedisContextStore, "get", lambda *args, **kwargs: [segment])
+    monkeypatch.setattr(RedisContextStore, "delete", lambda *args, **kwargs: deleted.append(args))
+
+    assert store.prune("session") == 0
+    assert deleted == []


### PR DESCRIPTION
## Summary
- honor disabled Redis prune TTL
- add focused regression coverage for the corrected behavior

## Root cause
Redis manual pruning treated a nonpositive TTL as an immediate expiration, inconsistent with normal expiration checks.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_redis_context_disabled_prune_ttl.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
