### PR TITLE
docs(llm): document max_context_length in gemini_openai_style_llm.py

### DIFF
--- a/agentuniverse/llm/default/gemini_openai_style_llm.py
+++ b/agentuniverse/llm/default/gemini_openai_style_llm.py
@@ -57,6 +57,12 @@ class GeminiOpenAIStyleLLM(OpenAIStyleLLM):
         return await super()._acall(messages, **kwargs)
 
     def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Gemini model.
+
+        Uses the value configured on the parent class when set, otherwise
+        looks the model up in ``GEMINI_MAX_CONTEXT_LENGTH`` and falls back to
+        8000 for unknown models.
+        """
         if super().max_context_length():
             return super().max_context_length()
         return GEMINI_MAX_CONTEXT_LENGTH.get(self.model_name, 8000)  # Default context length if model not found


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `GeminiOpenAIStyleLLM.max_context_length` in `agentuniverse/llm/default/gemini_openai_style_llm.py` describing the lookup in `GEMINI_MAX_CONTEXT_LENGTH` and the 8000 fallback.
- The method had no docstring, so the model lookup table and the default fallback were hard to discover.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
