### PR TITLE
docs(llm): document parse_result in claude_llm.py

### DIFF
--- a/agentuniverse/llm/default/claude_llm.py
+++ b/agentuniverse/llm/default/claude_llm.py
@@ -106,6 +106,17 @@ class ClaudeLLM(LLM):
 
     @staticmethod
     def parse_result(data):
+        """Extract the text content from a Claude chat completion.
+
+        Args:
+            data: The Claude response whose first content block is
+                expected to be text.
+
+        Returns:
+            An ``LLMOutput`` with the extracted text and the raw
+            response, or ``None`` when the first content block has no
+            text.
+        """
         text = data.content[0].text
         if not text:
             return


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `ClaudeLLM.parse_result` in `agentuniverse/llm/default/claude_llm.py` describing that it reads the first content block and returns `None` for empty text.
- The method had no docstring, so its expectation that the first content block is text and its `None` return path were hard to discover.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
