### PR TITLE
fix(base): return an isolated copy from assemble_memory_output

### DIFF
--- a/agentuniverse/base/util/agent_util.py
+++ b/agentuniverse/base/util/agent_util.py
@@ -55,8 +55,7 @@ def assemble_memory_output(memory: Memory, agent_input: dict,
         memory.add([cur_memory_message], **agent_input)
     if memory_messages is None:
         memory_messages = []
-    memory_messages.append(cur_memory_message)
-    return memory_messages
+    return [*memory_messages, cur_memory_message]
 
 
 def process_agent_llm_config(agent_id: str, agent_profile: dict, default_llm_configer: DefaultLLMConfiger) -> dict:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- In `assemble_memory_output`, when a caller passes its own `memory_messages` list (the documented 5th argument, "the historical memory messages"), the function does `memory_messages.append(cur_memory_message)` and returns the same object — silently mutating the caller's list. A caller that reuses its history list between turns (e.g. accumulating an agent conversation) would see the current message injected into its own object as a side effect.
- The fix returns a new list instead of mutating in place: `return [*memory_messages, cur_memory_message]`. When `memory_messages` is `None` (the case used by every in-repo caller — all planners and templates pass only `memory`, `agent_input`, `content`/`source`), the result is byte-for-byte identical to before; only the previously-mutating edge case changes.
- Verified with a standalone repro of the old vs new branch: with a caller-provided list the old code mutates it and returns the same object, the new code leaves it untouched and returns a fresh extended list; with `None` both return an identical single-message list. `ast.parse` passes on the modified file.
