### PR TITLE
docs(llm): document init_channel in llm.py

### DIFF
--- a/agentuniverse/llm/llm.py
+++ b/agentuniverse/llm/llm.py
@@ -66,6 +66,14 @@ class LLM(ComponentBase):
         super().__init__(component_type=ComponentEnum.LLM, **kwargs)
 
     def init_channel(self):
+        """Initialize the LLM channel instance from the ``channel`` setting.
+
+        Looks up the channel component registered under ``self.channel``,
+        stores it in ``_channel_instance``, and copies the current LLM
+        attributes into the channel's ``channel_model_config``. Does
+        nothing when no channel is configured, an instance is already
+        initialized, or the channel lookup fails.
+        """
         if self.channel and not self._channel_instance:
             llm_channel: LLMChannel = LLMChannelManager().get_instance_obj(
                 component_instance_name=self.channel)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `LLM.init_channel` in `agentuniverse/llm/llm.py` describing how the channel instance is looked up and configured, and when it is a no-op.
- The method had no docstring, so its side effect of copying LLM attributes into `channel_model_config` and its no-op conditions were hard to discover.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
