### PR TITLE
docs(base): document missing docstrings in custom_key_configer.py

### DIFF
--- a/agentuniverse/base/config/custom_configer/custom_key_configer.py
+++ b/agentuniverse/base/config/custom_configer/custom_key_configer.py
@@ -16,6 +16,13 @@ from ..configer import Configer
 class CustomKeyConfiger(Configer):
     """Use to manage user secret key."""
     def __init__(self, config_path: str = None):
+        """Initialize the CustomKeyConfiger.
+
+        Args:
+            config_path(str): the path of the custom key config file; when given
+                and readable, the KEY_LIST entries are exported as environment
+                variables, otherwise loading is skipped.
+        """
         self._Configer__value = {}
         super().__init__(config_path)
         if config_path:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/config/custom_configer/custom_key_configer.py`: __init__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/config/custom_configer/custom_key_configer.py').read())"` — the file remains syntactically valid.
