### PR TITLE
test: add unit tests for LogTypeEnum

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/logging/test_log_type_enum.py
+++ b/tests/test_agentuniverse/unit/base/util/logging/test_log_type_enum.py
@@ -1,0 +1,52 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/01/12 10:00
+# @Author  : yuewang
+# @FileName: test_log_type_enum.py
+"""Unit tests for the LogTypeEnum enumeration."""
+
+import pytest
+
+from agentuniverse.base.util.logging.log_type_enum import LogTypeEnum
+
+
+class TestLogTypeEnum:
+    """Test LogTypeEnum members and str-Enum behavior."""
+
+    @pytest.fixture
+    def member_map(self):
+        """Map of enum member names to values."""
+        return {item.name: item.value for item in LogTypeEnum}
+
+    def test_members_cover_all_log_sources(self, member_map):
+        """Every expected log type is registered."""
+        assert member_map["default"] == "default"
+        assert member_map["sls"] == "sls"
+        assert member_map["flask_request"] == "flask_request"
+        assert member_map["flask_response"] == "flask_response"
+        assert member_map["agent_input"] == "agent_input"
+        assert member_map["agent_first_token"] == "agent_first_token"
+        assert member_map["llm_invocation"] == "llm_invocation"
+        assert member_map["tool_invocation"] == "tool_invocation"
+
+    def test_member_values_match_names(self, member_map):
+        """Each member's value equals its name; count is fixed."""
+        assert len(LogTypeEnum) == 11
+        assert all(item.value == item.name for item in LogTypeEnum)
+
+    def test_str_enum_accepts_plain_strings(self):
+        """Members compare equal to their plain string values."""
+        assert LogTypeEnum.agent_input == "agent_input"
+        assert LogTypeEnum.llm_invocation.value == "llm_invocation"
+        assert isinstance(LogTypeEnum.default, str)
+
+    def test_from_value_roundtrip(self):
+        """LogTypeEnum(value) resolves to the matching member."""
+        for name in ("sls", "agent_invocation", "tool_input"):
+            assert LogTypeEnum(name) is getattr(LogTypeEnum, name)
+
+    def test_unknown_value_raises(self):
+        """Constructing from an unknown string raises ValueError."""
+        with pytest.raises(ValueError):
+            LogTypeEnum("not_a_log_type")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/util/logging/test_log_type_enum.py` covering LogTypeEnum: registration of all log types, value/name consistency, str-Enum equality with plain strings, value lookup roundtrip, and ValueError on unknown values.
- All 5 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/util/logging/test_log_type_enum.py -q` → 5 passed in 0.01s.
- No source changes; tests are dependency-light (no network/GPU/DB).
