### PR TITLE
docs(agent): document splitter in token_text_splitter.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py
+++ b/agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py
@@ -26,6 +26,7 @@ class TokenTextSplitter(DocProcessor):
 
     @property
     def splitter(self) -> Splitter:
+        """Return the lazily constructed token text splitter instance."""
         if not self.__splitter:
             self.__splitter = Splitter(
             encoding_name=self.encoding_name,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `splitter` in `agentuniverse/agent/action/knowledge/doc_processor/token_text_splitter.py`: Return the lazily constructed token text splitter instance.
- Why it matters: the lazy initialization of the underlying LangChain splitter was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
