### PR TITLE
docs: add docstring to max_context_length in gemini_openai_style_llm.py

### DIFF
--- a/agentuniverse/llm/default/gemini_openai_style_llm.py
+++ b/agentuniverse/llm/default/gemini_openai_style_llm.py
@@ -57,6 +57,7 @@ class GeminiOpenAIStyleLLM(OpenAIStyleLLM):
         return await super()._acall(messages, **kwargs)
 
     def max_context_length(self) -> int:
+        """Max Context Length."""
         if super().max_context_length():
             return super().max_context_length()
         return GEMINI_MAX_CONTEXT_LENGTH.get(self.model_name, 8000)  # Default context length if model not found


### PR DESCRIPTION
Add a short docstring for `max_context_length` to improve readability and IDE hover help. No functional changes.