### PR TITLE
fix(memory): validate memory storages before indexing first storage

### DIFF
--- a/agentuniverse/agent/memory/memory.py
+++ b/agentuniverse/agent/memory/memory.py
@@ -266,6 +266,9 @@ class Memory(ComponentBase):
         if component_configer.memory_retrieval_storage:
             self.memory_retrieval_storage = component_configer.memory_retrieval_storage
         if not self.memory_retrieval_storage:
+            if not self.memory_storages:
+                raise ValueError(f"Memory '{self.name}' has no memory_storages configured "
+                                 f"and no memory_retrieval_storage is set")
             self.memory_retrieval_storage = self.memory_storages[0]
         if component_configer.memory_summarize_agent:
             self.summarize_agent_id = component_configer.memory_summarize_agent


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- What was broken: in `Memory.initialize_by_component_configer` (agentuniverse/agent/memory/memory.py), when no `memory_retrieval_storage` is configured the code falls back to `self.memory_storages[0]`. The field is typed `Optional[List[str]]` and `create_copy()` in the same class already guards `if self.memory_storages is not None`, so an empty/`None` storage list is a state the class itself expects — e.g. a Memory instance constructed directly (or via a subclass with an empty default) with no storages, initialized with a configer that sets neither `memory_storages` nor `memory_retrieval_storage`. In that case the component crashes at initialization with a bare `IndexError` (or `TypeError` for `None`) that names neither the memory nor the missing configuration.
- What this PR changes: the fallback now checks that `self.memory_storages` is non-empty before indexing and raises a descriptive `ValueError` ("Memory '<name>' has no memory_storages configured and no memory_retrieval_storage is set") when it is not. All currently-working cases are untouched: when a storage list exists (the class default `['ram_memory_storage']`, a configured list, or a configured `memory_retrieval_storage`), the exact same value is selected as before; only the previously-crashing edge changes from an opaque indexing error to a descriptive one.
- How it was verified: `python3 -c "import ast; ast.parse(open('agentuniverse/agent/memory/memory.py').read())"` passes; a standalone repro of the fallback logic confirms the old code raises a bare `IndexError` for an empty storage list while the guarded code raises the descriptive `ValueError`, and a configured list still selects the first storage unchanged.
