### PR TITLE
docs: add docstring to get_single_embedding in ollama_embedding.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/ollama_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/ollama_embedding.py
@@ -78,6 +78,7 @@ class OllamaEmbedding(Embedding):
 
         try:
             async def get_single_embedding(text: str) -> List[float]:
+                """Get single embedding."""
                 response = await self.async_client.post(
                     f"{self.ollama_base_url}/api/embeddings",
                     json={


### PR DESCRIPTION
Add a short docstring for `get_single_embedding` to improve readability and IDE hover help. No functional changes.