### PR TITLE
docs: add docstring to create_react_agent in react_planner.py

### DIFF
--- a/agentuniverse/agent/plan/planner/react_planner/react_planner.py
+++ b/agentuniverse/agent/plan/planner/react_planner/react_planner.py
@@ -157,6 +157,7 @@ def create_react_agent(
         stop_sequence: Union[bool, List[str]] = True,
         bind_params: Optional[dict],
 ) -> Runnable:
+    """Create react agent."""
     missing_vars = {"tools", "tool_names", "agent_scratchpad"}.difference(
         prompt.input_variables + list(prompt.partial_variables)
     )


### PR DESCRIPTION
Add a short docstring for `create_react_agent` to improve readability and IDE hover help. No functional changes.