### PR TITLE
docs(agent): document to_dict in output_object.py

### DIFF
--- a/agentuniverse/agent/output_object.py
+++ b/agentuniverse/agent/output_object.py
@@ -14,6 +14,7 @@ class OutputObject(object):
             self.__dict__[k] = v
 
     def to_dict(self):
+        """Return a copy of the internal params dictionary."""
         return self.__params.copy()
 
     def to_json_str(self):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `to_dict` in `agentuniverse/agent/output_object.py`: Return a copy of the internal params dictionary.
- Why it matters: callers of to_dict previously had no documented contract that the returned dict is a defensive copy of the stored params.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
