### PR TITLE
test: add unit tests for start_node

### DIFF
--- a/tests/test_agentuniverse/unit/workflow/node/test_start_node.py
+++ b/tests/test_agentuniverse/unit/workflow/node/test_start_node.py
@@ -1,0 +1,46 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+# @FileName: test_start_node.py
+
+"""Unit tests for the workflow StartNode."""
+
+import pytest
+
+from agentuniverse.workflow.node.enum import NodeEnum, NodeStatusEnum
+from agentuniverse.workflow.node.start_node import StartNode
+from agentuniverse.workflow.workflow_output import WorkflowOutput
+
+
+@pytest.fixture
+def start_node():
+    return StartNode(id="start_1", name="start",
+                     data={"outputs": [{"name": "input", "value": None}]})
+
+
+class TestStartNode:
+    """Test StartNode startup input propagation."""
+
+    def test_type_is_start(self, start_node):
+        assert start_node.type == NodeEnum.START
+
+    def test_run_propagates_start_input(self, start_node):
+        workflow_output = WorkflowOutput()
+        workflow_output.workflow_start_params = {"input": "hello world"}
+        result = start_node.run(workflow_output)
+        assert result.node_id == "start_1"
+        assert result.status == NodeStatusEnum.SUCCEEDED
+        assert result.result[0].value == "hello world"
+        assert workflow_output.workflow_parameters["start_1"][0].value == \
+            "hello world"
+
+    def test_run_without_input_uses_empty_string(self, start_node):
+        workflow_output = WorkflowOutput()
+        start_node.run(workflow_output)
+        assert workflow_output.workflow_parameters["start_1"][0].value == ""
+
+    def test_run_with_empty_start_params(self, start_node):
+        workflow_output = WorkflowOutput(workflow_start_params={})
+        result = start_node.run(workflow_output)
+        assert result.result[0].value == ""


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/workflow/node/test_start_node.py` covering deterministic behaviors of `agentuniverse.workflow.node.start_node`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/workflow/node/test_start_node.py -q`: 4 passed in 0.04s
