### PR TITLE
docs(agent): document missing docstrings in view_file_tool.py

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/view_file_tool.py
@@ -14,10 +14,25 @@ from agentuniverse.agent.action.tool.common_tool.file_path_utils import resolve_
 
 
 class ViewFileTool(Tool):
+    """Tool that returns a selected line range of a file inside the configured base directory as a JSON string.
+    """
     base_dir: str = "."
 
     @staticmethod
     def _normalize_line_number(value, field_name: str, allow_none: bool = False):
+        """Normalize a line number value into an int, allowing None only when allow_none is set.
+
+        Args:
+            value: The raw line number.
+            field_name(str): Field name used in error messages.
+            allow_none(bool): Whether None is allowed.
+
+        Returns:
+            The normalized int or None.
+
+        Raises:
+            ValueError: If the value is not a canonical integer.
+        """
         if value is None and allow_none:
             return None
         if isinstance(value, bool):
@@ -39,6 +54,16 @@ class ViewFileTool(Tool):
                 start_line: int = 0,
                 end_line: int = None
                 ) -> str:
+        """Read the requested line range of the file and return it as a JSON string with status information.
+
+        Args:
+            file_path(str | ToolInput): Path of the file, or a ToolInput holding it.
+            start_line(int): First line to read (0-based).
+            end_line(int): Exclusive end line.
+
+        Returns:
+            str: A JSON string with the content and status.
+        """
         if isinstance(file_path, ToolInput):
             params = file_path.to_dict()
             start_line = params.get('start_line', start_line)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/tool/common_tool/view_file_tool.py`: execute, _normalize_line_number, ViewFileTool.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/tool/common_tool/view_file_tool.py').read())"` — the file remains syntactically valid.
