### PR TITLE
docs(agent): document missing docstrings in milvus_store.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/milvus_store.py
+++ b/agentuniverse/agent/action/knowledge/store/milvus_store.py
@@ -39,6 +39,8 @@ DEFAULT_INDEX_PARAMS = {
 
 
 class MilvusStore(Store):
+    """Milvus-backed vector store that connects to a Milvus server and loads the target collection for similarity search.
+    """
     connection_args: Optional[dict] = None
     search_args: Optional[dict] = None
     index_params: Optional[dict] = None
@@ -58,6 +60,8 @@ class MilvusStore(Store):
             )
 
     def _new_client(self) -> Any:
+        """Connect to Milvus using connection_args and load the target collection when it already exists.
+        """
         host = self.connection_args["host"]
         port = self.connection_args["port"]
         db_name = self.connection_args.get("db_name", "default")
@@ -72,6 +76,14 @@ class MilvusStore(Store):
 
     def _initialize_by_component_configer(self,
                                           milvus_store_configer: ComponentConfiger) -> 'DocProcessor':
+        """Initialize the milvus store fields from the store configer, applying the built-in defaults when options are absent.
+
+        Args:
+            milvus_store_configer(ComponentConfiger): The configer containing the store settings.
+
+        Returns:
+            DocProcessor: The initialized store instance.
+        """
         super()._initialize_by_component_configer(milvus_store_configer)
         if hasattr(milvus_store_configer, "connection_args"):
             self.connection_args = milvus_store_configer.connection_args


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/knowledge/store/milvus_store.py`: _initialize_by_component_configer, _new_client, MilvusStore.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/store/milvus_store.py').read())"` — the file remains syntactically valid.
