### PR TITLE
docs(examples): document missing docstrings in insurance_search_context_tool.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/tool/insurance_search_context_tool.py
+++ b/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/tool/insurance_search_context_tool.py
@@ -19,6 +19,16 @@ class MockAPI:
 
     def post(self, url, headers, data):
         # mock response
+        """Send a mock post request and return a MockResponse carrying the canned knowledge results.
+
+        Args:
+            url: The target url (unused by the mock).
+            headers: The request headers.
+            data: The serialized request payload.
+
+        Returns:
+            MockResponse: The mock http response.
+        """
         mock_response = {
             "result": {
                 "recallResultTuples": [
@@ -45,9 +55,19 @@ class MockResponse:
     """Mock API http response."""
 
     def __init__(self, json_data):
+        """Store the given json data on the response object.
+
+        Args:
+            json_data: The payload returned by json().
+        """
         self.json_data = json_data
 
     def json(self):
+        """Return the stored json payload.
+
+        Returns:
+            The json data passed at construction.
+        """
         return self.json_data
 
 
@@ -59,6 +79,15 @@ class SearchContextTool(Tool):
     """
 
     def execute(self, input: str, top_k: int = 2):
+        """Search the insurance knowledge context and assemble the recalled entries into a natural-language context string.
+
+        Args:
+            input(str): The search question.
+            top_k(int): Maximum number of recalled entries to include.
+
+        Returns:
+            str: The assembled search context.
+        """
         question = input
         try:
             headers = {


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/tool/insurance_search_context_tool.py`: execute, json, __init__, post.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/tool/insurance_search_context_tool.py').read())"` — the file remains syntactically valid.
