### PR TITLE
docs(agent): document batched in dashscope_embedding.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/dashscope_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/dashscope_embedding.py
@@ -21,6 +21,7 @@ DASHSCOPE_EMBEDDING_URL = "https://dashscope.aliyuncs.com/api/v1/services/embedd
 
 def batched(inputs: List,
             batch_size: int = DASHSCOPE_MAX_BATCH_SIZE) -> Generator[List, None, None]:
+    """Yield consecutive sublists of the input in the given batch size."""
     # Split input string list, due to dashscope support 25 strings in one call.
     for i in range(0, len(inputs), batch_size):
         yield inputs[i:i + batch_size]


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `batched` in `agentuniverse/agent/action/knowledge/embedding/dashscope_embedding.py`: Yield consecutive sublists of the input in the given batch size.
- Why it matters: the module-level batching generator used to respect the DashScope 25-request limit was undocumented.
- Verified: syntax-checked with `ast.parse` on the modified file; the docstring is inserted as the first statement of the function and no executable code was changed, so behavior is unchanged.
