### PR TITLE
docs: add docstring to input_keys in contextual_iteration_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/contextual_iteration_agent_template.py
+++ b/agentuniverse/agent/template/contextual_iteration_agent_template.py
@@ -26,6 +26,7 @@ class ContextualIterationAgentTemplate(AgentTemplate):
     if_loop_prompt_version: Optional[str] = None
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.