### PR TITLE
docs: add docstring to parse_metadata in image_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
@@ -105,6 +105,7 @@ class ImageReader(Reader):
                 "PIL is required. Install with: pip install Pillow") from e
 
         def parse_metadata(image: ImageFile) -> Dict[str, Any]:
+            """Parse metadata."""
             width, height = image.size
             channels = len(image.getbands())
             mode = image.mode


### PR DESCRIPTION
Add a short docstring for `parse_metadata` to improve readability and IDE hover help. No functional changes.