### PR TITLE
docs(agent): document process_llm in nlu_rag_route_agent.py

### DIFF
--- a/agentuniverse/agent/default/rag_route_agent/nlu_rag_route_agent.py
+++ b/agentuniverse/agent/default/rag_route_agent/nlu_rag_route_agent.py
@@ -48,6 +48,14 @@ class NluRagRouteAgent(RagAgentTemplate):
         return agent_result
 
     def process_llm(self, **kwargs) -> LLM:
+        """Get the LLM configured for this agent.
+        
+        Prefers the llm_model name from the agent profile and falls back to the
+        inherited llm_name.
+        
+        Returns:
+            LLM: The LLM instance.
+        """
         llm_name = self.agent_model.profile.get('llm_model', {}).get('name') or self.llm_name
         return LLMManager().get_instance_obj(llm_name)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `process_llm` in `agentuniverse/agent/default/rag_route_agent/nlu_rag_route_agent.py`: Get the LLM configured for this agent.
- Why it matters: the profile-over-inherited llm_name lookup order was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
