### PR TITLE
docs(base): document missing docstrings in agent_invocation_log_sink.py

### DIFF
--- a/agentuniverse/base/util/logging/log_sink/agent_invocation_log_sink.py
+++ b/agentuniverse/base/util/logging/log_sink/agent_invocation_log_sink.py
@@ -12,14 +12,30 @@ from agentuniverse.base.util.monitor.monitor import Monitor
 
 
 class AgentInvocationLogSink(BaseFileLogSink):
+    """Log sink that records agent invocation events to a log file."""
+
     log_type: LogTypeEnum = LogTypeEnum.agent_invocation
 
     def process_record(self, record):
+        """Fill the log record message with the generated agent invocation log.
+
+        Args:
+            record: the loguru log record being processed.
+        """
         record["message"] = self.generate_log(
             cost_time=record['extra'].get('cost_time'),
             agent_output=record['extra'].get('agent_output')
         )
 
     def generate_log(self, cost_time: float, agent_output: OutputObject) -> str:
+        """Generate the log text for an agent invocation event.
+
+        Args:
+            cost_time (float): the elapsed time of the agent invocation.
+            agent_output (OutputObject): the output produced by the agent.
+
+        Returns:
+            str: the invocation chain prefix followed by the cost and output.
+        """
         log_str = f" Agent cost {cost_time:.2f} seconds"
         return Monitor.get_invocation_chain_str() + log_str + f" Agent output is {agent_output.to_json_str()}"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/logging/log_sink/agent_invocation_log_sink.py`: AgentInvocationLogSink, process_record, generate_log.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/logging/log_sink/agent_invocation_log_sink.py').read())"` — the file remains syntactically valid.
