### PR TITLE
docs(agent): document missing docstrings in write_file_tool.py

### DIFF
--- a/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
+++ b/agentuniverse/agent/action/tool/common_tool/write_file_tool.py
@@ -15,12 +15,24 @@ from agentuniverse.agent.action.tool.common_tool.tool_input_utils import parse_s
 
 
 class WriteFileTool(Tool):
+    """Tool that writes text content to a file inside the configured base directory.
+    """
     base_dir: str = "."
 
     def execute(self,
                 file_path: str | ToolInput,
                 content: str = '',
                 append: bool = False) -> str:
+        """Write the given content to the target file, optionally appending, and return a JSON status string.
+
+        Args:
+            file_path(str | ToolInput): The file path, or a ToolInput holding it.
+            content(str): The text content to write.
+            append(bool): Whether to append to the file instead of overwriting.
+
+        Returns:
+            str: A JSON string with the write result and status.
+        """
         if isinstance(file_path, ToolInput):
             params = file_path.to_dict()
             content = params.get('content', content)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/tool/common_tool/write_file_tool.py`: execute, WriteFileTool.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/tool/common_tool/write_file_tool.py').read())"` — the file remains syntactically valid.
