### PR TITLE
test: add unit tests for ConfigTypeEnum

### DIFF
--- a/tests/test_agentuniverse/unit/base/config/test_config_type_enum.py
+++ b/tests/test_agentuniverse/unit/base/config/test_config_type_enum.py
@@ -1,0 +1,48 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/01/15 10:00
+# @Author  : Yue Wang
+# @FileName: test_config_type_enum.py
+"""Unit tests for ConfigTypeEnum."""
+
+import pytest
+
+from agentuniverse.base.config.config_type_enum import ConfigTypeEnum
+
+
+class TestConfigTypeEnum:
+    """Test ConfigTypeEnum member values and lookups."""
+
+    def test_expected_members_exist(self):
+        """All documented configuration file types are present."""
+        expected = {"TOML", "YAML", "JSON", "XML", "PROPERTIES", "INI", "ENV"}
+        assert set(m.name for m in ConfigTypeEnum) == expected
+
+    def test_member_values_are_lowercase_extensions(self):
+        """Each value is the lowercase of its name."""
+        for member in ConfigTypeEnum:
+            assert member.value == member.name.lower()
+
+    def test_specific_values(self):
+        """Concrete values match the documented configuration extensions."""
+        assert ConfigTypeEnum.TOML.value == "toml"
+        assert ConfigTypeEnum.YAML.value == "yaml"
+        assert ConfigTypeEnum.JSON.value == "json"
+        assert ConfigTypeEnum.PROPERTIES.value == "properties"
+
+    def test_from_value_lookup(self):
+        """Members can be resolved from their string values."""
+        assert ConfigTypeEnum("toml") is ConfigTypeEnum.TOML
+        assert ConfigTypeEnum("properties") is ConfigTypeEnum.PROPERTIES
+        assert ConfigTypeEnum("env") is ConfigTypeEnum.ENV
+
+    def test_from_value_unknown_raises(self):
+        """An unknown configuration type string raises ValueError."""
+        with pytest.raises(ValueError):
+            ConfigTypeEnum("csv")
+
+    def test_values_are_unique(self):
+        """No two members share the same value."""
+        values = [m.value for m in ConfigTypeEnum]
+        assert len(values) == len(set(values))


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/config/test_config_type_enum.py` covering ConfigTypeEnum: all documented members and their lowercase extension values, value-based lookup, unknown value raising ValueError, and value uniqueness.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/config/test_config_type_enum.py -q` → 6 passed in 0.01s
- No source changes; tests are dependency-light (no network/GPU/DB).
