### PR TITLE
test: add unit tests for DashscopeEmbedding

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_dashscope_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_dashscope_embedding.py
@@ -1,0 +1,72 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/10 13:45
+# @Author  : yuewang
+# @FileName: test_dashscope_embedding.py
+"""Unit tests for DashscopeEmbedding."""
+
+import json
+import pytest
+import requests
+from types import SimpleNamespace
+
+from agentuniverse.agent.action.knowledge.embedding.dashscope_embedding import (
+    DASHSCOPE_EMBEDDING_URL,
+    DashscopeEmbedding,
+    batched,
+)
+
+
+def _fake_response(payload):
+    return SimpleNamespace(json=lambda: payload)
+
+
+class TestBatched:
+    """Test the batched helper."""
+
+    def test_batches_of_25(self):
+        inputs = list(range(55))
+        chunks = list(batched(inputs))
+        assert [len(c) for c in chunks] == [25, 25, 5]
+        assert chunks[0] == list(range(25))
+
+    def test_empty_input(self):
+        assert list(batched([])) == []
+
+
+class TestDashscopeEmbedding:
+    """Test get_embeddings with a mocked HTTP layer."""
+
+    def test_missing_api_key_raises(self):
+        emb = DashscopeEmbedding(dashscope_api_key=None)
+        with pytest.raises(Exception, match='No DASHSCOPE_API_KEY'):
+            emb.get_embeddings(['a'])
+
+    def test_get_embeddings_success(self, monkeypatch):
+        captured = {}
+
+        def fake_post(url=None, headers=None, data=None, timeout=None):
+            captured['url'] = url
+            captured['params'] = json.loads(data)
+            return _fake_response({'output': {'embeddings': [
+                {'text_index': 0, 'embedding': [0.1, 0.2]},
+                {'text_index': 1, 'embedding': [0.3, 0.4]}]}})
+
+        monkeypatch.setattr(requests, 'post', fake_post)
+        emb = DashscopeEmbedding(dashscope_api_key='sk-x',
+                                 embedding_model_name='text-embedding-v3')
+        result = emb.get_embeddings(['a', 'b'])
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+        assert captured['url'] == DASHSCOPE_EMBEDDING_URL
+        assert captured['params']['input']['texts'] == ['a', 'b']
+        assert captured['params']['parameters']['dimension'] == 1024
+        assert captured['params']['parameters']['text_type'] == 'document'
+
+    def test_error_response_raises(self, monkeypatch):
+        monkeypatch.setattr(requests, 'post',
+                            lambda **kw: _fake_response({'code': 'Err', 'message': 'bad'}))
+        emb = DashscopeEmbedding(dashscope_api_key='sk-x',
+                                 embedding_model_name='text-embedding-v2')
+        with pytest.raises(Exception, match='error code:Err'):
+            emb.get_embeddings(['a'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_dashscope_embedding.py` covering DashscopeEmbedding: the `batched` helper (25-item batches), missing-API-key error, successful embedding request (URL, payload params, and result extraction), and error-response handling.
- All 5 tests pass locally: `python -m pytest tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_dashscope_embedding.py -q` → 5 passed in 0.25s.
- No source changes; tests are dependency-light (no network/GPU/DB).
