### PR TITLE
docs(test): document missing docstrings in test_doubao_embedding.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_doubao_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_doubao_embedding.py
@@ -18,12 +18,14 @@ class EmbeddingTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:        
+        """Configure a DoubaoEmbedding instance for the test methods."""
         self.embedding = DoubaoEmbedding()
         self.embedding.ark_api_key = "replace with your api key"
         self.embedding.endpoint_id = "replace with your endpoint id :)"
         self.embedding.embedding_dims = 1024
 
     def test_get_embeddings(self) -> None:
+        """Verify that get_embeddings returns a 1024-dim vector for one text."""
         res = self.embedding.get_embeddings(texts=["hello world"])
         print(res)
         self.assertIsInstance(res, list)
@@ -31,6 +33,7 @@ class EmbeddingTest(unittest.TestCase):
         self.assertEqual(len(res[0]), 1024)
 
     def test_async_get_embeddings(self) -> None:
+        """Verify that async_get_embeddings returns a 1024-dim vector for one text."""
         res = asyncio.run(
             self.embedding.async_get_embeddings(texts=["hello world"]))
         print(res)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_doubao_embedding.py`: setUp, test_get_embeddings, test_async_get_embeddings.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_doubao_embedding.py').read())"` — the file remains syntactically valid.
