### PR TITLE
docs: add docstring to set_by_agent_model in work_pattern.py

### DIFF
--- a/agentuniverse/agent/work_pattern/work_pattern.py
+++ b/agentuniverse/agent/work_pattern/work_pattern.py
@@ -61,4 +61,5 @@ class WorkPattern(ComponentBase):
         return self
 
     def set_by_agent_model(self, **kwargs):
+        """Set by agent model."""
         pass


### PR DESCRIPTION
Add a short docstring for `set_by_agent_model` to improve readability and IDE hover help. No functional changes.