### PR TITLE
docs(examples): document missing docstrings in openai_protocol_reviewing_agent.py

### DIFF
--- a/examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_reviewing_agent.py
+++ b/examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_reviewing_agent.py
@@ -5,9 +5,38 @@ from agentuniverse.agent.template.reviewing_agent_template import ReviewingAgent
 
 
 class ReviewingOpenAIAgentTemplate(OpenAIProtocolTemplate, ReviewingAgentTemplate):
+    """OpenAI-protocol agent template for reviewing tasks.
+
+    Combines the OpenAI chat protocol with reviewing-agent behavior so a
+    reviewing run can be served through an OpenAI-compatible interface while
+    its progress is streamed to the caller.
+    """
+
     def parse_openai_protocol_output(self, output_object: OutputObject) -> OutputObject:
+        """Keep the reviewing output object untouched.
+
+        Args:
+            output_object (OutputObject): The agent's raw result.
+
+        Returns:
+            OutputObject: The same output object, without reshaping it into
+            the standard OpenAI chat.completion payload.
+        """
         return output_object
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Prepare agent input and stream a reviewing heading.
+
+        Emits a '## Reviewing' chunk on the caller's output stream (when one
+        is present) and delegates the remaining input preparation to the
+        reviewing template.
+
+        Args:
+            input_object (InputObject): The original input object.
+            agent_input (dict): The agent input dict being built.
+
+        Returns:
+            dict: The prepared agent input dict.
+        """
         self.add_output_stream(input_object.get_data('output_stream', None), '## Reviewing \n\n')
         return super().parse_input(input_object, agent_input)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_reviewing_agent.py`: ReviewingOpenAIAgentTemplate, parse_openai_protocol_output, parse_input.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/openai_protocol_app/intelligence/agentic/agent/agent_template/openai_protocol_reviewing_agent.py').read())"` — the file remains syntactically valid.
