### PR TITLE
fix(base): narrow bare except to Exception in monitor.py

### DIFF
--- a/agentuniverse/base/util/monitor/monitor.py
+++ b/agentuniverse/base/util/monitor/monitor.py
@@ -243,7 +243,7 @@ class Monitor(BaseModel):
                 for key, value in cur_token_usage.items():
                     try:
                         result_usage[key] = old_token_usage[key] + value if key in old_token_usage else value
-                    except:
+                    except Exception:
                         # not addable value
                         pass
                 FrameworkContextManager().set_context(trace_id + '_token_usage', result_usage)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Changed `agentuniverse/base/util/monitor/monitor.py`: the bare `except` around token-usage accumulation in `Monitor.add_token_usage_to_framework_context` is now `except Exception`, still skipping non-addable values.
- A bare `except` also swallows `BaseException` subclasses such as `KeyboardInterrupt` and `SystemExit`; `except Exception` keeps the intended catch-every-error behavior without trapping process-level signals.
- Verified by syntax-checking with `ast.parse` and confirming the condition/exception handling is semantically identical, so behavior is unchanged
