### PR TITLE
test: add unit tests for insurance_agent

### DIFF
--- a/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/test_insurance_agent.py
+++ b/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/test_insurance_agent.py
@@ -1,0 +1,48 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/01 00:00
+# @Author  : Yue Wang
+# @FileName: test_insurance_agent.py
+"""Unit tests for the InsuranceAgent demo agent instance."""
+
+import pytest
+
+from agentuniverse.agent.input_object import InputObject
+from examples.startup_app.demo_startup_app_with_single_agent_and_actions.intelligence.agentic.agent.agent_instance.insurance_agent import (
+    InsuranceAgent,
+)
+
+
+class TestInsuranceAgent:
+    """Test InsuranceAgent key and input/output handling helpers."""
+
+    @pytest.fixture
+    def agent(self):
+        return InsuranceAgent()
+
+    def test_input_keys(self, agent):
+        assert agent.input_keys() == ['input']
+
+    def test_output_keys(self, agent):
+        assert agent.output_keys() == ['output']
+
+    def test_parse_input_fills_input_key(self, agent):
+        input_object = InputObject({'input': 'user question'})
+        result = agent.parse_input(input_object, {'input': None})
+        assert result == {'input': 'user question'}
+
+    def test_parse_input_with_default_key_value(self, agent):
+        input_object = InputObject({'other': 'value'})
+        result = agent.parse_input(input_object, {'input': 'unset'})
+        assert result['input'] is None
+
+    def test_parse_result_keeps_output(self, agent):
+        result = agent.parse_result({'input': 'q', 'output': 'answer'})
+        assert result['output'] == 'answer'
+        assert result['input'] == 'q'
+
+    def test_parse_result_round_trips_agent_input(self, agent):
+        input_object = InputObject({'input': 'q'})
+        parsed = agent.parse_input(input_object, {})
+        assert 'input' in parsed


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/test_insurance_agent.py` covering deterministic behaviors of `examples.startup_app.demo_startup_app_with_single_agent_and_actions.intelligence.agentic.agent.agent_instance.insurance_agent`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/agent/agent_instance/test_insurance_agent.py -q`: 6 passed
