### PR TITLE
docs(base): document missing docstrings in au_trace_manager.py

### DIFF
--- a/agentuniverse/base/util/tracing/au_trace_manager.py
+++ b/agentuniverse/base/util/tracing/au_trace_manager.py
@@ -11,6 +11,20 @@ from agentuniverse.base.tracing import au_trace_manager as new_module
 
 
 def __getattr__(name):
+    """Module-level shim forwarding deprecated attribute lookups to the new module.
+
+    Emits a DeprecationWarning and returns the requested attribute from the new
+    tracing module when present; raises AttributeError otherwise.
+
+    Args:
+        name: The name of the missing module attribute.
+
+    Returns:
+        The attribute value forwarded from the new module location.
+
+    Raises:
+        AttributeError: If the attribute is absent from the new module.
+    """
     if hasattr(new_module, name):
         warnings.warn(
             f"Importing {name} from 'agentuniverse.base.util.tracing.au_trace_manager' "


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/base/util/tracing/au_trace_manager.py`: __getattr__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/util/tracing/au_trace_manager.py').read())"` — the file remains syntactically valid.
