### PR TITLE
test: add unit tests for EnvUtil

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/test_env_util.py
+++ b/tests/test_agentuniverse/unit/base/util/test_env_util.py
@@ -1,0 +1,49 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/12/03 14:00
+# @Author  : Yue Wang
+# @FileName: test_env_util.py
+"""Unit tests for the environment variable helper."""
+
+import os
+
+import pytest
+
+from agentuniverse.base.util.env_util import get_from_env
+
+
+class TestEnvUtil:
+    """Test get_from_env lookups against os.environ."""
+
+    def test_returns_set_value(self, monkeypatch):
+        """A populated environment variable is returned as-is."""
+        monkeypatch.setenv("AU_TEST_ENV", "hello")
+        assert get_from_env("AU_TEST_ENV") == "hello"
+
+    def test_missing_key_returns_none(self, monkeypatch):
+        """A key absent from the environment yields None."""
+        monkeypatch.delenv("AU_TEST_MISSING", raising=False)
+        assert get_from_env("AU_TEST_MISSING") is None
+
+    def test_empty_value_returns_none(self, monkeypatch):
+        """An empty string is treated as unset."""
+        monkeypatch.setenv("AU_TEST_EMPTY", "")
+        assert get_from_env("AU_TEST_EMPTY") is None
+
+    @pytest.mark.parametrize(
+        "value",
+        ["0", "false", "a b c", "中文", "12345"],
+    )
+    def test_nonempty_values_pass_through(self, monkeypatch, value):
+        """Any non-empty value is returned unchanged."""
+        monkeypatch.setenv("AU_TEST_PASS", value)
+        assert get_from_env("AU_TEST_PASS") == value
+
+    def test_does_not_mutate_environment(self, monkeypatch):
+        """Reading a variable leaves the environment untouched."""
+        monkeypatch.setenv("AU_TEST_STABLE", "kept")
+        before = dict(os.environ)
+        get_from_env("AU_TEST_STABLE")
+        get_from_env("AU_TEST_NOT_THERE")
+        assert dict(os.environ) == before


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/util/test_env_util.py` covering get_from_env: returning a populated variable, None for a missing key, None for an empty value, pass-through of non-empty values (including unicode), and read-only behavior toward os.environ.
- All 9 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/util/test_env_util.py -q` → 9 passed in 0.01s.
- No source changes; tests are dependency-light (no network/GPU/DB).
