### PR TITLE
fix(reader): handle empty image caption results

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
@@ -76,8 +76,10 @@ class ImageReader(Reader):
     def generate_description(self, image: Any) -> str:
         """Generate description of the image content."""
         pipeline = self._get_description_pipeline()
-        description = pipeline(image)[0]['generated_text']
-        return description
+        results = pipeline(image)
+        if not results or not isinstance(results[0], dict):
+            return ""
+        return str(results[0].get('generated_text') or "")
 
     def _load_data(self,
                    file: Union[str, Path],

--- a/tests/test_agentuniverse/unit/regressions/test_image_reader_empty_caption.py
+++ b/tests/test_agentuniverse/unit/regressions/test_image_reader_empty_caption.py
@@ -1,0 +1,8 @@
+from agentuniverse.agent.action.knowledge.reader.image.image_reader import ImageReader
+
+
+def test_image_reader_handles_empty_caption_pipeline_result():
+    reader = ImageReader()
+    reader._description_pipeline = lambda image: []
+
+    assert reader.generate_description(object()) == ""


### PR DESCRIPTION
## Summary
- handle empty image caption results
- add focused regression coverage for the corrected behavior

## Root cause
An image-to-text pipeline can return no candidates; indexing the first result crashed an otherwise recoverable image read.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_image_reader_empty_caption.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
