### PR TITLE
docs(base): document missing docstrings in tool_input_log_sink.py

### DIFF
--- a/agentuniverse/base/util/logging/log_sink/tool_input_log_sink.py
+++ b/agentuniverse/base/util/logging/log_sink/tool_input_log_sink.py
@@ -14,12 +14,27 @@ from agentuniverse.base.util.monitor.monitor import Monitor
 
 
 class ToolInputLogSink(BaseFileLogSink):
+    """Log sink that records the tool input of a tool invocation to a log file."""
+
     log_type: LogTypeEnum = LogTypeEnum.tool_input
 
     def process_record(self, record):
+        """Fill the log record message with the generated tool-input log.
+
+        Args:
+            record: the loguru log record being processed.
+        """
         record["message"] = self.generate_log(
             tool_input=record['extra'].get('tool_input')
         )
 
     def generate_log(self, tool_input: Union[str, dict]) -> str:
+        """Generate the log text for the given tool input.
+
+        Args:
+            tool_input (Union[str, dict]): the input passed to the tool.
+
+        Returns:
+            str: the invocation chain prefix followed by the tool input text.
+        """
         return Monitor.get_invocation_chain_str() + f" Tool input is {tool_input}"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/logging/log_sink/tool_input_log_sink.py`: ToolInputLogSink, process_record, generate_log.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/logging/log_sink/tool_input_log_sink.py').read())"` — the file remains syntactically valid.
