### PR TITLE
docs: add docstring to async_get_embeddings in doubao_embedding.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
@@ -73,6 +73,7 @@ class DoubaoEmbedding(Embedding):
 
     async def async_get_embeddings(self, texts: List[str],
                                    **kwargs) -> List[List[float]]:
+        """Async Get Embeddings."""
         return self.get_embeddings(texts)
 
     def _initialize_by_component_configer(


### PR DESCRIPTION
Add a short docstring for `async_get_embeddings` to improve readability and IDE hover help. No functional changes.