### PR TITLE
refactor(agent): drop redundant explicit None return in academic_paper_fragmenter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/academic_paper_fragmenter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/academic_paper_fragmenter.py
@@ -308,8 +308,6 @@ class AcademicPaperFragmenter(DocProcessor):
                 if keyword in title_lower:
                     return section_name
 
-        return None
-
     def _extract_arguments(self, section: PaperSection) -> List[Argument]:
         """Extract arguments from a paper section.
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/action/knowledge/doc_processor/academic_paper_fragmenter.py`: removed the trailing explicit `return None` from `_map_to_known_section`; the method still returns `None` implicitly when no section keyword matches the title.
- The explicit `return None` is redundant: it is the method's last statement, and the method already returns `None` implicitly on that path, so behavior is unchanged.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
