### PR TITLE
docs(agent): document get_single_embedding in ollama_embedding.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/ollama_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/ollama_embedding.py
@@ -78,6 +78,7 @@ class OllamaEmbedding(Embedding):
 
         try:
             async def get_single_embedding(text: str) -> List[float]:
+                """Fetch the embedding of a single text from the Ollama API."""
                 response = await self.async_client.post(
                     f"{self.ollama_base_url}/api/embeddings",
                     json={


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `get_single_embedding` in `agentuniverse/agent/action/knowledge/embedding/ollama_embedding.py`: Fetch the embedding of a single text from the Ollama API.
- Why it matters: the nested per-text async request helper used by the concurrent embedding loop was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
