### PR TITLE
refactor(llm): prefer truthiness over len() == 0 in openai_llm.py

### DIFF
--- a/agentuniverse/llm/openai_llm.py
+++ b/agentuniverse/llm/openai_llm.py
@@ -176,7 +176,7 @@ class OpenAILLM(LLM):
         chat_completion = chunk
         if not isinstance(chunk, dict):
             chunk = chunk.dict()
-        if len(chunk["choices"]) == 0:
+        if not chunk["choices"]:
             return
         choice = chunk["choices"][0]
         message = choice.get("delta")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/llm/openai_llm.py`: `OpenAIStyleLLM.parse_result` now checks for an empty `choices` list with `if not chunk["choices"]` instead of `len(chunk["choices"]) == 0`.
- Truthiness is the more idiomatic Python check for an empty container and avoids calling `len()`; `choices` is a list, so the condition is equivalent.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
