### PR TITLE
test: add unit tests for FlaskResponseLogSink

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_response_log_sink.py
+++ b/tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_response_log_sink.py
@@ -1,0 +1,50 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 13:40
+# @Author  : yuewang
+# @FileName: test_flask_response_log_sink.py
+"""Unit tests for FlaskResponseLogSink."""
+
+import pytest
+
+from agentuniverse.base.util.logging.log_sink.flask_response_log_sink import FlaskResponseLogSink
+from agentuniverse.base.util.logging.log_type_enum import LogTypeEnum
+
+
+@pytest.fixture
+def sink():
+    """Create a FlaskResponseLogSink."""
+    return FlaskResponseLogSink()
+
+
+def _record(log_type, flask_response=None):
+    record = {'extra': {'log_type': log_type, 'elapsed_time': 0.5}}
+    if flask_response is not None:
+        record['extra']['flask_response'] = flask_response
+    return record
+
+
+class TestFlaskResponseLogSink:
+    """Test FlaskResponseLogSink filter and record processing."""
+
+    def test_log_type_default(self, sink):
+        assert sink.log_type == LogTypeEnum.flask_response
+
+    def test_filter_rejects_other_log_types(self, sink):
+        assert sink.filter(_record(LogTypeEnum.llm_input)) is False
+
+    def test_filter_accepts_matching_record(self, sink):
+        record = _record(LogTypeEnum.flask_response, {'status': 200})
+        assert sink.filter(record) is True
+        assert 'flask_response' not in record['extra']
+        assert 'elapsed_time' in record['extra']
+
+    def test_process_record_requires_elapsed_time(self, sink):
+        record = _record(LogTypeEnum.flask_response, {'status': 200})
+        sink.process_record(record)
+        assert 'message' in record
+        assert 'flask_response' not in record['extra']
+
+    def test_generate_log_returns_none_by_default(self, sink):
+        assert sink.generate_log(flask_response={'status': 200}, elapsed_time=0.1) is None


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_response_log_sink.py` covering FlaskResponseLogSink: default log type, filter accept/reject by log type, record processing (message set, flask_response popped, elapsed_time preserved), and default generate_log behavior.
- All 5 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/base/util/logging/log_sink/test_flask_response_log_sink.py -q` → 5 passed in 0.27s.
- No source changes; tests are dependency-light (no network/GPU/DB).
