### PR TITLE
docs(examples): document missing docstrings in test_demo_agent.py

### DIFF
--- a/examples/sample_standard_app/intelligence/test/test_demo_agent.py
+++ b/examples/sample_standard_app/intelligence/test/test_demo_agent.py
@@ -20,9 +20,21 @@ class DemoAgentTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        """Start the AgentUniverse runtime for the demo app.
+
+        Initializes the global runtime from ``config/config.toml`` so the
+        agent instance can be retrieved in the test methods.
+        """
         AgentUniverse().start(config_path='../../config/config.toml')
 
     def read_output(self, output_stream: queue.Queue):
+        """Consume streamed agent output in a loop until the EOF marker.
+
+        Args:
+            output_stream (queue.Queue): Queue the agent writes streamed
+                chunks into; reading stops on the EOF marker or an empty
+                queue.
+        """
         while True:
             try:
                 res = output_stream.get()
@@ -33,6 +45,11 @@ class DemoAgentTest(unittest.TestCase):
                 break
 
     def test_demo_agent_stream(self):
+        """Run the demo agent with an output stream.
+
+        Fetches the ``demo_agent`` instance, consumes its streamed output in
+        a background thread and prints the final run result.
+        """
         output_stream = queue.Queue(10)
         instance: Agent = AgentManager().get_instance_obj('demo_agent')
         Thread(target=self.read_output, args=(output_stream,)).start()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_standard_app/intelligence/test/test_demo_agent.py`: setUp, read_output, test_demo_agent_stream.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_standard_app/intelligence/test/test_demo_agent.py').read())"` — the file remains syntactically valid.
