### PR TITLE
fix(agent): guard None prompt_params in SlaveRAG parse_input

### DIFF
--- a/agentuniverse/agent/template/slave_rag_agent_template.py
+++ b/agentuniverse/agent/template/slave_rag_agent_template.py
@@ -36,7 +36,7 @@ class SlaveRagAgentTemplate(AgentTemplate):
         context_archive = get_current_context_archive()
 
         # get archive data from context
-        agent_input.update(agent_input.get('prompt_params'))
+        agent_input.update(agent_input.get('prompt_params') or {})
         for k, v in agent_input.items():
             result = v
             if isinstance(v, str):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- In `SlaveRagAgentTemplate.parse_input`, `agent_input.update(agent_input.get('prompt_params'))` crashes with `TypeError: 'NoneType' object is not iterable` when `prompt_params` is `None`. The key is required by `input_keys()`/`input_check`, but its value is not, so a caller that passes `prompt_params=None` (a RAG agent with no parameters) reaches `dict.update(None)` and fails.
- The fix changes the call to `agent_input.update(agent_input.get('prompt_params') or {})`, so a `None`/absent value updates nothing while a real dict still merges its keys exactly as before.
- Verified with a standalone repro: the old expression raises `TypeError` for `prompt_params=None`, the new one no-ops for `None` and produces identical merged output for a dict payload; `ast.parse` passes on the modified file.
