### PR TITLE
fix(agent): narrow bare except to Exception in financial_indicator_extractor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/financial_indicator_extractor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/financial_indicator_extractor.py
@@ -454,7 +454,7 @@ class FinancialIndicatorExtractor(DocProcessor):
                             if val and re.match(r'^[0-9,.]+$', val):
                                 change_percent_str = val
                                 break
-                        except:
+                        except Exception:
                             continue
 
                     if not change_percent_str:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/agent/action/knowledge/doc_processor/financial_indicator_extractor.py`: the bare `except` inside the regex-match loop is now `except Exception`, still skipping invalid group values.
- A bare `except` also swallows `BaseException` subclasses such as `KeyboardInterrupt` and `SystemExit`; `except Exception` keeps the intended catch-every-error behavior without trapping process-level signals.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
