### PR TITLE
docs: add docstring to splitter in recursive_character_text_splitter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/recursive_character_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/recursive_character_text_splitter.py
@@ -26,6 +26,7 @@ class RecursiveCharacterTextSplitter(DocProcessor):
 
     @property
     def splitter(self) -> Splitter:
+        """Splitter."""
         if not self.__splitter:
             self.__splitter = Splitter(separators=self.separators,
                                        chunk_size=self.chunk_size,


### PR DESCRIPTION
Add a short docstring for `splitter` to improve readability and IDE hover help. No functional changes.