### PR TITLE
docs(llm): document missing docstrings in kimi_official_llm_channel.py

### DIFF
--- a/agentuniverse/llm/llm_channel/kimi_official_llm_channel.py
+++ b/agentuniverse/llm/llm_channel/kimi_official_llm_channel.py
@@ -17,6 +17,8 @@ KIMI_MAX_CONTEXT_LENGTH = {
 
 
 class KimiOfficialLLMChannel(LLMChannel):
+    """Kimi official llm channel.
+    """
     channel_api_base: Optional[str] = "https://api.moonshot.cn/v1"
 
     def max_context_length(self) -> int:


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/llm/llm_channel/kimi_official_llm_channel.py`: KimiOfficialLLMChannel.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/llm/llm_channel/kimi_official_llm_channel.py').read())"` — the file remains syntactically valid.
