### PR TITLE
docs(llm): document as_langchain in ollama_llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/ollama_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/ollama_llm_channel.py
@@ -27,6 +27,11 @@ class OllamaLLMChannel(LLMChannel):
         return self
 
     def as_langchain(self) -> BaseLanguageModel:
+        """Return a LangChain instance for this Ollama channel.
+
+        Returns:
+            An ``OllamaChannelLangchainInstance`` wrapping this channel.
+        """
         return OllamaChannelLangchainInstance(self)
 
     def _new_client(self):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `OllamaLLMChannel.as_langchain` in `agentuniverse/llm/llm_channel/ollama_llm_channel.py` stating that it wraps the channel in an `OllamaChannelLangchainInstance`.
- The method had no docstring, so the type of LangChain instance it returns was only discoverable by reading the body.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
