### PR TITLE
docs(test): document missing docstrings in test_youtube_tool.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py
@@ -12,22 +12,29 @@ from agentuniverse.agent.action.tool.tool import ToolInput
 
 
 class FakeRequest:
+    """Minimal fake mimicking a googleapiclient HTTP request object."""
     def __init__(self, response):
+        """Store the canned response returned by execute()."""
         self.response = response
 
     def execute(self):
+        """Return the canned API response stored at construction."""
         return self.response
 
 
 class FakeSearchResource:
+    """Fake for the youtube search resource."""
     def list(self, **kwargs):
+        """Return a FakeRequest whose payload lists one video search result."""
         return FakeRequest({
             "items": [{"id": {"videoId": "video-1"}}]
         })
 
 
 class FakeVideosResource:
+    """Fake for the youtube videos resource."""
     def list(self, **kwargs):
+        """Return a FakeRequest with trending or generic video items depending on the chart kwarg."""
         if kwargs.get("chart") == "mostPopular":
             return FakeRequest({
                 "items": [{
@@ -60,7 +67,9 @@ class FakeVideosResource:
 
 
 class FakeChannelsResource:
+    """Fake for the youtube channels resource."""
     def list(self, **kwargs):
+        """Return a FakeRequest whose payload carries one channel with snippet, statistics, and contentDetails."""
         return FakeRequest({
             "items": [{
                 "snippet": {
@@ -80,7 +89,9 @@ class FakeChannelsResource:
 
 
 class FakePlaylistItemsResource:
+    """Fake for the youtube playlistItems resource."""
     def list(self, **kwargs):
+        """Return a FakeRequest whose payload lists a single upload item."""
         return FakeRequest({
             "items": [{
                 "contentDetails": {"videoId": "upload-1"},
@@ -93,11 +104,14 @@ class FakePlaylistItemsResource:
 
 
 class FakePagedPlaylistItemsResource:
+    """Fake playlistItems resource that pages two uploads per call and records requested maxResults."""
     def __init__(self):
+        """Initialize the paging counters and the recorded maxResults list."""
         self.calls = 0
         self.max_results_values = []
 
     def list(self, **kwargs):
+        """Return the next page of upload items, recording the requested maxResults kwarg."""
         self.calls += 1
         self.max_results_values.append(kwargs.get("maxResults"))
         start = (self.calls - 1) * 2
@@ -118,19 +132,25 @@ class FakePagedPlaylistItemsResource:
 
 
 class FakeYouTubeService:
+    """Fake of a googleapiclient YouTube service exposing the resource accessors used by the tool."""
     def __init__(self, playlist_items_resource=None):
+        """Store the playlistItems resource, defaulting to a fresh FakePlaylistItemsResource."""
         self.playlist_items_resource = playlist_items_resource or FakePlaylistItemsResource()
 
     def search(self):
+        """Return a FakeSearchResource instance."""
         return FakeSearchResource()
 
     def videos(self):
+        """Return a FakeVideosResource instance."""
         return FakeVideosResource()
 
     def channels(self):
+        """Return a FakeChannelsResource instance."""
         return FakeChannelsResource()
 
     def playlistItems(self):
+        """Return the configured playlistItems resource."""
         return self.playlist_items_resource
 
 
@@ -139,9 +159,11 @@ class YouTubeToolTest(unittest.TestCase):
     Test cases for YouTubeTool class
     """
     def setUp(self) -> None:
+        """Build a YouTubeTool backed by the fake service before each test."""
         self.tool = YouTubeTool(service=FakeYouTubeService(), api_key="test-key")
     
     def test_search_videos(self) -> None:
+        """Verify video search mode returns a non-empty result list."""
         tool_input = ToolInput({
             'mode': Mode.VIDEO_SEARCH.value,
             'input': 'machine learning'
@@ -150,6 +172,7 @@ class YouTubeToolTest(unittest.TestCase):
         self.assertTrue(result != [])
 
     def test_analyze_channel(self) -> None:
+        """Verify channel info mode returns a non-empty result dict."""
         tool_input = ToolInput({
             'mode': Mode.CHANNEL_INFO.value,
             'input': 'UC_x5XG1OV2P6uZZ5FSM9Ttw'
@@ -158,6 +181,7 @@ class YouTubeToolTest(unittest.TestCase):
         self.assertTrue(result != {})
 
     def test_channel_info_limits_latest_videos_to_max_results(self) -> None:
+        """Verify channel info fetches latest videos in pages up to max_results."""
         playlist_items_resource = FakePagedPlaylistItemsResource()
         tool = YouTubeTool(
             service=FakeYouTubeService(playlist_items_resource),
@@ -171,6 +195,7 @@ class YouTubeToolTest(unittest.TestCase):
         self.assertEqual(playlist_items_resource.max_results_values, [3, 1])
 
     def test_get_trending_videos_with_region(self) -> None:
+        """Verify trending videos mode works when a region code is supplied."""
         tool_input = ToolInput({
             'mode': Mode.TRENDING_VIDEOS.value,
             'input': 'US'
@@ -179,6 +204,7 @@ class YouTubeToolTest(unittest.TestCase):
         self.assertTrue(result != [])
 
     def test_get_trending_videos(self) -> None:
+        """Verify trending videos mode works without a region code."""
         tool_input = ToolInput({
             'mode': Mode.TRENDING_VIDEOS.value
         })
@@ -186,12 +212,15 @@ class YouTubeToolTest(unittest.TestCase):
         self.assertTrue(result != [])
 
     def test_parse_duration_with_day_component(self) -> None:
+        """Verify parse_duration converts an ISO-8601 duration with days to seconds."""
         self.assertEqual(self.tool.parse_duration('P1DT2H3M4S'), 93784)
 
     def test_parse_duration_rejects_partial_trailing_text(self) -> None:
+        """Verify parse_duration returns zero for malformed trailing text."""
         self.assertEqual(self.tool.parse_duration('PT1Mbad'), 0)
 
     def test_parse_stat_count_handles_missing_or_malformed_values(self) -> None:
+        """Verify _parse_stat_count handles missing or malformed count values."""
         self.assertEqual(self.tool._parse_stat_count("123"), 123)
         self.assertEqual(self.tool._parse_stat_count(None), 0)
         self.assertEqual(self.tool._parse_stat_count(""), 0)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py`: FakeRequest/FakeSearchResource/FakeVideosResource/FakeChannelsResource/FakePlaylistItemsResource/FakePagedPlaylistItemsResource/FakeYouTubeService (incl. __init__/execute/list/search/videos/channels/playlistItems), setUp, and 8 test methods.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_youtube_tool.py').read())"` — the file remains syntactically valid.
