### PR TITLE
fix(context): persist Redis segment session scope

### DIFF
--- a/agentuniverse/agent/context/store/redis_context_store.py
+++ b/agentuniverse/agent/context/store/redis_context_store.py
@@ -108,6 +108,9 @@ class RedisContextStore(ContextStore):
         ttl_seconds = kwargs.get("ttl_seconds", self.default_ttl_seconds)
 
         for segment in segments:
+            if not segment.session_id:
+                segment.session_id = session_id
+
             # Serialize segment to JSON
             segment_data = self._serialize_segment(segment)
 

--- a/tests/test_agentuniverse/unit/regressions/test_redis_context_segment_session.py
+++ b/tests/test_agentuniverse/unit/regressions/test_redis_context_segment_session.py
@@ -1,0 +1,29 @@
+from agentuniverse.agent.context.context_model import ContextSegment, ContextType
+from agentuniverse.agent.context.store.redis_context_store import RedisContextStore
+
+
+class FakeRedis:
+    def __init__(self):
+        self.payload = None
+
+    def hset(self, key, field, value):
+        self.payload = value
+
+    def expire(self, *args):
+        return None
+
+    def zadd(self, *args):
+        return None
+
+
+def test_redis_add_persists_missing_segment_session_id():
+    store = RedisContextStore()
+    redis = FakeRedis()
+    store._redis = redis
+    segment = ContextSegment(type=ContextType.TASK, content="text", tokens=1)
+
+    store.add([segment], session_id="session-a")
+
+    restored = store._deserialize_segment(redis.payload)
+    assert restored.session_id == "session-a"
+    assert segment.session_id == "session-a"


### PR DESCRIPTION
## Summary
- persist Redis segment session scope
- add focused regression coverage for the corrected behavior

## Root cause
Redis serialized new segments before filling their missing session_id, so retrieved records lost their session scope.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_redis_context_segment_session.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
