### PR TITLE
docs: add docstring to query_paraphrase in query_keyword_extractor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
+++ b/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
@@ -22,6 +22,7 @@ class QueryKeywordExtractor(QueryParaphraser):
 
     def query_paraphrase(self, origin_query: Query) -> Query:
 
+        """Query Paraphrase."""
         keyword_extractor_instance = DocProcessorManager().get_instance_obj(self.keyword_extractor)
 
         keywords = keyword_extractor_instance.process_docs(


### PR DESCRIPTION
Add a short docstring for `query_paraphrase` to improve readability and IDE hover help. No functional changes.