### PR TITLE
docs(test): document missing docstrings in test_github_tool.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_github_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_github_tool.py
@@ -10,7 +10,9 @@ from agentuniverse.agent.action.tool.common_tool.github_tool import GitHubTool
 
 
 class GitHubToolTest(unittest.TestCase):
+    """Unit tests for GitHubTool request handling."""
     def test_make_request_handles_http_error_without_response(self):
+        """Verify an HTTPError without an attached response is reported as an error containing the original message."""
         tool = GitHubTool(api_key=None)
 
         with patch(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_github_tool.py`: GitHubToolTest, test_make_request_handles_http_error_without_response.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_github_tool.py').read())"` — the file remains syntactically valid.
