### PR TITLE
test: add unit tests for product_b_info

### DIFF
--- a/tests/test_agentuniverse/unit/examples/sample_apps/basic_sop_app/intelligence/utils/constant/test_product_b_info.py
+++ b/tests/test_agentuniverse/unit/examples/sample_apps/basic_sop_app/intelligence/utils/constant/test_product_b_info.py
@@ -1,0 +1,64 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+# @Time    : 2025/06/13 00:00
+# @Author  : Yue Wang
+# @FileName: test_product_b_info.py
+
+import unittest
+import string
+
+import examples.sample_apps.basic_sop_app.intelligence.utils.constant.product_b_info as product_b_info
+
+
+class TestProductBInfo(unittest.TestCase):
+    """Unit tests for the product_b_info constant module."""
+
+    def test_base_product_description_present(self):
+        """The module exposes a non-empty base product description."""
+        self.assertIsInstance(product_b_info.BASE_PRODUCT_DESCRIPTION, str)
+        self.assertTrue(product_b_info.BASE_PRODUCT_DESCRIPTION.strip())
+
+    def test_base_product_description_mentions_product_name(self):
+        """The base description identifies the ZeRenXian B product."""
+        description = product_b_info.BASE_PRODUCT_DESCRIPTION
+        self.assertIn('责任险', description)
+        self.assertIn('基础版', description)
+
+    def test_description_map_keys_are_letters_a_to_m(self):
+        """PRODUCT_DESCRIPTION_MAP covers exactly the sections A..M."""
+        self.assertEqual(set(product_b_info.PRODUCT_DESCRIPTION_MAP.keys()),
+                         set(string.ascii_uppercase[:13]))
+
+    def test_description_map_values_are_non_empty_strings(self):
+        """Every mapped section is a non-empty textual description."""
+        for key, value in product_b_info.PRODUCT_DESCRIPTION_MAP.items():
+            with self.subTest(key=key):
+                self.assertIsInstance(value, str)
+                self.assertTrue(value.strip())
+
+    def test_description_map_contains_applicant_rules(self):
+        """Section A states the applicant/insured eligibility rules."""
+        applicant = product_b_info.PRODUCT_DESCRIPTION_MAP['A']
+        self.assertIn('投保人', applicant)
+        self.assertIn('被保险人', applicant)
+
+    def test_description_map_contains_purchase_limit(self):
+        """Section C states the maximum purchase quantity."""
+        self.assertIn('限购', product_b_info.PRODUCT_DESCRIPTION_MAP['C'])
+
+    def test_description_map_contains_cancellation_rules(self):
+        """Section H documents the contract cancellation/refund rules."""
+        cancellation = product_b_info.PRODUCT_DESCRIPTION_MAP['H']
+        self.assertIn('退保', cancellation)
+        self.assertIn('未满期净保险费', cancellation)
+
+    def test_description_map_contains_waiting_period_info(self):
+        """Section M states that there is no waiting period."""
+        waiting = product_b_info.PRODUCT_DESCRIPTION_MAP['M']
+        self.assertIn('等待期', waiting)
+        self.assertIn('无等待期', waiting)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added unit test file `tests/test_agentuniverse/unit/examples/sample_apps/basic_sop_app/intelligence/utils/constant/test_product_b_info.py` covering deterministic behaviors of `examples.sample_apps.basic_sop_app.intelligence.utils.constant.product_b_info`.
- Adds regression coverage for the module's pure/unit-testable logic following the repo test conventions.
- Verified with `python3 -m pytest tests/test_agentuniverse/unit/examples/sample_apps/basic_sop_app/intelligence/utils/constant/test_product_b_info.py -q`: 8 passed, 13 subtests passed in 0.01s
