### PR TITLE
test: add unit tests for chat_prompt

### DIFF
--- a/tests/test_agentuniverse/unit/prompt/test_chat_prompt.py
+++ b/tests/test_agentuniverse/unit/prompt/test_chat_prompt.py
@@ -1,0 +1,61 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/01 10:00
+# @Author  : Yue Wang
+# @Email   : 1939455790@qq.com
+# @FileName: test_chat_prompt.py
+"""Unit tests for ChatPrompt."""
+
+import pytest
+
+from agentuniverse.agent.memory.enum import ChatMessageEnum
+from agentuniverse.agent.memory.message import Message
+from agentuniverse.prompt.chat_prompt import ChatPrompt
+from agentuniverse.prompt.prompt_model import AgentPromptModel
+from langchain_core.prompts import ChatPromptTemplate
+
+
+class TestChatPrompt:
+    def test_default_messages_empty(self):
+        assert ChatPrompt().messages == []
+
+    def test_as_langchain(self):
+        prompt = ChatPrompt(messages=[Message(type=ChatMessageEnum.HUMAN.value, content='Hi')])
+        template = prompt.as_langchain()
+        assert isinstance(template, ChatPromptTemplate)
+        assert len(template.messages) == 1
+
+    def test_extract_placeholders(self):
+        prompt = ChatPrompt(messages=[
+            Message(type=ChatMessageEnum.HUMAN.value, content='Hello {name}, do {task}')
+        ])
+        assert set(prompt.extract_placeholders()) == {'name', 'task'}
+
+    def test_build_prompt_orders_messages(self):
+        prompt = ChatPrompt()
+        model = AgentPromptModel(introduction='Intro', instruction='Task')
+        prompt.build_prompt(model, ['introduction', 'instruction'])
+        assert len(prompt.messages) == 2
+        assert prompt.messages[0].type == ChatMessageEnum.SYSTEM.value
+
+    def test_generate_image_prompt_http_url(self):
+        prompt = ChatPrompt()
+        prompt.generate_image_prompt(['https://example.com/a.png'])
+        assert len(prompt.messages) == 1
+        content = prompt.messages[0].content
+        assert content[0]['type'] == 'image_url'
+
+    def test_generate_image_prompt_ignores_bad_extension(self, tmp_path):
+        prompt = ChatPrompt()
+        prompt.generate_image_prompt(['note.txt'])
+        assert prompt.messages == []
+
+    def test_generate_image_prompt_dict_url(self):
+        prompt = ChatPrompt()
+        prompt.generate_image_prompt([{'url': 'https://example.com/b.jpg'}])
+        assert len(prompt.messages) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/prompt/test_chat_prompt.py` covering deterministic behaviors of `agentuniverse.prompt.chat_prompt (ChatPrompt)`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/prompt/test_chat_prompt.py -q`: 7 passed, 9 warnings in 0.90s
