### PR TITLE
docs: add docstring to get_file_default_reader in reader_manager.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/reader_manager.py
+++ b/agentuniverse/agent/action/knowledge/reader/reader_manager.py
@@ -44,6 +44,7 @@ class ReaderManager(ComponentManagerBase[Reader]):
     def get_file_default_reader(self,
                                 file_type: str,
                                 new_instance: bool = False) -> Reader | None:
+        """Get file default reader."""
         if file_type in self.DEFAULT_READER:
             return self.get_instance_obj(self.DEFAULT_READER[file_type])
         else:


### PR DESCRIPTION
Add a short docstring for `get_file_default_reader` to improve readability and IDE hover help. No functional changes.