### PR TITLE
docs(agent): document repl in yuque_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py
@@ -95,6 +95,7 @@ class YuqueReader(Reader):
         md = data.get('sourcecode', '')
         # Process image references inline
         def repl(m):
+            """Return a markdown image reference for a regex match."""
             src = m.group(1)
             return f'![]({src})'
         return re.sub(r'!\[.*?\]\((.*?)\)', repl, md)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `repl` in `agentuniverse/agent/action/knowledge/reader/cloud_file_reader/yuque_reader.py`: Return a markdown image reference for a regex match.
- Why it matters: the nested regex replacement that rewrites Yuque image links was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
