### PR TITLE
fix(tool): isolate Jina request overrides

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/jina_ai_tool.py
@@ -50,19 +50,20 @@ class JinaAITool(Tool):
         if not input:
             return None
         
-        # Update optional configurations
-        if mode:
-            self.mode = mode
-        if timeout:
-            self.timeout = timeout
-        if api_key:
-            self.api_key = api_key
-        if max_read_content_length:
-            self.max_read_content_length = max_read_content_length
-        if remove_image is not None:
-            self.remove_image = remove_image
-        if headers:
-            self.headers = headers
+        overrides = {
+            "mode": mode,
+            "timeout": timeout,
+            "api_key": api_key,
+            "max_read_content_length": max_read_content_length,
+            "remove_image": remove_image,
+            "headers": headers,
+        }
+        if any(value is not None for value in overrides.values()):
+            request_tool = self.model_copy(deep=True)
+            for name, value in overrides.items():
+                if value is not None:
+                    setattr(request_tool, name, value)
+            return request_tool.execute(input)
 
         # print(f"mode: {self.mode}, max_read_content_length: {self.max_read_content_length}, headers: {self.headers}")
 

--- a/tests/test_agentuniverse/unit/regressions/test_jina_request_override_isolation.py
+++ b/tests/test_agentuniverse/unit/regressions/test_jina_request_override_isolation.py
@@ -1,0 +1,17 @@
+from agentuniverse.agent.action.tool.common_tool.jina_ai_tool import JinaAITool
+
+
+def test_jina_request_overrides_do_not_mutate_shared_tool(monkeypatch):
+    monkeypatch.setattr(
+        JinaAITool,
+        "search_query",
+        lambda self, query: (self.mode, self.timeout, self.remove_image, query),
+    )
+    tool = JinaAITool(mode="read", timeout=30, remove_image=True)
+
+    result = tool.execute("query", mode="search", timeout=5, remove_image=False)
+
+    assert result == ("search", 5, False, "query")
+    assert tool.mode == "read"
+    assert tool.timeout == 30
+    assert tool.remove_image is True


### PR DESCRIPTION
## Summary
- isolate Jina request overrides
- add focused regression coverage for the corrected behavior

## Root cause
Per-call Jina overrides mutated the shared tool instance and leaked mode, timeout, headers, and filtering choices into later requests.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_jina_request_override_isolation.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
