### PR TITLE
test: add unit tests for ComponentBase

### DIFF
--- a/tests/test_agentuniverse/unit/base/component/test_component_base.py
+++ b/tests/test_agentuniverse/unit/base/component/test_component_base.py
@@ -1,0 +1,71 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/12/03 14:00
+# @Author  : Yue Wang
+# @FileName: test_component_base.py
+"""Unit tests for ComponentBase."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agentuniverse.base.component.component_base import ComponentBase
+from agentuniverse.base.component.component_enum import ComponentEnum
+
+
+class TestComponentBase:
+    """Test ComponentBase model defaults and helpers."""
+
+    @pytest.fixture
+    def component(self):
+        """Create a minimal ComponentBase instance."""
+        return ComponentBase(component_type=ComponentEnum.LLM)
+
+    def test_model_defaults(self, component):
+        """Optional fields fall back to documented defaults."""
+        assert component.component_type == ComponentEnum.LLM
+        assert component.component_config_path is None
+        assert component.default_symbol is False
+
+    def test_is_default_object_false(self, component):
+        """A plain instance is not a default object."""
+        assert component.is_default_object() is False
+
+    def test_create_copy_is_independent(self, component):
+        """create_copy returns a separate, equal instance."""
+        component.component_config_path = "some/path.yaml"
+        copy = component.create_copy()
+        assert copy is not component
+        assert copy.component_config_path == "some/path.yaml"
+        assert copy.component_type == ComponentEnum.LLM
+
+    def test_initialize_copies_default_symbol(self, component):
+        """default_symbol from a configer is transferred to the component."""
+        configer = SimpleNamespace(default_symbol=True)
+        result = component.initialize_by_component_configer(configer)
+        assert result is component
+        assert component.is_default_object() is True
+
+    def test_initialize_without_symbol_attribute(self, component):
+        """Configer without default_symbol leaves the component unchanged."""
+        configer = SimpleNamespace()
+        component.initialize_by_component_configer(configer)
+        assert component.default_symbol is False
+
+    def test_get_instance_code_uses_app_name(self):
+        """Instance code is appname.component_type.name in lowercase type."""
+
+        class NamedComponent(ComponentBase):
+            """ComponentBase subclass that declares a name field."""
+
+            name: str = "anon"
+
+        component = NamedComponent(component_type=ComponentEnum.LLM, name="test_llm")
+        with patch(
+            "agentuniverse.base.component.component_base.ApplicationConfigManager"
+        ) as manager_cls:
+            manager_cls.return_value.app_configer.base_info_appname = "demo_app"
+            code = component.get_instance_code()
+        assert code == "demo_app.llm.test_llm"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/component/test_component_base.py` covering ComponentBase: model field defaults, is_default_object flag, deep create_copy independence, default_symbol transfer via initialize_by_component_configer (with and without the attribute), and get_instance_code formatting.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/component/test_component_base.py -q` → 6 passed in 0.06s.
- No source changes; tests are dependency-light (no network/GPU/DB).
