### PR TITLE
fix: replace bare except with except Exception in au_session_propagator.py

### DIFF
--- a/agentuniverse/base/tracing/otel/propagator/au_session_propagator.py
+++ b/agentuniverse/base/tracing/otel/propagator/au_session_propagator.py
@@ -65,7 +65,7 @@ class AUSessionPropagator(textmap.TextMapPropagator):
                 span = trace.get_current_span(context)
                 try:
                     span.set_attribute(SPAN_SESSION_ID_KEY, _value[0])
-                except:
+                except Exception:
                     pass
                 break
         return context


### PR DESCRIPTION
A bare `except:` also swallows control-flow exceptions such as `KeyboardInterrupt` and `SystemExit`. Narrowing it to `except Exception:` keeps the intended error handling while letting control-flow signals propagate.