### PR TITLE
docs: add docstring to input_keys in executing_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/executing_agent_template.py
+++ b/agentuniverse/agent/template/executing_agent_template.py
@@ -36,6 +36,7 @@ class ExecutingAgentTemplate(AgentTemplate):
         arbitrary_types_allowed = True
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input', 'planning_result']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.