### PR TITLE
docs: add docstrings to summarize_processor

### DIFF
--- a/examples/third_party_examples/tools/knowledge_process_tool/summarize_processor.py
+++ b/examples/third_party_examples/tools/knowledge_process_tool/summarize_processor.py
@@ -38,6 +38,15 @@ class SummarizeDocs(DocProcessor):
     summary_metadata_key: str = "is_summary"
 
     def _process_docs(self, origin_docs: List[Document], query: Query | None = None) -> List[Document]:
+        """Summarize the retrieved documents through the configured LLM and return the summary (plus originals when requested).
+
+        Args:
+            origin_docs(List[Document]): The documents to summarize.
+            query(Query | None): Unused, kept for interface compatibility.
+
+        Returns:
+            List[Document]: The summary document, plus the original documents when return_only_summary is False.
+        """
         if not origin_docs:
             return origin_docs
 
@@ -58,6 +67,14 @@ class SummarizeDocs(DocProcessor):
         return [summary_doc] + origin_docs
 
     def _initialize_by_component_configer(self, doc_processor_configer: ComponentConfiger) -> "DocProcessor":
+        """Initialize the processor fields from the doc processor configer.
+
+        Args:
+            doc_processor_configer(ComponentConfiger): The configer containing the settings.
+
+        Returns:
+            DocProcessor: The initialized processor instance.
+        """
         super()._initialize_by_component_configer(doc_processor_configer)
         if hasattr(doc_processor_configer, "llm"):
             self.llm = str(doc_processor_configer.llm)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/third_party_examples/tools/knowledge_process_tool/summarize_processor.py`: _initialize_by_component_configer, _process_docs.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/tools/knowledge_process_tool/summarize_processor.py').read())"` — the file remains syntactically valid.
