### PR TITLE
test: add unit tests for component_enum

### DIFF
--- a/tests/test_agentuniverse/unit/base/component/test_component_enum.py
+++ b/tests/test_agentuniverse/unit/base/component/test_component_enum.py
@@ -1,0 +1,44 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+"""Unit tests for the ComponentEnum enumeration."""
+
+import pytest
+
+from agentuniverse.base.component.component_enum import ComponentEnum
+
+
+class TestComponentEnum:
+    """Tests for the ComponentEnum enumeration."""
+
+    def test_members_have_expected_values(self):
+        assert ComponentEnum.AGENT.value == "AGENT"
+        assert ComponentEnum.KNOWLEDGE.value == "KNOWLEDGE"
+        assert ComponentEnum.LLM.value == "LLM"
+        assert ComponentEnum.TOOL.value == "TOOL"
+        assert ComponentEnum.WORKFLOW.value == "WORKFLOW"
+        assert ComponentEnum.LOG_SINK.value == "LOG_SINK"
+
+    def test_to_value_list_contains_all_members(self):
+        values = ComponentEnum.to_value_list()
+        assert len(values) == len(list(ComponentEnum))
+        assert set(values) == {member.value for member in ComponentEnum}
+        assert "AGENT" in values
+        assert "DEFAULT" in values
+
+    def test_from_value_returns_matching_member(self):
+        assert ComponentEnum.from_value("AGENT") is ComponentEnum.AGENT
+        assert ComponentEnum.from_value("PLANNER") is ComponentEnum.PLANNER
+        assert ComponentEnum.from_value("PROMPT") is ComponentEnum.PROMPT
+
+    def test_from_value_unknown_value_raises(self):
+        with pytest.raises(ValueError):
+            ComponentEnum.from_value("UNKNOWN_COMPONENT")
+
+    def test_member_iteration_order(self):
+        members = [member.value for member in ComponentEnum]
+        assert members[0] == "AGENT"
+        assert members[-1] == "CONTEXT_ROUTER"
+
+    def test_enum_members_are_distinct(self):
+        assert len({member.value for member in ComponentEnum}) == len(list(ComponentEnum))


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/base/component/test_component_enum.py` covering deterministic behaviors of `agentuniverse.base.component.component_enum`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/base/component/test_component_enum.py -q`: 6 passed in 0.01s
