### PR TITLE
refactor(agent): drop redundant explicit None return in yahoo_finance_tool.py

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py
@@ -247,7 +247,6 @@ class YahooFinanceTool(Tool):
         for key in keys:
             if key in row and row[key] is not None:
                 return row[key]
-        return None
 
     @staticmethod
     def _fmt_num(value: Any) -> str:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/action/tool/common_tool/yahoo_finance_tool.py`: removed the trailing explicit `return None` from `_row_value`; the method still returns `None` implicitly when none of the candidate keys are present in the row.
- The explicit `return None` is redundant: it is the method's last statement, and the method already returns `None` implicitly on that path, so behavior is unchanged.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
