### PR TITLE
docs(examples): document missing docstrings in demo_agent_template.py

### DIFF
--- a/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_template/demo_agent_template.py
+++ b/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_template/demo_agent_template.py
@@ -10,6 +10,7 @@ from agentuniverse.agent.template.agent_template import AgentTemplate
 
 
 class DemoAgentTemplate(AgentTemplate):
+    """Demo agent template echoing a single ``input`` key to a demo output."""
 
     def input_keys(self) -> list[str]:
         """Return the input keys of the Agent."""
@@ -20,13 +21,43 @@ class DemoAgentTemplate(AgentTemplate):
         return ['output']
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Put the request input under the ``input`` agent key.
+
+        Falls back to the template topic when the request carries no input.
+
+        Args:
+            input_object: The agent's input object.
+            agent_input: The dict of agent input parameters.
+
+        Returns:
+            dict: The agent input dict enriched with the ``input`` key.
+        """
         agent_input['input'] = input_object.get_data('input') or self.topic
         return agent_input
 
     def parse_result(self, agent_result: dict) -> dict:
+        """Return the raw agent result unchanged.
+
+        Args:
+            agent_result: The dict produced by the agent execution.
+
+        Returns:
+            dict: The same agent result dict.
+        """
         return agent_result
 
     def execute(self, input_object: InputObject, agent_input: dict, **kwargs) -> dict:
+        """Run the demo template and return a placeholder output.
+
+        Replace this body with the real template logic when extending the demo.
+
+        Args:
+            input_object: The agent's input object.
+            agent_input: The dict of agent input parameters.
+
+        Returns:
+            dict: The execution result, e.g. ``{'output': 'demo output.'}``.
+        """
         result = {'output': 'demo output.'}
         # Please fill out your template codes. The following is a sample of a peer template.
         # #================= sample ====================#


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_template/demo_agent_template.py`: DemoAgentTemplate, parse_input, parse_result, execute.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_template/demo_agent_template.py').read())"` — the file remains syntactically valid.
