### PR TITLE
docs(agent): document delete in qdrant_memory_storage.py

### DIFF
--- a/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
+++ b/agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py
@@ -115,6 +115,17 @@ class QdrantMemoryStorage(MemoryStorage):
         return Filter(must=must_conditions)
 
     def delete(self, session_id: str = None, agent_id: str = None, **kwargs) -> None:
+        """Delete messages from the Qdrant collection.
+        
+        Builds a filter from the optional session_id, agent_id and 'type'
+        keyword arguments and deletes the matching points. Does nothing when no
+        filter field is provided.
+        
+        Args:
+            session_id: The session id to filter by.
+            agent_id: The agent id to filter by.
+            **kwargs: May carry a 'type' filter value.
+        """
         client = self._ensure_client()
         filt = self._build_filter(session_id=session_id, agent_id=agent_id, source=None, type_value=kwargs.get("type"))
         if not filt:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `delete` in `agentuniverse/agent/memory/memory_storage/qdrant_memory_storage.py`: Delete messages from the Qdrant collection.
- Why it matters: delete's filter-building behavior and its no-op when no filter is given were undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
