### PR TITLE
docs(examples): document missing docstrings in txt_file_util.py

### DIFF
--- a/examples/sample_apps/peer_agent_app/intelligence/utils/common/txt_file_util.py
+++ b/examples/sample_apps/peer_agent_app/intelligence/utils/common/txt_file_util.py
@@ -12,11 +12,22 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 class TxtFileOps(object):
+    """Utility operations for text file handling."""
+
     def __init__(self):
+        """Initialize the TxtFileOps instance."""
         return
 
     @classmethod
     def is_file_exist(cls, file_path):
+        """Check whether the given text file exists.
+
+        Args:
+            file_path (str): Path of the file to check.
+
+        Returns:
+            bool: True if the file exists, False otherwise.
+        """
         file_name, ext = os.path.splitext(file_path)
         if ext.lower() != '.txt':
             raise Exception('Unsupported file extension')
@@ -24,14 +35,25 @@ class TxtFileOps(object):
 
 
 class TxtFileReader(object):
+    """Reader that reads non-empty lines from a text file."""
 
     def __init__(self, file_path: str):
+        """Initialize the reader with the target text file.
+
+        Args:
+            file_path (str): Path of the .txt file to read.
+        """
         self.file_handler = None
         self.file_name = file_path
         if TxtFileOps.is_file_exist(file_path):
             self.file_handler = open(file_path, 'r', encoding='utf-8')
 
     def read_txt_obj(self):
+        """Read the next line from the file.
+
+        Returns:
+            str or None: The stripped line, or None when no line remains.
+        """
         if not self.file_handler:
             raise Exception(f"No txt file to read: {self.file_name}")
         txt_line = self.file_handler.readline()
@@ -41,6 +63,11 @@ class TxtFileReader(object):
             return None
 
     def read_txt_obj_list(self):
+        """Read all remaining lines from the file.
+
+        Returns:
+            list: All remaining lines, stripped of surrounding whitespace.
+        """
         obj_list = []
         while True:
             obj = self.read_txt_obj()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/peer_agent_app/intelligence/utils/common/txt_file_util.py`: TxtFileOps|TxtFileReader|__init__|is_file_exist|__init__|read_txt_obj|read_txt_obj_list.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/peer_agent_app/intelligence/utils/common/txt_file_util.py').read())"` — the file remains syntactically valid.
