### PR TITLE
docs: add docstring to acquire_tools in nl2api_planner.py

### DIFF
--- a/agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
+++ b/agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
@@ -55,6 +55,7 @@ class Nl2ApiPlanner(Planner):
 
     @staticmethod
     def acquire_tools(action) -> list[LangchainTool]:
+        """Acquire Tools."""
         tool_names: list = action.get('tool') or list()
         lc_tools: list[LangchainTool] = list()
         for tool_name in tool_names:


### PR DESCRIPTION
Add a short docstring for `acquire_tools` to improve readability and IDE hover help. No functional changes.