### PR TITLE
docs(workflow): document missing docstrings in condition_node.py

### DIFF
--- a/agentuniverse/workflow/node/condition_node.py
+++ b/agentuniverse/workflow/node/condition_node.py
@@ -16,6 +16,7 @@ from agentuniverse.workflow.workflow_output import WorkflowOutput
 
 
 class ConditionNodeData(NodeData):
+    """Data model of the condition node holding its input configuration."""
     inputs: Optional[ConditionNodeInputParams] = None
 
 
@@ -24,16 +25,36 @@ class ConditionNode(Node):
     _data_cls = ConditionNodeData
 
     def __init__(self, **kwargs):
+        """Initialize the condition node and mark it with the CONDITION type."""
         super().__init__(**kwargs)
         self.type = NodeEnum.CONDITION
 
     def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
+        """Evaluate the first condition branch and produce the routing result.
+
+        Args:
+            workflow_output: The workflow output used to resolve referenced
+                node values.
+
+        Returns:
+            A NodeOutput whose edge_source_handler is the branch name when the
+            condition holds, otherwise 'branch-default'.
+        """
         inputs: ConditionNodeInputParams = self._data.inputs
         condition_branches: List[ConditionBranchParams] = inputs.branches
         condition_branch: ConditionBranchParams = condition_branches[0]
         condition: ConditionParams = condition_branch.conditions[0]
 
         def resolve_value(node_input: NodeInputParams):
+            """Resolve the actual value of a condition node input.
+
+            Args:
+                node_input: The input parameter to resolve.
+
+            Returns:
+                The referenced node output value when the input type is
+                'reference', otherwise the literal content of the input.
+            """
             if node_input.value.type == 'reference':
                 reference_node_id = node_input.value.content[0]
                 reference_output_params: List[NodeOutputParams] = workflow_output.workflow_parameters.get(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/workflow/node/condition_node.py`: ConditionNodeData, __init__, _run, resolve_value.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/workflow/node/condition_node.py').read())"` — the file remains syntactically valid.
