### PR TITLE
docs(agent): document missing docstrings in query_keyword_extractor.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
+++ b/agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py
@@ -18,6 +18,8 @@ from agentuniverse.base.config.component_configer.component_configer import \
 
 
 class QueryKeywordExtractor(QueryParaphraser):
+    """Query paraphraser that expands query keywords by running the configured keyword-extractor doc processor over the query text.
+    """
     keyword_extractor: Optional[str] = "jieba_keyword_extractor"
 
     def query_paraphrase(self, origin_query: Query) -> Query:
@@ -33,6 +35,14 @@ class QueryKeywordExtractor(QueryParaphraser):
 
     def _initialize_by_component_configer(self,
                                          query_paraphraser_configer: ComponentConfiger) -> 'QueryParaphraser':
+        """Initialize the query paraphraser from a component configer.
+
+        Args:
+            query_paraphraser_configer(ComponentConfiger): The configer containing the settings.
+
+        Returns:
+            QueryParaphraser: The initialized paraphraser instance.
+        """
         super()._initialize_by_component_configer(query_paraphraser_configer)
         if hasattr(query_paraphraser_configer, "keyword_extractor"):
             self.keyword_extractor = query_paraphraser_configer.keyword_extractor


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py`: _initialize_by_component_configer, QueryKeywordExtractor.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/query_paraphraser/query_keyword_extractor.py').read())"` — the file remains syntactically valid.
