### PR TITLE
docs(examples): document missing docstrings in insurance_agent.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/insurance_agent.py
+++ b/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/insurance_agent.py
@@ -16,18 +16,38 @@ from agentuniverse.prompt.prompt import Prompt
 
 
 class InsuranceAgent(Agent):
+    """Agent instance that answers insurance questions using tool results."""
 
     def input_keys(self) -> list[str]:
+        """Return the input keys accepted by this agent."""
         return ['input']
 
     def output_keys(self) -> list[str]:
+        """Return the output keys produced by this agent."""
         return ['output']
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Copy the user input into the agent input dict.
+
+        Args:
+            input_object (InputObject): the user-supplied input object.
+            agent_input (dict): the agent input dict being populated.
+
+        Returns:
+            dict: the populated agent input dict.
+        """
         agent_input['input'] = input_object.get_data('input')
         return agent_input
 
     def parse_result(self, agent_result: dict) -> dict:
+        """Expose the output key on the final agent result.
+
+        Args:
+            agent_result (dict): the raw result produced by execution.
+
+        Returns:
+            dict: the result dict including an 'output' key.
+        """
         return {**agent_result, 'output': agent_result['output']}
 
     def execute(self, input_object: InputObject, agent_input: dict, **kwargs) -> dict:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/insurance_agent.py`: InsuranceAgent, input_keys, output_keys, parse_input, parse_result.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/insurance_agent.py').read())"` — the file remains syntactically valid.
