### PR TITLE
docs(agent): document message_to_dict in langchain_instance.py

### DIFF
--- a/agentuniverse/agent/memory/langchain_instance.py
+++ b/agentuniverse/agent/memory/langchain_instance.py
@@ -95,6 +95,7 @@ class AuConversationSummaryBufferMemory(ConversationSummaryBufferMemory):
         """Save context from the conversation to buffer and prune memories"""
 
         def message_to_dict(message):
+            """Convert a message to a plain dict with its content and type."""
             return {
                 "content": message.content,
                 "type": message.type


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `message_to_dict` in `agentuniverse/agent/memory/langchain_instance.py`: Convert a message to a plain dict with its content and type.
- Why it matters: the helper used to serialize buffered messages for the memory key had no documentation of its output shape.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
