### PR TITLE
docs: add docstring to initialize_by_component_configer in openai_style_llm.py

### DIFF
--- a/agentuniverse/llm/openai_style_llm.py
+++ b/agentuniverse/llm/openai_style_llm.py
@@ -222,6 +222,7 @@ class OpenAIStyleLLM(LLM):
                 yield llm_output
 
     def initialize_by_component_configer(self, component_configer: LLMConfiger) -> 'LLM':
+        """Initialize By Component Configer."""
         if 'api_base' in component_configer.configer.value:
             api_base = component_configer.configer.value.get('api_base')
             self.api_base = process_yaml_func(api_base, component_configer.yaml_func_instance)


### PR DESCRIPTION
Add a short docstring for `initialize_by_component_configer` to improve readability and IDE hover help. No functional changes.