### PR TITLE
docs: add docstring to input_keys in default_summarize_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/default_summarize_agent_template.py
+++ b/agentuniverse/agent/template/default_summarize_agent_template.py
@@ -12,6 +12,7 @@ from agentuniverse.agent.template.rag_agent_template import RagAgentTemplate
 class SummarizeRagAgentTemplate(RagAgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input', 'summarize_content']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.