### PR TITLE
docs: add docstring to input_keys in react_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/react_agent_template.py
+++ b/agentuniverse/agent/template/react_agent_template.py
@@ -40,6 +40,7 @@ class ReActAgentTemplate(AgentTemplate):
     max_iterations: Optional[int] = None
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.