### PR TITLE
fix(memory): isolate conversation conversion metadata

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_message.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_message.py
@@ -90,25 +90,24 @@ class ConversationMessage(Message):
 
     @classmethod
     def from_message(cls, message: Message, session_id: str):
-        if not message.metadata:
-            message.metadata = {}
-        message.metadata['prefix'] = '之前对话的摘要：' if message.type == 'summarize' else ''
-        message.metadata['params'] = "{}"
-        trace_id = message.metadata.get('trace_id')
+        metadata = dict(message.metadata or {})
+        metadata['prefix'] = '之前对话的摘要：' if message.type == 'summarize' else ''
+        metadata['params'] = "{}"
+        trace_id = metadata.get('trace_id')
         if not trace_id:
             trace_id = FrameworkContextManager().get_context('trace_id')
-            message.metadata['trace_id'] = trace_id
+            metadata['trace_id'] = trace_id
         return cls(
             id=uuid.uuid4().hex,
             content=message.content,
-            metadata=message.metadata,
+            metadata=metadata,
             type=message.type,
             source=message.source,
             source_type='agent',
             target=message.source,
             target_type='agent',
             trace_id=trace_id,
-            conversation_id=message.metadata.get('session_id') if not session_id else session_id,
+            conversation_id=metadata.get('session_id') if not session_id else session_id,
         )
 
     @classmethod

--- a/tests/test_agentuniverse/unit/regressions/test_conversation_metadata_isolation.py
+++ b/tests/test_agentuniverse/unit/regressions/test_conversation_metadata_isolation.py
@@ -1,0 +1,16 @@
+from agentuniverse.agent.memory.conversation_memory.conversation_message import ConversationMessage
+from agentuniverse.agent.memory.message import Message
+
+
+def test_conversation_conversion_does_not_mutate_source_metadata():
+    source_metadata = {"custom": "value", "session_id": "stored-session"}
+    message = Message(
+        content="summary", type="summarize", source="agent", metadata=source_metadata
+    )
+
+    converted = ConversationMessage.from_message(message, session_id=None)
+
+    assert message.metadata == {"custom": "value", "session_id": "stored-session"}
+    assert converted.metadata is not message.metadata
+    assert converted.metadata["prefix"] == "之前对话的摘要："
+    assert converted.conversation_id == "stored-session"


### PR DESCRIPTION
## Summary
- isolate conversation conversion metadata
- add focused regression coverage for the corrected behavior

## Root cause
Converting a Message modified the caller-owned metadata dictionary by injecting trace and rendering fields.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_conversation_metadata_isolation.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
