### PR TITLE
docs(agent): document rich_text_to_str in notion_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py
@@ -91,6 +91,7 @@ class NotionReader(Reader):
         t = block.get("type")
         data = block.get(t, {}) if t else {}
         def rich_text_to_str(items: List[Dict]) -> str:
+            """Concatenate the plain text of Notion rich text items."""
             parts: List[str] = []
             for it in items or []:
                 plain = it.get("plain_text") or ""


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `rich_text_to_str` in `agentuniverse/agent/action/knowledge/reader/cloud/notion_reader.py`: Concatenate the plain text of Notion rich text items.
- Why it matters: the nested helper that flattens Notion rich text blocks to plain strings was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
