### PR TITLE
docs: add docstring to rich_text_to_str in notion_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
@@ -91,6 +91,7 @@ class NotionReader(Reader):
         t = block.get("type")
         data = block.get(t, {}) if t else {}
         def rich_text_to_str(items: List[Dict]) -> str:
+            """Rich Text To Str."""
             parts: List[str] = []
             for it in items or []:
                 plain = it.get("plain_text") or ""


### PR DESCRIPTION
Add a short docstring for `rich_text_to_str` to improve readability and IDE hover help. No functional changes.