### PR TITLE
docs: add docstring to on_chain_start in stream_callback.py

### DIFF
--- a/agentuniverse/agent/plan/planner/react_planner/stream_callback.py
+++ b/agentuniverse/agent/plan/planner/react_planner/stream_callback.py
@@ -36,6 +36,7 @@ class StreamOutPutCallbackHandler(BaseCallbackHandler):
     def on_chain_start(
             self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
+        """On Chain Start."""
         return
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:


### PR DESCRIPTION
Add a short docstring for `on_chain_start` to improve readability and IDE hover help. No functional changes.