### PR TITLE
fix(llm): use channel for async retry calls

### DIFF
--- a/agentuniverse/llm/llm_channel/langchain_instance/default_channel_langchain_instance.py
+++ b/agentuniverse/llm/llm_channel/langchain_instance/default_channel_langchain_instance.py
@@ -154,7 +154,7 @@ class DefaultChannelLangchainInstance(ChatOpenAI):
         @retry_decorator
         async def _completion_with_retry(**kwargs: Any) -> Any:
             # Use OpenAI's async api https://github.com/openai/openai-python#async-api
-            return await llm.llm.acall(**kwargs)
+            return await llm.llm_channel.acall(**kwargs)
 
         return await _completion_with_retry(**kwargs)
 

--- a/tests/test_agentuniverse/unit/regressions/test_channel_async_retry_delegate.py
+++ b/tests/test_agentuniverse/unit/regressions/test_channel_async_retry_delegate.py
@@ -1,0 +1,21 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from agentuniverse.llm.llm_channel.langchain_instance import default_channel_langchain_instance as module
+
+
+def test_non_v1_async_retry_uses_channel_delegate(monkeypatch):
+    acall = AsyncMock(return_value="ok")
+    adapter = SimpleNamespace(llm_channel=SimpleNamespace(acall=acall))
+    monkeypatch.setattr(module, "is_openai_v1", lambda: False)
+    monkeypatch.setattr(module, "_create_retry_decorator", lambda *args, **kwargs: (lambda fn: fn))
+
+    result = asyncio.run(
+        module.DefaultChannelLangchainInstance.acompletion_with_retry(
+            None, adapter, messages=[{"role": "user", "content": "hi"}]
+        )
+    )
+
+    assert result == "ok"
+    acall.assert_awaited_once()


### PR DESCRIPTION
## Summary
- use channel for async retry calls
- add focused regression coverage for the corrected behavior

## Root cause
The non-v1 async retry path dereferenced llm.llm, an attribute that channel adapters do not expose, instead of calling llm_channel.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_channel_async_retry_delegate.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
