### PR TITLE
fix: replace bare except with except Exception in framework_context_manager.py

### DIFF
--- a/agentuniverse/base/context/framework_context_manager.py
+++ b/agentuniverse/base/context/framework_context_manager.py
@@ -104,7 +104,7 @@ class FrameworkContextManager:
             for var_name in self.context_dict.keys():
                 try:
                     context_values[var_name] = copy.deepcopy(self.get_context(var_name))
-                except:
+                except Exception:
                     context_values[var_name] = self.get_context(var_name)
         return context_values
 


### PR DESCRIPTION
A bare `except:` also swallows control-flow exceptions such as `KeyboardInterrupt` and `SystemExit`. Narrowing it to `except Exception:` keeps the intended error handling while letting control-flow signals propagate.