### PR TITLE
docs(agent): document invoke_chain in planner.py

### DIFF
--- a/agentuniverse/agent/plan/planner/planner.py
+++ b/agentuniverse/agent/plan/planner/planner.py
@@ -190,6 +190,16 @@ class Planner(ComponentBase):
     def invoke_chain(self, agent_model: AgentModel, chain: RunnableSerializable[Any, str], planner_input: dict,
                      chat_history,
                      input_object: InputObject):
+        """Invoke a planner chain, streaming tokens to the output stream when present.
+        
+        If the input object carries an output stream, the chain is streamed and
+        each token is pushed to the stream and the joined text is returned;
+        otherwise the chain is invoked in a single call and its result returned.
+        
+        Returns:
+            The chain result: the raw invoke result, or the joined streamed
+            token string when streaming.
+        """
 
         if not input_object.get_data('output_stream'):
             res = chain.invoke(input=planner_input, config={"configurable": {"session_id": "unused"}})


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `invoke_chain` in `agentuniverse/agent/plan/planner/planner.py`: Invoke a planner chain, streaming tokens to the output stream when present.
- Why it matters: invoke_chain's two execution modes (single invoke vs token streaming) and its differing return shapes were undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
