### PR TITLE
test: add unit tests for txt_file_util

### DIFF
--- a/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/utils/common/test_txt_file_util.py
+++ b/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/utils/common/test_txt_file_util.py
@@ -1,0 +1,50 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+"""Unit tests for the example-app TxtFile utilities (file based)."""
+
+import pytest
+
+from examples.startup_app.demo_startup_app_with_agent_templates.intelligence.utils.common.txt_file_util import TxtFileOps, TxtFileReader
+
+
+class TestTxtFileOps:
+    """Test extension validation and existence checks."""
+
+    def test_unsupported_extension_raises(self, tmp_path):
+        path = tmp_path / "notes.jsonl"
+        path.write_text("x")
+        with pytest.raises(Exception, match="Unsupported file extension"):
+            TxtFileOps.is_file_exist(str(path))
+
+    def test_missing_txt_file_returns_false(self):
+        assert TxtFileOps.is_file_exist("/tmp/missing_b6.txt") is False
+
+    def test_existing_txt_file_returns_true(self, tmp_path):
+        path = tmp_path / "data.txt"
+        path.write_text("hi", encoding="utf-8")
+        assert TxtFileOps.is_file_exist(str(path)) is True
+
+
+class TestTxtFileReader:
+    """Test reading txt lines."""
+
+    def test_read_txt_obj_lines(self, tmp_path):
+        path = tmp_path / "data.txt"
+        path.write_text("line one\nline two\n", encoding="utf-8")
+        reader = TxtFileReader(str(path))
+        assert reader.read_txt_obj() == "line one"
+        assert reader.read_txt_obj() == "line two"
+        assert reader.read_txt_obj() is None
+
+    def test_missing_file_raises(self):
+        reader = TxtFileReader("/tmp/no_such_b6.txt")
+        assert reader.file_handler is None
+        with pytest.raises(Exception, match="No txt file to read"):
+            reader.read_txt_obj()
+
+    def test_read_txt_obj_list(self, tmp_path):
+        path = tmp_path / "data.txt"
+        path.write_text("a\nb\nc\n", encoding="utf-8")
+        assert TxtFileReader(str(path)).read_txt_obj_list() == ["a", "b", "c"]


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/utils/common/test_txt_file_util.py` covering deterministic behaviors of `examples.startup_app.demo_startup_app_with_agent_templates.intelligence.utils.common.txt_file_util`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/utils/common/test_txt_file_util.py -q`: 6 passed
