### PR TITLE
docs: add docstring to flush in markdown_header_text_splitter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
@@ -113,6 +113,7 @@ class MarkdownHeaderTextSplitter(DocProcessor):
         sections: List[Tuple[str, str]] = []
 
         def flush() -> None:
+            """Flush."""
             body = "\n".join(buffer).strip("\n")
             buffer.clear()
             if not body:


### PR DESCRIPTION
Add a short docstring for `flush` to improve readability and IDE hover help. No functional changes.