### PR TITLE
docs(llm): document generate_result in default_ollama_llm.py

### DIFF
--- a/agentuniverse/llm/default/default_ollama_llm.py
+++ b/agentuniverse/llm/default/default_ollama_llm.py
@@ -70,6 +70,16 @@ class OllamaLLM(LLM):
             return self.agenerate_result(res)
 
     def generate_result(self, data):
+        """Yield an ``LLMOutput`` for each chunk of a streamed ollama chat.
+
+        Args:
+            data: Iterable of raw ollama response chunks, each a dict
+                with a ``message`` field.
+
+        Yields:
+            LLMOutput: One per chunk, carrying the message content as
+            text and the raw chunk JSON as ``raw``.
+        """
         for line in data:
             yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line))
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `DefaultOllamaLLM.generate_result` in `agentuniverse/llm/default/default_ollama_llm.py` describing the expected chunk shape and the yielded `LLMOutput` objects.
- The generator had no docstring, so the shape of the ollama chunks it expects was only discoverable by reading the loop body.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
