### PR TITLE
docs(agent): document missing docstrings in memory_compressor_manager.py

### DIFF
--- a/agentuniverse/agent/memory/memory_compressor/memory_compressor_manager.py
+++ b/agentuniverse/agent/memory/memory_compressor/memory_compressor_manager.py
@@ -16,4 +16,6 @@ class MemoryCompressorManager(ComponentManagerBase[MemoryCompressor]):
     """A singleton manager class of the MemoryCompressor."""
 
     def __init__(self):
+        """Initialize the memory compressor manager.
+        """
         super().__init__(ComponentEnum.MEMORY_COMPRESSOR)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/memory/memory_compressor/memory_compressor_manager.py`: __init__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/memory/memory_compressor/memory_compressor_manager.py').read())"` — the file remains syntactically valid.
