### PR TITLE
test: add unit tests for custom_key_configer

### DIFF
--- a/tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py
@@ -1,0 +1,38 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+# @FileName: test_custom_key_configer.py
+
+"""Unit tests for the CustomKeyConfiger singleton."""
+
+import os
+import tempfile
+
+from agentuniverse.base.config.custom_configer.custom_key_configer import \
+    CustomKeyConfiger
+
+
+def test_loads_key_list_into_environment():
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml",
+                                     delete=False) as f:
+        f.write("KEY_LIST:\n  AU_TEST_SECRET_KEY: abc123\n")
+        path = f.name
+    try:
+        CustomKeyConfiger.__wrapped__(path)
+        assert os.environ.get("AU_TEST_SECRET_KEY") == "abc123"
+    finally:
+        os.environ.pop("AU_TEST_SECRET_KEY", None)
+        os.unlink(path)
+
+
+def test_missing_config_file_is_tolerated(capsys):
+    CustomKeyConfiger.__wrapped__("/tmp/missing_custom_key_file.yaml")
+    assert "skip load custom key" in capsys.readouterr().out
+
+
+def test_set_get_roundtrip():
+    configer = CustomKeyConfiger()
+    configer.set("x", 1)
+    assert configer.get("x") == 1
+    assert configer.to_dict()["x"] == 1


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py` covering deterministic behaviors of `agentuniverse.agentuniverse.base.config.custom_configer.custom_key_configer`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/config/custom_configer/test_custom_key_configer.py -q`: 3 passed
