### PR TITLE
docs(service): document missing docstrings in message_dto.py

### DIFF
--- a/agentuniverse_product/service/model/message_dto.py
+++ b/agentuniverse_product/service/model/message_dto.py
@@ -11,6 +11,15 @@ from pydantic import BaseModel, Field
 
 
 class MessageDTO(BaseModel):
+    """DTO (data transfer object) representing a chat message within a session.
+
+    Attributes:
+        id (int): The unique message id.
+        session_id (str): The id of the session the message belongs to.
+        content (Optional[str]): The message content.
+        gmt_created (Optional[str]): The message create time.
+        gmt_modified (Optional[str]): The message update time.
+    """
     id: int = Field(description="ID")
     session_id: str = Field(description="Session ID")
     content: Optional[str] = Field(description="message content", default="")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse_product/service/model/message_dto.py`: MessageDTO.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse_product/service/model/message_dto.py').read())"` — the file remains syntactically valid.
