### PR TITLE
test: add unit tests for NodeInputParams

### DIFF
--- a/tests/test_agentuniverse/unit/workflow/__init__.py
+++ b/tests/test_agentuniverse/unit/workflow/__init__.py
@@ -1,0 +1,2 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-

--- a/tests/test_agentuniverse/unit/workflow/node/__init__.py
+++ b/tests/test_agentuniverse/unit/workflow/node/__init__.py
@@ -1,0 +1,2 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-

--- a/tests/test_agentuniverse/unit/workflow/node/test_node_config.py
+++ b/tests/test_agentuniverse/unit/workflow/node/test_node_config.py
@@ -1,0 +1,82 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 12:05
+# @Author  : yuewang
+# @FileName: test_node_config.py
+"""Unit tests for the workflow node config models."""
+
+import pytest
+from pydantic import ValidationError
+
+from agentuniverse.workflow.node.node_config import (
+    AgentNodeInputParams,
+    ConditionNodeInputParams,
+    EndNodeInputParams,
+    InputValueParams,
+    LLMNodeInputParams,
+    NodeInputParams,
+    NodeOutputParams,
+)
+
+
+class TestBasicParams:
+    """Test the flat param models."""
+
+    def test_node_output_params_defaults(self):
+        p = NodeOutputParams()
+        assert p.name is None and p.type is None and p.value is None
+
+    def test_node_input_params_nested_value(self):
+        p = NodeInputParams(name='q', type='str',
+                            value=InputValueParams(type='literal', content='hello'))
+        assert p.value.content == 'hello'
+        assert p.value.type == 'literal'
+
+
+class TestNodeInputParamContainers:
+    """Test the per-node-type input param containers."""
+
+    def test_llm_node_input_params_defaults(self):
+        p = LLMNodeInputParams()
+        assert p.llm_param == []
+        assert p.input_param == []
+
+    def test_agent_node_input_params_accepts_dicts(self):
+        p = AgentNodeInputParams(
+            agent_param=[{'name': 'a1', 'type': 'agent', 'value': None}],
+            input_param=[{'name': 'q', 'type': 'str',
+                          'value': {'type': 'literal', 'content': 'hi'}}],
+        )
+        assert p.agent_param[0].name == 'a1'
+        assert p.input_param[0].value.content == 'hi'
+
+    def test_invalid_nested_type_raises(self):
+        with pytest.raises(ValidationError):
+            LLMNodeInputParams(llm_param='not-a-list')
+
+
+class TestConditionAndEndParams:
+    """Test condition and end node param models."""
+
+    def test_condition_node_input_params(self):
+        p = ConditionNodeInputParams(branches=[
+            {'name': 'b1', 'conditions': [
+                {'compare': '==',
+                 'left': {'name': 'l', 'type': 'str'},
+                 'right': {'name': 'r', 'type': 'str'}}]}])
+        branch = p.branches[0]
+        assert branch.name == 'b1'
+        assert branch.conditions[0].compare == '=='
+        assert branch.conditions[0].left.name == 'l'
+
+    def test_end_node_input_params(self):
+        p = EndNodeInputParams(
+            prompt={'name': 'prompt', 'type': 'str', 'value': 'tpl'},
+            input_param=[{'name': 'x', 'type': 'str'}])
+        assert p.prompt.value == 'tpl'
+        assert p.input_param[0].name == 'x'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/workflow/node/test_node_config.py` covering the workflow node config models: flat param defaults, nested input-value validation, per-node-type input param containers (defaults, dict coercion, invalid type), and condition/end node param models.
- All 7 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/workflow/node/test_node_config.py -q` → 7 passed in 0.03s.
- No source changes; tests are dependency-light (no network/GPU/DB).
