### PR TITLE
docs: add docstring to init_channel in llm.py

### DIFF
--- a/agentuniverse/llm/llm.py
+++ b/agentuniverse/llm/llm.py
@@ -66,6 +66,7 @@ class LLM(ComponentBase):
         super().__init__(component_type=ComponentEnum.LLM, **kwargs)
 
     def init_channel(self):
+        """Initialize channel."""
         if self.channel and not self._channel_instance:
             llm_channel: LLMChannel = LLMChannelManager().get_instance_obj(
                 component_instance_name=self.channel)


### PR DESCRIPTION
Add a short docstring for `init_channel` to improve readability and IDE hover help. No functional changes.