### PR TITLE
docs(sample_apps): document missing docstrings in mcp_application.py

### DIFF
--- a/examples/sample_apps/discussion_group_app/bootstrap/intelligence/mcp_application.py
+++ b/examples/sample_apps/discussion_group_app/bootstrap/intelligence/mcp_application.py
@@ -16,6 +16,11 @@ class ServerApplication:
 
     @classmethod
     def start(cls):
+        """Start the AgentUniverse core and the MCP server.
+
+        Boots the AgentUniverse runtime in core mode and then starts the MCP
+        server manager to expose the configured servers over MCP.
+        """
         AgentUniverse().start(core_mode=True)
         MCPServerManager().start_server()
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/discussion_group_app/bootstrap/intelligence/mcp_application.py`: ServerApplication.start.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/discussion_group_app/bootstrap/intelligence/mcp_application.py').read())"` — the file remains syntactically valid.
