### PR TITLE
docs: add docstring to max_context_length in deepseek_official_llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/deepseek_official_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/deepseek_official_llm_channel.py
@@ -20,6 +20,7 @@ class DeepseekOfficialLLMChannel(LLMChannel):
     channel_api_base: Optional[str] = 'https://api.deepseek.com/v1'
 
     def max_context_length(self) -> int:
+        """Max Context Length."""
         if super().max_context_length():
             return super().max_context_length()
         return DEEPSEEK_MAX_CONTEXT_LENGTH.get(self.channel_model_name, 8000)


### PR DESCRIPTION
Add a short docstring for `max_context_length` to improve readability and IDE hover help. No functional changes.