### PR TITLE
test: add unit tests for default_llm_configer

### DIFF
--- a/tests/test_agentuniverse/unit/base/config/custom_configer/test_default_llm_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/custom_configer/test_default_llm_configer.py
@@ -1,0 +1,31 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+# @FileName: test_default_llm_configer.py
+
+"""Unit tests for the DefaultLLMConfiger singleton."""
+
+import os
+import tempfile
+
+from agentuniverse.base.config.custom_configer.default_llm_configer import     DefaultLLMConfiger
+
+
+def test_loads_default_llm_from_toml():
+    with tempfile.NamedTemporaryFile("w", suffix=".toml",
+                                     delete=False) as f:
+        f.write("[DEFAULT]\ndefault_llm = \"gpt-4o\"\n")
+        path = f.name
+    try:
+        configer = DefaultLLMConfiger(path)
+        assert configer.default_llm == "gpt-4o"
+        assert configer.value.get("DEFAULT", {}).get("default_llm") == "gpt-4o"
+    finally:
+        os.unlink(path)
+
+
+def test_set_get_roundtrip():
+    configer = DefaultLLMConfiger()
+    configer.set("a", 5)
+    assert configer.get("a") == 5


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/config/custom_configer/test_default_llm_configer.py` covering deterministic behaviors of `agentuniverse.agentuniverse.base.config.custom_configer.default_llm_configer`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/config/custom_configer/test_default_llm_configer.py -q`: 2 passed
