### PR TITLE
fix(tool): validate Google search result counts

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/google_search_tool_v2.py
+++ b/agentuniverse/agent/action/tool/common_tool/google_search_tool_v2.py
@@ -16,6 +16,15 @@ from langchain_community.utilities.google_serper import GoogleSerperAPIWrapper
 from pydantic import Field
 
 
+def _resolve_result_count(value: int | None, default: int) -> int:
+    result_count = default if value is None else value
+    if isinstance(result_count, bool) or not isinstance(result_count, int):
+        raise ValueError("k must be an integer between 1 and 100")
+    if not 1 <= result_count <= 100:
+        raise ValueError("k must be between 1 and 100")
+    return result_count
+
+
 class GoogleSearchTool(Tool):
     """增强的Google搜索工具。
 
@@ -55,7 +64,7 @@ class GoogleSearchTool(Tool):
         if not self.serper_api_key:
             return self._get_mock_result(query)
             
-        k = k or self.default_k
+        k = _resolve_result_count(k, self.default_k)
         gl = gl or self.default_gl
         hl = hl or self.default_hl
         
@@ -78,7 +87,7 @@ class GoogleSearchTool(Tool):
         if not self.serper_api_key:
             return self._get_mock_result(query)
             
-        k = k or self.default_k
+        k = _resolve_result_count(k, self.default_k)
         gl = gl or self.default_gl
         hl = hl or self.default_hl
         
@@ -176,7 +185,7 @@ class GoogleScholarSearchTool(Tool):
         if not self.serper_api_key:
             return self._get_mock_scholar_result(query)
             
-        k = k or self.default_k
+        k = _resolve_result_count(k, self.default_k)
         
         # 构建学术搜索查询
         scholar_query = self._build_scholar_query(query, year, author, journal)
@@ -200,7 +209,7 @@ class GoogleScholarSearchTool(Tool):
         if not self.serper_api_key:
             return self._get_mock_scholar_result(query)
             
-        k = k or self.default_k
+        k = _resolve_result_count(k, self.default_k)
         scholar_query = self._build_scholar_query(query, year, author, journal)
         
         try:

--- a/tests/test_agentuniverse/unit/regressions/test_google_search_result_count.py
+++ b/tests/test_agentuniverse/unit/regressions/test_google_search_result_count.py
@@ -1,0 +1,19 @@
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.google_search_tool_v2 import (
+    GoogleScholarSearchTool,
+    GoogleSearchTool,
+)
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        GoogleSearchTool(serper_api_key="test-key"),
+        GoogleScholarSearchTool(serper_api_key="test-key"),
+    ],
+)
+@pytest.mark.parametrize("count", [0, -1, True, 101])
+def test_google_search_rejects_invalid_result_counts(tool, count):
+    with pytest.raises(ValueError, match="k must"):
+        tool.execute("agent universe", k=count)


### PR DESCRIPTION
## Summary
- validate Google search result counts
- add focused regression coverage for the corrected behavior

## Root cause
Falsy and out-of-range result counts were silently replaced or forwarded, producing surprising or invalid Serper requests.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_agentuniverse/unit/regressions/test_google_search_result_count.py`
- `python -m py_compile` on changed Python files
- `git diff --check`
