### PR TITLE
docs: add docstring to splitter in token_text_splitter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py
@@ -26,6 +26,7 @@ class TokenTextSplitter(DocProcessor):
 
     @property
     def splitter(self) -> Splitter:
+        """Splitter."""
         if not self.__splitter:
             self.__splitter = Splitter(
             encoding_name=self.encoding_name,


### PR DESCRIPTION
Add a short docstring for `splitter` to improve readability and IDE hover help. No functional changes.