### PR TITLE
docs(test): document missing docstrings in test_output_object.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/test_output_object.py
+++ b/tests/test_agentuniverse/unit/agent/test_output_object.py
@@ -2,6 +2,7 @@ from agentuniverse.agent.output_object import OutputObject
 
 
 def test_output_object_copies_constructor_params():
+    """Verify OutputObject copies constructor params to isolate external changes."""
     params = {"output": "original"}
     output_object = OutputObject(params)
 
@@ -11,6 +12,7 @@ def test_output_object_copies_constructor_params():
 
 
 def test_to_dict_returns_an_independent_mapping():
+    """Verify to_dict returns a mapping independent from the OutputObject data."""
     output_object = OutputObject({"output": "original"})
 
     exported = output_object.to_dict()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/test_output_object.py`: test_output_object_copies_constructor_params, test_to_dict_returns_an_independent_mapping.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/test_output_object.py').read())"` — the file remains syntactically valid.
