### PR TITLE
docs: add docstring to as_langchain in ollama_llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/ollama_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/ollama_llm_channel.py
@@ -27,6 +27,7 @@ class OllamaLLMChannel(LLMChannel):
         return self
 
     def as_langchain(self) -> BaseLanguageModel:
+        """As Langchain."""
         return OllamaChannelLangchainInstance(self)
 
     def _new_client(self):


### PR DESCRIPTION
Add a short docstring for `as_langchain` to improve readability and IDE hover help. No functional changes.