### PR TITLE
docs: add docstring to process_llm in nlu_rag_route_agent.py

### DIFF
--- a/agentuniverse/agent/default/rag_route_agent/nlu_rag_route_agent.py
+++ b/agentuniverse/agent/default/rag_route_agent/nlu_rag_route_agent.py
@@ -48,6 +48,7 @@ class NluRagRouteAgent(RagAgentTemplate):
         return agent_result
 
     def process_llm(self, **kwargs) -> LLM:
+        """Process llm."""
         llm_name = self.agent_model.profile.get('llm_model', {}).get('name') or self.llm_name
         return LLMManager().get_instance_obj(llm_name)
 


### PR DESCRIPTION
Add a short docstring for `process_llm` to improve readability and IDE hover help. No functional changes.