### PR TITLE
refactor(examples): add return type annotations in test_google_search_tool.py

### DIFF
--- a/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/test/test_google_search_tool.py
+++ b/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/test/test_google_search_tool.py
@@ -22,22 +22,22 @@ AgentUniverse().start(config_path='../../config/config.toml')
 class GoogleSearchToolTest(unittest.TestCase):
     """Google搜索工具测试类"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """测试前准备"""
         self.search_tool = ToolManager().get_instance_obj("google_search_tool")
         self.scholar_tool = ToolManager().get_instance_obj("google_scholar_search_tool")
 
-    def test_google_search_tool_creation(self):
+    def test_google_search_tool_creation(self) -> None:
         """测试Google搜索工具创建"""
         self.assertIsNotNone(self.search_tool)
         self.assertEqual(self.search_tool.name, 'google_search_tool')
 
-    def test_google_scholar_tool_creation(self):
+    def test_google_scholar_tool_creation(self) -> None:
         """测试Google学术搜索工具创建"""
         self.assertIsNotNone(self.scholar_tool)
         self.assertEqual(self.scholar_tool.name, 'google_scholar_search_tool')
 
-    def test_google_search_mock_mode(self):
+    def test_google_search_mock_mode(self) -> None:
         """测试Google搜索工具模拟模式"""
         # 不设置API密钥，测试模拟模式
         result = self.search_tool.execute(query="测试查询")
@@ -46,7 +46,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertTrue(any(text in result for text in expected_texts))
         self.assertIn("测试查询", result)
 
-    def test_google_search_with_parameters(self):
+    def test_google_search_with_parameters(self) -> None:
         """测试Google搜索工具参数"""
         result = self.search_tool.execute(
             query="人工智能",
@@ -58,7 +58,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertIsInstance(result, str)
         self.assertIn("人工智能", result)
 
-    def test_google_scholar_search_mock_mode(self):
+    def test_google_scholar_search_mock_mode(self) -> None:
         """测试Google学术搜索工具模拟模式"""
         result = self.scholar_tool.execute(query="机器学习")
         self.assertIsInstance(result, str)
@@ -66,7 +66,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertTrue(any(text in result for text in expected_texts))
         self.assertIn("机器学习", result)
 
-    def test_google_scholar_search_with_filters(self):
+    def test_google_scholar_search_with_filters(self) -> None:
         """测试Google学术搜索工具筛选功能"""
         result = self.scholar_tool.execute(
             query="深度学习",
@@ -77,7 +77,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertIsInstance(result, str)
         self.assertIn("深度学习", result)
 
-    def test_scholar_query_building(self):
+    def test_scholar_query_building(self) -> None:
         """测试学术搜索查询构建"""
         query = self.scholar_tool._build_scholar_query(
             "神经网络",
@@ -91,7 +91,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertIn("Yann LeCun", query)
         self.assertIn("ICML", query)
 
-    def test_search_result_formatting(self):
+    def test_search_result_formatting(self) -> None:
         """测试搜索结果格式化"""
         mock_result = '[{"title": "测试标题", "link": "https://example.com", "snippet": "测试描述"}]'
         formatted = self.search_tool._format_search_result(mock_result, "测试查询", "search")
@@ -99,7 +99,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertIn("测试标题", formatted)
         self.assertIn("https://example.com", formatted)
 
-    def test_scholar_result_formatting(self):
+    def test_scholar_result_formatting(self) -> None:
         """测试学术搜索结果格式化"""
         mock_result = '[{"title": "学术论文", "link": "https://scholar.google.com", "snippet": "论文摘要"}]'
         formatted = self.scholar_tool._format_scholar_result(mock_result, "机器学习", "site:scholar.google.com 机器学习")
@@ -107,7 +107,7 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertIn("学术论文", formatted)
         self.assertIn("https://scholar.google.com", formatted)
 
-    def test_error_handling(self):
+    def test_error_handling(self) -> None:
         """测试错误处理"""
         # 测试无效的JSON结果
         invalid_result = "invalid json result"
@@ -115,12 +115,12 @@ class GoogleSearchToolTest(unittest.TestCase):
         self.assertIn("Google Search 搜索结果", formatted)
         self.assertIn("invalid json result", formatted)
 
-    def test_tool_input_keys(self):
+    def test_tool_input_keys(self) -> None:
         """测试工具输入键"""
         self.assertEqual(self.search_tool.input_keys, ['input'])
         self.assertEqual(self.scholar_tool.input_keys, ['input'])
 
-    def test_tool_type(self):
+    def test_tool_type(self) -> None:
         """测试工具类型"""
         self.assertEqual(self.search_tool.tool_type.value, 'func')
         self.assertEqual(self.scholar_tool.tool_type.value, 'func')


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- `examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/test/test_google_search_tool.py`: added return annotations for setUp, test_error_handling, test_google_scholar_search_mock_mode, test_google_scholar_search_with_filters, test_google_scholar_tool_creation, test_google_search_mock_mode, test_google_search_tool_creation, test_google_search_with_parameters, test_scholar_query_building, test_scholar_result_formatting, test_search_result_formatting, test_tool_input_keys, test_tool_type.
- Explicit return annotations document the API contract for readers and type checkers; only unambiguously-typed returns (None/bool/list/str) were annotated.
- No functional changes; syntax-checked with `ast.parse`.
