### PR TITLE
docs(test): document missing docstrings in test_knowledge_rrf_integration.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_rrf_integration.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_rrf_integration.py
@@ -32,9 +32,22 @@ class _FakeStore:
     """
 
     def __init__(self, docs):
+        """Store the fixed document list this fake store will return.
+
+        Args:
+            docs: The list of Document objects served on every query.
+        """
         self._docs = docs
 
     def query(self, query: Query):
+        """Return fresh copies of the fixed documents for the given query.
+
+        Args:
+            query: The query being served by the fake store.
+
+        Returns:
+            A list of new Document copies mirroring the stored documents.
+        """
         return [Document(text=d.text, metadata=dict(d.metadata or {}))
                 for d in self._docs]
 
@@ -43,6 +56,16 @@ class TestKnowledgeRrfIntegration(unittest.TestCase):
     """Multi-store recall fused by RRF through the Knowledge pipeline."""
 
     def _build_knowledge(self, stores):
+        """Build a Knowledge wired for RRF fusion over the given stores.
+
+        Args:
+            stores: Mapping of store code to store instance used as the
+                knowledge's backing stores.
+
+        Returns:
+            A Knowledge instance configured with the base router and the
+            reciprocal rank fusion post-processor.
+        """
         return Knowledge(
             name="rrf_knowledge",
             stores=list(stores.keys()),


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_rrf_integration.py`: __init__, query, _build_knowledge.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/test_knowledge_rrf_integration.py').read())"` — the file remains syntactically valid.
