### PR TITLE
docs(examples): document missing docstrings in test_discussion_agents.py

### DIFF
--- a/examples/sample_apps/discussion_group_app/intelligence/test/test_discussion_agents.py
+++ b/examples/sample_apps/discussion_group_app/intelligence/test/test_discussion_agents.py
@@ -14,11 +14,14 @@ from agentuniverse.base.agentuniverse import AgentUniverse
 
 
 class DiscussionAgentsTest(unittest.TestCase):
+    """Integration test for the discussion-group sample app agents."""
 
     def setUp(self) -> None:
+        """Start the agentUniverse application before each test case."""
         AgentUniverse().start(config_path='../../config/config.toml')
 
     def test_discussion_agents(self):
+        """Run the discussion-group agent and check an output is produced."""
         instance: Agent = AgentManager().get_instance_obj('discussion_group_agent')
         output_object: OutputObject = instance.run(input='甜粽子好吃还是咸粽子好吃')
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/discussion_group_app/intelligence/test/test_discussion_agents.py`: DiscussionAgentsTest, setUp, test_discussion_agents.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/discussion_group_app/intelligence/test/test_discussion_agents.py').read())"` — the file remains syntactically valid.
