### PR TITLE
test: add unit tests for run_command_tool

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_run_command_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_run_command_tool.py
@@ -1,0 +1,65 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/01 10:00
+# @Author  : Yue Wang
+# @Email   : 1939455790@qq.com
+# @FileName: test_run_command_tool.py
+"""Unit tests for RunCommandTool."""
+
+import json
+import time
+
+import pytest
+
+from agentuniverse.agent.action.tool.common_tool.run_command_tool import (
+    CommandStatus,
+    RunCommandTool,
+    get_command_result,
+)
+from agentuniverse.agent.action.tool.tool import ToolInput
+
+
+class TestRunCommandTool:
+    @pytest.fixture
+    def tool(self):
+        return RunCommandTool(allow_command_execution=True)
+
+    def test_disabled_by_default_refuses(self):
+        tool = RunCommandTool()
+        result = json.loads(tool.execute(ToolInput({'command': 'echo nope', 'blocking': True})))
+        assert result['status'] == CommandStatus.ERROR.value
+        assert 'allow_command_execution' in result['stderr']
+
+    def test_blocking_echo(self, tool):
+        result = json.loads(tool.execute(ToolInput({'command': 'echo hello-au-0181', 'blocking': True})))
+        assert result['status'] == CommandStatus.COMPLETED.value
+        assert 'hello-au-0181' in result['stdout']
+        assert result['exit_code'] == 0
+
+    def test_blocking_result_registered(self, tool):
+        result = json.loads(tool.execute(ToolInput({'command': 'echo registered-run', 'blocking': True})))
+        thread_id = result['thread_id']
+        command_result = get_command_result(thread_id)
+        assert command_result is not None
+        assert 'registered-run' in command_result.stdout
+
+    def test_nonblocking_becomes_completed(self, tool):
+        result = json.loads(tool.execute(ToolInput({
+            'command': 'echo async-run-0181; sleep 0.2', 'blocking': False})))
+        assert result['status'] == CommandStatus.RUNNING.value
+        thread_id = result['thread_id']
+        final = None
+        for _ in range(20):
+            current = get_command_result(thread_id)
+            if current and current.status != CommandStatus.RUNNING:
+                final = current
+                break
+            time.sleep(0.1)
+        assert final is not None
+        assert final.status == CommandStatus.COMPLETED
+        assert 'async-run-0181' in final.stdout
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/agent/action/tool/test_run_command_tool.py` covering deterministic behaviors of `agentuniverse.agent.action.tool.common_tool.run_command_tool (RunCommandTool)`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/agent/action/tool/test_run_command_tool.py -q`: 4 passed, 7 warnings in 0.77s
