### PR TITLE
docs(llm): document prune_none in llm_output.py

### DIFF
--- a/agentuniverse/llm/llm_output.py
+++ b/agentuniverse/llm/llm_output.py
@@ -42,6 +42,19 @@ class FunctionCall(BaseModel):
 
 
 def prune_none(obj):
+    """Recursively remove ``None`` values from a nested dict/list structure.
+
+    Dict entries and list items whose value is ``None`` are dropped, and
+    nested dicts and lists are pruned the same way. Any other object is
+    returned unchanged.
+
+    Args:
+        obj: A dict, list, or any other object.
+
+    Returns:
+        The pruned structure, or ``obj`` itself when it is neither a
+        dict nor a list.
+    """
     if isinstance(obj, dict):
         return {k: prune_none(v) for k, v in obj.items() if v is not None}
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `prune_none` in `agentuniverse/llm/llm_output.py` describing that it recursively drops `None` values from nested dicts and lists.
- The function had no docstring, so its recursive pruning behavior and its pass-through for other objects were hard to discover for library users and IDE tooling.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
