### PR TITLE
docs: add docstring to input_keys in expressing_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/expressing_agent_template.py
+++ b/agentuniverse/agent/template/expressing_agent_template.py
@@ -17,6 +17,7 @@ from agentuniverse.base.util.logging.logging_util import LOGGER
 class ExpressingAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input', 'executing_result']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.