### PR TITLE
docs(agent): document from_message in conversation_message.py

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_message.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_message.py
@@ -90,6 +90,19 @@ class ConversationMessage(Message):
 
     @classmethod
     def from_message(cls, message: Message, session_id: str):
+        """Create a ConversationMessage from a base Message.
+        
+        Copies the message content, type and metadata (filling in a summary
+        prefix and trace id when missing) and a new uuid id, with 'agent' as
+        both the source and target type.
+        
+        Args:
+            message: The base message to convert.
+            session_id: Optional session id used as the conversation id.
+        
+        Returns:
+            ConversationMessage: The converted conversation message.
+        """
         if not message.metadata:
             message.metadata = {}
         message.metadata['prefix'] = '之前对话的摘要：' if message.type == 'summarize' else ''


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `from_message` in `agentuniverse/agent/memory/conversation_memory/conversation_message.py`: Create a ConversationMessage from a base Message.
- Why it matters: the classmethod that converts base messages into conversation messages mutates the input metadata and was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
