### PR TITLE
docs: add docstring to generate_result in default_ollama_llm.py

### DIFF
--- a/agentuniverse/llm/default/default_ollama_llm.py
+++ b/agentuniverse/llm/default/default_ollama_llm.py
@@ -70,6 +70,7 @@ class OllamaLLM(LLM):
             return self.agenerate_result(res)
 
     def generate_result(self, data):
+        """Generate result."""
         for line in data:
             yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line))
 


### PR DESCRIPTION
Add a short docstring for `generate_result` to improve readability and IDE hover help. No functional changes.