### PR TITLE
docs(agent): document calculate_score in selective_compressor.py

### DIFF
--- a/agentuniverse/agent/context/compressor/selective_compressor.py
+++ b/agentuniverse/agent/context/compressor/selective_compressor.py
@@ -434,6 +434,12 @@ class SelectiveCompressor(ContextCompressor):
             Sorted list (highest score first)
         """
         def calculate_score(seg: ContextSegment) -> float:
+            """Calculate a keep/drop score for a context segment.
+            
+            Combines the segment's decay (relevance) score, recency of its last
+            access within a 24-hour window and a normalized access count using the
+            configurer weights; a higher score means the segment is kept first.
+            """
             # Relevance: decay score
             relevance_score = seg.calculate_decay()
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `calculate_score` in `agentuniverse/agent/context/compressor/selective_compressor.py`: Calculate a keep/drop score for a context segment.
- Why it matters: the scoring formula used to decide which segments survive compression was undocumented on the function that implements it.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
