### PR TITLE
test: add unit tests for ConversationMessageEnum

### DIFF
--- a/tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_enum.py
+++ b/tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_enum.py
@@ -1,0 +1,61 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 10:05
+# @Author  : yuewang
+# @FileName: test_enum.py
+"""Unit tests for conversation_memory enum definitions."""
+
+import pytest
+
+from agentuniverse.agent.memory.conversation_memory.enum import (
+    ConversationMessageEnum,
+    ConversationMessageSourceType,
+)
+
+
+class TestConversationMessageEnum:
+    """Test ConversationMessageEnum values and uniqueness."""
+
+    def test_expected_members(self):
+        assert set(m.name for m in ConversationMessageEnum) == {'INPUT', 'OUTPUT'}
+
+    def test_values(self):
+        assert ConversationMessageEnum.INPUT.value == 'input'
+        assert ConversationMessageEnum.OUTPUT.value == 'output'
+
+    def test_lookup_by_value(self):
+        assert ConversationMessageEnum('input') is ConversationMessageEnum.INPUT
+        assert ConversationMessageEnum('output') is ConversationMessageEnum.OUTPUT
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            ConversationMessageEnum('unknown')
+
+    def test_values_are_unique(self):
+        values = [m.value for m in ConversationMessageEnum]
+        assert len(values) == len(set(values))
+
+
+class TestConversationMessageSourceType:
+    """Test ConversationMessageSourceType values."""
+
+    def test_expected_members(self):
+        assert set(m.name for m in ConversationMessageSourceType) == {
+            'AGENT', 'TOOL', 'KNOWLEDGE', 'LLM', 'USER'
+        }
+
+    def test_values(self):
+        assert ConversationMessageSourceType.AGENT.value == 'agent'
+        assert ConversationMessageSourceType.TOOL.value == 'tool'
+        assert ConversationMessageSourceType.KNOWLEDGE.value == 'knowledge'
+        assert ConversationMessageSourceType.LLM.value == 'llm'
+        assert ConversationMessageSourceType.USER.value == 'user'
+
+    def test_lookup_by_value(self):
+        for member in ConversationMessageSourceType:
+            assert ConversationMessageSourceType(member.value) is member
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_enum.py` covering ConversationMessageEnum / ConversationMessageSourceType: member sets, member values, value-based lookup, invalid-value errors, and value uniqueness.
- All 8 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/agent/memory/conversation_memory/test_enum.py -q` → 8 passed in 0.01s.
- No source changes; tests are dependency-light (no network/GPU/DB).
