### PR TITLE
docs: add docstring to create_copy in knowledge.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -381,6 +381,7 @@ class Knowledge(ComponentBase):
         )
 
     def create_copy(self):
+        """Create copy."""
         copied = self.model_copy()
         copied.stores = self.stores.copy()
         copied.query_paraphrasers = self.query_paraphrasers.copy()


### PR DESCRIPTION
Add a short docstring for `create_copy` to improve readability and IDE hover help. No functional changes.