### PR TITLE
docs(test): document missing docstrings in test_faiss_store.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py
@@ -459,6 +459,7 @@ class TestFAISSStore(unittest.TestCase):
         errors = []
 
         def query_worker():
+            """Run a sequence of queries against the store and record result sizes."""
             try:
                 for i in range(10):
                     query = Query(embeddings=[[0.1 + i * 0.01, 0.2, 0.3, 0.4]])
@@ -469,6 +470,7 @@ class TestFAISSStore(unittest.TestCase):
                 errors.append(str(e))
 
         def insert_worker():
+            """Insert a sequence of documents into the store and record failures."""
             try:
                 for i in range(5):
                     doc = Document(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py`: query_worker, insert_worker.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/store/test_faiss_store.py').read())"` — the file remains syntactically valid.
