### PR TITLE
test: add unit tests for AgentInputLogSink

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/logging/log_sink/test_agent_input_log_sink.py
+++ b/tests/test_agentuniverse/unit/base/util/logging/log_sink/test_agent_input_log_sink.py
@@ -1,0 +1,84 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/08/13 10:00
+# @Author  : kaichuan
+# @FileName: test_agent_input_log_sink.py
+"""Unit tests for AgentInputLogSink."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agentuniverse.base.component.component_base import ComponentEnum
+from agentuniverse.base.util.logging.log_sink.agent_input_log_sink import (
+    AgentInputLogSink,
+)
+from agentuniverse.base.util.logging.log_type_enum import LogTypeEnum
+
+_CHAIN = "agent->llm"
+
+
+@pytest.fixture
+def sink():
+    """Create an AgentInputLogSink with a stubbed invocation chain."""
+    return AgentInputLogSink()
+
+
+class TestAgentInputLogSink:
+    """Test AgentInputLogSink type markers and record handling."""
+
+    def test_log_type_marker(self, sink):
+        """The sink is tagged with the agent_input log type."""
+        assert sink.log_type == LogTypeEnum.agent_input
+
+    def test_component_type_marker(self, sink):
+        """The sink reports the LOG_SINK component type."""
+        assert sink.component_type == ComponentEnum.LOG_SINK
+
+    def test_generate_log_string_input(self, sink):
+        """generate_log embeds the string input after the chain prefix."""
+        with patch(
+                "agentuniverse.base.util.monitor.monitor."
+                "Monitor.get_invocation_chain_str",
+                return_value=_CHAIN):
+            assert sink.generate_log("hi") == f"{_CHAIN} Agent input is hi"
+
+    def test_process_record_sets_message(self, sink):
+        """process_record writes the generated message onto the record."""
+        record = {"extra": {"agent_input": "inp"}}
+        with patch(
+                "agentuniverse.base.util.monitor.monitor."
+                "Monitor.get_invocation_chain_str",
+                return_value=_CHAIN):
+            sink.process_record(record)
+        assert record["message"] == f"{_CHAIN} Agent input is inp"
+
+    def test_process_record_missing_agent_input(self, sink):
+        """A missing agent_input renders as None in the message."""
+        record = {"extra": {}}
+        with patch(
+                "agentuniverse.base.util.monitor.monitor."
+                "Monitor.get_invocation_chain_str",
+                return_value=_CHAIN):
+            sink.process_record(record)
+        assert record["message"] == f"{_CHAIN} Agent input is None"
+
+    def test_filter_matches_only_agent_input(self, sink):
+        """filter accepts agent_input records and rejects others."""
+        with patch(
+                "agentuniverse.base.util.monitor.monitor."
+                "Monitor.get_invocation_chain_str",
+                return_value=_CHAIN):
+            matching = {
+                "extra": {"log_type": LogTypeEnum.agent_input,
+                          "agent_input": "x"}}
+            assert sink.filter(matching) is True
+            assert "message" in matching
+
+            other = {"extra": {"log_type": LogTypeEnum.default}}
+            assert sink.filter(other) is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/util/logging/log_sink/test_agent_input_log_sink.py` covering AgentInputLogSink: the agent_input log-type and LOG_SINK component markers, generate_log embedding the input after the (mocked) invocation-chain prefix, process_record writing the generated message onto the record (including the missing-agent_input `None` case), and filter accepting only agent_input records while rejecting others.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/util/logging/log_sink/test_agent_input_log_sink.py -q` → 6 passed, 3 warnings in 0.29s.
- No source changes; tests are dependency-light (no network/GPU/DB).
