### PR TITLE
docs(agentuniverse_extension): document missing docstrings in custom_flask_response_sink.py

### DIFF
--- a/agentuniverse_extension/logger/log_sink/custom_flask_response_sink.py
+++ b/agentuniverse_extension/logger/log_sink/custom_flask_response_sink.py
@@ -10,7 +10,18 @@ from agentuniverse.base.util.logging.log_sink.flask_response_log_sink import Fla
 
 
 class CustomFlaskResponseSink(FlaskResponseLogSink):
+    """Custom flask response log sink that formats the response and its duration into a log string.
+    """
     def generate_log(self, flask_response, elapsed_time) -> str:
+        """Format the flask response and elapsed time into a log string.
+
+        Args:
+            flask_response: The flask response object or string.
+            elapsed_time: The response elapsed time in seconds.
+
+        Returns:
+            str: The formatted response log string.
+        """
         if isinstance(flask_response, str):
             response_str = (f"Response: {flask_response} "
                             f"Duration: {elapsed_time:.3f}s")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse_extension/logger/log_sink/custom_flask_response_sink.py`: generate_log, CustomFlaskResponseSink.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_extension/logger/log_sink/custom_flask_response_sink.py').read())"` — the file remains syntactically valid.
