### PR TITLE
test: add unit tests for context archive utils

### DIFF
--- a/tests/test_agentuniverse/unit/base/context/test_context_archive_utils.py
+++ b/tests/test_agentuniverse/unit/base/context/test_context_archive_utils.py
@@ -1,0 +1,80 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/12/03 14:00
+# @Author  : Yue Wang
+# @FileName: test_context_archive_utils.py
+"""Unit tests for the context archive utilities."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agentuniverse.base.context import context_archive_utils
+from agentuniverse.base.context.context_archive_utils import (
+    get_current_context_archive,
+    update_context_archive,
+)
+from agentuniverse.base.context.framework_context_manager import FrameworkContextManager
+
+
+class TestContextArchiveUtils:
+    """Test the archive helpers against the framework context manager."""
+
+    @pytest.fixture(autouse=True)
+    def shared_manager(self):
+        """Patch the module-level manager and clear the archive per test."""
+        manager = FrameworkContextManager()
+        manager.del_context("context_archive", force=True)
+        with patch.object(
+            context_archive_utils, "FrameworkContextManager", return_value=manager
+        ):
+            yield manager
+        manager.del_context("context_archive", force=True)
+
+    def test_get_returns_dict(self, shared_manager):
+        """The helper always yields a dict."""
+        assert get_current_context_archive() == {}
+        assert isinstance(get_current_context_archive(), dict)
+
+    def test_get_sees_preexisting_archive(self, shared_manager):
+        """A non-empty stored archive is returned unchanged."""
+        seed = {"seed": {"data": 1, "description": "s"}}
+        shared_manager.set_context("context_archive", seed)
+        assert get_current_context_archive() is seed
+
+    def test_get_initializes_missing_archive(self, shared_manager):
+        """A missing archive is initialized as an empty dict in the context."""
+        assert not shared_manager.is_context_exist("context_archive")
+        assert get_current_context_archive() == {}
+        assert shared_manager.get_context("context_archive") == {}
+
+    def test_update_appends_record(self, shared_manager):
+        """update_context_archive appends data and description to the archive."""
+        shared_manager.set_context(
+            "context_archive", {"seed": {"data": 1, "description": "s"}}
+        )
+        update_context_archive("retrieval", {"docs": 3}, "top-3 docs")
+        archive = shared_manager.get_context("context_archive")
+        assert archive["retrieval"] == {
+            "data": {"docs": 3},
+            "description": "top-3 docs",
+        }
+
+    def test_update_overwrites_same_name(self, shared_manager):
+        """Updating an existing name replaces its previous record."""
+        shared_manager.set_context("context_archive", {"base": {"data": 0}})
+        update_context_archive("step", {"v": 1}, "first")
+        update_context_archive("step", {"v": 2}, "second")
+        record = shared_manager.get_context("context_archive")["step"]
+        assert record == {"data": {"v": 2}, "description": "second"}
+
+    def test_multiple_records_coexist(self, shared_manager):
+        """Distinct names are archived side by side."""
+        shared_manager.set_context("context_archive", {"base": {"data": 0}})
+        update_context_archive("a", 1, "record a")
+        update_context_archive("b", 2, "record b")
+        archive = get_current_context_archive()
+        assert set(archive.keys()) == {"base", "a", "b"}
+        assert archive["a"] == {"data": 1, "description": "record a"}
+        assert archive["b"] == {"data": 2, "description": "record b"}


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/context/test_context_archive_utils.py` covering the context archive utils: dict return type, retrieval of a pre-existing archive, lazy initialization of a missing archive, appending records via update_context_archive, overwriting same-name records, and coexistence of multiple records.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/context/test_context_archive_utils.py -q` → 6 passed in 0.01s.
- No source changes; tests are dependency-light (no network/GPU/DB).
