### PR TITLE
docs(agent): document prune in memory.py

### DIFF
--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -95,6 +95,18 @@ class Memory(ComponentBase):
         return []
 
     def prune(self, memories: List[Message]) -> List[Message]:
+        """Prune memory messages so they fit within the configured token budget.
+        
+        Messages are dropped from the beginning until the remaining list fits
+        within ``max_tokens``; the dropped messages are optionally compressed
+        into a single summary message inserted at the front.
+        
+        Args:
+            memories: The messages to prune.
+        
+        Returns:
+            List[Message]: The pruned message list.
+        """
         if not memories:
             return []
         new_memories = memories[:]


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `prune` in `agentuniverse/agent/memory/memory.py`: Prune memory messages so they fit within the configured token budget.
- Why it matters: prune implements the token-budget trimming plus optional compression of dropped messages, behavior that was previously undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
