### PR TITLE
docs: add docstring to max_context_length in qwen_openai_style_llm.py

### DIFF
--- a/agentuniverse/llm/default/qwen_openai_style_llm.py
+++ b/agentuniverse/llm/default/qwen_openai_style_llm.py
@@ -63,6 +63,7 @@ class QWenOpenAIStyleLLM(OpenAIStyleLLM):
         return await super()._acall(messages, **kwargs)
 
     def max_context_length(self) -> int:
+        """Max Context Length."""
         if super().max_context_length():
             return super().max_context_length()
         return QWen_Max_CONTEXT_LENGTH.get(self.model_name, 8000)


### PR DESCRIPTION
Add a short docstring for `max_context_length` to improve readability and IDE hover help. No functional changes.