### PR TITLE
docs(test): document missing docstrings in test_tool_async_compatibility.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py
@@ -4,13 +4,16 @@ from agentuniverse.agent.action.tool.tool import Tool, ToolInput
 
 
 class LegacyInputTool(Tool):
+    """A minimal Tool subclass using the legacy execute(tool_input) signature."""
     name: str = "legacy_input_tool"
 
     def execute(self, tool_input: ToolInput):
+        """Return the value requested from the tool input."""
         return tool_input.get_data("value")
 
 
 def test_async_run_supports_legacy_tool_input_signature():
+    """Verify async_run accepts a legacy execute signature and forwards keyword arguments as tool input."""
     tool = LegacyInputTool(input_keys=["value"])
 
     result = asyncio.run(Tool.async_run.__wrapped__(tool, value="from-async-run"))
@@ -19,6 +22,7 @@ def test_async_run_supports_legacy_tool_input_signature():
 
 
 def test_async_langchain_run_supports_legacy_tool_input_signature():
+    """Verify async_langchain_run accepts a legacy execute signature and forwards a plain string argument."""
     tool = LegacyInputTool(input_keys=["value"])
 
     result = asyncio.run(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py`: LegacyInputTool, execute, test_async_run_supports_legacy_tool_input_signature, test_async_langchain_run_supports_legacy_tool_input_signature.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_tool_async_compatibility.py').read())"` — the file remains syntactically valid.
