### PR TITLE
docs: add docstring to eviction_key in context_manager.py

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -460,6 +460,7 @@ class ContextManager(ComponentBase):
 
         # Sort by: priority (lower first), decay score (lower first), last_accessed (older first)
         def eviction_key(seg):
+            """Eviction Key."""
             priority_order = {
                 ContextPriority.EPHEMERAL: 0,
                 ContextPriority.LOW: 1,


### PR DESCRIPTION
Add a short docstring for `eviction_key` to improve readability and IDE hover help. No functional changes.