### PR TITLE
fix(llm): validate completion choices before indexing in OpenAIStyleLLM

### DIFF
--- a/agentuniverse/llm/openai_style_llm.py
+++ b/agentuniverse/llm/openai_style_llm.py
@@ -133,6 +133,8 @@ class OpenAIStyleLLM(LLM):
             **kwargs,
         )
         if not streaming:
+            if not chat_completion.choices:
+                raise ValueError(f"OpenAI style LLM '{self.model_name}' returned a completion with no choices")
             text = chat_completion.choices[0].message.content
             return LLMOutput(text=text, raw=chat_completion.model_dump())
         return self.generate_stream_result(chat_completion)
@@ -168,6 +170,8 @@ class OpenAIStyleLLM(LLM):
             **kwargs,
         )
         if not streaming:
+            if not chat_completion.choices:
+                raise ValueError(f"OpenAI style LLM '{self.model_name}' returned a completion with no choices")
             text = chat_completion.choices[0].message.content
             return LLMOutput(text=text, raw=chat_completion.model_dump())
         return self.agenerate_stream_result(chat_completion)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- What was broken: in `OpenAIStyleLLM._call` and `OpenAIStyleLLM._acall` (agentuniverse/llm/openai_style_llm.py), the non-streaming path indexes `chat_completion.choices[0]` immediately after `client.chat.completions.create(...)`. When an OpenAI-compatible provider returns a completion with an empty `choices` list (e.g. content-filtered or edge-case responses), the agent crashes with a bare `IndexError` that does not identify the model or the cause.
- What this PR changes: both non-streaming sites now check that `chat_completion.choices` is non-empty before indexing, and raise a descriptive `ValueError` naming the model (`OpenAI style LLM '<model_name>' returned a completion with no choices`) when it is empty. This flows through the `LLM.call`/`LLM.acall` base-class handlers, which log `Error in LLM call: ...` and re-raise, matching how this module surfaces LLM errors. The normal path (one or more choices) is untouched, so existing callers see identical behavior.
- How it was verified: `python3 -c "import ast; ast.parse(open('agentuniverse/llm/openai_style_llm.py').read())"` passes; a small standalone repro with a stubbed completion (`choices=[]`) confirms the pre-fix indexing raises a bare `IndexError` while the guarded path raises the descriptive `ValueError`.
