### PR TITLE
docs(test): document missing docstrings in test_google_docs_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py
@@ -7,18 +7,26 @@ from agentuniverse.agent.action.knowledge.reader.cloud.google_docs_reader import
 
 
 class FakeGoogleDocsReader(GoogleDocsReader):
+    """Fake GoogleDocsReader subclass stubbing out network/service helpers."""
+
     def _build_drive_service(self, ext_info):
+        """Return a stub drive service object instead of building a real one."""
         return object()
 
     def _export_html(self, drive, file_id: str) -> str:
+        """Return canned HTML for the given file id without calling Drive."""
         return "<html><body>Hello</body></html>"
 
     def _html_to_text(self, html: str) -> str:
+        """Convert the given HTML string to plain text (canned for tests)."""
         return "Hello"
 
 
 class TestGoogleDocsReader(unittest.TestCase):
+    """Tests for GoogleDocsReader metadata sanitization."""
+
     def test_service_account_path_is_not_copied_to_metadata(self):
+        """Load data must not leak the service account JSON path into metadata."""
         reader = FakeGoogleDocsReader()
 
         docs = reader._load_data(
@@ -34,6 +42,7 @@ class TestGoogleDocsReader(unittest.TestCase):
         self.assertNotIn("GOOGLE_SERVICE_ACCOUNT_JSON", metadata)
 
     def test_public_metadata_filters_known_secret_keys(self):
+        """_public_metadata strips known secret keys such as credentials."""
         metadata = GoogleDocsReader._public_metadata({
             "service_account_json": "secret.json",
             "credentials": "secret",


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py`: FakeGoogleDocsReader, TestGoogleDocsReader, _build_drive_service, _export_html, _html_to_text, test_service_account_path_is_not_copied_to_metadata, test_public_metadata_filters_known_secret_keys.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/reader/cloud/test_google_docs_reader.py').read())"` — the file remains syntactically valid.
