### PR TITLE
docs(agent): document generate_relation_str in conversation_memory_module.py

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py
@@ -29,6 +29,12 @@ from agentuniverse.base.util.logging.logging_util import LOGGER
 
 
 def generate_relation_str(source: str, target: str, source_type: str, target_type: str, type: str):
+    """Build a Chinese relation sentence describing a conversation message.
+    
+    Selects a human-readable sentence based on the source/target types and
+    the message type (input/output/summary); returns None when no case
+    matches.
+    """
     if source_type == 'agent' and target_type == 'agent' and type == 'input':
         return f"智能体 {source} 向智能体 {target} 提出了一个问题"
     if source_type == 'agent' and target_type == 'agent' and type == 'output':


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `generate_relation_str` in `agentuniverse/agent/memory/conversation_memory/conversation_memory_module.py`: Build a Chinese relation sentence describing a conversation message.
- Why it matters: the module-level helper that renders conversation relations into Chinese sentences had no documentation of its cases or None return.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
