### PR TITLE
docs(agent): document acquire_tools in nl2api_planner.py

### DIFF
--- a/agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
+++ b/agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py
@@ -55,6 +55,15 @@ class Nl2ApiPlanner(Planner):
 
     @staticmethod
     def acquire_tools(action) -> list[LangchainTool]:
+        """Resolve the langchain tools listed in a planning action.
+        
+        Args:
+            action: An action dict whose 'tool' key holds tool names.
+        
+        Returns:
+            list[LangchainTool]: The langchain tools resolved from the
+                ToolManager for each name; empty when the action lists none.
+        """
         tool_names: list = action.get('tool') or list()
         lc_tools: list[LangchainTool] = list()
         for tool_name in tool_names:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `acquire_tools` in `agentuniverse/agent/plan/planner/nl2api_planner/nl2api_planner.py`: Resolve the langchain tools listed in a planning action.
- Why it matters: the static helper that resolves tool names from an action into langchain tools was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
