### PR TITLE
docs(agent): document missing docstrings in es_conversation_memory_storage.py

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
+++ b/agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py
@@ -231,6 +231,12 @@ class ElasticsearchMemoryStorage(MemoryStorage):
         return messages
 
     def _client(self):
+        """Create and return an HTTPX client bound to the Elasticsearch URL.
+
+        Returns:
+            httpx.Client: An HTTP client configured with retries and, when set,
+                the Elasticsearch basic-auth credentials.
+        """
         transport = httpx.HTTPTransport(retries=3)
         if self.user and self.password:
             return httpx.Client(
@@ -250,6 +256,12 @@ class DefaultMemoryConverter:
     """The default memory converter for ElasticsearchMemoryStorage."""
 
     def __init__(self, index_name: str, **kwargs: Any):
+        """Initialize the converter with the target Elasticsearch index name.
+
+        Args:
+            index_name (str): The name of the Elasticsearch index to write to.
+            **kwargs: Additional arguments forwarded to the parent initializer.
+        """
         super().__init__(**kwargs)
         self.index_name = index_name
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py`: _client, __init__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/memory/conversation_memory/memory_storage/es_conversation_memory_storage.py').read())"` — the file remains syntactically valid.
