### PR TITLE
docs: add docstring to create_copy in llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/llm_channel.py
+++ b/agentuniverse/llm/llm_channel/llm_channel.py
@@ -86,6 +86,7 @@ class LLMChannel(ComponentBase):
         return self
 
     def create_copy(self):
+        """Create copy."""
         return self
 
     @property


### PR DESCRIPTION
Add a short docstring for `create_copy` to improve readability and IDE hover help. No functional changes.