### PR TITLE
test: add unit tests for insurance_planning_agent

### DIFF
--- a/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/agent/agent_instance/test_insurance_planning_agent.py
+++ b/tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/agent/agent_instance/test_insurance_planning_agent.py
@@ -1,0 +1,30 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2026/09/02
+"""Unit tests for the InsurancePlanningAgent example agent (pure parts)."""
+
+from agentuniverse.agent.input_object import InputObject
+from examples.startup_app.demo_startup_app_with_agent_templates.intelligence.agentic.agent.agent_instance.insurance_planning_agent import InsurancePlanningAgent
+
+
+class TestInsurancePlanningAgent:
+    """Test agent input/output keys and pure parse methods."""
+
+    def test_input_keys(self):
+        assert InsurancePlanningAgent().input_keys() == [
+            "input", "prod_description"]
+
+    def test_output_keys(self):
+        assert InsurancePlanningAgent().output_keys() == ["planning_output"]
+
+    def test_parse_input_copies_fields(self):
+        agent = InsurancePlanningAgent()
+        input_object = InputObject({"input": "i", "prod_description": "p"})
+        agent_input = agent.parse_input(input_object, {})
+        assert agent_input == {"input": "i", "prod_description": "p"}
+
+    def test_parse_result_exposes_planning_output(self):
+        agent = InsurancePlanningAgent()
+        result = agent.parse_result({"output": "plan"})
+        assert result["planning_output"] == "plan"


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/agent/agent_instance/test_insurance_planning_agent.py` covering deterministic behaviors of `examples.startup_app.demo_startup_app_with_agent_templates.intelligence.agentic.agent.agent_instance.insurance_planning_agent`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/agentic/agent/agent_instance/test_insurance_planning_agent.py -q`: 4 passed
