### PR TITLE
fix(agent): avoid mutable default argument in summarize_memory

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -556,7 +556,9 @@ class Agent(ComponentBase, ABC):
                           })
         memory.add([message], session_id=session_id, agent_id=agent_id)
 
-    def summarize_memory(self, agent_input: dict[str, Any] = {}, memory: Memory = None):
+    def summarize_memory(self, agent_input: dict[str, Any] = None, memory: Memory = None):
+        if agent_input is None:
+            agent_input = {}
         def do_summarize(params):
             content = memory.summarize_memory(**params)
             memory.add([


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/agent.py`: `Agent.summarize_memory` now declares `agent_input` with a `None` default and initializes an empty dict inside the body, replacing the mutable `{}` default argument.
- Mutable default arguments are shared across all calls, so a caller that mutates the dict would leak state between invocations of `summarize_memory`.
- Verified by syntax-checking with `ast.parse`; the explicit `None` default initializes the same empty dict, so behavior is unchanged
