### PR TITLE
docs(agent): document query_paraphrase in query_keyword_extractor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
+++ b/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
@@ -21,6 +21,17 @@ class QueryKeywordExtractor(QueryParaphraser):
     keyword_extractor: Optional[str] = "jieba_keyword_extractor"
 
     def query_paraphrase(self, origin_query: Query) -> Query:
+        """Extract keywords from the query and attach them to it.
+        
+        Runs the configured keyword extractor doc processor over the query text
+        and updates the query's keyword set.
+        
+        Args:
+            origin_query: The original query.
+        
+        Returns:
+            Query: The same query object with keywords added.
+        """
 
         keyword_extractor_instance = DocProcessorManager().get_instance_obj(self.keyword_extractor)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `query_paraphrase` in `agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py`: Extract keywords from the query and attach them to it.
- Why it matters: query_paraphrase's use of the doc processor and its in-place keyword update were undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
