### PR TITLE
docs(examples): document missing docstrings in test_translation_agent.py

### DIFF
--- a/examples/sample_apps/translation_agent_app/intelligence/test/test_translation_agent.py
+++ b/examples/sample_apps/translation_agent_app/intelligence/test/test_translation_agent.py
@@ -19,9 +19,11 @@ class TranslationAgentTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        """Start the AgentUniverse runtime with the sample app config before each test."""
         AgentUniverse().start(config_path='../../config/config.toml')
 
     def test_translation_agent_long(self):
+        """Run the translation_by_token agent over the long sample text and persist its output."""
         instance: Agent = AgentManager().get_instance_obj('translation_by_token_agent')
         with open('translation_data/long_text.txt', 'r') as f:
             data = f.read()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/translation_agent_app/intelligence/test/test_translation_agent.py`: setUp, test_translation_agent_long.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/translation_agent_app/intelligence/test/test_translation_agent.py').read())"` — the file remains syntactically valid.
