### PR TITLE
fix(agent): narrow bare except to Exception in planning_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/planning_agent_template.py
+++ b/agentuniverse/agent/template/planning_agent_template.py
@@ -61,7 +61,7 @@ class PlanningAgentTemplate(AgentTemplate):
             return
         try:
             output = parse_json_markdown(agent_output).get('framework')
-        except:
+        except Exception:
             output = agent_output
         # add planning agent final result into the stream output.
         stream_output(output_stream,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/template/planning_agent_template.py`: the bare `except` in `PlanningAgentTemplate.add_output_stream` is now `except Exception`, so parsing failures still fall back to the raw output.
- A bare `except` also swallows `BaseException` subclasses such as `KeyboardInterrupt` and `SystemExit`; `except Exception` keeps the intended catch-every-error behavior without trapping process-level signals.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
