### PR TITLE
docs(test): document missing docstrings in test_email_document_tool.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_email_document_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_email_document_tool.py
@@ -18,15 +18,19 @@ YAML_PATH = os.path.join(os.path.dirname(email_module.__file__), "email_document
 
 
 class EmailDocumentToolTest(unittest.TestCase):
+    """Unit tests for the create/read/extract/info modes of EmailDocumentTool."""
     def setUp(self):
+        """Set up a temporary directory and an EmailDocumentTool instance backed by it, seeded with a sample attachment file."""
         self.directory = tempfile.TemporaryDirectory()
         self.tool = EmailDocumentTool(base_dir=self.directory.name)
         self.write("files/report.txt", b"quarterly data")
 
     def tearDown(self):
+        """Clean up the temporary directory created in setUp."""
         self.directory.cleanup()
 
     def write(self, name, content):
+        """Write the given bytes to the named file inside the temporary directory, creating parent directories as needed."""
         path = os.path.join(self.directory.name, name)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "wb") as output:
@@ -34,6 +38,7 @@ class EmailDocumentToolTest(unittest.TestCase):
         return path
 
     def create(self, name="message.eml", **kwargs):
+        """Execute the tool in create mode with default headers/body, letting keyword arguments override any parameter."""
         params = {
             "mode": "create",
             "file_path": name,
@@ -44,9 +49,11 @@ class EmailDocumentToolTest(unittest.TestCase):
         return self.tool.execute(**params)
 
     def save_message(self, name, message):
+        """Serialize an EmailMessage with the default email policy and write it to the named file inside the temporary directory."""
         self.write(name, message.as_bytes(policy=policy.default))
 
     def test_create_read_info_round_trip(self):
+        """Verify a created message can be read back with headers/body/attachment intact and info reports the attachment count."""
         result = self.create(html_body="<p>Hello</p>", attachments=["files/report.txt"])
         self.assertEqual(result["status"], "success")
         read = self.tool.execute(mode="read", file_path="message.eml")
@@ -58,6 +65,7 @@ class EmailDocumentToolTest(unittest.TestCase):
         self.assertEqual(info["attachment_count"], 1)
 
     def test_extract_attachment(self):
+        """Verify extract mode writes the message attachment into the output directory."""
         self.create(attachments=["files/report.txt"])
         result = self.tool.execute(mode="extract", file_path="message.eml", output_dir="out")
         self.assertEqual(result["status"], "success")
@@ -65,6 +73,7 @@ class EmailDocumentToolTest(unittest.TestCase):
             self.assertEqual(stream.read(), b"quarterly data")
 
     def test_selective_extract(self):
+        """Verify extract mode honors attachment_names and only extracts the requested attachment."""
         self.write("files/other.bin", b"other")
         self.create(attachments=["files/report.txt", "files/other.bin"])
         result = self.tool.execute(
@@ -74,6 +83,7 @@ class EmailDocumentToolTest(unittest.TestCase):
         self.assertTrue(result["output_paths"][0].endswith("other.bin"))
 
     def test_extract_preflights_overwrite(self):
+        """Verify extract mode refuses to overwrite an existing output file unless overwrite is set, leaving no partial output."""
         self.write("files/other.bin", b"other")
         self.create(attachments=["files/report.txt", "files/other.bin"])
         self.write("out/other.bin", b"existing")
@@ -82,6 +92,7 @@ class EmailDocumentToolTest(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(self.directory.name, "out/report.txt")))
 
     def test_rejects_unsafe_attachment_filename(self):
+        """Verify reading a message with a path-traversing attachment filename is rejected."""
         message = EmailMessage()
         message["From"] = "a@example.com"
         message["To"] = "b@example.com"
@@ -92,6 +103,7 @@ class EmailDocumentToolTest(unittest.TestCase):
         self.assertIn("unsafe attachment filename", result["error"])
 
     def test_rejects_duplicate_attachment_names(self):
+        """Verify messages whose attachments share a filename are rejected in info mode."""
         message = EmailMessage()
         message["From"] = "a@example.com"
         message["To"] = "b@example.com"
@@ -103,18 +115,22 @@ class EmailDocumentToolTest(unittest.TestCase):
         self.assertIn("duplicate attachment", result["error"])
 
     def test_rejects_header_injection(self):
+        """Verify headers containing newline characters are rejected as invalid."""
         result = self.create(headers={"from": "a@example.com\nBcc: x@example.com", "to": "b@example.com"})
         self.assertIn("invalid characters", result["error"])
 
     def test_requires_sender_and_recipient(self):
+        """Verify create mode requires both the from and to headers."""
         result = self.create(headers={"from": "a@example.com"})
         self.assertIn("headers.to is required", result["error"])
 
     def test_requires_a_body(self):
+        """Verify create mode requires a text or html body."""
         result = self.create(text_body=None, html_body=None)
         self.assertIn("text_body or html_body", result["error"])
 
     def test_read_truncates_body(self):
+        """Verify read mode truncates the body to max_body_chars and flags the result as truncated."""
         self.create(text_body="abcdefgh")
         self.tool.max_body_chars = 4
         result = self.tool.execute(mode="read", file_path="message.eml")
@@ -122,16 +138,19 @@ class EmailDocumentToolTest(unittest.TestCase):
         self.assertEqual(result["text_body"], "abcd")
 
     def test_attachment_size_limit(self):
+        """Verify create mode rejects attachments larger than max_attachment_bytes."""
         self.tool.max_attachment_bytes = 3
         result = self.create(attachments=["files/report.txt"])
         self.assertIn("max_attachment_bytes", result["error"])
 
     def test_create_refuses_overwrite(self):
+        """Verify create mode refuses to overwrite an existing file unless overwrite is set."""
         self.create()
         result = self.create(text_body="replacement")
         self.assertIn("overwrite=true", result["error"])
 
     def test_write_limit_preserves_existing(self):
+        """Verify exceeding max_write_bytes fails without modifying the existing destination file."""
         self.write("message.eml", b"existing")
         self.tool.max_write_bytes = 1
         result = self.create(overwrite=True)
@@ -140,10 +159,12 @@ class EmailDocumentToolTest(unittest.TestCase):
             self.assertEqual(stream.read(), b"existing")
 
     def test_path_and_extension_validation(self):
+        """Verify path escapes and non-.eml file names are rejected in info mode."""
         self.assertIn("escapes", self.tool.execute(mode="info", file_path="../message.eml")["error"])
         self.assertIn(".eml", self.tool.execute(mode="info", file_path="message.txt")["error"])
 
     def test_missing_requested_attachment(self):
+        """Verify extract mode reports an error when a requested attachment is not present in the message."""
         self.create(attachments=["files/report.txt"])
         result = self.tool.execute(
             mode="extract", file_path="message.eml", output_dir="out", attachment_names=["missing.bin"]
@@ -152,7 +173,9 @@ class EmailDocumentToolTest(unittest.TestCase):
 
 
 class EmailDocumentRegistrationTest(unittest.TestCase):
+    """Tests that the email_document_tool.yaml configuration registers an EmailDocumentTool component."""
     def setUp(self):
+        """Load the email_document_tool.yaml config and stash the current application configer so it can be restored."""
         self.config = Configer(path=os.path.abspath(YAML_PATH)).load()
         try:
             self.previous = ApplicationConfigManager().app_configer
@@ -160,14 +183,17 @@ class EmailDocumentRegistrationTest(unittest.TestCase):
             self.previous = None
 
     def tearDown(self):
+        """Restore the application configer saved in setUp."""
         ApplicationConfigManager().app_configer = self.previous
 
     def test_schema(self):
+        """Verify the yaml loads as a TOOL component whose metadata class is EmailDocumentTool."""
         component = ComponentConfiger().load_by_configer(self.config)
         self.assertEqual(component.get_component_config_type(), ComponentEnum.TOOL.value)
         self.assertEqual(component.metadata_class, "EmailDocumentTool")
 
     def test_manager(self):
+        """Verify ToolManager instantiates an EmailDocumentTool from the yaml config with the expected input keys."""
         configer = ToolConfiger().load_by_configer(self.config)
         app = AppConfiger()
         app.tool_configer_map = {configer.name: configer}


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_email_document_tool.py`: EmailDocumentToolTest, EmailDocumentRegistrationTest, setUp, tearDown, write, create, save_message, test_create_read_info_round_trip, test_extract_attachment, test_selective_extract, test_extract_preflights_overwrite, test_rejects_unsafe_attachment_filename, test_rejects_duplicate_attachment_names, test_rejects_header_injection, test_requires_sender_and_recipient, test_requires_a_body, test_read_truncates_body, test_attachment_size_limit, test_create_refuses_overwrite, test_write_limit_preserves_existing, test_path_and_extension_validation, test_missing_requested_attachment, test_schema, test_manager.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_email_document_tool.py').read())"` — the file remains syntactically valid.
