### PR TITLE
refactor(agent): drop redundant explicit None return in rar_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/rar_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/rar_reader.py
@@ -248,8 +248,6 @@ class RarReader(Reader):
             self._reader_cache[suffix] = reader_class
             return reader_class()
 
-        return None
-
     def _get_reader_class(self, suffix: str) -> Optional[Type[Reader]]:
         """Map file extension to reader class."""
         reader_map = {


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/action/knowledge/reader/file/rar_reader.py`: removed the trailing explicit `return None` from `RarReader._get_reader_for_file`; the method still returns `None` implicitly when no reader class maps to the suffix.
- The explicit `return None` is redundant: it is the method's last statement, and the method already returns `None` implicitly on that path, so behavior is unchanged.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
