### PR TITLE
docs(agent): document create_copy in knowledge.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -381,6 +381,12 @@ class Knowledge(ComponentBase):
         )
 
     def create_copy(self):
+        """Create a copy of the knowledge component.
+        
+        The stores, query_paraphrasers, processor and reader list references are
+        copied (readers and ext_info are deep-copied) so the copy does not share
+        mutable state with the original.
+        """
         copied = self.model_copy()
         copied.stores = self.stores.copy()
         copied.query_paraphrasers = self.query_paraphrasers.copy()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `create_copy` in `agentuniverse/agent/action/knowledge/knowledge.py`: Create a copy of the knowledge component.
- Why it matters: create_copy's shallow-copy-vs-deep-copy distinction for the component's mutable collections was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
