### PR TITLE
fix(memory): validate embeddings before indexing in ChromaConversationMemoryStorage

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py
@@ -108,9 +108,12 @@ class ChromaConversationMemoryStorage(MemoryStorage):
         for message in message_list:
             embedding = []
             if self.embedding_model:
-                embedding = EmbeddingManager().get_instance_obj(
+                embeddings = EmbeddingManager().get_instance_obj(
                     self.embedding_model
-                ).get_embeddings([message.content])[0]
+                ).get_embeddings([message.content])
+                if not embeddings:
+                    raise ValueError(f"Embedding model '{self.embedding_model}' returned no embeddings")
+                embedding = embeddings[0]
             metadata = {'timestamp': datetime.now().isoformat()}
             if session_id:
                 metadata['session_id'] = session_id


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- What was broken: in `ChromaConversationMemoryStorage.add` (agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py), the live site at the top of the per-message loop runs `...get_embeddings([message.content])[0]` and indexes the first element of the provider's result list without checking it is non-empty. When the configured `embedding_model` returns an empty list (e.g. a provider/edge-case failure), this raises a bare `IndexError` with no indication that the embedding model produced no vectors.
- What this PR changes: the result of `get_embeddings` is captured into `embeddings` and guarded — an empty result raises a descriptive `ValueError` naming the embedding model (`Embedding model '<name>' returned no embeddings`) before indexing. The non-empty path is untouched (`embedding = embeddings[0]`, identical to the previous `[0]`), so existing callers see identical behavior; only the previously crashing edge case changes from an opaque `IndexError` to a descriptive `ValueError`. A second, identical-looking site exists further down in `get`, but it sits inside a dead `if input:` block (the local `input` is set to `None` immediately before it) and is intentionally left out to keep the diff minimal.
- How it was verified: `python3 -c "import ast; ast.parse(open('agentuniverse/agent/memory/conversation_memory/memory_storage/chroma_conversation_memory_storage.py').read())"` passes; a small standalone repro with an embedding manager whose `get_embeddings` returns `[]` confirms the pre-fix code path raises a bare `IndexError` while the guarded path raises the descriptive `ValueError`.
