### PR TITLE
docs(llm): document as_langchain_chunk in openai_style_langchain_instance.py

### DIFF
--- a/agentuniverse/llm/openai_style_langchain_instance.py
+++ b/agentuniverse/llm/openai_style_langchain_instance.py
@@ -183,6 +183,22 @@ class LangchainOpenAIStyleInstance(ChatOpenAI):
 
     @staticmethod
     def as_langchain_chunk(stream, run_manager=None):
+        """Yield LangChain ``ChatGenerationChunk`` objects from an LLM result stream.
+
+        Each result's ``raw`` payload is converted to a dict when needed,
+        and results with no choices are skipped. The first choice's delta
+        is converted into a message chunk and yielded, and
+        ``run_manager.on_llm_new_token`` is called for each chunk when a
+        run manager is provided.
+
+        Args:
+            stream: Iterable of LLM results whose ``raw`` field holds the
+                raw OpenAI-style response.
+            run_manager: Optional LangChain run manager for token events.
+
+        Yields:
+            ChatGenerationChunk: One per non-empty choice in the stream.
+        """
         default_chunk_class = AIMessageChunk
         for llm_result in stream:
             chunk = llm_result.raw


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `OpenAILangchainInstance.as_langchain_chunk` in `agentuniverse/llm/openai_style_langchain_instance.py` describing the streaming chunk conversion, its arguments, and what it yields.
- The generator had no docstring, so how raw LLM results are converted into LangChain `ChatGenerationChunk` objects was only discoverable by reading the loop body.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
