### PR TITLE
docs(agent): document update_trace_context in agent.py

### DIFF
--- a/agentuniverse/agent/agent.py
+++ b/agentuniverse/agent/agent.py
@@ -98,6 +98,11 @@ class Agent(ComponentBase, ABC):
         pass
 
     def update_trace_context(self, input_object: InputObject):
+        """Copy trace ids from the input object into the trace context.
+        
+        Sets the session id and trace id on the AuTraceManager trace context
+        when the corresponding keys are present in the input object.
+        """
         session_id = input_object.get_data("session_id")
         if session_id:
             AuTraceManager().trace_context.set_session_id(session_id)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `update_trace_context` in `agentuniverse/agent/agent.py`: Copy trace ids from the input object into the trace context.
- Why it matters: the base Agent hook that wires user-supplied session_id/trace_id into tracing had no documentation of its side effect on the global trace context.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
