### PR TITLE
test: add unit tests for component_manager_base

### DIFF
--- a/tests/test_agentuniverse/unit/base/component/test_component_manager_base.py
+++ b/tests/test_agentuniverse/unit/base/component/test_component_manager_base.py
@@ -1,0 +1,75 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for agentuniverse.base.component.component_manager_base."""
+
+import pytest
+
+from agentuniverse.base.component.component_base import ComponentBase
+from agentuniverse.base.component.component_enum import ComponentEnum
+from agentuniverse.base.component.component_manager_base import ComponentManagerBase
+
+
+class _DummyComponent(ComponentBase):
+    component_type: ComponentEnum = ComponentEnum.AGENT
+
+
+class _DummyManager(ComponentManagerBase[_DummyComponent]):
+    def __init__(self):
+        super().__init__(ComponentEnum.AGENT)
+
+
+@pytest.fixture
+def manager():
+    """Return an empty _DummyManager instance."""
+    return _DummyManager()
+
+
+class TestComponentManagerBase:
+    """Tests for the base component manager registration logic."""
+
+    def test_register_adds_instance(self, manager):
+        instance = _DummyComponent()
+        manager.register("mock_agent", instance)
+        assert "mock_agent" in manager.get_instance_name_list()
+        assert instance in manager.get_instance_obj_list()
+
+    def test_register_duplicate_keeps_first_instance(self, manager):
+        first = _DummyComponent()
+        manager.register("mock_agent", first)
+        manager.register("mock_agent", _DummyComponent())
+        assert manager.get_instance_obj_list().count(first) == 1
+
+    def test_register_default_symbol_sets_default_instance(self, manager):
+        instance = _DummyComponent(default_symbol=True)
+        manager.register("mock_agent", instance)
+        assert "__default_instance__" in manager.get_instance_name_list()
+        assert manager.get_default_instance() is instance
+
+    def test_get_instance_obj_default_returns_same_object(self, manager):
+        instance = _DummyComponent(default_symbol=True)
+        manager.register("mock_agent", instance)
+        assert manager.get_instance_obj("__default_instance__", new_instance=False) is instance
+
+    def test_get_instance_obj_default_returns_copy(self, manager):
+        instance = _DummyComponent(default_symbol=True)
+        manager.register("mock_agent", instance)
+        copy = manager.get_instance_obj("__default_instance__")
+        assert copy is not instance
+        assert copy == instance
+
+    def test_unregister_removes_instance(self, manager):
+        manager.register("mock_agent", _DummyComponent())
+        manager.unregister("mock_agent")
+        assert "mock_agent" not in manager.get_instance_name_list()
+
+    def test_register_builtin_conflict_is_skipped(self, manager, monkeypatch):
+        first = _DummyComponent()
+        manager.register("mock_agent", first)
+        monkeypatch.setattr(
+            "agentuniverse.base.component.component_manager_base.is_system_builtin",
+            lambda obj: True,
+        )
+        manager.register("mock_agent", _DummyComponent(default_symbol=True))
+        assert manager._instance_obj_map["mock_agent"] is first
+        assert "__default_instance__" not in manager.get_instance_name_list()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/component/test_component_manager_base.py` covering deterministic behaviors of `agentuniverse.base.component.component_manager_base`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/component/test_component_manager_base.py -q`: 7 passed in 0.19s
