### PR TITLE
docs(agent): document is_nested_list in chroma_conversation_memory_storage.py

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -277,4 +277,5 @@ class ChromaConversationMemoryStorage(MemoryStorage):
 
     @staticmethod
     def is_nested_list(variable: List) -> bool:
+        """Check whether the variable is a non-empty list whose first item is a list."""
         return isinstance(variable, list) and len(variable) > 0 and isinstance(variable[0], list)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `is_nested_list` in `agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py`: Check whether the variable is a non-empty list whose first item is a list.
- Why it matters: the static helper used to normalize Chroma query results had no documentation of the exact shape it detects.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
