### PR TITLE
docs(examples): document missing docstrings in memory_query_test.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/test/memory_query_test.py
+++ b/examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/test/memory_query_test.py
@@ -9,6 +9,11 @@ AgentUniverse().start(config_path='../../config/config.toml', core_mode=True)
 
 
 def test_query_memory(s_id: str):
+    """Print the input/output conversation messages stored for the given session.
+
+    Args:
+        s_id: The session id whose stored messages are queried.
+    """
     memory_instance: Memory = MemoryManager().get_instance_obj('global_conversation_memory')
     messages: List[Message] = memory_instance.get(session_id=s_id, top_k=500, type=['input', 'output'])
     for message in messages:
@@ -16,6 +21,11 @@ def test_query_memory(s_id: str):
         print(f"{message.metadata.get('timestamp')} {message.metadata.get('prefix')}: {message.content}")
 
 def test_query_memory_with_trace_id(s_id: str):
+    """Print the stored messages of a session filtered by a specific trace id.
+
+    Args:
+        s_id: The session id whose stored messages are queried.
+    """
     memory_instance: Memory = MemoryManager().get_instance_obj('global_conversation_memory')
     messages: List[Message] = memory_instance.get(session_id=s_id, trace_id="39fbcb33aca8427cb59c37d6f39adc10",
                                                   type=['input', 'output'])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/test/memory_query_test.py`: test_query_memory, test_query_memory_with_trace_id.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/test/memory_query_test.py').read())"` — the file remains syntactically valid.
