### PR TITLE
docs(examples): document missing docstrings in jsonl_file_util.py

### DIFF
--- a/examples/sample_apps/react_agent_app/intelligence/utils/common/jsonl_file_util.py
+++ b/examples/sample_apps/react_agent_app/intelligence/utils/common/jsonl_file_util.py
@@ -17,11 +17,14 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 class JsonFileOps(object):
+    """Operations over .jsonl files such as checking that a file exists."""
     def __init__(self):
+        """Initialize the JsonFileOps utility object."""
         return
 
     @classmethod
     def is_file_exist(cls, file_path):
+        """Check whether file_path is an existing file with a .jsonl extension. Raises: Exception when the extension is not .jsonl. Args: file_path: The path to check. Returns: bool: True when the file exists."""
         file_name, ext = os.path.splitext(file_path)
         if ext.lower() != '.jsonl':
             raise Exception('Unsupported file extension')
@@ -29,13 +32,16 @@ class JsonFileOps(object):
 
 
 class JsonFileReader(object):
+    """Reads JSON objects from a .jsonl file, one JSON object per line."""
     def __init__(self, file_path: str):
+        """Open the .jsonl file at file_path for reading when it exists. Args: file_path (str): Path of the .jsonl file to read."""
         self.file_handler = None
         self.file_name = file_path
         if JsonFileOps.is_file_exist(file_path):
             self.file_handler = open(file_path, 'r', encoding='utf-8')
 
     def read_json_obj(self):
+        """Read and parse the next line of the file as a JSON object. Returns: The parsed object, None at end of file, or an empty dict when the line cannot be parsed (the parse error is logged)."""
         if not self.file_handler:
             raise Exception(f"None json file to read: {self.file_name}")
         json_line = self.file_handler.readline()
@@ -60,7 +66,9 @@ class JsonFileReader(object):
 
 
 class JsonFileWriter(object):
+    """Writes JSON objects to a .jsonl output file, one JSON object per line."""
     def __init__(self, output_file_name: str, extension='jsonl', directory=DATA_DIR):
+        """Open the output .jsonl file at directory/output_file_name.extension for writing, creating the directory when needed. Args: output_file_name (str): Base name of the output file. extension (str): File extension, defaults to jsonl. directory (str): Output directory, defaults to DATA_DIR."""
         self.outfile_path = directory + output_file_name + '.' + extension
         directory = os.path.dirname(self.outfile_path)
         if not os.path.exists(directory):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Adds missing docstrings for: __init__, __init__, __init__, JsonFileOps, JsonFileReader, JsonFileWriter, is_file_exist, read_json_obj in `examples/sample_apps/react_agent_app/intelligence/utils/common/jsonl_file_util.py`.
- docs(examples): document missing docstrings in jsonl_file_util.py
- no functional changes; syntax-checked with ast.parse
