### PR TITLE
docs(examples): document missing docstrings in insurance_info_tool.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/insurance_info_tool.py
+++ b/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/insurance_info_tool.py
@@ -11,7 +11,17 @@ from demo_startup_app_with_single_agent_and_actions.intelligence.utils.constant.
 
 
 class InsuranceInfoTool(Tool):
+    """A tool that returns the description of the given insurance product."""
+
     def execute(self, input: str):
+        """Return the description matching the given insurance product name.
+
+        Args:
+            input: The insurance product name (e.g. '保险产品A').
+
+        Returns:
+            The description of the matching product, defaulting to product B.
+        """
         ins_name = input
         if ins_name == '保险产品A':
             return PROD_A_DESCRIPTION


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/insurance_info_tool.py`: InsuranceInfoTool, execute.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/insurance_info_tool.py').read())"` — the file remains syntactically valid.
