### PR TITLE
docs(agent): document get_file_default_reader in reader_manager.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/reader_manager.py
+++ b/agentuniverse/agent/action/knowledge/reader/reader_manager.py
@@ -44,6 +44,17 @@ class ReaderManager(ComponentManagerBase[Reader]):
     def get_file_default_reader(self,
                                 file_type: str,
                                 new_instance: bool = False) -> Reader | None:
+        """Get the default reader instance for a file type.
+        
+        Args:
+            file_type: The file extension/type to look up.
+            new_instance: Accepted for interface compatibility; the registered
+                instance is returned.
+        
+        Returns:
+            Reader | None: The default reader for the file type, or None when no
+                default is configured.
+        """
         if file_type in self.DEFAULT_READER:
             return self.get_instance_obj(self.DEFAULT_READER[file_type])
         else:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `get_file_default_reader` in `agentuniverse/agent/action/knowledge/reader/reader_manager.py`: Get the default reader instance for a file type.
- Why it matters: get_file_default_reader's registry lookup and None-on-unknown-type contract were undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
