### PR TITLE
test: add unit tests for insurance_search_context_tool

### DIFF
--- a/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/test_insurance_search_context_tool.py
+++ b/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/test_insurance_search_context_tool.py
@@ -1,0 +1,58 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/01/01 00:00
+# @Author  : Yue Wang
+# @FileName: test_insurance_search_context_tool.py
+"""Unit tests for the SearchContextTool demo knowledge-retrieval tool."""
+
+from examples.startup_app.demo_startup_app_with_single_agent_and_actions.intelligence.agentic.tool.insurance_search_context_tool import (
+    MockAPI,
+    MockResponse,
+    SearchContextTool,
+)
+
+
+class TestMockApi:
+    """Test the mock API helpers used by the tool."""
+
+    def test_mock_response_returns_json(self):
+        response = MockResponse({"result": {}})
+        assert response.json() == {"result": {}}
+
+    def test_mock_api_post_returns_recall_tuples(self):
+        response = MockAPI().post('url', {'Content-Type': 'application/json'}, '{}')
+        tuples = response.json()['result']['recallResultTuples']
+        assert len(tuples) == 3
+
+
+class TestSearchContextTool:
+    """Test SearchContextTool.execute output assembly."""
+
+    def test_execute_with_top_k_two_limits_results(self):
+        result = SearchContextTool().execute('保险产品A升级规则', top_k=2)
+        assert '提出的问题是:保险产品A升级规则' in result
+        assert 'mock data: 保险产品A升级规则' in result
+        assert 'mock data: 保险产品A简介' in result
+        assert '保障期限12个月' not in result
+
+    def test_execute_with_top_k_one_returns_single_block(self):
+        result = SearchContextTool().execute('保险产品A升级规则', top_k=1)
+        assert result.count('knowledgeTitle:') == 1
+        assert '不支持升级' in result
+        assert '免费体验版' not in result
+
+    def test_execute_with_large_top_k_returns_all_blocks(self):
+        result = SearchContextTool().execute('保险产品A', top_k=10)
+        assert result.count('knowledgeTitle:') == 3
+        assert '保障期限12个月' in result
+
+    def test_execute_with_zero_top_k_returns_header_only(self):
+        result = SearchContextTool().execute('question', top_k=0)
+        assert '提出的问题是:question' in result
+        assert 'knowledgeTitle:' not in result
+
+    def test_execute_includes_question_and_content_fields(self):
+        result = SearchContextTool().execute('保险产品A简介', top_k=2)
+        assert 'knowledgeTitle: mock data: 保险产品A简介' in result
+        assert 'knowledgeContent:' in result


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/test_insurance_search_context_tool.py` covering deterministic behaviors of `examples.startup_app.demo_startup_app_with_single_agent_and_actions.intelligence.agentic.tool.insurance_search_context_tool`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_single_agent_and_actions/intelligence/agentic/tool/test_insurance_search_context_tool.py -q`: 7 passed
