### PR TITLE
docs: add docstring to input_keys in reviewing_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/reviewing_agent_template.py
+++ b/agentuniverse/agent/template/reviewing_agent_template.py
@@ -19,6 +19,7 @@ from agentuniverse.base.util.logging.logging_util import LOGGER
 class ReviewingAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Input Keys."""
         return ['input', 'expressing_result']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
Add a short docstring for `input_keys` to improve readability and IDE hover help. No functional changes.