### PR TITLE
fix(agent): honor explicit empty tool selections

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -386,7 +386,7 @@ class Agent(ComponentBase, ABC):
         return tool_name_list
 
     def invoke_tools(self, input_object: InputObject, **kwargs) -> str:
-        tool_names = kwargs.get('tool_names') or self.tool_names
+        tool_names = kwargs['tool_names'] if 'tool_names' in kwargs else self.tool_names
         if not tool_names:
             return ''
 
@@ -410,7 +410,8 @@ class Agent(ComponentBase, ABC):
         return "\n\n".join(tool_results)
 
     async def async_invoke_tools(self, input_object: InputObject, **kwargs) -> str:
-        tool_names = kwargs.get('tool_names') or self.agent_model.action.get('tool', [])
+        tool_names = (kwargs['tool_names'] if 'tool_names' in kwargs
+                      else self.agent_model.action.get('tool', []))
         if not tool_names:
             return ''
         tool_results: list = list()

--- a/tests/test_agentuniverse/unit/regressions/test_agent_empty_tool_selection.py
+++ b/tests/test_agentuniverse/unit/regressions/test_agent_empty_tool_selection.py
@@ -1,0 +1,20 @@
+import asyncio
+from types import SimpleNamespace
+
+from agentuniverse.agent.agent import Agent
+
+
+def test_sync_tool_invocation_honors_explicit_empty_selection():
+    fake_agent = SimpleNamespace(tool_names=["configured"])
+
+    assert Agent.invoke_tools(fake_agent, None, tool_names=[]) == ""
+
+
+def test_async_tool_invocation_honors_explicit_empty_selection():
+    fake_agent = SimpleNamespace(
+        agent_model=SimpleNamespace(action={"tool": ["configured"]})
+    )
+
+    result = asyncio.run(Agent.async_invoke_tools(fake_agent, None, tool_names=[]))
+
+    assert result == ""


### PR DESCRIPTION
## Summary
- honor explicit empty tool selections
- add focused regression coverage for the corrected behavior

## Root cause
The truthy fallback made an explicit empty tool list run all configured tools instead of disabling tool invocation for that call.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_agent_empty_tool_selection.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
