### PR TITLE
fix: replace bare except with except Exception in llm_instrumentor.py

### DIFF
--- a/agentuniverse/base/tracing/otel/instrumentation/llm/llm_instrumentor.py
+++ b/agentuniverse/base/tracing/otel/instrumentation/llm/llm_instrumentor.py
@@ -95,7 +95,7 @@ class LLMSpanManager:
                     get_current_token_usage(self.span.context.span_id),
                     self.span.parent.span_id
                 )
-            except:
+            except Exception:
                 pass
             self.span.end()
             self.span = None


### PR DESCRIPTION
A bare `except:` also swallows control-flow exceptions such as `KeyboardInterrupt` and `SystemExit`. Narrowing it to `except Exception:` keeps the intended error handling while letting control-flow signals propagate.