### PR TITLE
docs(agent): document set_by_agent_model in work_pattern.py

### DIFF
--- a/agentuniverse/agent/work_pattern/work_pattern.py
+++ b/agentuniverse/agent/work_pattern/work_pattern.py
@@ -61,4 +61,9 @@ class WorkPattern(ComponentBase):
         return self
 
     def set_by_agent_model(self, **kwargs):
+        """Bind the member agent templates on the work pattern.
+        
+        Base implementation is a no-op; subclasses store the agent templates
+        provided through the keyword arguments.
+        """
         pass


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `set_by_agent_model` in `agentuniverse/agent/work_pattern/work_pattern.py`: Bind the member agent templates on the work pattern.
- Why it matters: the base work-pattern hook that subclasses use to wire their member agents was an undocumented no-op.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
