### PR TITLE
fix(tool): reject blank Tavily search queries

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/tavily_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/tavily_tool.py
@@ -123,7 +123,7 @@ class TavilyTool(Tool):
             else:
                 # 搜索模式
                 query = input
-                if not query:
+                if not isinstance(query, str) or not query.strip():
                     return {"error": "未提供搜索查询"}
                 
                 # 搜索参数

--- a/tests/test_agentuniverse/unit/regressions/test_tavily_blank_query.py
+++ b/tests/test_agentuniverse/unit/regressions/test_tavily_blank_query.py
@@ -1,0 +1,21 @@
+from agentuniverse.agent.action.tool.common_tool import tavily_tool
+
+
+class FakeClient:
+    def __init__(self, api_key):
+        self.search_calls = 0
+
+    def search(self, **kwargs):
+        self.search_calls += 1
+        return kwargs
+
+
+def test_tavily_search_rejects_whitespace_query(monkeypatch):
+    client = FakeClient("key")
+    monkeypatch.setattr(tavily_tool, "_get_tavily_client_class", lambda: lambda **kwargs: client)
+    tool = tavily_tool.TavilyTool(api_key="key")
+
+    result = tool.execute("   ")
+
+    assert result == {"error": "未提供搜索查询"}
+    assert client.search_calls == 0


### PR DESCRIPTION
## Summary
- reject blank Tavily search queries
- add focused regression coverage for the corrected behavior

## Root cause
Whitespace-only Tavily searches passed the existing truthiness check and consumed an external API request with no meaningful query.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_tavily_blank_query.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
