### PR TITLE
docs(base): document missing docstrings in logging_config.py

### DIFF
--- a/agentuniverse/base/util/logging/logging_config.py
+++ b/agentuniverse/base/util/logging/logging_config.py
@@ -134,4 +134,10 @@ class LoggingConfig(object):
 
 
 def init_log_config(config_path: Optional[str] = None):
+    """Initialize the log config with the given config file.
+
+    Args:
+        config_path(str): the path of the toml log config file; if it is None
+            or cannot be loaded, the default log config is used.
+    """
     LoggingConfig(config_path)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/logging/logging_config.py`: init_log_config.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/logging/logging_config.py').read())"` — the file remains syntactically valid.
