### PR TITLE
docs: add docstring to parse_result in claude_llm.py

### DIFF
--- a/agentuniverse/llm/default/claude_llm.py
+++ b/agentuniverse/llm/default/claude_llm.py
@@ -106,6 +106,7 @@ class ClaudeLLM(LLM):
 
     @staticmethod
     def parse_result(data):
+        """Parse result."""
         text = data.content[0].text
         if not text:
             return


### PR DESCRIPTION
Add a short docstring for `parse_result` to improve readability and IDE hover help. No functional changes.