### PR TITLE
docs: add docstring to query in redis_vector_store.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/redis_vector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/redis_vector_store.py
@@ -337,6 +337,7 @@ class RedisVectorStore(Store):
         return documents
 
     def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        """Query."""
         vector = self._embedding_for_query(query)
         top_k = self._top_k(query)
         self._ensure_index(len(vector))


### PR DESCRIPTION
Add a short docstring for `query` to improve readability and IDE hover help. No functional changes.