### PR TITLE
docs(agent): document on_chain_start in stream_callback.py

### DIFF
--- a/agentuniverse/agent/plan/planner/react_planner/stream_callback.py
+++ b/agentuniverse/agent/plan/planner/react_planner/stream_callback.py
@@ -36,6 +36,7 @@ class StreamOutPutCallbackHandler(BaseCallbackHandler):
     def on_chain_start(
             self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
+        """Callback invoked when a chain starts; does nothing by default."""
         return
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `on_chain_start` in `agentuniverse/agent/plan/planner/react_planner/stream_callback.py`: Callback invoked when a chain starts; does nothing by default.
- Why it matters: the empty chain-start override in the stream callback handler had no documentation of its no-op intent.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
