### PR TITLE
docs(test): document missing docstrings in test_xlsx_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py
@@ -44,6 +44,7 @@ class TestXlsxReader:
         ]
         
         def mock_cell(row, column):
+            """Return the mocked cell value at the given 1-based row/column."""
             return mock_cells[row-1][column-1]
         
         mock_worksheet.cell = mock_cell
@@ -82,6 +83,7 @@ class TestXlsxReader:
         mock_sheet2.cell.return_value = MagicMock(value='Data2')
         
         def mock_getitem(sheet_name):
+            """Return the mocked worksheet for a given sheet name."""
             if sheet_name == 'Sheet1':
                 return mock_sheet1
             elif sheet_name == 'Sheet2':


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py`: mock_cell, mock_getitem.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py').read())"` — the file remains syntactically valid.
