### PR TITLE
docs(examples): document missing docstrings in translation_agent.py

### DIFF
--- a/examples/sample_apps/translation_agent_app/intelligence/agentic/agent/agent_instance/translation_agent_case/translation_agent.py
+++ b/examples/sample_apps/translation_agent_app/intelligence/agentic/agent/agent_instance/translation_agent_case/translation_agent.py
@@ -14,21 +14,62 @@ from agentuniverse.prompt.prompt_model import AgentPromptModel
 
 
 class TranslationAgent(RagAgentTemplate):
+    """RAG agent template subclass that translates text based on the execute_type and country profile settings.
+    """
     def input_keys(self) -> list[str]:
+        """Return the input keys declared in the agent profile.
+
+        Returns:
+            list[str]: The configured input keys.
+        """
         return self.agent_model.profile.get('input_keys')
 
     def output_keys(self) -> list[str]:
+        """Return the output keys declared in the agent profile.
+
+        Returns:
+            list[str]: The configured output keys.
+        """
         return self.agent_model.profile.get('output_keys')
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Copy every data field of the input object into the agent input.
+
+        Args:
+            input_object(InputObject): The user input object.
+            agent_input(dict): The agent input dictionary to be filled.
+
+        Returns:
+            dict: The updated agent input.
+        """
         for key in input_object.to_dict():
             agent_input[key] = input_object.get_data(key)
         return agent_input
 
     def parse_result(self, planner_result: dict) -> dict:
+        """Return the agent result unchanged.
+
+        Args:
+            planner_result(dict): The raw agent result.
+
+        Returns:
+            dict: The agent result.
+        """
         return planner_result
 
     def process_prompt(self, agent_input: dict, **kwargs) -> ChatPrompt:
+        """Build the chat prompt, selecting a prompt version based on the translation type and the target country when relevant.
+
+        Args:
+            agent_input(dict): The agent input containing translation hints.
+            **kwargs: Extra keyword arguments accepted for interface compatibility.
+
+        Returns:
+            ChatPrompt: The built chat prompt.
+
+        Raises:
+            Exception: If neither a prompt version nor an inline prompt model is available.
+        """
         profile: dict = self.agent_model.profile
         profile_prompt_model: AgentPromptModel = AgentPromptModel(introduction=profile.get('introduction'),
                                                                   target=profile.get('target'),


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/translation_agent_app/intelligence/agentic/agent/agent_instance/translation_agent_case/translation_agent.py`: TranslationAgent, input_keys, output_keys, parse_input, parse_result, process_prompt.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/translation_agent_app/intelligence/agentic/agent/agent_instance/translation_agent_case/translation_agent.py').read())"` — the file remains syntactically valid.
