### PR TITLE
docs(llm): document create_copy in llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/llm_channel.py
+++ b/agentuniverse/llm/llm_channel/llm_channel.py
@@ -86,6 +86,14 @@ class LLMChannel(ComponentBase):
         return self
 
     def create_copy(self):
+        """Return the channel instance itself.
+
+        Channels store their configuration directly, so a copy is the
+        same instance rather than a new object.
+
+        Returns:
+            This ``LLMChannel`` instance.
+        """
         return self
 
     @property


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `LLMChannel.create_copy` in `agentuniverse/llm/llm_channel/llm_channel.py` stating that it returns the instance itself because channels hold their configuration directly.
- The method had no docstring, so its identity-return behavior (no new object is created) was easy to misread as a bug.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
