### PR TITLE
test: add unit tests for PlannerManager

### DIFF
--- a/tests/test_agentuniverse/unit/agent/plan/__init__.py
+++ b/tests/test_agentuniverse/unit/agent/plan/__init__.py
@@ -1,0 +1,2 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-

--- a/tests/test_agentuniverse/unit/agent/plan/planner/__init__.py
+++ b/tests/test_agentuniverse/unit/agent/plan/planner/__init__.py
@@ -1,0 +1,2 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-

--- a/tests/test_agentuniverse/unit/agent/plan/planner/test_planner_manager.py
+++ b/tests/test_agentuniverse/unit/agent/plan/planner/test_planner_manager.py
@@ -1,0 +1,55 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 11:25
+# @Author  : yuewang
+# @FileName: test_planner_manager.py
+"""Unit tests for PlannerManager."""
+
+import pytest
+
+from agentuniverse.agent.plan.planner.planner_manager import PlannerManager
+from agentuniverse.base.component.component_base import ComponentBase
+from agentuniverse.base.component.component_enum import ComponentEnum
+
+
+class DummyPlanner(ComponentBase):
+    """Minimal component object for registration tests."""
+    component_type: ComponentEnum = ComponentEnum.PLANNER
+
+
+@pytest.fixture
+def manager():
+    """Return the PlannerManager singleton."""
+    return PlannerManager()
+
+
+class TestPlannerManager:
+    """Test PlannerManager registration behavior."""
+
+    def test_singleton(self, manager):
+        assert manager is PlannerManager()
+
+    def test_component_type(self, manager):
+        assert manager._component_type == ComponentEnum.PLANNER
+
+    def test_register_and_get(self, manager):
+        planner = DummyPlanner()
+        manager.register('app.planner.p1', planner)
+        assert manager.get_instance_obj('p1', appname='app', new_instance=False) is planner
+
+    def test_get_unknown_returns_none(self, manager):
+        assert manager.get_instance_obj('absent_p_xyz', appname='app') is None
+
+    def test_get_unknown_strict_raises(self, manager):
+        with pytest.raises(ValueError, match='is not registered'):
+            manager.get_instance_obj('absent_p_xyz', appname='app', strict=True)
+
+    def test_unregister(self, manager):
+        manager.register('app.planner.p2', DummyPlanner())
+        manager.unregister('app.planner.p2')
+        assert manager.get_instance_obj('p2', appname='app') is None
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/agent/plan/planner/test_planner_manager.py` covering PlannerManager: singleton identity, component type, and register/get/unregister behavior including strict lookup errors.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/agent/plan/planner/test_planner_manager.py -q` → 6 passed in 0.31s.
- No source changes; tests are dependency-light (no network/GPU/DB).
