### PR TITLE
docs(test): document missing docstrings in test_gemini_openai_style_llm.py

### DIFF
--- a/tests/test_agentuniverse/unit/llm/test_gemini_openai_style_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_gemini_openai_style_llm.py
@@ -7,13 +7,17 @@ from agentuniverse.llm.default.gemini_openai_style_llm import GeminiOpenAIStyleL
 
 
 class TestGeminiOpenAIStyleLLM(unittest.TestCase):
+    """Unit tests for the GeminiOpenAIStyleLLM wrapper."""
+
     def setUp(self) -> None:
+        """Create a GeminiOpenAIStyleLLM instance under test."""
         self.llm = GeminiOpenAIStyleLLM(model_name='gemini-2.0-flash',
                                         api_key='xxxx',
                                         api_base='https://generativelanguage.googleapis.com/v1beta/openai/',
                                         proxy='http://127.0.0.1:10808')
 
     def test_call(self) -> None:
+        """Verify a synchronous non-streaming call returns an LLM result."""
         messages = [
             {
                 "role": "user",
@@ -24,6 +28,7 @@ class TestGeminiOpenAIStyleLLM(unittest.TestCase):
         print(output.__str__())
 
     def test_acall(self) -> None:
+        """Verify an asynchronous non-streaming call returns an LLM result."""
         messages = [
             {
                 "role": "user",
@@ -34,6 +39,7 @@ class TestGeminiOpenAIStyleLLM(unittest.TestCase):
         print(output.__str__())
 
     def test_call_stream(self):
+        """Verify a synchronous streaming call yields response chunks."""
         messages = [
             {
                 "role": "user",
@@ -46,6 +52,7 @@ class TestGeminiOpenAIStyleLLM(unittest.TestCase):
 
     #
     def test_acall_stream(self):
+        """Verify the async streaming path through the call_stream helper."""
         messages = [
             {
                 "role": "user",
@@ -55,18 +62,24 @@ class TestGeminiOpenAIStyleLLM(unittest.TestCase):
         asyncio.run(self.call_stream(messages=messages))
 
     async def call_stream(self, messages: list):
+        """Consume and print chunks from an asynchronous streaming call.
 
+        Args:
+            messages: The chat messages to send to the LLM.
+        """
         async for chunk in await self.llm.acall(messages=messages, streaming=True):
             print(chunk, end='')
         print()
 
     def test_as_langchain(self):
+        """Verify the LLM can be wrapped for use in a langchain chain."""
         langchain_llm = self.llm.as_langchain()
         llm_chain = ConversationChain(llm=langchain_llm)
         res = llm_chain.predict(input='hello')
         print(res)
 
     def test_get_num_tokens(self):
+        """Verify the token-count estimation call runs successfully."""
         print(self.llm.get_num_tokens('"content": "hi, please introduce yourself",'))
 
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/llm/test_gemini_openai_style_llm.py`: TestGeminiOpenAIStyleLLM, setUp, test_call, test_acall, test_call_stream, test_acall_stream, call_stream, test_as_langchain, test_get_num_tokens.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/llm/test_gemini_openai_style_llm.py').read())"` — the file remains syntactically valid.
