### PR TITLE
docs(examples): document missing docstrings in openai_protocol_executing_agent.py

### DIFF
--- a/examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_executing_agent.py
+++ b/examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_executing_agent.py
@@ -13,15 +13,52 @@ from agentuniverse.prompt.prompt import Prompt
 
 
 class ExecutingOpenAIAgentTemplate(OpenAIProtocolTemplate, ExecutingAgentTemplate):
+    """Executing agent template adapted to the OpenAI chat protocol.
+
+    Sub-tasks of the planning framework are executed through the standard
+    executing-agent pipeline while the response is streamed back in the
+    OpenAI-protocol chunk format.
+    """
+
     def parse_openai_protocol_output(self, output_object: OutputObject) -> OutputObject:
+        """Keep the executing result untouched for protocol formatting.
+
+        Args:
+            output_object (OutputObject): agent execution result.
+        Returns:
+            OutputObject: the same output object, unmodified.
+        """
         return output_object
 
     def customized_execute(self, input_object: InputObject, agent_input: dict, memory: Memory, llm: LLM, prompt: Prompt,
                            **kwargs) -> dict:
+        """Execute the sub-tasks stored in the planning framework.
+
+        Args:
+            input_object (InputObject): input parameters passed by the user.
+            agent_input (dict): agent input prepared by the framework.
+            memory (Memory): agent memory instance.
+            llm (LLM): llm instance used by the agent.
+            prompt (Prompt): prompt instance used by the agent.
+        Returns:
+            dict: dict containing the ``executing_result`` and output stream.
+        """
         return ExecutingAgentTemplate.customized_execute(self, input_object, agent_input, memory, llm, prompt, **kwargs)
 
     def invoke_chain(self, chain: RunnableSerializable[Any, str], agent_input: dict, input_object: InputObject,
                      **kwargs):
+        """Invoke or stream the LLM chain and forward streamed tokens.
+
+        When the chain supports streaming, each chunk is collected and the
+        assembled answer is pushed to the OpenAI-protocol output stream.
+
+        Args:
+            chain (RunnableSerializable): langchain runnable to invoke.
+            agent_input (dict): agent input prepared by the framework.
+            input_object (InputObject): input parameters passed by the user.
+        Returns:
+            The invocation result of the chain, or the generated answer.
+        """
         if not self.judge_chain_stream(chain):
             res = chain.invoke(input=agent_input, config=self.get_run_config())
             return res
@@ -34,5 +71,13 @@ class ExecutingOpenAIAgentTemplate(OpenAIProtocolTemplate, ExecutingAgentTemplat
         return self.generate_result(result)
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Parse the input object and announce the executing phase.
+
+        Args:
+            input_object (InputObject): input parameters passed by the user.
+            agent_input (dict): agent input prepared by the framework.
+        Returns:
+            dict: agent input parsed from ``input_object``.
+        """
         self.add_output_stream(input_object.get_data('output_stream', None), '## Executing  \n\n')
         return super().parse_input(input_object, agent_input)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_executing_agent.py`: ExecutingOpenAIAgentTemplate, parse_openai_protocol_output, customized_execute, invoke_chain, parse_input.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_executing_agent.py').read())"` — the file remains syntactically valid.
