### PR TITLE
docs(dal): document missing docstrings in message_library.py

### DIFF
--- a/agentuniverse_product/dal/message_library.py
+++ b/agentuniverse_product/dal/message_library.py
@@ -35,6 +35,12 @@ class MessageORM(Base):
 
 @singleton
 class MessageLibrary:
+    """Provides database access for chat messages.
+
+    Adds, deletes and queries messages stored in the `message` table,
+    converting between MessageORM and MessageDO objects.
+    """
+
     @staticmethod
     def get_db_session():
         """Get the database session."""


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a missing Google-style docstring for the `MessageLibrary` class in `agentuniverse_product/dal/message_library.py`.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_product/dal/message_library.py').read())"` — the file remains syntactically valid.
