### PR TITLE
test: add unit tests for Prompt

### DIFF
--- a/tests/test_agentuniverse/unit/prompt/test_prompt.py
+++ b/tests/test_agentuniverse/unit/prompt/test_prompt.py
@@ -1,0 +1,61 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 12:35
+# @Author  : yuewang
+# @FileName: test_prompt.py
+"""Unit tests for the base Prompt class."""
+
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.prompts import PromptTemplate
+
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.prompt.prompt import Prompt
+from agentuniverse.prompt.prompt_model import AgentPromptModel
+
+
+@pytest.fixture
+def prompt():
+    """Create a base Prompt."""
+    return Prompt()
+
+
+class TestPrompt:
+    """Test Prompt behavior."""
+
+    def test_component_type(self, prompt):
+        assert prompt.component_type == ComponentEnum.PROMPT
+
+    def test_as_langchain(self, prompt):
+        prompt.prompt_template = 'Say {word}'
+        prompt.input_variables = ['word']
+        lc = prompt.as_langchain()
+        assert isinstance(lc, PromptTemplate)
+        assert lc.input_variables == ['word']
+
+    def test_build_prompt(self, prompt):
+        model = AgentPromptModel(introduction='intro', instruction='do {q}')
+        result = prompt.build_prompt(model, ['introduction', 'instruction'])
+        assert result is prompt
+        assert prompt.prompt_template == 'intro\ndo {q}'
+        assert prompt.input_variables == ['q']
+
+    def test_initialize_by_component_configer(self, prompt):
+        configer = SimpleNamespace(
+            configer=SimpleNamespace(value={'instruction': 'say {x}', 'metadata': {'m': 1}}),
+            metadata_version='v9')
+        assert prompt.initialize_by_component_configer(configer) is prompt
+        assert prompt.prompt_version == 'v9'
+        assert prompt.prompt_template == 'say {x}'
+        assert prompt.input_variables == ['x']
+        assert not hasattr(prompt, 'metadata') or 'metadata' not in prompt.prompt_template
+
+    def test_get_instance_code_returns_prompt_version(self, prompt):
+        prompt.prompt_version = 'my.prompt.v1'
+        assert prompt.get_instance_code() == 'my.prompt.v1'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/prompt/test_prompt.py` covering the base Prompt class: component type, `as_langchain` conversion, `build_prompt` template assembly with placeholder extraction, configer-based initialization (metadata skipping, version stamping), and `get_instance_code`.
- All 5 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/prompt/test_prompt.py -q` → 5 passed in 0.75s.
- No source changes; tests are dependency-light (no network/GPU/DB).
