### PR TITLE
test: add unit tests for knowledge_configer

### DIFF
--- a/tests/test_agentuniverse/unit/base/config/component_configer/configers/test_knowledge_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/component_configer/configers/test_knowledge_configer.py
@@ -1,0 +1,40 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+# @FileName: test_knowledge_configer.py
+
+"""Unit tests for the KnowledgeConfiger."""
+
+from types import SimpleNamespace
+
+from agentuniverse.base.config.component_configer.configers.knowledge_configer import \
+    KnowledgeConfiger
+
+
+class TestKnowledgeConfiger:
+    """Test knowledge configuration loading."""
+
+    def test_defaults(self):
+        configer = KnowledgeConfiger()
+        assert configer.name is None
+        assert configer.description is None
+        assert configer.ext_info is None
+        assert configer.stores == []
+        assert configer.rag_router == "base_router"
+        assert configer.post_processors == []
+        assert configer.readers == {}
+
+    def test_load_by_configer(self):
+        configer = KnowledgeConfiger()
+        value = {"name": "kb", "description": "docs",
+                 "ext_info": {"a": 1},
+                 "metadata": {"type": "knowledge", "module": "m",
+                              "class": "C"}}
+        returned = configer.load_by_configer(SimpleNamespace(value=value,
+                                                             path="x.yaml"))
+        assert returned is configer
+        assert configer.name == "kb"
+        assert configer.description == "docs"
+        assert configer.ext_info == {"a": 1}
+        assert configer.metadata_type == "knowledge"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/config/component_configer/configers/test_knowledge_configer.py` covering deterministic behaviors of `agentuniverse.agentuniverse.base.config.component_configer.configers.knowledge_configer`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/config/component_configer/configers/test_knowledge_configer.py -q`: 2 passed
