### PR TITLE
docs: add docstring to invoke in peer_work_pattern.py

### DIFF
--- a/agentuniverse/agent/work_pattern/peer_work_pattern.py
+++ b/agentuniverse/agent/work_pattern/peer_work_pattern.py
@@ -21,6 +21,7 @@ class PeerWorkPattern(WorkPattern):
     reviewing: ReviewingAgentTemplate = None
 
     def invoke(self, input_object: InputObject, work_pattern_input: dict, **kwargs) -> dict:
+        """Invoke."""
         self._validate_work_pattern_members()
 
         peer_results = list()


### PR DESCRIPTION
Add a short docstring for `invoke` to improve readability and IDE hover help. No functional changes.