### PR TITLE
docs(agent): document flush in markdown_header_text_splitter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py
@@ -113,6 +113,12 @@ class MarkdownHeaderTextSplitter(DocProcessor):
         sections: List[Tuple[str, str]] = []
 
         def flush() -> None:
+            """Flush the buffered section text into the sections list.
+            
+            Joins the buffered lines, clears the buffer, and appends the section with
+            its current header path, unless it is an empty body or a preamble that is
+            configured to be dropped.
+            """
             body = "\n".join(buffer).strip("\n")
             buffer.clear()
             if not body:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `flush` in `agentuniverse/agent/action/knowledge/doc_processor/markdown_header_text_splitter.py`: Flush the buffered section text into the sections list.
- Why it matters: the nested flush callback's buffer handling and preamble-dropping rule were undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
