### PR TITLE
docs(agent): document parse_metadata in image_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_reader.py
@@ -105,6 +105,11 @@ class ImageReader(Reader):
                 "PIL is required. Install with: pip install Pillow") from e
 
         def parse_metadata(image: ImageFile) -> Dict[str, Any]:
+            """Build the document metadata for a loaded image.
+            
+            Collects the file name, format, size, channel count and color mode,
+            merged with any provided ext_info.
+            """
             width, height = image.size
             channels = len(image.getbands())
             mode = image.mode


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `parse_metadata` in `agentuniverse/agent/action/knowledge/reader/image/image_reader.py`: Build the document metadata for a loaded image.
- Why it matters: the nested metadata builder that records image properties for the knowledge document was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
