### PR TITLE
docs(agent): document input_keys in contextual_iteration_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/contextual_iteration_agent_template.py
+++ b/agentuniverse/agent/template/contextual_iteration_agent_template.py
@@ -26,6 +26,7 @@ class ContextualIterationAgentTemplate(AgentTemplate):
     if_loop_prompt_version: Optional[str] = None
 
     def input_keys(self) -> list[str]:
+        """Return the input keys of the agent: 'input'."""
         return ['input']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `input_keys` in `agentuniverse/agent/template/contextual_iteration_agent_template.py`: Return the input keys of the agent: 'input'.
- Why it matters: the input contract of the contextual iteration agent template was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
