### PR TITLE
docs(workflow): document missing docstrings in end_node.py

### DIFF
--- a/agentuniverse/workflow/node/end_node.py
+++ b/agentuniverse/workflow/node/end_node.py
@@ -16,6 +16,8 @@ from agentuniverse.workflow.workflow_output import WorkflowOutput
 
 
 class EndNodeData(NodeData):
+    """NodeData subclass holding the end node input configuration.
+    """
     inputs: Optional[EndNodeInputParams] = None
 
 
@@ -24,10 +26,26 @@ class EndNode(Node):
     _data_cls = EndNodeData
 
     def __init__(self, **kwargs):
+        """Initialize the end node and set its type to the end node enum.
+
+        Args:
+            **kwargs: Field values for the node.
+        """
         super().__init__(**kwargs)
         self.type = NodeEnum.END
 
     def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
+        """Resolve the template variables of the end prompt with the resolved input parameters and store the final output.
+
+        Args:
+            workflow_output(WorkflowOutput): The workflow execution output.
+
+        Returns:
+            NodeOutput: The node output holding the final prompt value.
+
+        Raises:
+            ValueError: If a template variable can not be resolved.
+        """
         inputs: EndNodeInputParams = self._data.inputs
         prompt: NodeInfoParams = inputs.prompt
         if isinstance(prompt.value, dict):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/workflow/node/end_node.py`: _run, __init__, EndNodeData.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/workflow/node/end_node.py').read())"` — the file remains syntactically valid.
