### PR TITLE
docs: add docstring to input_keys in peer_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/peer_agent_template.py
+++ b/agentuniverse/agent/template/peer_agent_template.py
@@ -33,6 +33,7 @@ class PeerAgentTemplate(AgentTemplate):
     expert_framework: Optional[dict[str, Union[str, dict]]] = None
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.