### PR TITLE
docs(service): document missing docstrings in session_dto.py

### DIFF
--- a/agentuniverse_product/service/model/session_dto.py
+++ b/agentuniverse_product/service/model/session_dto.py
@@ -13,6 +13,15 @@ from agentuniverse_product.service.model.message_dto import MessageDTO
 
 
 class SessionDTO(BaseModel):
+    """DTO (data transfer object) representing an agent session.
+
+    Attributes:
+        id (str): The unique session id.
+        agent_id (str): The id of the agent the session belongs to.
+        messages (Optional[list[MessageDTO]]): The messages in the session.
+        gmt_created (Optional[str]): The session create time.
+        gmt_modified (Optional[str]): The session update time.
+    """
     id: str = Field(description="ID")
     agent_id: str = Field(description="session agent id")
     messages: Optional[list[MessageDTO]] = Field(description="session messages", default=[])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse_product/service/model/session_dto.py`: SessionDTO.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_product/service/model/session_dto.py').read())"` — the file remains syntactically valid.
