### PR TITLE
docs: add docstring to pair_sim in mmr_processor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
@@ -213,6 +213,7 @@ class MMRProcessor(DocProcessor):
         sim_cache: Dict[Tuple[int, int], float] = {}
 
         def pair_sim(i: int, j: int) -> float:
+            """Pair Sim."""
             key = (i, j) if i < j else (j, i)
             cached = sim_cache.get(key)
             if cached is None:


### PR DESCRIPTION
Add a short docstring for `pair_sim` to improve readability and IDE hover help. No functional changes.