### PR TITLE
docs(agent): document missing docstrings in image_ocr_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py
@@ -21,6 +21,18 @@ class ImageOCRReader(Reader):
     """
 
     def _load_data(self, file: Union[str, Path], ext_info: Optional[Dict] = None) -> List[Document]:
+        """OCR an image file and return a single Document holding the recognized text.
+
+        Args:
+            file(Union[str, Path]): Path of the image file.
+            ext_info(Optional[Dict]): Extra metadata merged into the document.
+
+        Returns:
+            List[Document]: A one-element list with the recognized text.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
         print(f"debugging: ImageOCRReader start load file={file}")
         if isinstance(file, str):
             file = Path(file)
@@ -37,6 +49,17 @@ class ImageOCRReader(Reader):
 
     def _ocr(self, file: Path) -> (str, str):
         # Try PaddleOCR
+        """Recognize text from an image file, trying PaddleOCR, pytesseract and easyocr in that order.
+
+        Args:
+            file(Path): Path of the image file.
+
+        Returns:
+            tuple: The recognized text and the name of the engine used.
+
+        Raises:
+            ImportError: If no OCR engine is installed.
+        """
         try:
             from paddleocr import PaddleOCR  # type: ignore
             print("debugging: ImageOCRReader using PaddleOCR")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py`: _ocr, _load_data.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/reader/image/image_ocr_reader.py').read())"` — the file remains syntactically valid.
