### PR TITLE
refactor(base): drop redundant explicit None return in context_coordinator.py

### DIFF
--- a/agentuniverse/base/context/context_coordinator.py
+++ b/agentuniverse/base/context/context_coordinator.py
@@ -98,8 +98,6 @@ class ContextCoordinator:
             token = otel_context.attach(context_pack.otel_context)
             return token
 
-        return None
-
     @classmethod
     def end_context(cls):
         """Clear all active contexts and close resources safely.


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/base/context/context_coordinator.py`: removed the trailing explicit `return None` from `ContextCoordinator.recover_context`; the method still returns `None` implicitly when no OTEL context is attached.
- The explicit `return None` is redundant: it is the method's last statement, and the method already returns `None` implicitly on that path, so behavior is unchanged.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
