### PR TITLE
fix(memory): convert mixed conversation message lists

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_message.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_message.py
@@ -115,8 +115,14 @@ class ConversationMessage(Message):
     def check_and_convert_message(cls, messages, session_id: str = None):
         if len(messages) == 0:
             return []
-        message = messages[0]
-        if isinstance(message, cls):
-            return messages
-        if isinstance(message, Message):
-            return [cls.from_message(m, session_id) for m in messages]
+        converted_messages = []
+        for message in messages:
+            if isinstance(message, cls):
+                converted_messages.append(message)
+            elif isinstance(message, Message):
+                converted_messages.append(cls.from_message(message, session_id))
+            else:
+                raise TypeError(
+                    "messages must contain only Message or ConversationMessage instances"
+                )
+        return converted_messages

--- a/tests/test_agentuniverse/unit/regressions/test_conversation_mixed_messages.py
+++ b/tests/test_agentuniverse/unit/regressions/test_conversation_mixed_messages.py
@@ -1,0 +1,16 @@
+from agentuniverse.agent.memory.conversation_memory.conversation_message import ConversationMessage
+from agentuniverse.agent.memory.message import Message
+
+
+def test_conversation_conversion_handles_mixed_message_subclasses():
+    existing = ConversationMessage(content="first", type="input")
+    plain = Message(content="second", type="output", source="agent")
+
+    result = ConversationMessage.check_and_convert_message(
+        [existing, plain], session_id="session"
+    )
+
+    assert result[0] is existing
+    assert isinstance(result[1], ConversationMessage)
+    assert result[1].content == "second"
+    assert result[1].conversation_id == "session"


### PR DESCRIPTION
## Summary
- convert mixed conversation message lists
- add focused regression coverage for the corrected behavior

## Root cause
Message conversion inspected only the first element and therefore mishandled lists mixing converted and plain message instances.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_conversation_mixed_messages.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
