### PR TITLE
docs(workflow): document missing docstrings in knowledge_node.py

### DIFF
--- a/agentuniverse/workflow/node/knowledge_node.py
+++ b/agentuniverse/workflow/node/knowledge_node.py
@@ -17,6 +17,8 @@ from agentuniverse.workflow.workflow_output import WorkflowOutput
 
 
 class KnowledgeNodeData(NodeData):
+    """NodeData subclass holding the knowledge node input configuration.
+    """
     inputs: Optional[KnowledgeNodeInputParams] = None
 
 
@@ -26,10 +28,26 @@ class KnowledgeNode(Node):
     _data_cls = KnowledgeNodeData
 
     def __init__(self, **kwargs):
+        """Initialize the knowledge node and set its type to the knowledge node enum.
+
+        Args:
+            **kwargs: Field values for the node.
+        """
         super().__init__(**kwargs)
         self.type = NodeEnum.KNOWLEDGE
 
     def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
+        """Query the configured knowledge instances with the resolved input parameters and concatenate the retrieved document texts.
+
+        Args:
+            workflow_output(WorkflowOutput): The workflow execution output.
+
+        Returns:
+            NodeOutput: The node output holding the retrieved knowledge text.
+
+        Raises:
+            ValueError: If a referenced knowledge is not registered.
+        """
         inputs: KnowledgeNodeInputParams = self._data.inputs
 
         param_map = {


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/workflow/node/knowledge_node.py`: _run, __init__, KnowledgeNodeData.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/workflow/node/knowledge_node.py').read())"` — the file remains syntactically valid.
