### PR TITLE
docs(llm): document missing docstrings in default_ollama_llm.py

### DIFF
--- a/agentuniverse/llm/default/default_ollama_llm.py
+++ b/agentuniverse/llm/default/default_ollama_llm.py
@@ -59,6 +59,7 @@ class OllamaLLM(LLM):
             return LLMOutput(text=res.get("message").get('content'), raw=json.dumps(res))
 
     async def _acall(self, messages, stop=None, **kwargs) -> Union[LLMOutput, AsyncIterator[LLMOutput]]:
+        """Asynchronously call the Ollama chat endpoint for the messages. When streaming is on the streamed responses are returned, otherwise a single LLMOutput is built. Args: messages: The chat messages. stop: Optional stop words. **kwargs: Extra call options. Returns: Union[LLMOutput, AsyncIterator[LLMOutput]]: The model result."""
         client = self._new_async_client()
         should_stream = kwargs.pop("stream", self.streaming)
         options = self._options()
@@ -74,10 +75,12 @@ class OllamaLLM(LLM):
             yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line))
 
     async def agenerate_result(self, data):
+        """Asynchronously yield one LLMOutput per streamed response line. Args: data: The async stream of response lines. Yields: LLMOutput: The parsed output of each line."""
         async for line in data:
             yield LLMOutput(text=line.get("message").get('content'), raw=json.dumps(line))
 
     def as_langchain(self) -> BaseLanguageModel:
+        """Return a LangChain-compatible wrapper for this LLM, preferring the configured channel instance. Returns: BaseLanguageModel: The LangChain wrapper."""
         self.init_channel()
         if self._channel_instance:
             return self._channel_instance.as_langchain()
@@ -86,6 +89,7 @@ class OllamaLLM(LLM):
         )
 
     def initialize_by_component_configer(self, component_configer: LLMConfiger) -> 'LLM':
+        """Apply the LLM component configuration, reading base_url and max_context_length. Args: component_configer (LLMConfiger): The LLM configuration. Returns: LLM: self."""
         super().initialize_by_component_configer(component_configer)
         if 'base_url' in component_configer.configer.value:
             base_url = component_configer.configer.value['base_url']
@@ -95,6 +99,7 @@ class OllamaLLM(LLM):
         return self
 
     def get_num_tokens(self, text: str) -> int:
+        """Count the tokens of text using a tiktoken encoding for the model. Args: text (str): The input text. Returns: int: The number of tokens."""
         try:
             encoding = tiktoken.encoding_for_model(self.model_name)
         except KeyError:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Adds missing docstrings for: _acall, agenerate_result, as_langchain, initialize_by_component_configer, get_num_tokens in `agentuniverse/llm/default/default_ollama_llm.py`.
- docs(llm): document missing docstrings in default_ollama_llm.py
- no functional changes; syntax-checked with ast.parse
