### PR TITLE
docs(examples): document missing docstrings in insurance_planning_agent.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_multi_agents/intelligence/agentic/agent/agent_instance/insurance_planning_agent.py
+++ b/examples/startup_app/demo_startup_app_with_multi_agents/intelligence/agentic/agent/agent_instance/insurance_planning_agent.py
@@ -17,24 +17,63 @@ from agentuniverse.prompt.prompt import Prompt
 
 class InsurancePlanningAgent(Agent):
 
+    """Insurance planning agent that drafts a planning proposal from the user input and the product description using an LLM chain.
+    """
     def input_keys(self) -> list[str]:
+        """Return the input keys required by this agent.
+
+        Returns:
+            list[str]: The list of required input keys.
+        """
         return ['input', 'prod_description']
 
     def output_keys(self) -> list[str]:
+        """Return the output keys produced by this agent.
+
+        Returns:
+            list[str]: The list of output keys.
+        """
         return ['planning_output']
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Copy the user input and product description from the input object into the agent input.
+
+        Args:
+            input_object(InputObject): The user input object.
+            agent_input(dict): The agent input dictionary to be filled.
+
+        Returns:
+            dict: The updated agent input.
+        """
         agent_input['input'] = input_object.get_data('input')
         agent_input['prod_description'] = input_object.get_data('prod_description')
         return agent_input
 
     def parse_result(self, agent_result: dict) -> dict:
+        """Extract the generated output from the agent result, log it and expose it under the planning_output key.
+
+        Args:
+            agent_result(dict): The raw agent result.
+
+        Returns:
+            dict: The agent result enriched with the planning_output key.
+        """
         planning_output = agent_result['output']
         LOGGER.info(f'智能体 insurance_planning_agent 执行结果为： {planning_output}')
         return {**agent_result, 'planning_output': agent_result['output']}
 
     def execute(self, input_object: InputObject, agent_input: dict, **kwargs) -> dict:
         # 1. get the llm instance.
+        """Run the planning chain: process the prompt and LLM, invoke the chain and return the agent input together with the generated output.
+
+        Args:
+            input_object(InputObject): The user input object.
+            agent_input(dict): The agent input dictionary.
+            **kwargs: Extra keyword arguments passed to the chain invocation.
+
+        Returns:
+            dict: The agent input enriched with the generated output.
+        """
         llm: LLM = self.process_llm(**kwargs)
         # 2. get the agent prompt.
         prompt: Prompt = self.process_prompt(agent_input, **kwargs)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_multi_agents/intelligence/agentic/agent/agent_instance/insurance_planning_agent.py`: InsurancePlanningAgent, input_keys, output_keys, parse_input, parse_result, execute.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_multi_agents/intelligence/agentic/agent/agent_instance/insurance_planning_agent.py').read())"` — the file remains syntactically valid.
