### PR TITLE
docs(test): document missing docstrings in test_agent.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/test_agent.py
+++ b/tests/test_agentuniverse/unit/agent/test_agent.py
@@ -9,20 +9,42 @@ from agentuniverse.agent.input_object import InputObject
 
 
 class _StubAgent(Agent):
+    """A minimal Agent stub exposing the abstract interface directly."""
+
     def input_keys(self) -> list[str]:
+        """Return an empty list of input keys for the stub agent."""
         return []
 
     def output_keys(self) -> list[str]:
+        """Return an empty list of output keys for the stub agent."""
         return []
 
     def parse_input(self, input_object: InputObject, agent_input: dict) -> dict:
+        """Pass the agent input through unchanged.
+
+        Args:
+            input_object: The input object received by the agent.
+            agent_input: The parsed agent input dictionary.
+
+        Returns:
+            The agent input dictionary unmodified.
+        """
         return agent_input
 
     def parse_result(self, agent_result: dict) -> dict:
+        """Pass the agent result through unchanged.
+
+        Args:
+            agent_result: The agent result dictionary.
+
+        Returns:
+            The agent result dictionary unmodified.
+        """
         return agent_result
 
 
 def test_process_prompt_preserves_agent_input_for_repeated_calls():
+    """Verify repeated process_prompt calls do not mutate the agent input."""
     agent = _StubAgent()
     agent.agent_model = AgentModel(
         profile={
@@ -57,29 +79,45 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
 
     @staticmethod
     def _make_tools():
+        """Build the dict of failing/ok tool instances used by the tests.
+
+        Returns:
+            A mapping of tool name to Tool instance, containing one tool that
+            always raises and one tool that always succeeds.
+        """
         from agentuniverse.agent.action.tool.tool import Tool
 
         # The tool's NAME is "failing_tool"; the exception MESSAGE is the
         # sensitive token "secret_token_value" so the leak test can tell them
         # apart and assert only the name (not the exception) reaches the agent.
         class _FailingTool(Tool):
+            """A tool that always raises on invocation."""
+
             def execute(self, *args, **kwargs):
+                """Raise a RuntimeError carrying the sensitive marker."""
                 raise RuntimeError("secret_token_value leaked")
 
             def run(self, **kwargs):
+                """Raise a RuntimeError carrying the sensitive marker."""
                 raise RuntimeError("secret_token_value leaked")
 
             async def async_run(self, **kwargs):
+                """Raise a RuntimeError carrying the sensitive marker."""
                 raise RuntimeError("secret_token_value leaked")
 
         class _OkTool(Tool):
+            """A tool that always succeeds with a fixed result."""
+
             def execute(self, *args, **kwargs):
+                """Return the fixed ok result."""
                 return "ok"
 
             def run(self, **kwargs):
+                """Return the fixed ok result."""
                 return "ok"
 
             async def async_run(self, **kwargs):
+                """Return the fixed ok result."""
                 return "ok"
 
         return {
@@ -88,6 +126,7 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
         }
 
     def test_failing_tool_leaves_marker_and_others_still_run(self):
+        """Verify a failing tool becomes a marker and other tools still run."""
         tools = self._make_tools()
         with patch("agentuniverse.agent.agent.ToolManager") as mgr:
             mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
@@ -102,6 +141,7 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
         self.assertEqual(result, "ok\n\n[tool failing_tool failed]\n\nok")
 
     def test_failed_tool_marker_does_not_leak_exception_detail(self):
+        """Verify only the tool-named marker, never exception detail, is visible."""
         tools = self._make_tools()
         with patch("agentuniverse.agent.agent.ToolManager") as mgr:
             mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
@@ -115,6 +155,7 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
         self.assertNotIn("RuntimeError", result)
 
     def test_mixed_success_failure_ordering_is_preserved(self):
+        """Verify mixed success/failure output order matches the input order."""
         tools = self._make_tools()
         with patch("agentuniverse.agent.agent.ToolManager") as mgr:
             mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
@@ -128,6 +169,7 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
         )
 
     def test_async_failing_tool_leaves_marker_and_others_still_run(self):
+        """Verify async invocation also turns a failing tool into a marker."""
         tools = self._make_tools()
         with patch("agentuniverse.agent.agent.ToolManager") as mgr:
             mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
@@ -144,6 +186,7 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
         self.assertNotIn("secret_token_value", result)
 
     def test_async_mixed_success_failure_ordering_is_preserved(self):
+        """Verify async mixed output order matches the input tool order."""
         tools = self._make_tools()
         with patch("agentuniverse.agent.agent.ToolManager") as mgr:
             mgr.return_value.get_instance_obj.side_effect = lambda name: tools.get(name)
@@ -159,18 +202,34 @@ class TestInvokeToolsErrorIsolation(unittest.TestCase):
 
 
 def test_generate_result_returns_empty_text_for_empty_stream():
+    """Verify an empty stream yields empty text from generate_result."""
     agent = _StubAgent()
 
     assert agent.generate_result([]) == ""
 
 
 def test_tool_names_does_not_mutate_agent_action(monkeypatch):
+    """Verify reading tool_names leaves the underlying agent action unchanged."""
+
     class _StubToolkit:
+        """A minimal toolkit stub exposing a fixed tool name list."""
+
         def __init__(self):
+            """Initialize the stub with a single toolkit tool name."""
             self.tool_names = ["toolkit_tool"]
 
     class _StubToolkitManager:
+        """A minimal toolkit manager returning the stub toolkit by name."""
+
         def get_instance_obj(self, toolkit_name):
+            """Assert the requested toolkit name and return the stub toolkit.
+
+            Args:
+                toolkit_name: The toolkit name being resolved.
+
+            Returns:
+                A _StubToolkit instance.
+            """
             assert toolkit_name == "test_toolkit"
             return _StubToolkit()
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/test_agent.py`: _StubAgent, _StubToolkit, _StubToolkitManager, _FailingTool, _OkTool, _make_tools, __init__, get_instance_obj, execute, run, async_run, input_keys, output_keys, parse_input, parse_result and 7 test functions.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/test_agent.py').read())"` — the file remains syntactically valid.
