### PR TITLE
docs(examples): document missing docstrings in txt_file_util.py

### DIFF
--- a/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/utils/common/txt_file_util.py
+++ b/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/utils/common/txt_file_util.py
@@ -13,11 +13,25 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 class TxtFileOps(object):
+    """Utility class for text file operations.
+
+    Currently validates file extensions and checks file existence.
+    """
     def __init__(self):
+        """Initialize a TxtFileOps instance."""
         return
 
     @classmethod
     def is_file_exist(cls, file_path):
+        """Check whether a '.txt' file exists at the given path.
+
+        Args:
+            file_path (str): the path of the file to check.
+        Raises:
+            Exception: if the file extension is not '.txt'.
+        Returns:
+            bool: True if the file exists, otherwise False.
+        """
         file_name, ext = os.path.splitext(file_path)
         if ext.lower() != '.txt':
             raise Exception('Unsupported file extension')
@@ -26,13 +40,33 @@ class TxtFileOps(object):
 
 class TxtFileReader(object):
 
+    """Reader that reads a '.txt' file line by line.
+
+    Opens the file in utf-8 read mode when it exists and provides
+    methods to read one line or all remaining lines.
+    """
     def __init__(self, file_path: str):
+        """Initialize the reader with the file to read.
+
+        Args:
+            file_path (str): path of the '.txt' file to read.
+        Raises:
+            Exception: if the file extension is not '.txt'.
+        """
         self.file_handler = None
         self.file_name = file_path
         if TxtFileOps.is_file_exist(file_path):
             self.file_handler = open(file_path, 'r', encoding='utf-8')
 
     def read_txt_obj(self):
+        """Read the next line of the text file.
+
+        Returns:
+            str: the next line with surrounding whitespace stripped, or None
+            when the end of the file is reached.
+        Raises:
+            Exception: if no file is open to read.
+        """
         if not self.file_handler:
             raise Exception(f"No txt file to read: {self.file_name}")
         txt_line = self.file_handler.readline()
@@ -42,6 +76,11 @@ class TxtFileReader(object):
             return None
 
     def read_txt_obj_list(self):
+        """Read all remaining lines of the text file.
+
+        Returns:
+            list: the remaining lines, stripped, in file order.
+        """
         obj_list = []
         while True:
             obj = self.read_txt_obj()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- `examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/utils/common/txt_file_util.py`: added Google-style docstrings for 7 symbols (TxtFileOps, TxtFileReader, __init__, is_file_exist, read_txt_obj, read_txt_obj_list).
- These classes/methods had no docstring; documenting them improves readability and IDE hover help.
- No functional changes; syntax-checked with `ast.parse`.
