### PR TITLE
test: add unit tests for reasoning_output_parse

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py
+++ b/tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for agentuniverse.base.util.reasoning_output_parse."""
+
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration
+
+from agentuniverse.base.util.reasoning_output_parse import ReasoningOutputParser
+
+
+class TestReasoningOutputParser:
+    """Tests for the ReasoningOutputParser.parse_result method."""
+
+    def _parse(self, *generations, partial=False):
+        parser = ReasoningOutputParser()
+        return parser.parse_result(list(generations), partial=partial)
+
+    def test_empty_result_returns_empty_string(self):
+        assert self._parse() == ""
+
+    def test_with_reasoning_content(self):
+        generation = ChatGeneration(message=AIMessage(
+            content="final answer",
+            additional_kwargs={"reasoning_content": "chain of thought"}))
+        assert self._parse(generation) == {
+            "text": "final answer",
+            "reasoning_content": "chain of thought",
+        }
+
+    def test_without_additional_kwargs(self):
+        generation = ChatGeneration(message=AIMessage(content="plain answer"))
+        assert self._parse(generation) == {"text": "plain answer"}
+
+    def test_with_empty_additional_kwargs(self):
+        generation = ChatGeneration(message=AIMessage(
+            content="plain answer", additional_kwargs={}))
+        assert self._parse(generation) == {"text": "plain answer"}
+
+    def test_additional_kwargs_without_reasoning_content(self):
+        generation = ChatGeneration(message=AIMessage(
+            content="answer", additional_kwargs={"finish_reason": "stop"}))
+        assert self._parse(generation) == {"text": "answer", "reasoning_content": ""}
+
+    def test_partial_flag_is_supported(self):
+        generation = ChatGeneration(message=AIMessage(content="answer"))
+        assert self._parse(generation, partial=True) == {"text": "answer"}


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py` covering deterministic behaviors of `agentuniverse.base.util.reasoning_output_parse`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/util/test_reasoning_output_parse.py -q`: 6 passed in 0.20s
