### PR TITLE
docs(base): document missing docstrings in tool_invocation_log_sink.py

### DIFF
--- a/agentuniverse/base/util/logging/log_sink/tool_invocation_log_sink.py
+++ b/agentuniverse/base/util/logging/log_sink/tool_invocation_log_sink.py
@@ -13,14 +13,30 @@ from agentuniverse.base.util.monitor.monitor import Monitor
 
 
 class ToolInvocationLogSink(BaseFileLogSink):
+    """Log sink that records tool invocation events to a log file."""
+
     log_type: LogTypeEnum = LogTypeEnum.tool_invocation
 
     def process_record(self, record):
+        """Fill the log record message with the generated tool invocation log.
+
+        Args:
+            record: the loguru log record being processed.
+        """
         record["message"] = self.generate_log(
             cost_time=record['extra'].get('cost_time'),
             tool_output=record['extra'].get('tool_output')
         )
 
     def generate_log(self, cost_time: float, tool_output) -> str:
+        """Generate the log text for a tool invocation event.
+
+        Args:
+            cost_time (float): the elapsed time of the tool invocation.
+            tool_output: the output produced by the tool.
+
+        Returns:
+            str: the invocation chain prefix followed by the cost and output.
+        """
         log_str = f" Tool cost {cost_time:.2f} seconds"
         return Monitor.get_invocation_chain_str() + log_str + f" Tool output is {tool_output}"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/logging/log_sink/tool_invocation_log_sink.py`: ToolInvocationLogSink, process_record, generate_log.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/logging/log_sink/tool_invocation_log_sink.py').read())"` — the file remains syntactically valid.
