### PR TITLE
docs: add docstring to as_langchain_chunk in openai_style_langchain_instance.py

### DIFF
--- a/agentuniverse/llm/openai_style_langchain_instance.py
+++ b/agentuniverse/llm/openai_style_langchain_instance.py
@@ -183,6 +183,7 @@ class LangchainOpenAIStyleInstance(ChatOpenAI):
 
     @staticmethod
     def as_langchain_chunk(stream, run_manager=None):
+        """As Langchain Chunk."""
         default_chunk_class = AIMessageChunk
         for llm_result in stream:
             chunk = llm_result.raw


### PR DESCRIPTION
Add a short docstring for `as_langchain_chunk` to improve readability and IDE hover help. No functional changes.