### PR TITLE
docs: add docstring to importance_score in context_compressor.py

### DIFF
--- a/agentuniverse/agent/context/compressor/context_compressor.py
+++ b/agentuniverse/agent/context/compressor/context_compressor.py
@@ -196,6 +196,7 @@ class ContextCompressor(ComponentBase):
         }
 
         def importance_score(seg: ContextSegment) -> float:
+            """Importance Score."""
             priority_weight = priority_weights.get(seg.priority.value.lower(), 2.0)
             decay = seg.calculate_decay()
             access_bonus = 1.0 + (seg.metadata.access_count * 0.1)


### PR DESCRIPTION
Add a short docstring for `importance_score` to improve readability and IDE hover help. No functional changes.