### PR TITLE
docs(workflow): document missing docstrings in llm_node.py

### DIFF
--- a/agentuniverse/workflow/node/llm_node.py
+++ b/agentuniverse/workflow/node/llm_node.py
@@ -19,6 +19,8 @@ from agentuniverse.workflow.workflow_output import WorkflowOutput
 
 
 class LLMNodeData(NodeData):
+    """NodeData subclass holding the llm node input configuration.
+    """
     inputs: Optional[LLMNodeInputParams] = None
 
 
@@ -28,10 +30,26 @@ class LLMNode(Node):
     _data_cls = LLMNodeData
 
     def __init__(self, **kwargs):
+        """Initialize the llm node and set its type to the llm node enum.
+
+        Args:
+            **kwargs: Field values for the node.
+        """
         super().__init__(**kwargs)
         self.type = NodeEnum.LLM
 
     def _run(self, workflow_output: WorkflowOutput) -> NodeOutput:
+        """Invoke the referenced LLM with the prompt resolved from the input parameters and store the model answer.
+
+        Args:
+            workflow_output(WorkflowOutput): The workflow execution output.
+
+        Returns:
+            NodeOutput: The node output holding the model answer.
+
+        Raises:
+            ValueError: If the referenced llm is not registered or a template variable can not be resolved.
+        """
         inputs: LLMNodeInputParams = self._data.inputs
 
         param_map = {


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/workflow/node/llm_node.py`: _run, __init__, LLMNodeData.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/workflow/node/llm_node.py').read())"` — the file remains syntactically valid.
