### PR TITLE
test: add unit tests for prompt_configer

### DIFF
--- a/tests/test_agentuniverse/unit/base/config/component_configer/configers/test_prompt_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/component_configer/configers/test_prompt_configer.py
@@ -1,0 +1,39 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+# @FileName: test_prompt_configer.py
+
+"""Unit tests for the PromptConfiger."""
+
+from types import SimpleNamespace
+
+from agentuniverse.base.config.component_configer.configers.prompt_configer import \
+    PromptConfiger
+
+
+class TestPromptConfiger:
+    """Test prompt configuration loading."""
+
+    def test_defaults(self):
+        configer = PromptConfiger()
+        assert configer.metadata_version is None
+
+    def test_load_with_metadata_version(self):
+        configer = PromptConfiger()
+        value = {"metadata": {"type": "prompt", "version": "v2",
+                              "module": "mod.prompt", "class": "MyPrompt"}}
+        returned = configer.load_by_configer(SimpleNamespace(value=value,
+                                                             path="x.yaml"))
+        assert returned is configer
+        assert configer.metadata_version == "v2"
+        assert configer.metadata_module == "mod.prompt"
+        assert configer.metadata_class == "MyPrompt"
+
+    def test_load_without_metadata_derives_version_from_path(self):
+        configer = PromptConfiger()
+        configer.load_by_configer(SimpleNamespace(
+            value={}, path="/tmp/prompts/hello.yaml"))
+        assert configer.metadata_version == "prompts.hello"
+        assert configer.metadata_module == "agentuniverse.prompt.prompt"
+        assert configer.metadata_class == "Prompt"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/config/component_configer/configers/test_prompt_configer.py` covering deterministic behaviors of `agentuniverse.agentuniverse.base.config.component_configer.configers.prompt_configer`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/config/component_configer/configers/test_prompt_configer.py -q`: 3 passed
