### PR TITLE
docs(service): document missing docstrings in plugin_dto.py

### DIFF
--- a/agentuniverse_product/service/model/plugin_dto.py
+++ b/agentuniverse_product/service/model/plugin_dto.py
@@ -13,6 +13,16 @@ from agentuniverse_product.service.model.tool_dto import ToolDTO
 
 
 class PluginDTO(BaseModel):
+    """DTO (data transfer object) representing a plugin.
+
+    Attributes:
+        id (str): The unique plugin id.
+        nickname (Optional[str]): The plugin nickname.
+        avatar (Optional[str]): The plugin avatar path.
+        description (Optional[str]): The plugin description.
+        toolset (Optional[List[ToolDTO]]): The tools provided by the plugin.
+        openapi_desc (Optional[str]): The plugin OpenAPI schema description.
+    """
     id: str = Field(description="ID")
     nickname: Optional[str] = Field(description="plugin nickname", default="")
     avatar: Optional[str] = Field(description="plugin avatar path", default="")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse_product/service/model/plugin_dto.py`: PluginDTO.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_product/service/model/plugin_dto.py').read())"` — the file remains syntactically valid.
