### PR TITLE
docs(agent_serve): document missing docstrings in agentuniverse_service_pb2_grpc.py

### DIFF
--- a/agentuniverse/agent_serve/web/rpc/grpc/agentuniverse_service_pb2_grpc.py
+++ b/agentuniverse/agent_serve/web/rpc/grpc/agentuniverse_service_pb2_grpc.py
@@ -58,6 +58,12 @@ class AgentUniverseServiceServicer(object):
 
 
 def add_AgentUniverseServiceServicer_to_server(servicer, server):
+    """Register the servicer's RPC handlers on the given gRPC server.
+
+    Args:
+        servicer: The AgentUniverseServiceServicer implementation.
+        server: The gRPC server to register the handlers on.
+    """
     rpc_method_handlers = {
             'service_run': grpc.unary_unary_rpc_method_handler(
                     servicer.service_run,
@@ -96,6 +102,16 @@ class AgentUniverseService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
+        """Invoke the service_run RPC through the experimental unary-unary API.
+
+        Args:
+            request: The request object to send.
+            target: The server address of the unary-unary call.
+            Remaining arguments are standard experimental gRPC call options.
+
+        Returns:
+            The result of the experimental unary-unary call.
+        """
         return grpc.experimental.unary_unary(request, target, '/agentuniverse.AgentUniverseService/service_run',
             agentuniverse__service__pb2.AgentServiceRequest.SerializeToString,
             agentuniverse__service__pb2.AgentServiceResponse.FromString,
@@ -113,6 +129,16 @@ class AgentUniverseService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
+        """Invoke the service_run_async RPC through the experimental unary-unary API.
+
+        Args:
+            request: The request object to send.
+            target: The server address of the unary-unary call.
+            Remaining arguments are standard experimental gRPC call options.
+
+        Returns:
+            The result of the experimental unary-unary call.
+        """
         return grpc.experimental.unary_unary(request, target, '/agentuniverse.AgentUniverseService/service_run_async',
             agentuniverse__service__pb2.AgentServiceRequest.SerializeToString,
             agentuniverse__service__pb2.AgentServiceResponse.FromString,
@@ -130,6 +156,16 @@ class AgentUniverseService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
+        """Invoke the service_run_result RPC through the experimental unary-unary API.
+
+        Args:
+            request: The request object to send.
+            target: The server address of the unary-unary call.
+            Remaining arguments are standard experimental gRPC call options.
+
+        Returns:
+            The result of the experimental unary-unary call.
+        """
         return grpc.experimental.unary_unary(request, target, '/agentuniverse.AgentUniverseService/service_run_result',
             agentuniverse__service__pb2.AgentResultRequest.SerializeToString,
             agentuniverse__service__pb2.AgentServiceResponse.FromString,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent_serve/web/rpc/grpc/agentuniverse_service_pb2_grpc.py`: add_AgentUniverseServiceServicer_to_server, service_run, service_run_async, service_run_result.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent_serve/web/rpc/grpc/agentuniverse_service_pb2_grpc.py').read())"` — the file remains syntactically valid.
