### PR TITLE
test: add unit tests for FlaskRequestLogSink

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_request_log_sink.py
+++ b/tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_request_log_sink.py
@@ -1,0 +1,47 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 13:35
+# @Author  : yuewang
+# @FileName: test_flask_request_log_sink.py
+"""Unit tests for FlaskRequestLogSink."""
+
+import pytest
+
+from agentuniverse.base.util.logging.log_sink.flask_request_log_sink import FlaskRequestLogSink
+from agentuniverse.base.util.logging.log_type_enum import LogTypeEnum
+
+
+@pytest.fixture
+def sink():
+    """Create a FlaskRequestLogSink."""
+    return FlaskRequestLogSink()
+
+
+def _record(log_type, flask_request=None):
+    return {'extra': {'log_type': log_type, 'flask_request': flask_request}}
+
+
+class TestFlaskRequestLogSink:
+    """Test FlaskRequestLogSink filter and record processing."""
+
+    def test_log_type_default(self, sink):
+        assert sink.log_type == LogTypeEnum.flask_request
+
+    def test_filter_rejects_other_log_types(self, sink):
+        assert sink.filter(_record(LogTypeEnum.default, {})) is False
+
+    def test_filter_accepts_matching_record(self, sink):
+        record = _record(LogTypeEnum.flask_request, {'path': '/x'})
+        assert sink.filter(record) is True
+        assert 'flask_request' not in record['extra']
+        assert record['message'] is None  # generate_log not overridden
+
+    def test_process_record_sets_message_and_pops_extra(self, sink):
+        record = _record(LogTypeEnum.flask_request, {'path': '/y'})
+        sink.process_record(record)
+        assert 'message' in record
+        assert 'flask_request' not in record['extra']
+
+    def test_generate_log_returns_none_by_default(self, sink):
+        assert sink.generate_log(flask_request={'path': '/z'}) is None


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_request_log_sink.py` covering FlaskRequestLogSink: default log type, filter accept/reject by log type, record processing (message set + extra popped), and default generate_log behavior.
- All 5 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_request_log_sink.py -q` → 5 passed in 0.27s.
- No source changes; tests are dependency-light (no network/GPU/DB).
