### PR TITLE
docs(agent): document pair_sim in mmr_processor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py
@@ -213,6 +213,7 @@ class MMRProcessor(DocProcessor):
         sim_cache: Dict[Tuple[int, int], float] = {}
 
         def pair_sim(i: int, j: int) -> float:
+            """Return the cached cosine similarity between two document vectors."""
             key = (i, j) if i < j else (j, i)
             cached = sim_cache.get(key)
             if cached is None:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `pair_sim` in `agentuniverse/agent/action/knowledge/doc_processor/mmr_processor.py`: Return the cached cosine similarity between two document vectors.
- Why it matters: the nested similarity helper with symmetric caching was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
