### PR TITLE
docs(test): document missing docstrings in test_neo4j_store.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_store.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_store.py
@@ -30,10 +30,12 @@ class TestNeo4jNodeIdsQuery(unittest.TestCase):
     """node_ids_query must parameterize ids and reject non-integer payloads."""
 
     def setUp(self):
+        """Instantiate the store under test without making any driver connection."""
         # No connection is made; the methods under test are pure.
         self.store = Neo4jStore()
 
     def test_build_node_ids_query_is_parameterized(self):
+        """Verify node ids are bound as parameters instead of interpolated SQL."""
         query, params = self.store._build_node_ids_query([1, 2, 3])
         self.assertEqual(query, "MATCH (n) WHERE id(n) IN $au_node_ids RETURN n")
         # No id value is interpolated into the query text.
@@ -41,20 +43,24 @@ class TestNeo4jNodeIdsQuery(unittest.TestCase):
         self.assertEqual(params, {"au_node_ids": [1, 2, 3]})
 
     def test_parse_node_ids_accepts_int_list(self):
+        """Verify a JSON payload holding an int list parses to that list."""
         self.assertEqual(self.store._parse_node_ids("[1, 2, 3]"), [1, 2, 3])
 
     def test_parse_node_ids_rejects_injection_payload(self):
+        """Verify a payload attempting Cypher injection is rejected."""
         # A payload that would inject Cypher if string-interpolated is rejected.
         with self.assertRaises(ValueError):
             self.store._parse_node_ids('["1) OR 1=1 OR id(n) IN (1"]')
 
     def test_parse_node_ids_rejects_non_list(self):
+        """Verify payloads that are not JSON lists are rejected."""
         with self.assertRaises(ValueError):
             self.store._parse_node_ids('"not a list"')
         with self.assertRaises(ValueError):
             self.store._parse_node_ids("42")
 
     def test_parse_node_ids_rejects_bool_float_and_empty(self):
+        """Verify bool, float and empty-list payloads are rejected as node ids."""
         with self.assertRaises(ValueError):  # bool is an int subclass
             self.store._parse_node_ids("[true, 1]")
         with self.assertRaises(ValueError):  # floats are not node ids
@@ -63,6 +69,7 @@ class TestNeo4jNodeIdsQuery(unittest.TestCase):
             self.store._parse_node_ids("[]")
 
     def test_parse_node_ids_rejects_invalid_json(self):
+        """Verify malformed JSON payloads are rejected."""
         with self.assertRaises(ValueError):
             self.store._parse_node_ids("not json")
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_store.py`: setUp, test_build_node_ids_query_is_parameterized, test_parse_node_ids_accepts_int_list, test_parse_node_ids_rejects_injection_payload, test_parse_node_ids_rejects_non_list, test_parse_node_ids_rejects_bool_float_and_empty, test_parse_node_ids_rejects_invalid_json.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/store/test_neo4j_store.py').read())"` — the file remains syntactically valid.
