### PR TITLE
docs: add docstring to message_to_dict in langchain_instance.py

### DIFF
--- a/agentuniverse/agent/memory/langchain_instance.py
+++ b/agentuniverse/agent/memory/langchain_instance.py
@@ -95,6 +95,7 @@ class AuConversationSummaryBufferMemory(ConversationSummaryBufferMemory):
         """Save context from the conversation to buffer and prune memories"""
 
         def message_to_dict(message):
+            """Message To Dict."""
             return {
                 "content": message.content,
                 "type": message.type


### PR DESCRIPTION
Add a short docstring for `message_to_dict` to improve readability and IDE hover help. No functional changes.