### PR TITLE
docs(agent): document eviction_key in context_manager.py

### DIFF
--- a/agentuniverse/agent/context/context_manager.py
+++ b/agentuniverse/agent/context/context_manager.py
@@ -460,6 +460,11 @@ class ContextManager(ComponentBase):
 
         # Sort by: priority (lower first), decay score (lower first), last_accessed (older first)
         def eviction_key(seg):
+            """Return the sort key used to order segments for eviction.
+            
+            Segments are ordered by priority (lowest first), decay score and last
+            access time, so the least important segment is evicted first.
+            """
             priority_order = {
                 ContextPriority.EPHEMERAL: 0,
                 ContextPriority.LOW: 1,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `eviction_key` in `agentuniverse/agent/context/context_manager.py`: Return the sort key used to order segments for eviction.
- Why it matters: the fallback eviction strategy's ordering rule was only implied by the surrounding comments, not documented on the key function itself.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
