### PR TITLE
docs(test): document missing docstrings in test_code_ast_processor.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_code_ast_processor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_code_ast_processor.py
@@ -28,8 +28,10 @@ except ImportError:
 
 @pytest.mark.skipif(not TREE_SITTER_AVAILABLE, reason="tree-sitter not installed")
 class TestCodeAstProcessor(unittest.TestCase):
+    """Tests for CodeAstProcessor AST parsing and code metrics."""
 
     def setUp(self):
+        """Create sample python/java/cpp sources and an initialized processor."""
         self.temp_dir = tempfile.TemporaryDirectory()
         self.py_code = '''
 class FileProcessor:
@@ -106,9 +108,11 @@ public:
         self.processor._initialize_by_component_configer(configer)
 
     def tearDown(self):
+        """Clean up the temporary directory holding the sample sources."""
         self.temp_dir.cleanup()
 
     def test_process_python(self):
+        """_process_docs produces AST/features JSON for python source."""
         doc = Document(
             text=self.py_code,
             metadata={"language": "python", "file_name": "test.py"}
@@ -128,6 +132,7 @@ public:
         print(f'result: {result_docs[0].text}')
 
     def test_process_java(self):
+        """_process_docs produces AST/features JSON for java source."""
         doc = Document(
             text=self.java_code,
             metadata={"language": "java", "file_name": "test.java"}
@@ -146,6 +151,7 @@ public:
         # print(f'ast_doc: {ast_doc}\nfeatures: {features}\n')
 
     def test_process_cpp(self):
+        """_process_docs produces AST/features JSON for cpp source."""
         doc = Document(
             text=self.cpp_code,
             metadata={"language": "cpp", "file_name": "test.cpp"}
@@ -164,6 +170,7 @@ public:
         # print(f'ast_doc: {ast_doc}\nfeatures: {features}\n')
 
     def test_code_metrics(self):
+        """_calculate_code_metrics reports positive metrics for each language."""
         for code, language in [
             (self.py_code, "python"),
             (self.java_code, "java"),


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_code_ast_processor.py`: TestCodeAstProcessor, setUp, tearDown, test_process_python, test_process_java, test_process_cpp, test_code_metrics.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_code_ast_processor.py').read())"` — the file remains syntactically valid.
