### PR TITLE
docs(examples): document missing docstrings in rag_agent_case_template.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/agentic/agent/agent_instance/rag_agent_case_template.py
+++ b/examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/agentic/agent/agent_instance/rag_agent_case_template.py
@@ -21,6 +21,8 @@ from agentuniverse.prompt.prompt import Prompt
 
 
 class RagAgentCaseTemplate(RagAgentTemplate):
+    """A RAG agent template that grounds answers with a web search and memory."""
+
     def execute_query(self, input: str):
         """
         Args:
@@ -43,6 +45,18 @@ class RagAgentCaseTemplate(RagAgentTemplate):
 
     def customized_execute(self, input_object: InputObject, agent_input: dict, memory: Memory, llm: LLM, prompt: Prompt,
                            **kwargs) -> dict:
+        """Run the customized RAG flow: tool grounding, memory handling, and the LLM chain.
+
+        Args:
+            input_object: The input object carrying the output stream.
+            agent_input: The agent input dict, updated with background and memory.
+            memory: The memory used to store and summarize the conversation.
+            llm: The LLM instance used to build the chain.
+            prompt: The prompt template used to build the chain.
+
+        Returns:
+            The agent input dict enriched with the answer under 'output'.
+        """
         # invoke tool
         knowledge_res: str = self.execute_query(agent_input.get('input'))
         agent_input['background'] = knowledge_res


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/agentic/agent/agent_instance/rag_agent_case_template.py`: RagAgentCaseTemplate, customized_execute.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_single_agent_and_memory/intelligence/agentic/agent/agent_instance/rag_agent_case_template.py').read())"` — the file remains syntactically valid.
