### PR TITLE
fix: replace bare except with except Exception in component_base.py

### DIFF
--- a/agentuniverse/base/component/component_base.py
+++ b/agentuniverse/base/component/component_base.py
@@ -54,5 +54,5 @@ class ComponentBase(BaseModel):
     def create_copy(self):
         try:
             return self.model_copy(deep=True)
-        except:
+        except Exception:
             return self.model_copy()


### PR DESCRIPTION
A bare `except:` also swallows control-flow exceptions such as `KeyboardInterrupt` and `SystemExit`. Narrowing it to `except Exception:` keeps the intended error handling while letting control-flow signals propagate.