### PR TITLE
docs(agent): document missing docstrings in langchain_tool.py

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/langchain_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/langchain_tool.py
@@ -14,17 +14,44 @@ from langchain_core.tools import BaseTool
 
 
 class LangChainTool(Tool):
+    """Tool that wraps a langchain BaseTool instance."""
     name: Optional[str] = ""
     description: Optional[str] = ""
     tool: Optional[BaseTool] = None
 
     def execute(self, input: str, callbacks):
+        """Run the wrapped langchain tool synchronously.
+        
+        Args:
+            input (str): The tool input.
+            callbacks: LangChain callbacks for the run.
+        
+        Returns:
+            The tool execution result.
+        """
         return self.tool.run(input, callbacks=callbacks)
 
     async def async_execute(self, input: str, callbacks):
+        """Run the wrapped langchain tool asynchronously.
+        
+        Args:
+            input (str): The tool input.
+            callbacks: LangChain callbacks for the run.
+        
+        Returns:
+            The tool execution result.
+        """
         return await self.tool.arun(input, callbacks=callbacks)
 
     def initialize_by_component_configer(self, component_configer: ToolConfiger) -> 'Tool':
+        """Initialize the tool from a component configer.
+        
+        Args:
+            component_configer (ToolConfiger): The component configer.
+        
+        Returns:
+            Tool: The initialized tool.
+        """
         super().initialize_by_component_configer(component_configer)
         self.tool = self.init_langchain_tool(component_configer)
         if not component_configer.description and self.tool is not None:
@@ -32,6 +59,14 @@ class LangChainTool(Tool):
         return self
 
     def init_langchain_tool(self, component_configer):
+        """Instantiate the wrapped langchain tool from the configer's langchain section.
+        
+        Args:
+            component_configer: The component configer holding langchain metadata.
+        
+        Returns:
+            BaseTool: The instantiated langchain tool.
+        """
         langchain_info = component_configer.configer.value.get('langchain')
         module = langchain_info.get("module")
         class_name = langchain_info.get("class_name")
@@ -42,6 +77,12 @@ class LangChainTool(Tool):
         return self.tool
 
     def get_langchain_tool(self, init_params: dict, clz: Type[BaseTool]):
+        """Create and store the langchain tool instance.
+        
+        Args:
+            init_params (dict): Constructor kwargs for the tool class.
+            clz (Type[BaseTool]): The langchain tool class.
+        """
         if init_params:
             self.tool = clz(**init_params)
         else:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/tool/common_tool/langchain_tool.py`: LangChainTool|execute|async_execute|initialize_by_component_configer|init_langchain_tool|get_langchain_tool.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/tool/common_tool/langchain_tool.py').read())"` — the file remains syntactically valid.
