### PR TITLE
fix(tool): validate text file content type

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
@@ -26,6 +26,13 @@ class WriteFileTool(Tool):
             content = params.get('content', content)
             append = params.get('append', append)
             file_path = params.get('file_path')
+        if not isinstance(content, str):
+            return json.dumps({
+                "error": "content must be a string",
+                "file_path": file_path,
+                "status": "error"
+            })
+
         try:
             append = parse_strict_bool(append, "append", default=False)
         except ValueError as e:

--- a/tests/test_agentuniverse/unit/regressions/test_write_file_content_type.py
+++ b/tests/test_agentuniverse/unit/regressions/test_write_file_content_type.py
@@ -1,0 +1,13 @@
+import json
+
+from agentuniverse.agent.action.tool.common_tool.write_file_tool import WriteFileTool
+
+
+def test_write_file_rejects_non_string_content(tmp_path):
+    tool = WriteFileTool(base_dir=str(tmp_path))
+
+    result = json.loads(tool.execute("output.txt", content=None))
+
+    assert result["status"] == "error"
+    assert result["error"] == "content must be a string"
+    assert not (tmp_path / "output.txt").exists()


### PR DESCRIPTION
## Summary
- validate text file content type
- add focused regression coverage for the corrected behavior

## Root cause
Non-string text content reached file.write and surfaced an implementation TypeError instead of a stable structured tool error.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_write_file_content_type.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
