### PR TITLE
docs: add docstring to repl in yuque_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py
@@ -95,6 +95,7 @@ class YuqueReader(Reader):
         md = data.get('sourcecode', '')
         # Process image references inline
         def repl(m):
+            """Repl."""
             src = m.group(1)
             return f'![]({src})'
         return re.sub(r'!\[.*?\]\((.*?)\)', repl, md)


### PR DESCRIPTION
Add a short docstring for `repl` to improve readability and IDE hover help. No functional changes.