### PR TITLE
docs(base): document missing docstrings in agent_first_token_log_sink.py

### DIFF
--- a/agentuniverse/base/util/logging/log_sink/agent_first_token_log_sink.py
+++ b/agentuniverse/base/util/logging/log_sink/agent_first_token_log_sink.py
@@ -14,12 +14,27 @@ from agentuniverse.base.util.monitor.monitor import Monitor
 
 
 class AgentFirstTokenLogSink(BaseFileLogSink):
+    """Log sink that records the agent first-token latency to a file log."""
+
     log_type: LogTypeEnum = LogTypeEnum.agent_first_token
 
     def process_record(self, record):
+        """Rewrite the record message with the generated first-token log.
+
+        Args:
+            record: The log record dict being processed.
+        """
         record["message"] = self.generate_log(
             cost_time=record['extra'].get('cost_time')
         )
 
     def generate_log(self, cost_time) -> str:
+        """Build the first-token cost log message.
+
+        Args:
+            cost_time: The elapsed time in seconds before the first token.
+
+        Returns:
+            str: The invocation chain prefix followed by the cost text.
+        """
         return Monitor.get_invocation_chain_str() + f" Agent first token cost {cost_time:.2f} seconds."


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/logging/log_sink/agent_first_token_log_sink.py`: AgentFirstTokenLogSink, process_record, generate_log.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/logging/log_sink/agent_first_token_log_sink.py').read())"` — the file remains syntactically valid.
