### PR TITLE
docs: add docstring to splitter in character_text_splitter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/character_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/character_text_splitter.py
@@ -36,6 +36,7 @@ class CharacterTextSplitter(DocProcessor):
 
     @property
     def splitter(self) -> Splitter:
+        """Splitter."""
         if not self.__splitter:
             self.__splitter = Splitter(separator=self.separator,
                                  chunk_size=self.chunk_size,


### PR DESCRIPTION
Add a short docstring for `splitter` to improve readability and IDE hover help. No functional changes.