### PR TITLE
fix(llm): preserve disabled LangChain retries

### DIFF
--- a/agentuniverse/llm/claude_langchain_instance.py
+++ b/agentuniverse/llm/claude_langchain_instance.py
@@ -33,7 +33,7 @@ class ClaudeLangChainInstance(ChatAnthropic):
         init_params['streaming'] = llm.streaming if llm.streaming else False
         init_params['anthropic_api_key'] = llm.api_key if llm.api_key else 'blank'
         init_params['max_tokens'] = llm.max_tokens
-        init_params['max_retries'] = llm.max_retries if llm.max_retries else 2
+        init_params['max_retries'] = llm.max_retries if llm.max_retries is not None else 2
         init_params['anthropic_api_url'] = llm.api_url
         init_params['streaming'] = llm.streaming
         init_params['llm'] = llm

--- a/agentuniverse/llm/langchain_instance.py
+++ b/agentuniverse/llm/langchain_instance.py
@@ -38,7 +38,7 @@ class LangchainOpenAI(ChatOpenAI):
         init_params['temperature'] = llm.temperature if llm.temperature else 0.7
         init_params['request_timeout'] = llm.request_timeout
         init_params['max_tokens'] = llm.max_tokens
-        init_params['max_retries'] = llm.max_retries if llm.max_retries else 2
+        init_params['max_retries'] = llm.max_retries if llm.max_retries is not None else 2
         init_params['streaming'] = llm.streaming if llm.streaming else False
         init_params['openai_api_key'] = llm.openai_api_key if llm.openai_api_key else 'blank'
         init_params['openai_organization'] = llm.openai_organization

--- a/agentuniverse/llm/llm_channel/langchain_instance/default_channel_langchain_instance.py
+++ b/agentuniverse/llm/llm_channel/langchain_instance/default_channel_langchain_instance.py
@@ -29,7 +29,7 @@ class DefaultChannelLangchainInstance(ChatOpenAI):
         init_params['temperature'] = llm_channel.temperature if llm_channel.temperature else 0.7
         init_params['request_timeout'] = llm_channel.request_timeout
         init_params['max_tokens'] = llm_channel.max_tokens
-        init_params['max_retries'] = llm_channel.max_retries if llm_channel.max_retries else 2
+        init_params['max_retries'] = llm_channel.max_retries if llm_channel.max_retries is not None else 2
         init_params['streaming'] = llm_channel.streaming if llm_channel.streaming else False
         init_params['openai_api_key'] = llm_channel.channel_api_key if llm_channel.channel_api_key else 'blank'
         init_params['openai_organization'] = llm_channel.channel_organization

--- a/agentuniverse/llm/openai_style_langchain_instance.py
+++ b/agentuniverse/llm/openai_style_langchain_instance.py
@@ -135,7 +135,7 @@ class LangchainOpenAIStyleInstance(ChatOpenAI):
         init_params['temperature'] = llm.temperature if llm.temperature else 0.7
         init_params['request_timeout'] = llm.request_timeout
         init_params['max_tokens'] = llm.max_tokens
-        init_params['max_retries'] = llm.max_retries if llm.max_retries else 2
+        init_params['max_retries'] = llm.max_retries if llm.max_retries is not None else 2
         init_params['streaming'] = llm.streaming if llm.streaming else False
         init_params['openai_api_key'] = llm.api_key if llm.api_key else 'blank'
         init_params['openai_organization'] = llm.organization

--- a/agentuniverse/llm/wenxin_langchain_instance.py
+++ b/agentuniverse/llm/wenxin_langchain_instance.py
@@ -24,7 +24,7 @@ class WenXinLangChainInstance(QianfanChatEndpoint):
     def __init__(self, llm: LLM):
         init_params = {"qianfan_ak": llm.api_key, "qianfan_sk": llm.secret_key, "model": llm.model_name,
                        "max_tokens": llm.max_tokens, "timeout": llm.request_timeout,
-                       'max_retries': llm.max_retries if llm.max_retries else 2,
+                       'max_retries': llm.max_retries if llm.max_retries is not None else 2,
                        'streaming': llm.streaming if llm.streaming else False,
                        'temperature': llm.temperature if llm.temperature else 0.7, 'llm': llm}
         super().__init__(**init_params)

--- a/tests/test_agentuniverse/unit/regressions/test_langchain_zero_max_retries.py
+++ b/tests/test_agentuniverse/unit/regressions/test_langchain_zero_max_retries.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from agentuniverse.llm.openai_style_langchain_instance import LangchainOpenAIStyleInstance
+
+
+def test_openai_style_adapter_preserves_zero_max_retries():
+    llm = SimpleNamespace(
+        model_name="demo",
+        temperature=0.5,
+        request_timeout=30,
+        max_tokens=10,
+        max_retries=0,
+        streaming=False,
+        api_key="test-key",
+        organization=None,
+        api_base=None,
+        proxy=None,
+    )
+
+    adapter = LangchainOpenAIStyleInstance(llm)
+
+    assert adapter.max_retries == 0


### PR DESCRIPTION
## Summary
- preserve disabled LangChain retries
- add focused regression coverage for the corrected behavior

## Root cause
LangChain adapters replaced max_retries=0 with the default, making it impossible to explicitly disable retries.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_langchain_zero_max_retries.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
