### PR TITLE
docs: add docstring to to_dict in input_object.py

### DIFF
--- a/agentuniverse/agent/input_object.py
+++ b/agentuniverse/agent/input_object.py
@@ -14,6 +14,7 @@ class InputObject(object):
             self.__dict__[k] = v
 
     def to_dict(self):
+        """To Dict."""
         return self.__params.copy()
 
     def to_json_str(self):


### PR DESCRIPTION
Add a short docstring for `to_dict` to improve readability and IDE hover help. No functional changes.