### PR TITLE
docs: add docstring to calculate_score in selective_compressor.py

### DIFF
--- a/agentuniverse/agent/context/compressor/selective_compressor.py
+++ b/agentuniverse/agent/context/compressor/selective_compressor.py
@@ -434,6 +434,7 @@ class SelectiveCompressor(ContextCompressor):
             Sorted list (highest score first)
         """
         def calculate_score(seg: ContextSegment) -> float:
+            """Calculate score."""
             # Relevance: decay score
             relevance_score = seg.calculate_decay()
 


### PR DESCRIPTION
Add a short docstring for `calculate_score` to improve readability and IDE hover help. No functional changes.