### PR TITLE
docs(base): document missing docstrings in llm_input_log_sink.py

### DIFF
--- a/agentuniverse/base/util/logging/log_sink/llm_input_log_sink.py
+++ b/agentuniverse/base/util/logging/log_sink/llm_input_log_sink.py
@@ -14,12 +14,27 @@ from agentuniverse.base.util.monitor.monitor import Monitor
 
 
 class LLMInputLogSink(BaseFileLogSink):
+    """Log sink that records the input received by an LLM call to a log file."""
+
     log_type: LogTypeEnum = LogTypeEnum.llm_input
 
     def process_record(self, record):
+        """Fill the log record message with the generated LLM-input log.
+
+        Args:
+            record: the loguru log record being processed.
+        """
         record["message"] = self.generate_log(
             llm_input=record['extra'].get('llm_input')
         )
 
     def generate_log(self, llm_input: Union[str, dict]) -> str:
+        """Generate the log text for an LLM input event.
+
+        Args:
+            llm_input (Union[str, dict]): the input payload sent to the LLM.
+
+        Returns:
+            str: the invocation chain prefix followed by the LLM-input notice.
+        """
         return Monitor.get_invocation_chain_str() + f" LLM get an input."


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/logging/log_sink/llm_input_log_sink.py`: LLMInputLogSink, process_record, generate_log.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/logging/log_sink/llm_input_log_sink.py').read())"` — the file remains syntactically valid.
