### PR TITLE
refactor(sample_apps): add return type annotations in multimodal_agent.py

### DIFF
--- a/examples/sample_apps/multimodal_app/intelligence/test/multimodal_agent.py
+++ b/examples/sample_apps/multimodal_app/intelligence/test/multimodal_agent.py
@@ -12,7 +12,7 @@ from agentuniverse.agent.agent_manager import AgentManager
 AgentUniverse().start(config_path='../../config/config.toml', core_mode=True)
 
 
-def chat_with_images():
+def chat_with_images() -> None:
     instance: Agent = AgentManager().get_instance_obj('multimodal_agent')
     output_object = instance.run(input="图中描绘的是什么景象?", session_id='test_image', image_urls=[
         'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20241022/emyrja/dog_and_girl.jpeg'])
@@ -25,7 +25,7 @@ def chat_with_images():
     print(res_info)
 
 
-def chat_with_audio():
+def chat_with_audio() -> None:
     instance: Agent = AgentManager().get_instance_obj('multimodal_agent')
     output_object = instance.run(input='帮我完成音频里的任务内容？', session_id='test_audio',
                                  audio_url='https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20240916/kvkadk/%E6%8E%A8%E8%8D%90%E4%B9%A6.wav')


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added `-> None` return annotations for `chat_with_images` and `chat_with_audio` in `examples/sample_apps/multimodal_app/intelligence/test/multimodal_agent.py`.
- Both functions perform actions and never return a value, so `-> None` is unambiguous and safe.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/multimodal_app/intelligence/test/multimodal_agent.py').read())"` — the file remains syntactically valid.
