### PR TITLE
docs(agent): document input_keys in slave_rag_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/slave_rag_agent_template.py
+++ b/agentuniverse/agent/template/slave_rag_agent_template.py
@@ -24,6 +24,7 @@ from agentuniverse.base.context.context_archive_utils import get_current_context
 class SlaveRagAgentTemplate(AgentTemplate):
 
     def input_keys(self) -> list[str]:
+        """Return the input keys of the agent: 'prompt_name' and 'prompt_params'."""
         return ['prompt_name', 'prompt_params']
 
     def output_keys(self) -> list[str]:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `input_keys` in `agentuniverse/agent/template/slave_rag_agent_template.py`: Return the input keys of the agent: 'prompt_name' and 'prompt_params'.
- Why it matters: the input contract of the slave RAG agent template was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
