### PR TITLE
test: add unit tests for WorkPattern

### DIFF
--- a/tests/test_agentuniverse/unit/agent/work_pattern/__init__.py
+++ b/tests/test_agentuniverse/unit/agent/work_pattern/__init__.py
@@ -1,0 +1,2 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-

--- a/tests/test_agentuniverse/unit/agent/work_pattern/test_work_pattern.py
+++ b/tests/test_agentuniverse/unit/agent/work_pattern/test_work_pattern.py
@@ -1,0 +1,63 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 11:15
+# @Author  : yuewang
+# @FileName: test_work_pattern.py
+"""Unit tests for the WorkPattern base class."""
+
+import asyncio
+
+import pytest
+
+from agentuniverse.agent.work_pattern.work_pattern import WorkPattern
+from agentuniverse.base.component.component_enum import ComponentEnum
+
+
+class EchoWorkPattern(WorkPattern):
+    """Concrete WorkPattern used for testing."""
+
+    def invoke(self, input_object, work_pattern_input, **kwargs):
+        return {'result': 'sync'}
+
+    async def async_invoke(self, input_object, work_pattern_input, **kwargs):
+        return {'result': 'async'}
+
+
+@pytest.fixture
+def pattern():
+    """Create an EchoWorkPattern instance."""
+    return EchoWorkPattern()
+
+
+class TestWorkPattern:
+    """Test WorkPattern behavior."""
+
+    def test_component_type(self, pattern):
+        assert pattern.component_type == ComponentEnum.WORK_PATTERN
+
+    def test_defaults(self, pattern):
+        assert pattern.name is None
+        assert pattern.description is None
+
+    def test_base_is_abstract(self):
+        with pytest.raises(TypeError):
+            WorkPattern()
+
+    def test_invoke_and_async_invoke(self, pattern):
+        assert pattern.invoke(None, {}) == {'result': 'sync'}
+        assert asyncio.run(pattern.async_invoke(None, {})) == {'result': 'async'}
+
+    def test_initialize_by_component_configer(self):
+        configer = type('C', (), {'name': 'wp1', 'description': 'dp1'})()
+        pattern = EchoWorkPattern()
+        assert pattern.initialize_by_component_configer(configer) is pattern
+        assert pattern.name == 'wp1'
+        assert pattern.description == 'dp1'
+
+    def test_set_by_agent_model_is_noop(self, pattern):
+        assert pattern.set_by_agent_model(anything='x') is None
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/agent/work_pattern/test_work_pattern.py` covering WorkPattern: component type, defaults, abstract-base instantiation, sync/async invoke, configer initialization, and `set_by_agent_model`.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/agent/work_pattern/test_work_pattern.py -q` → 6 passed in 0.07s.
- No source changes; tests are dependency-light (no network/GPU/DB).
