### PR TITLE
refactor(llm): add return type annotations in llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/llm_channel.py
+++ b/agentuniverse/llm/llm_channel/llm_channel.py
@@ -93,7 +93,7 @@ class LLMChannel(ComponentBase):
         return self._channel_model_config
 
     @channel_model_config.setter
-    def channel_model_config(self, config: dict):
+    def channel_model_config(self, config: dict) -> None:
         self._channel_model_config = config
         if config:
             for key, value in config.items():


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- `agentuniverse/llm/llm_channel/llm_channel.py`: added return annotations `channel_model_config@96`.
- Explicit return annotations document the API contract for readers and type checkers; only unambiguously-typed returns (None/str/dict/list) were annotated.
- Verified with `python3 -c "import ast; ast.parse(...)"`; no behavioral change.
