### PR TITLE
docs(third_party_examples): document missing docstrings in server_application.py

### DIFF
--- a/examples/third_party_examples/apps/app_with_goole_search_tool/bootstrap/intelligence/server_application.py
+++ b/examples/third_party_examples/apps/app_with_goole_search_tool/bootstrap/intelligence/server_application.py
@@ -17,6 +17,7 @@ class ServerApplication:
 
     @classmethod
     def start(cls):
+        """Bootstrap the AgentUniverse core and start the web server."""
         AgentUniverse().start()
         start_web_server()
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/third_party_examples/apps/app_with_goole_search_tool/bootstrap/intelligence/server_application.py`: ServerApplication.start.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/app_with_goole_search_tool/bootstrap/intelligence/server_application.py').read())"` — the file remains syntactically valid.
