### PR TITLE
fix(template): concatenate multi-part text content in convert_message

### DIFF
--- a/agentuniverse/agent/template/openai_protocol_template.py
+++ b/agentuniverse/agent/template/openai_protocol_template.py
@@ -77,7 +77,7 @@ class OpenAIProtocolTemplate(AgentTemplate):
                 text = ""
                 for item in content:
                     if item.get('type') == 'text':
-                        text = item.get('text')
+                        text += item.get('text') or ''
                     elif item.get('type') == 'image_url':
                         image_urls.append(item.get('image_url'))
                 message['content'] = text


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- In `OpenAIProtocolTemplate.convert_message`, when a message's `content` is a list with multiple `text` parts (e.g. OpenAI-style interleaved text/image content: `[{'type': 'text', 'text': 'Hello '}, {'type': 'image_url', ...}, {'type': 'text', 'text': 'world'}]`), the loop did `text = item.get('text')`, so each text part overwrote the previous one and all but the last text part were silently dropped from the converted chat history.
- The fix changes the assignment to `text += item.get('text') or ''`, accumulating all text parts in order. Single-text-part and single-string contents behave exactly as before, and image_url parts are still collected into `image_urls` unchanged.
- Verified with a standalone repro of the old vs new loop (old: `'world'`, new: `'Hello world'` for the multi-part case; identical result for a single text part) and `ast.parse` on the modified file. The only caller of `convert_message` is `parse_openai_agent_input` in the same file, which relies on the flattened string content.
