### PR TITLE
fix(llm): avoid mutating Claude message inputs

### DIFF
--- a/agentuniverse/llm/claude_langchain_instance.py
+++ b/agentuniverse/llm/claude_langchain_instance.py
@@ -39,6 +39,14 @@ class ClaudeLangChainInstance(ChatAnthropic):
         init_params['llm'] = llm
         super().__init__(**init_params)
 
+    @staticmethod
+    def _normalize_messages(messages: List[BaseMessage]) -> List[BaseMessage]:
+        """Return Anthropic-compatible messages without mutating caller input."""
+        normalized = list(messages)
+        if len(normalized) > 1 and isinstance(normalized[1], SystemMessage):
+            normalized[1] = HumanMessage(content=normalized[1].content)
+        return normalized
+
     def _generate(
             self,
             messages: List[BaseMessage],
@@ -46,8 +54,7 @@ class ClaudeLangChainInstance(ChatAnthropic):
             run_manager: Optional[CallbackManagerForLLMRun] = None,
             **kwargs: Any,
     ) -> ChatResult:
-        if len(messages) > 1 and isinstance(messages[1], SystemMessage):
-            messages[1] = HumanMessage(content=messages[1].content)
+        messages = self._normalize_messages(messages)
         params = self._format_params(messages=messages, stop=stop, **kwargs)
         if self.streaming:
             if _tools_in_params(params):
@@ -72,8 +79,7 @@ class ClaudeLangChainInstance(ChatAnthropic):
             run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
             **kwargs: Any,
     ) -> ChatResult:
-        if len(messages) > 1 and isinstance(messages[1], SystemMessage):
-            messages[1] = HumanMessage(content=messages[1].content)
+        messages = self._normalize_messages(messages)
         params = self._format_params(messages=messages, stop=stop, **kwargs)
         if self.streaming:
             if _tools_in_params(params):

--- a/tests/test_agentuniverse/unit/regressions/test_claude_message_input_isolation.py
+++ b/tests/test_agentuniverse/unit/regressions/test_claude_message_input_isolation.py
@@ -1,0 +1,29 @@
+import sys
+import types
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+anthropic_module = types.ModuleType("langchain_anthropic")
+anthropic_chat_models = types.ModuleType("langchain_anthropic.chat_models")
+
+class ChatAnthropic:
+    pass
+
+anthropic_module.ChatAnthropic = ChatAnthropic
+anthropic_chat_models._tools_in_params = lambda params: False
+sys.modules.setdefault("langchain_anthropic", anthropic_module)
+sys.modules.setdefault("langchain_anthropic.chat_models", anthropic_chat_models)
+
+from agentuniverse.llm.claude_langchain_instance import ClaudeLangChainInstance
+
+
+def test_claude_message_normalization_does_not_mutate_input_list():
+    system = SystemMessage(content="rules")
+    messages = [HumanMessage(content="hello"), system]
+
+    normalized = ClaudeLangChainInstance._normalize_messages(messages)
+
+    assert messages[1] is system
+    assert isinstance(messages[1], SystemMessage)
+    assert isinstance(normalized[1], HumanMessage)
+    assert normalized is not messages


### PR DESCRIPTION
## Summary
- avoid mutating Claude message inputs
- add focused regression coverage for the corrected behavior

## Root cause
Claude message normalization replaced an element in the caller's list in place, leaking adapter-specific conversion to later consumers.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_claude_message_input_isolation.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
