### PR TITLE
test: add unit tests for prompt_manager

### DIFF
--- a/tests/test_agentuniverse/unit/prompt/test_prompt_manager.py
+++ b/tests/test_agentuniverse/unit/prompt/test_prompt_manager.py
@@ -1,0 +1,46 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/01 10:00
+# @Author  : Yue Wang
+# @Email   : 1939455790@qq.com
+# @FileName: test_prompt_manager.py
+"""Unit tests for PromptManager."""
+
+import pytest
+
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.prompt.prompt import Prompt
+from agentuniverse.prompt.prompt_manager import PromptManager
+
+
+class TestPromptManager:
+    def test_singleton(self):
+        assert PromptManager() is PromptManager()
+
+    def test_get_missing_instance_returns_none(self):
+        assert PromptManager().get_instance_obj('no_such_prompt') is None
+
+    def test_register_and_get(self):
+        manager = PromptManager()
+        prompt = Prompt(prompt_version='v1', prompt_template='tpl {x}')
+        manager.register('test_prompt_185', prompt)
+        try:
+            retrieved = manager.get_instance_obj('test_prompt_185')
+            assert retrieved is prompt
+            assert retrieved.prompt_version == 'v1'
+        finally:
+            manager.unregister('test_prompt_185')
+
+    def test_unregister_removes_instance(self):
+        manager = PromptManager()
+        manager.register('test_prompt_185_b', Prompt(prompt_version='v2'))
+        manager.unregister('test_prompt_185_b')
+        assert manager.get_instance_obj('test_prompt_185_b') is None
+
+    def test_component_type_is_prompt(self):
+        assert PromptManager()._component_type == ComponentEnum.PROMPT
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/prompt/test_prompt_manager.py` covering deterministic behaviors of `agentuniverse.prompt.prompt_manager (PromptManager)`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/prompt/test_prompt_manager.py -q`: 5 passed, 9 warnings in 0.97s
