### PR TITLE
docs: add docstring to input_keys in slave_rag_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/slave_rag_agent_template.py
+++ b/agentuniverse/agent/template/slave_rag_agent_template.py
@@ -24,6 +24,7 @@ from agentuniverse.base.context.context_archive_utils import get_current_context
 class SlaveRagAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['prompt_name', 'prompt_params']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.