### PR TITLE
test: add unit tests for DefaultMemory

### DIFF
--- a/tests/test_agentuniverse/unit/agent/memory/default/__init__.py
+++ b/tests/test_agentuniverse/unit/agent/memory/default/__init__.py
@@ -1,0 +1,2 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-

--- a/tests/test_agentuniverse/unit/agent/memory/default/test_default_memory.py
+++ b/tests/test_agentuniverse/unit/agent/memory/default/test_default_memory.py
@@ -1,0 +1,52 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 10:15
+# @Author  : yuewang
+# @FileName: test_default_memory.py
+"""Unit tests for DefaultMemory."""
+
+import pytest
+
+from agentuniverse.agent.memory.chat_memory import ChatMemory
+from agentuniverse.agent.memory.default.default_memory import DefaultMemory
+from agentuniverse.llm.default.default_openai_llm import DefaultOpenAILLM
+
+
+@pytest.fixture
+def memory():
+    """Create a DefaultMemory instance for testing."""
+    return DefaultMemory(name="test_default_memory", description="d")
+
+
+class TestDefaultMemory:
+    """Test DefaultMemory initialization behavior."""
+
+    def test_name_and_description(self, memory):
+        """Test that name/description are set from kwargs."""
+        assert memory.name == "test_default_memory"
+        assert memory.description == "d"
+
+    def test_is_chat_memory(self, memory):
+        """Test that DefaultMemory is a ChatMemory subclass instance."""
+        assert isinstance(memory, ChatMemory)
+        assert type(memory).__name__ == "DefaultMemory"
+
+    def test_llm_is_default_openai_llm(self, memory):
+        """Test that the memory uses a DefaultOpenAILLM instance."""
+        assert isinstance(memory.llm, DefaultOpenAILLM)
+
+    def test_llm_model_name(self, memory):
+        """Test that the memory LLM is configured with gpt-4o."""
+        assert memory.llm.model_name == "gpt-4o"
+
+    def test_llm_is_independent_per_instance(self):
+        """Test that two memories do not share the same LLM object."""
+        m1 = DefaultMemory(name="m1")
+        m2 = DefaultMemory(name="m2")
+        assert m1.llm is not m2.llm
+        assert m1.llm.model_name == m2.llm.model_name
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/agent/memory/default/test_default_memory.py` covering DefaultMemory: name/description injection, ChatMemory inheritance, and the DefaultOpenAILLM (gpt-4o) wiring.
- All 5 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/agent/memory/default/test_default_memory.py -q` → 5 passed in 0.69s.
- No source changes; tests are dependency-light (no network/GPU/DB).
