### PR TITLE
docs(llm): document initialize_by_component_configer in openai_style_llm.py

### DIFF
--- a/agentuniverse/llm/openai_style_llm.py
+++ b/agentuniverse/llm/openai_style_llm.py
@@ -222,6 +222,21 @@ class OpenAIStyleLLM(LLM):
                 yield llm_output
 
     def initialize_by_component_configer(self, component_configer: LLMConfiger) -> 'LLM':
+        """Initialize OpenAI-style settings from the component configer.
+
+        Reads ``api_base``/``api_key`` (or the ``api_base_env``/
+        ``api_key_env`` environment-variable variants), ``organization``,
+        ``proxy``, ``extra_headers`` and ``extra_body`` from the configer
+        value, resolving yaml functions and environment variables, then
+        delegates to the base class implementation.
+
+        Args:
+            component_configer: The configer carrying the component's
+                configuration values.
+
+        Returns:
+            The initialized LLM instance returned by the base class.
+        """
         if 'api_base' in component_configer.configer.value:
             api_base = component_configer.configer.value.get('api_base')
             self.api_base = process_yaml_func(api_base, component_configer.yaml_func_instance)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `OpenAIStyleLLM.initialize_by_component_configer` in `agentuniverse/llm/openai_style_llm.py` listing every configer key it reads and the delegation to the base class.
- The method had no docstring, so the set of supported configuration keys (including the `_env` variants) was only discoverable by reading the body.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
