### PR TITLE
docs(test): document missing docstrings in test_llm_configuration.py

### DIFF
--- a/tests/test_agentuniverse/unit/llm/test_llm_configuration.py
+++ b/tests/test_agentuniverse/unit/llm/test_llm_configuration.py
@@ -4,17 +4,37 @@ from agentuniverse.llm.llm import LLM
 
 
 class ConfigurableLLM(LLM):
+    """A minimal LLM subclass used to exercise configuration merging."""
+
     def _call(self, *args, **kwargs):
+        """Stub synchronous completion call that always returns None."""
         return None
 
     async def _acall(self, *args, **kwargs):
+        """Stub asynchronous completion call that always returns None."""
         return None
 
     def get_num_tokens(self, text: str) -> int:
+        """Return the number of tokens as the character length of the text.
+
+        Args:
+            text: The input text to count.
+
+        Returns:
+            The length of the text in characters.
+        """
         return len(text)
 
 
 def _llm_configer(**overrides) -> LLMConfiger:
+    """Build an LLMConfiger loaded from a base LLM config plus overrides.
+
+    Args:
+        **overrides: Additional config keys merged over the base config.
+
+    Returns:
+        An LLMConfiger populated with the merged configuration.
+    """
     configer = Configer()
     configer.value = {
         "name": "configured_llm",
@@ -25,6 +45,7 @@ def _llm_configer(**overrides) -> LLMConfiger:
 
 
 def test_initialize_preserves_explicit_falsy_values():
+    """Verify config initialization keeps explicit falsy option values."""
     llm = ConfigurableLLM(
         model_name="initial-model",
         temperature=0.8,
@@ -49,6 +70,7 @@ def test_initialize_preserves_explicit_falsy_values():
 
 
 def test_agent_model_overrides_preserve_explicit_falsy_values():
+    """Verify agent model overrides keep explicit falsy option values."""
     llm = ConfigurableLLM(
         model_name="gpt-4o",
         temperature=0.8,
@@ -71,6 +93,7 @@ def test_agent_model_overrides_preserve_explicit_falsy_values():
 
 
 def test_agent_model_none_values_do_not_override_defaults():
+    """Verify None agent model overrides leave existing option values intact."""
     llm = ConfigurableLLM(
         model_name="gpt-4o",
         temperature=0.8,


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/llm/test_llm_configuration.py`: ConfigurableLLM, _llm_configer, test_initialize_preserves_explicit_falsy_values, test_agent_model_overrides_preserve_explicit_falsy_values, test_agent_model_none_values_do_not_override_defaults, _call, _acall, get_num_tokens.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/llm/test_llm_configuration.py').read())"` — the file remains syntactically valid.
