### PR TITLE
docs: add docstring to input_keys in nl2api_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/nl2api_agent_template.py
+++ b/agentuniverse/agent/template/nl2api_agent_template.py
@@ -15,6 +15,7 @@ from agentuniverse.base.config.component_configer.configers.agent_configer impor
 class Nl2ApiAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.