### PR TITLE
docs(agent): document invoke in peer_work_pattern.py

### DIFF
--- a/agentuniverse/agent/work_pattern/peer_work_pattern.py
+++ b/agentuniverse/agent/work_pattern/peer_work_pattern.py
@@ -21,6 +21,20 @@ class PeerWorkPattern(WorkPattern):
     reviewing: ReviewingAgentTemplate = None
 
     def invoke(self, input_object: InputObject, work_pattern_input: dict, **kwargs) -> dict:
+        """Run the peer work pattern loop and collect the per-round results.
+        
+        Iterates up to retry_count times, invoking the planning, executing,
+        expressing and reviewing templates (honoring jump_step), and stops
+        early when the reviewing score reaches eval_threshold.
+        
+        Args:
+            input_object: The input parameters passed by the user.
+            work_pattern_input: Work pattern input; may carry retry_count,
+                jump_step and eval_threshold.
+        
+        Returns:
+            dict: A dict with the 'result' key holding the per-round results.
+        """
         self._validate_work_pattern_members()
 
         peer_results = list()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `invoke` in `agentuniverse/agent/work_pattern/peer_work_pattern.py`: Run the peer work pattern loop and collect the per-round results.
- Why it matters: the retry/jump_step/eval_threshold loop semantics of the peer work pattern were previously undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
