### PR TITLE
docs(examples): document missing docstrings in law_knowledge.py

### DIFF
--- a/examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.py
+++ b/examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.py
@@ -13,7 +13,18 @@ from agentuniverse.agent.action.knowledge.store.document import Document
 
 
 class LawKnowledge(Knowledge):
+    """A Knowledge subclass that serializes retrieved legal documents for the LLM."""
+
     def to_llm(self, retrieved_docs: List[Document]) -> Any:
+        """Convert the retrieved documents into a single LLM-readable text block.
+
+        Args:
+            retrieved_docs: The documents retrieved from the knowledge store.
+
+        Returns:
+            str: One JSON snippet per document (its text and source file name),
+            joined by '=' separator lines.
+        """
 
         retrieved_texts = [json.dumps({
             "text": doc.text,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.py`: LawKnowledge, to_llm.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/react_agent_app/intelligence/agentic/knowledge/law_knowledge.py').read())"` — the file remains syntactically valid.
