### PR TITLE
docs(agent): document missing docstrings in planning_agent_template.py

### DIFF
--- a/agentuniverse/agent/template/planning_agent_template.py
+++ b/agentuniverse/agent/template/planning_agent_template.py
@@ -18,18 +18,41 @@ from agentuniverse.base.util.logging.logging_util import LOGGER
 
 class PlanningAgentTemplate(AgentTemplate):
 
+    """Planning agent template.
+
+    Splits a task into a structured framework plus a thought, and can
+    stream the planning result to an output queue.
+    """
     def input_keys(self) -> list[str]:
         return ['input']
 
     def output_keys(self) -> list[str]:
+        """Output keys of the planning agent, ['framework', 'thought']."""
         return ['framework', 'thought']
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Parse the raw input object into the agent input dict.
+
+        Args:
+            input_object (InputObject): raw input from the caller.
+            agent_input (dict): agent input dict to fill.
+
+        Returns:
+            dict: agent input with the 'input' and 'expert_framework' keys set.
+        """
         agent_input['input'] = input_object.get_data('input')
         agent_input['expert_framework'] = input_object.get_data('expert_framework', {}).get('planning')
         return agent_input
 
     def parse_result(self, agent_result: dict) -> dict:
+        """Parse the agent result and extract framework and thought.
+
+        Args:
+            agent_result (dict): raw result of the agent execution.
+
+        Returns:
+            dict: result with the 'framework' and 'thought' keys.
+        """
         final_result = dict()
 
         output = agent_result.get('output')
@@ -45,18 +68,37 @@ class PlanningAgentTemplate(AgentTemplate):
         return final_result
 
     def initialize_by_component_configer(self, component_configer: AgentConfiger) -> 'PlanningAgentTemplate':
+        """Initialize the planning agent from a component configer.
+
+        Args:
+            component_configer (AgentConfiger): the agent component configer.
+
+        Returns:
+            PlanningAgentTemplate: the initialized agent template.
+        """
         super().initialize_by_component_configer(component_configer)
         self.prompt_version = self.agent_model.profile.get('prompt_version', 'default_planning_agent.cn')
         self.validate_required_params()
         return self
 
     def validate_required_params(self):
+        """Validate that the agent has the required parameters set.
+
+        Raises:
+            ValueError: if the agent's llm_name is not configured.
+        """
         if not self.llm_name:
             raise ValueError(f'llm_name of the agent {self.agent_model.info.get("name")}'
                              f' is not set, please go to the agent profile configuration'
                              ' and set the `name` attribute in the `llm_model`.')
 
     def add_output_stream(self, output_stream: Queue, agent_output: str) -> None:
+        """Parse the agent output and push the framework into the output queue.
+
+        Args:
+            output_stream (Queue): queue that receives the stream output.
+            agent_output (str): raw agent output to parse.
+        """
         if not output_stream:
             return
         try:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- `agentuniverse/agent/template/planning_agent_template.py`: added Google-style docstrings for 7 symbols (PlanningAgentTemplate, add_output_stream, initialize_by_component_configer, output_keys, parse_input, parse_result, validate_required_params).
- These classes/methods had no docstring; documenting them improves readability and IDE hover help.
- No functional changes; syntax-checked with `ast.parse`.
