### PR TITLE
docs(test): document missing docstrings in test_knowledge_with_milvus.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_with_milvus.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_with_milvus.py
@@ -20,6 +20,7 @@ class KnowledgeTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        """Build a Knowledge instance backed by a MilvusStore."""
         init_params = {}
         init_params['name'] = 'test_knowledge'
         init_params['description'] = 'test_knowledge_description'
@@ -28,21 +29,25 @@ class KnowledgeTest(unittest.TestCase):
         self.knowledge = Knowledge(**init_params)
 
     def test_store_update_documents(self) -> None:
+        """Verify MilvusStore.update_document runs with sample documents."""
         store = self.knowledge.store
         store.update_document([Document(text='This is an iPhone', metadata={'type': 'Electronic products'}),
                                Document(text='This is a Tesla.', metadata={'type': 'Industrial products'})])
 
     def test_store_upsert_documents(self) -> None:
+        """Verify MilvusStore.upsert_document runs with sample documents."""
         store = self.knowledge.store
         store.upsert_document([Document(text='This is an iPhone', metadata={'type': 'Cell phone'}),
                                Document(text='This is a Tesla.', metadata={'type': 'Car'})])
 
     def test_store_insert_documents(self) -> None:
+        """Verify MilvusStore.insert_documents runs with sample documents."""
         store = self.knowledge.store
         store.insert_documents([Document(text='This is a document about engineer'),
                                 Document(text='This is a document about finance')])
 
     def test_query(self) -> None:
+        """Verify a MilvusStore query returns results for a sample query."""
         store = self.knowledge.store
         query = Query(query_str='Which one is a cell phone?', similarity_top_k=1)
         res = store.query(query)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_with_milvus.py`: setUp, test_store_update_documents, test_store_upsert_documents, test_store_insert_documents, test_query.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_with_milvus.py').read())"` — the file remains syntactically valid.
