### PR TITLE
docs(test): document missing docstrings in test_confluence_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_confluence_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_confluence_reader.py
@@ -7,7 +7,10 @@ from agentuniverse.agent.action.knowledge.reader.cloud.confluence_reader import 
 
 
 class TestConfluenceReader(unittest.TestCase):
+    """Tests for the ConfluenceReader._public_metadata helper."""
+
     def test_public_metadata_filters_token_fields(self):
+        """_public_metadata drops secret token/password style fields."""
         metadata = ConfluenceReader._public_metadata({
             "token": "secret",
             "password": "secret-2",
@@ -18,6 +21,7 @@ class TestConfluenceReader(unittest.TestCase):
         self.assertEqual(metadata, {"site_url": "https://example.atlassian.net"})
 
     def test_public_metadata_keeps_non_secret_fields(self):
+        """_public_metadata keeps ordinary non-secret fields untouched."""
         metadata = ConfluenceReader._public_metadata({
             "space": "ENG",
             "label": "design",


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_confluence_reader.py`: TestConfluenceReader, test_public_metadata_filters_token_fields, test_public_metadata_keeps_non_secret_fields.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_confluence_reader.py').read())"` — the file remains syntactically valid.
