### PR TITLE
docs(examples): document missing docstrings in law_knowledge.py

### DIFF
--- a/examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.py
+++ b/examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.py
@@ -13,7 +13,18 @@ from agentuniverse.agent.action.knowledge.store.document import Document
 
 
 class LawKnowledge(Knowledge):
+    """Knowledge subclass that formats retrieved legal documents for LLM consumption."""
+
     def to_llm(self, retrieved_docs: List[Document]) -> Any:
+        """Serialize the retrieved documents into a single text block for the LLM.
+
+        Args:
+            retrieved_docs (List[Document]): The documents retrieved from the store.
+
+        Returns:
+            Any: A string joining each document's JSON payload (text and source
+                file name) with separator lines.
+        """
 
         retrieved_texts = [json.dumps({
             "text": doc.text,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.py`: LawKnowledge, to_llm.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/rag_app/intelligence/agentic/knowledge/law_knowledge.py').read())"` — the file remains syntactically valid.
