### PR TITLE
docs(agent): document query in redis_vector_store.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/redis_vector_store.py
+++ b/agentuniverse/agent/action/knowledge/store/redis_vector_store.py
@@ -337,6 +337,19 @@ class RedisVectorStore(Store):
         return documents
 
     def query(self, query: Query, **kwargs: Any) -> list[Document]:
+        """Query the vector index and return the matching documents.
+        
+        Uses the query's precomputed embedding or embeds its text with the
+        configured model, ensures the index exists, runs the vector search and
+        converts the raw rows to Document objects.
+        
+        Args:
+            query: The query to search with.
+            **kwargs: May carry a metadata_filter for the search.
+        
+        Returns:
+            list[Document]: The documents returned by the vector search.
+        """
         vector = self._embedding_for_query(query)
         top_k = self._top_k(query)
         self._ensure_index(len(vector))


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `query` in `agentuniverse/agent/action/knowledge/store/redis_vector_store.py`: Query the vector index and return the matching documents.
- Why it matters: query's embedding resolution, index-ensure and search pipeline was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
