### PR TITLE
fix: replace bare except with except Exception in planning_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/planning_agent_template.py
+++ b/agentuniverse/agent/template/planning_agent_template.py
@@ -61,7 +61,7 @@ class PlanningAgentTemplate(AgentTemplate):
             return
         try:
             output = parse_json_markdown(agent_output).get('framework')
-        except:
+        except Exception:
             output = agent_output
         # add planning agent final result into the stream output.
         stream_output(output_stream,


### PR DESCRIPTION
A bare `except:` also swallows control-flow exceptions such as `KeyboardInterrupt` and `SystemExit`. Narrowing it to `except Exception:` keeps the intended error handling while letting control-flow signals propagate.