### PR TITLE
docs(examples): document missing docstrings in product_info_tool.py

### DIFF
--- a/examples/sample_apps/basic_sop_app/intelligence/agentic/tool/product_info_tool.py
+++ b/examples/sample_apps/basic_sop_app/intelligence/agentic/tool/product_info_tool.py
@@ -10,8 +10,18 @@ from basic_sop_app.intelligence.utils.constant import product_b_info, product_c_
 
 
 class SearchProductInfoTool(Tool):
+    """Tool that composes insurance product descriptions for brands B and C from requested tags."""
 
     def execute(self, input: list):
+        """Compose the product description texts for brands B and C.
+
+        Args:
+            input (list): Tags of the product clauses to include (e.g. 'A'-'L').
+                The tag 'G' is skipped and 'K' is treated as 'L'.
+
+        Returns:
+            dict: Mapping of brand keys 'B' and 'C' to their extended descriptions.
+        """
         product_info_item_list = input
 
         product_b_description = product_b_info.BASE_PRODUCT_DESCRIPTION


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/basic_sop_app/intelligence/agentic/tool/product_info_tool.py`: SearchProductInfoTool, execute.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/basic_sop_app/intelligence/agentic/tool/product_info_tool.py').read())"` — the file remains syntactically valid.
