### PR TITLE
refactor(examples): add return type annotations in prompt_generator.py

### DIFF
--- a/examples/third_party_examples/apps/prompt_generator_app/app/intelligence/test/prompt_generator.py
+++ b/examples/third_party_examples/apps/prompt_generator_app/app/intelligence/test/prompt_generator.py
@@ -24,7 +24,7 @@ from examples.third_party_examples.apps.prompt_generator_app.prompt_generator_he
 )
 
 
-def demo_prompt_generation():
+def demo_prompt_generation() -> None:
     """Demo prompt generation functionality."""
     print("Prompt Generator Demo")
     print("=" * 50)
@@ -42,7 +42,7 @@ def demo_prompt_generation():
     demo_supported_types()
 
 
-def demo_react_agent_prompt():
+def demo_react_agent_prompt() -> None:
     """Demo ReAct agent prompt generation."""
     print("\nDemo 1: ReAct Agent Prompt Generation")
     print("-" * 40)
@@ -78,7 +78,7 @@ def demo_react_agent_prompt():
         print(f"Error generating ReAct prompt: {str(e)}")
 
 
-def demo_rag_agent_prompt():
+def demo_rag_agent_prompt() -> None:
     """Demo RAG agent prompt generation."""
     print("\nDemo 2: RAG Agent Prompt Generation")
     print("-" * 40)
@@ -114,7 +114,7 @@ def demo_rag_agent_prompt():
         print(f"Error generating RAG prompt: {str(e)}")
 
 
-def demo_custom_scenario():
+def demo_custom_scenario() -> None:
     """Demo custom scenario prompt generation."""
     print("\nDemo 3: Custom Scenario Prompt Generation")
     print("-" * 40)
@@ -150,7 +150,7 @@ def demo_custom_scenario():
         print(f"Error generating Planning prompt: {str(e)}")
 
 
-def demo_supported_types():
+def demo_supported_types() -> None:
     """Demo supported agent types listing."""
     print("\nDemo 4: Supported Agent Types")
     print("-" * 40)
@@ -168,7 +168,7 @@ def demo_supported_types():
         print(f"Error listing agent types: {str(e)}")
 
 
-def main():
+def main() -> None:
     """Main function to run all demos."""
     try:
         demo_prompt_generation()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Adds return type annotations (6 changed def lines) in `examples/third_party_examples/apps/prompt_generator_app/app/intelligence/test/prompt_generator.py` where the return type is unambiguous.
- refactor(examples): add return type annotations in prompt_generator.py
- no functional changes; syntax-checked with ast.parse
