### PR TITLE
docs(llm): document max_context_length in wenxin_llm.py

### DIFF
--- a/agentuniverse/llm/default/wenxin_llm.py
+++ b/agentuniverse/llm/default/wenxin_llm.py
@@ -100,6 +100,13 @@ class WenXinLLM(LLM):
         return self.agenerate_stream_result(chat_completion)
 
     def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Wenxin model.
+
+        Uses the value configured on the parent class when set, otherwise
+        queries the client for the model info and returns its max input
+        tokens, falling back to the max input chars when tokens is not
+        reported.
+        """
         if super().max_context_length():
             return super().max_context_length()
         res = self._new_client().get_model_info(self.model_name)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `WenxinLLM.max_context_length` in `agentuniverse/llm/default/wenxin_llm.py` describing the client model-info query and the tokens-to-chars fallback.
- The method had no docstring, so its reliance on a live client call and the fallback to character count were hard to discover.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
