### PR TITLE
docs: add docstring to to_dict in output_object.py

### DIFF
--- a/agentuniverse/agent/output_object.py
+++ b/agentuniverse/agent/output_object.py
@@ -14,6 +14,7 @@ class OutputObject(object):
             self.__dict__[k] = v
 
     def to_dict(self):
+        """To Dict."""
         return self.__params.copy()
 
     def to_json_str(self):


### PR DESCRIPTION
Add a short docstring for `to_dict` to improve readability and IDE hover help. No functional changes.