### PR TITLE
docs(agentuniverse_extension): document missing docstrings in base_sls_log_sink.py

### DIFF
--- a/agentuniverse_extension/logger/log_sink/base_sls_log_sink.py
+++ b/agentuniverse_extension/logger/log_sink/base_sls_log_sink.py
@@ -16,18 +16,39 @@ from loguru import logger
 
 
 class BaseSLSLogSink(LogSink):
+    """Loguru sink that ships records to Alibaba Cloud SLS.
 
+    Subclasses implement :meth:`process_record` to serialize a single record.
+    """
 
     def process_record(self, record):
+        """Process a single log record.
+
+        Args:
+            record: The loguru log record to process.
+        """
         raise NotImplementedError("Subclasses must implement process_record.")
 
     def filter(self, record):
+        """Keep and process only records matching this sink's log type.
+
+        Args:
+            record: The loguru log record being filtered.
+
+        Returns:
+            bool: True when the record belongs to this sink's log type.
+        """
         if not record['extra'].get('log_type') == self.log_type:
             return False
         self.process_record(record)
         return True
 
     def register_sink(self):
+        """Register this sink with the loguru logger when SLS logging is enabled.
+
+        Uses the async SLS sender inside a coroutine context and the sync
+        sender otherwise; the loguru sink is added only once (sink_id == -1).
+        """
         if LoggingConfig.log_extend_module_switch["sls_log"]:
             print(
                 f"biz_logger_is_in_coroutine_context={is_in_coroutine_context()}")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse_extension/logger/log_sink/base_sls_log_sink.py`: BaseSLSLogSink, process_record, filter, register_sink.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_extension/logger/log_sink/base_sls_log_sink.py').read())"` — the file remains syntactically valid.
