### PR TITLE
refactor(agent): drop redundant explicit None return in powerpoint_tool.py

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py
@@ -599,7 +599,6 @@ class PowerPointTool(Tool):
             if title_shape is not None and shape.shape_id == title_shape.shape_id:
                 continue
             return shape
-        return None
 
     def _get_title_shape(self, slide: Any) -> Any | None:
         """Return a native title placeholder or a title textbox created by this tool."""


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/action/tool/common_tool/powerpoint_tool.py`: removed the trailing explicit `return None` from `_find_body_placeholder`; the method still returns `None` implicitly when the slide has no usable body placeholder.
- The explicit `return None` is redundant: it is the method's last statement, and the method already returns `None` implicitly on that path, so behavior is unchanged.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
