### PR TITLE
docs(agent): document missing docstrings in react_planner.py

### DIFF
--- a/agentuniverse/agent/plan/planner/react_planner/react_planner.py
+++ b/agentuniverse/agent/plan/planner/react_planner/react_planner.py
@@ -78,6 +78,15 @@ class ReActPlanner(Planner):
 
     @staticmethod
     def get_run_config(agent_model: AgentModel, input_object: InputObject) -> RunnableConfig:
+        """Build the RunnableConfig with stream-output and invoke callbacks.
+
+        Args:
+            agent_model (AgentModel): The agent model whose info and profile drive the callbacks.
+            input_object (InputObject): The user input carrying the optional output stream.
+
+        Returns:
+            RunnableConfig: Config with stream-output and invoke callbacks registered.
+        """
         config = RunnableConfig()
         callbacks = []
         output_stream = input_object.get_data('output_stream')
@@ -89,6 +98,14 @@ class ReActPlanner(Planner):
 
     @staticmethod
     def acquire_tools(action) -> list[LangchainTool]:
+        """Resolve the action's tools, knowledge and agents into LangChain tools.
+
+        Args:
+            action: The action dict listing the tool, knowledge and agent names.
+
+        Returns:
+            list[LangchainTool]: The LangChain tool list built from the resolved instances.
+        """
         tool_names: list = action.get('tool') or list()
         lc_tools: list[LangchainTool] = list()
         for tool_name in tool_names:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/plan/planner/react_planner/react_planner.py`: get_run_config, acquire_tools.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/plan/planner/react_planner/react_planner.py').read())"` — the file remains syntactically valid.
