### PR TITLE
docs(sample_apps): document missing docstrings in test_rag_agent.py

### DIFF
--- a/examples/sample_apps/rag_app/intelligence/test/test_rag_agent.py
+++ b/examples/sample_apps/rag_app/intelligence/test/test_rag_agent.py
@@ -19,6 +19,11 @@ class RagAgentTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        """Set up the test case.
+
+        Starts the AgentUniverse runtime with the sample app configuration in
+        core mode so the rag agent can be instantiated by the tests.
+        """
         AgentUniverse().start(config_path='../../config/config.toml', core_mode=True)
 
     def test_rag_agent(self):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/rag_app/intelligence/test/test_rag_agent.py`: RagAgentTest.setUp.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/rag_app/intelligence/test/test_rag_agent.py').read())"` — the file remains syntactically valid.
