### PR TITLE
fix: replace bare except with except Exception in financial_indicator_extractor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/financial_indicator_extractor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/financial_indicator_extractor.py
@@ -454,7 +454,7 @@ class FinancialIndicatorExtractor(DocProcessor):
                             if val and re.match(r'^[0-9,.]+$', val):
                                 change_percent_str = val
                                 break
-                        except:
+                        except Exception:
                             continue
 
                     if not change_percent_str:


### PR DESCRIPTION
A bare `except:` also swallows control-flow exceptions such as `KeyboardInterrupt` and `SystemExit`. Narrowing it to `except Exception:` keeps the intended error handling while letting control-flow signals propagate.