### PR TITLE
docs: add docstring to invoke_chain in planner.py

### DIFF
--- a/agentuniverse/agent/plan/planner/planner.py
+++ b/agentuniverse/agent/plan/planner/planner.py
@@ -191,6 +191,7 @@ class Planner(ComponentBase):
                      chat_history,
                      input_object: InputObject):
 
+        """Invoke Chain."""
         if not input_object.get_data('output_stream'):
             res = chain.invoke(input=planner_input, config={"configurable": {"session_id": "unused"}})
             return res


### PR DESCRIPTION
Add a short docstring for `invoke_chain` to improve readability and IDE hover help. No functional changes.