### PR TITLE
docs: add docstring to input_keys in planning_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/planning_agent_template.py
+++ b/agentuniverse/agent/template/planning_agent_template.py
@@ -19,6 +19,7 @@ from agentuniverse.base.util.logging.logging_util import LOGGER
 class PlanningAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.