### PR TITLE
fix(tool): validate Word content type

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/write_word_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_word_tool.py
@@ -7,6 +7,10 @@ from agentuniverse.agent.action.tool.tool import Tool
 
 class WriteWordDocumentTool(Tool):
     def execute(self, file_path: str, content: str = "", append: bool = False) -> str:
+        if not isinstance(content, str):
+            return json.dumps(
+                {"error": "content must be a string", "file_path": file_path, "status": "error"}
+            )
         if not file_path.lower().endswith(".docx"):
             return json.dumps(
                 {"error": "The target file must have a .docx extension.", "file_path": file_path, "status": "error"}

--- a/tests/test_agentuniverse/unit/regressions/test_write_word_content_type.py
+++ b/tests/test_agentuniverse/unit/regressions/test_write_word_content_type.py
@@ -1,0 +1,13 @@
+import json
+
+from agentuniverse.agent.action.tool.common_tool.write_word_tool import WriteWordDocumentTool
+
+
+def test_write_word_rejects_non_string_content(tmp_path):
+    target = tmp_path / "output.docx"
+
+    result = json.loads(WriteWordDocumentTool().execute(str(target), content=None))
+
+    assert result["status"] == "error"
+    assert result["error"] == "content must be a string"
+    assert not target.exists()


### PR DESCRIPTION
## Summary
- validate Word content type
- add focused regression coverage for the corrected behavior

## Root cause
Non-string Word content failed deep in python-docx or byte accounting instead of returning a deterministic input error.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_write_word_content_type.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
