### PR TITLE
fix(llm): validate content blocks before indexing in ClaudeLLM

### DIFF
--- a/agentuniverse/llm/default/claude_llm.py
+++ b/agentuniverse/llm/default/claude_llm.py
@@ -106,6 +106,8 @@ class ClaudeLLM(LLM):
 
     @staticmethod
     def parse_result(data):
+        if not data.content:
+            raise ValueError("Claude LLM returned a response with no content blocks")
         text = data.content[0].text
         if not text:
             return


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- What was broken: `ClaudeLLM.parse_result` (agentuniverse/llm/default/claude_llm.py) indexes `data.content[0]` immediately after a non-streaming `client.messages.create(...)` response. The Anthropic API can return a message whose `content` list is empty (provider edge case), in which case the agent crashes with a bare `IndexError` instead of a readable error. The following `if not text: return` only guards empty *text*, not an empty *content list*.
- What this PR changes: `parse_result` now checks `if not data.content:` before indexing and raises a descriptive `ValueError` ("Claude LLM returned a response with no content blocks"). This flows through the `LLM.call`/`LLM.acall` base-class handlers, which log `Error in LLM call: ...` and re-raise, matching how this module surfaces LLM errors. When the content list is non-empty (all currently-working cases), behavior is byte-for-byte identical; the guard also covers a `None` content field.
- How it was verified: `python3 -c "import ast; ast.parse(open('agentuniverse/llm/default/claude_llm.py').read())"` passes; a standalone repro with a stubbed response confirms the old code raises a bare `IndexError` on empty content, the new code raises the descriptive `ValueError`, and a normal response still parses to the same `LLMOutput`.
