### PR TITLE
docs: add docstring to input_keys in rag_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/rag_agent_template.py
+++ b/agentuniverse/agent/template/rag_agent_template.py
@@ -16,6 +16,7 @@ from agentuniverse.prompt.prompt import Prompt
 class RagAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.