### PR TITLE
docs(test): document missing docstrings in test_gemini_embedding.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_gemini_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_gemini_embedding.py
@@ -16,6 +16,7 @@ class GeminiEmbeddingTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        """Create a GeminiEmbedding instance for the test methods."""
         self.embedding = GeminiEmbedding(embedding_model_name='text-embedding-004',
                                          embedding_dims=768,
                                          gemini_api_key='xxxxxxx')
@@ -24,18 +25,21 @@ class GeminiEmbeddingTest(unittest.TestCase):
         # os.environ['https_proxy'] = 'http://127.0.0.1:10808'
 
     def test_get_embeddings(self) -> None:
+        """Verify that get_embeddings returns one 768-dim vector per text."""
         res = self.embedding.get_embeddings(texts=["hello world", "agentUniverse"])
         print(res)
         self.assertEqual(len(res), 2)
         self.assertEqual(len(res[0]), 768)
 
     def test_async_get_embeddings(self) -> None:
+        """Verify that async_get_embeddings returns one 768-dim vector per text."""
         res = asyncio.run(self.embedding.async_get_embeddings(texts=["hello world", "agentUniverse"]))
         print(res)
         self.assertEqual(len(res), 2)
         self.assertEqual(len(res[0]), 768)
 
     def test_as_langchain(self) -> None:
+        """Verify that as_langchain produces a working langchain embedding wrapper."""
         langchain_embedding = self.embedding.as_langchain()
         res = langchain_embedding.embed_documents(texts=["hello world", "agentUniverse"])
         print(res)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_gemini_embedding.py`: setUp, test_get_embeddings, test_async_get_embeddings, test_as_langchain.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_gemini_embedding.py').read())"` — the file remains syntactically valid.
