### PR TITLE
docs(llm): document max_context_length in kimi_official_llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/kimi_official_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/kimi_official_llm_channel.py
@@ -20,6 +20,12 @@ class KimiOfficialLLMChannel(LLMChannel):
     channel_api_base: Optional[str] = "https://api.moonshot.cn/v1"
 
     def max_context_length(self) -> int:
+        """Return the maximum context length for the configured Kimi model.
+
+        Uses the value configured on the parent class when set, otherwise
+        looks the model up in ``KIMI_MAX_CONTEXT_LENGTH`` and falls back to
+        8000 for unknown models.
+        """
         if super().max_context_length():
             return super().max_context_length()
         return KIMI_MAX_CONTEXT_LENGTH.get(self.channel_model_name, 8000)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `KimiOfficialLLMChannel.max_context_length` in `agentuniverse/llm/llm_channel/kimi_official_llm_channel.py` describing the lookup in `KIMI_MAX_CONTEXT_LENGTH` and the 8000 fallback.
- The method had no docstring, so the model lookup table and the default fallback were hard to discover.
- Verified by syntax-checking with `ast.parse`; the change is a docstring only, so runtime behavior is unchanged
