### PR TITLE
docs(base): document missing docstrings in planner_product.py

### DIFF
--- a/agentuniverse_product/base/planner_product.py
+++ b/agentuniverse_product/base/planner_product.py
@@ -20,6 +20,7 @@ class PlannerProduct(Product):
 
     @property
     def instance(self) -> Planner:
+        """Return the concrete Planner instance bound to this product."""
         return self._instance
 
     def initialize_by_component_configer(self,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse_product/base/planner_product.py`: PlannerProduct.instance.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_product/base/planner_product.py').read())"` — the file remains syntactically valid.
