### PR TITLE
docs(test): document missing docstrings in test_web_pdf_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py
@@ -10,15 +10,21 @@ from agentuniverse.agent.action.knowledge.reader.file.web_pdf_reader import WebP
 
 
 class NonOkResponse:
+    """Minimal requests.Response stand-in for a non-OK HTTP response."""
+
     status_code = 404
     content = b''
 
     def raise_for_status(self):
+        """Raise an HTTPError mirroring what requests would raise."""
         raise requests.HTTPError("404 Client Error", response=self)
 
 
 class TestWebPdfReader(unittest.TestCase):
+    """Unit tests for WebPdfReader error handling."""
+
     def test_non_ok_response_surfaces_fetch_error(self):
+        """A non-OK HTTP response surfaces as a descriptive RuntimeError."""
         reader = WebPdfReader()
         url = 'https://example.com/missing.pdf'
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py`: NonOkResponse, TestWebPdfReader, raise_for_status, test_non_ok_response_surfaces_fetch_error.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_web_pdf_reader.py').read())"` — the file remains syntactically valid.
