### PR TITLE
docs(base): document missing docstrings in framework_context_manager.py

### DIFF
--- a/agentuniverse/base/context/framework_context_manager.py
+++ b/agentuniverse/base/context/framework_context_manager.py
@@ -25,6 +25,8 @@ class FrameworkContextManager:
 
     @property
     def context_dict(self) -> dict:
+        """Return the current task-level context dict, initializing it to an empty dict when unset.
+        """
         if not self.__context_dict.get(None):
             self.__context_dict.set({})
         return self.__context_dict.get({})
@@ -116,9 +118,17 @@ class FrameworkContextManager:
         return context_tokens
 
     def clear_all_contexts(self):
+        """Reset the current context dict so that all context variables are cleared.
+        """
         self.__context_dict.set({})
 
     def set_log_context(self, context_key: str, context_value: Any):
+        """Merge the given key-value pair into the LOG_CONTEXT dict of the current context.
+
+        Args:
+            context_key(str): The log context key.
+            context_value(Any): The log context value.
+        """
         current_context = self.get_context("LOG_CONTEXT")
         log_context = current_context.copy() if isinstance(current_context, dict) else {}
         log_context[context_key] = context_value


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/context/framework_context_manager.py`: set_log_context, clear_all_contexts, context_dict.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/context/framework_context_manager.py').read())"` — the file remains syntactically valid.
