### PR TITLE
docs: add docstring to as_langchain_chunk in langchain_instance.py

### DIFF
--- a/agentuniverse/llm/langchain_instance.py
+++ b/agentuniverse/llm/langchain_instance.py
@@ -85,6 +85,7 @@ class LangchainOpenAI(ChatOpenAI):
 
     @staticmethod
     def as_langchain_chunk(stream, run_manager=None):
+        """As Langchain Chunk."""
         default_chunk_class = AIMessageChunk
         for llm_result in stream:
             chunk = llm_result.raw


### PR DESCRIPTION
Add a short docstring for `as_langchain_chunk` to improve readability and IDE hover help. No functional changes.