### PR TITLE
test: add unit tests for AgentPromptModel

### DIFF
--- a/tests/test_agentuniverse/unit/prompt/test_prompt_model.py
+++ b/tests/test_agentuniverse/unit/prompt/test_prompt_model.py
@@ -1,0 +1,57 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 12:00
+# @Author  : yuewang
+# @FileName: test_prompt_model.py
+"""Unit tests for AgentPromptModel."""
+
+import pytest
+
+from agentuniverse.prompt.prompt_model import AgentPromptModel
+
+
+@pytest.fixture
+def model():
+    """Create an empty AgentPromptModel."""
+    return AgentPromptModel()
+
+
+class TestAgentPromptModel:
+    """Test AgentPromptModel behavior."""
+
+    def test_defaults(self, model):
+        assert model.introduction is None
+        assert model.target is None
+        assert model.instruction is None
+
+    def test_bool_empty(self, model):
+        assert not model
+
+    def test_bool_nonempty(self):
+        assert AgentPromptModel(introduction='i')
+        assert AgentPromptModel(target='t')
+        assert AgentPromptModel(instruction='ins')
+
+    def test_get_message_type(self, model):
+        assert model.get_message_type('introduction') == 'system'
+        assert model.get_message_type('target') == 'system'
+        assert model.get_message_type('instruction') == 'human'
+        assert model.get_message_type('unknown_attr') == 'human'
+
+    def test_add_merges_with_left_priority(self):
+        left = AgentPromptModel(introduction='keep-left', target=None)
+        right = AgentPromptModel(introduction='right', target='right-target')
+        merged = left + right
+        assert merged.introduction == 'keep-left'
+        assert merged.target == 'right-target'
+
+    def test_add_empty_left_takes_right(self):
+        right = AgentPromptModel(instruction='only-right')
+        merged = AgentPromptModel() + right
+        assert merged.instruction == 'only-right'
+        assert merged.introduction is None
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/prompt/test_prompt_model.py` covering AgentPromptModel: defaults, empty/non-empty truthiness, `get_message_type` mapping (including the fallback), and `__add__` merging with left-priority semantics.
- All 6 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/prompt/test_prompt_model.py -q` → 6 passed in 0.05s.
- No source changes; tests are dependency-light (no network/GPU/DB).
