### PR TITLE
docs(examples): document missing docstrings in discussion_group_template.py

### DIFF
--- a/examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_template/discussion_group_template.py
+++ b/examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_template/discussion_group_template.py
@@ -25,6 +25,8 @@ from agentuniverse.prompt.chat_prompt import ChatPrompt
 
 
 class DiscussionGroupTemplate(AgentTemplate):
+    """Template that runs a multi-agent discussion group: participant agents talk over several rounds and a host agent summarizes the conclusion.
+    """
     participant_names: Optional[list[str]] = None
     total_round: int = 2
     topic: Optional[str] = None
@@ -38,19 +40,54 @@ class DiscussionGroupTemplate(AgentTemplate):
         return ['output']
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Fill the agent input with the discussion topic, participant names and total rounds.
+
+        Args:
+            input_object(InputObject): The user input object.
+            agent_input(dict): The agent input dictionary to be filled.
+
+        Returns:
+            dict: The updated agent input.
+        """
         agent_input['input'] = input_object.get_data('input') or self.topic
         agent_input['participants'] = self.participant_names
         agent_input['total_round'] = self.total_round
         return agent_input
 
     def parse_result(self, agent_result: dict) -> dict:
+        """Return the agent result unchanged.
+
+        Args:
+            agent_result(dict): The raw agent result.
+
+        Returns:
+            dict: The agent result.
+        """
         return agent_result
 
     def execute(self, input_object: InputObject, agent_input: dict, **kwargs) -> dict:
+        """Execute the discussion group by generating the participant agents and running the full discussion.
+
+        Args:
+            input_object(InputObject): The user input object.
+            agent_input(dict): The agent input dictionary.
+            **kwargs: Extra keyword arguments accepted for interface compatibility.
+
+        Returns:
+            dict: The discussion group result.
+        """
         participant_agents = self.generate_participant_agents()
         return self.agents_run(participant_agents, agent_input, input_object)
 
     def generate_participant_agents(self) -> dict:
+        """Build a dict of participant agents keyed by their names.
+
+        Returns:
+            dict: Mapping from participant name to the corresponding Agent instance.
+
+        Raises:
+            ValueError: If the participant_names list is empty.
+        """
         if len(self.participant_names) == 0:
             raise ValueError("The participant agents is empty.")
         agents = dict()
@@ -160,6 +197,14 @@ class DiscussionGroupTemplate(AgentTemplate):
         return {**agent_input, 'output': res}
 
     def initialize_by_component_configer(self, component_configer: AgentConfiger) -> 'DiscussionGroupTemplate':
+        """Initialize the discussion group template from the configer profile fields.
+
+        Args:
+            component_configer(AgentConfiger): The configer containing the template settings.
+
+        Returns:
+            DiscussionGroupTemplate: The initialized template instance.
+        """
         super().initialize_by_component_configer(component_configer)
         if self.agent_model.profile.get('topic'):
             self.topic = self.agent_model.profile.get('topic')


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_template/discussion_group_template.py`: DiscussionGroupTemplate, parse_input, parse_result, execute, generate_participant_agents, initialize_by_component_configer.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/react_agent_app/intelligence/agentic/agent/agent_template/discussion_group_template.py').read())"` — the file remains syntactically valid.
