### PR TITLE
docs(base): document missing docstrings in retry.py

### DIFF
--- a/agentuniverse/base/annotation/retry.py
+++ b/agentuniverse/base/annotation/retry.py
@@ -12,9 +12,38 @@ from typing import Any, Callable
 
 
 def retry(max_retries: int = 3, delay: float = 1.0) -> Callable:
+    """Return a decorator that retries the wrapped callable on failure.
+
+    Args:
+        max_retries: The maximum number of attempts for the callable.
+        delay: The number of seconds to wait between attempts.
+
+    Returns:
+        Callable: the decorator that applies the retry behavior.
+    """
     def decorator(func: Callable) -> Callable:
+        """Wrap the given callable with retry logic.
+
+        Args:
+            func: The callable to invoke and retry on exception.
+
+        Returns:
+            Callable: the retry-enabled wrapper around ``func``.
+        """
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """Execute func, retrying until success or retries are exhausted.
+
+            Args:
+                args: Positional arguments forwarded to the wrapped callable.
+                kwargs: Keyword arguments forwarded to the wrapped callable.
+
+            Returns:
+                Any: the result of the wrapped callable.
+
+            Raises:
+                Exception: if the callable fails on every attempt.
+            """
             retries = 0
             last_exception = None
             while retries < max_retries:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/annotation/retry.py`: retry, decorator, wrapper.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/annotation/retry.py').read())"` — the file remains syntactically valid.
