### PR TITLE
fix(agent): validate tool input keys in ExecutingAgentTemplate._process_tool_inputs

### DIFF
--- a/agentuniverse/agent/template/executing_agent_template.py
+++ b/agentuniverse/agent/template/executing_agent_template.py
@@ -151,6 +151,8 @@ class ExecutingAgentTemplate(AgentTemplate):
         for tool_name in self.tool_names:
             tool = ToolManager().get_instance_obj(tool_name)
             if tool is not None:
+                if not tool.input_keys:
+                    continue
                 # note: only insert the first key of tool input.
                 input_object.add_data(tool.input_keys[0], subtask)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [ ] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- What was broken: in `ExecutingAgentTemplate._process_tool_inputs` (agentuniverse/agent/template/executing_agent_template.py), the loop unconditionally does `input_object.add_data(tool.input_keys[0], subtask)` for every configured tool. `Tool.input_keys` is declared `Optional[List] = None` (agentuniverse/agent/action/tool/tool.py), so a tool whose `input_keys` is unset (`None`) or an empty list makes `tool.input_keys[0]` raise a bare `IndexError` (or `TypeError` for `None`) in the middle of the per-subtask thread, killing that subtask with no indication which tool was misconfigured.
- What this PR changes: the loop now skips the tool with a clear guard (`if not tool.input_keys: continue`) when the tool declares no input keys, before indexing the first key. This matches the surrounding defensive style (`if tool is not None:`) and the intent of the "only insert the first key of tool input" comment: a tool that declares no input keys has nothing to receive, so skipping it (rather than crashing the subtask) is the natural behavior. Tools with one or more input keys are untouched, so existing callers see identical behavior.
- How it was verified: `python3 -c "import ast; ast.parse(open('agentuniverse/agent/template/executing_agent_template.py').read())"` passes; a small standalone repro with a tool whose `input_keys` is `[]` confirms the pre-fix code path raises a bare `IndexError` while the guarded path skips the tool and continues.
