### PR TITLE
refactor(agent): drop redundant explicit None return in conversation_memory_module.py

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py
@@ -93,7 +93,6 @@ def generate_relation_str_en(source: str, target: str, source_type: str, target_
         return f"{target} answered {source}'s question"
     elif type == 'summary':
         return f"{source} summary"
-    return None
 
 
 def sync_to_sub_agent_memory(message: ConversationMessage, session_id: str, memory_name: str):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py`: removed the trailing explicit `return None` from `generate_relation_str_en`, which is now simply omitted when no relation matches.
- The explicit `return None` is redundant: it is the function's last statement and the function already returns `None` implicitly on that path, so behavior is unchanged.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
