### PR TITLE
fix(llm): validate completion choices before indexing in OpenAILLM

### DIFF
--- a/agentuniverse/llm/openai_llm.py
+++ b/agentuniverse/llm/openai_llm.py
@@ -103,6 +103,8 @@ class OpenAILLM(LLM):
             **kwargs,
         )
         if not streaming:
+            if not chat_completion.choices:
+                raise ValueError("OpenAI completion returned no choices")
             text = chat_completion.choices[0].message.content
             return LLMOutput(text=text, raw=chat_completion.model_dump())
         return self.generate_stream_result(chat_completion)
@@ -125,6 +127,8 @@ class OpenAILLM(LLM):
             **kwargs,
         )
         if not streaming:
+            if not chat_completion.choices:
+                raise ValueError("OpenAI completion returned no choices")
             text = chat_completion.choices[0].message.content
             return LLMOutput(text=text, raw=chat_completion.model_dump())
         return self.agenerate_stream_result(chat_completion)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- What was broken: in `OpenAILLM._call` and `OpenAILLM._acall` (agentuniverse/llm/openai_llm.py), the non-streaming path indexes `chat_completion.choices[0]` immediately after the API call. When the OpenAI API (or an OpenAI-compatible provider) returns a completion with an empty `choices` list, this raises a bare `IndexError` with no indication that the completion produced no choices. Notably, the streaming path in the same file already guards this case (`parse_result` checks `len(chunk["choices"]) == 0`), so the non-streaming path was inconsistent.
- What this PR changes: both non-streaming sites now check that `chat_completion.choices` is non-empty before indexing, and raise a descriptive `ValueError` (`OpenAI completion returned no choices`) when it is empty. The normal path (one or more choices) is untouched, so existing callers see identical behavior; only the previously crashing edge case changes from an opaque `IndexError` to a descriptive `ValueError`.
- How it was verified: `python3 -c "import ast; ast.parse(open('agentuniverse/llm/openai_llm.py').read())"` passes; a small standalone repro with an object whose `choices` is `[]` confirms the pre-fix code path raises a bare `IndexError` while the guarded path raises the descriptive `ValueError`.
