### PR TITLE
test: add unit tests for CodeMetrics

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/types/test_metrics_types.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/types/test_metrics_types.py
@@ -1,0 +1,52 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/01/15 13:30
+# @Author  : Yue Wang
+# @FileName: test_metrics_types.py
+"""Unit tests for CodeMetrics typed dict."""
+
+import typing
+
+from agentuniverse.agent.action.knowledge.doc_processor.types.metrics_types import \
+    CodeMetrics
+
+
+class TestCodeMetrics:
+    """Test CodeMetrics structure and usage."""
+
+    def test_is_typed_dict(self):
+        """CodeMetrics is a TypedDict subclass."""
+        assert issubclass(CodeMetrics, dict)
+        assert typing.get_type_hints(CodeMetrics)
+
+    def test_expected_fields(self):
+        """CodeMetrics declares exactly the documented metric fields."""
+        assert set(CodeMetrics.__annotations__) == {
+            "line_count",
+            "code_line_count",
+            "avg_line_length",
+            "max_line_length",
+            "character_count",
+        }
+
+    def test_field_types(self):
+        """Field annotations use int for counts and float for the average."""
+        hints = typing.get_type_hints(CodeMetrics)
+        assert hints["line_count"] is int
+        assert hints["code_line_count"] is int
+        assert hints["avg_line_length"] is float
+        assert hints["max_line_length"] is int
+        assert hints["character_count"] is int
+
+    def test_instantiation_and_access(self):
+        """A CodeMetrics value is a plain dict with the metric fields."""
+        metrics: CodeMetrics = {
+            "line_count": 100,
+            "code_line_count": 80,
+            "avg_line_length": 25.5,
+            "max_line_length": 120,
+            "character_count": 2000,
+        }
+        assert metrics["code_line_count"] == 80
+        assert metrics["avg_line_length"] == 25.5


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/types/test_metrics_types.py` covering CodeMetrics: TypedDict nature, the exact documented field set, int/float field annotations, and dict-style instantiation/access.
- All 4 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/types/test_metrics_types.py -q` → 4 passed in 0.01s
- No source changes; tests are dependency-light (no network/GPU/DB).
