### PR TITLE
docs: add docstring to prune in memory.py

### DIFF
--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -95,6 +95,7 @@ class Memory(ComponentBase):
         return []
 
     def prune(self, memories: List[Message]) -> List[Message]:
+        """Prune."""
         if not memories:
             return []
         new_memories = memories[:]


### PR DESCRIPTION
Add a short docstring for `prune` to improve readability and IDE hover help. No functional changes.