### PR TITLE
docs(test): document missing docstrings in test_rar_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py
@@ -22,10 +22,12 @@ class TestRarReaderBasic(unittest.TestCase):
     """Basic functionality tests"""
 
     def setUp(self):
+        """Set up a fresh RarReader instance and a temporary directory for each test."""
         self.reader = RarReader()
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
@@ -137,10 +139,12 @@ class TestRarReaderComplexScenarios(unittest.TestCase):
     """Complex scenario tests"""
 
     def setUp(self):
+        """Set up a fresh RarReader instance and a temporary directory for each test."""
         self.reader = RarReader()
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
@@ -414,10 +418,12 @@ class TestRarReaderSizeLimits(unittest.TestCase):
     """Size limit tests"""
 
     def setUp(self):
+        """Set up a fresh RarReader instance and a temporary directory for each test."""
         self.reader = RarReader()
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
@@ -538,10 +544,12 @@ class TestRarReaderRealWorldScenarios(unittest.TestCase):
     """Real-world scenario tests"""
 
     def setUp(self):
+        """Set up a fresh RarReader instance and a temporary directory for each test."""
         self.reader = RarReader()
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
@@ -859,14 +867,17 @@ class TestRarReaderEdgeCases(unittest.TestCase):
     """Edge case tests"""
 
     def setUp(self):
+        """Set up a fresh RarReader instance and a temporary directory for each test."""
         self.reader = RarReader()
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
     def test_rejects_unsafe_archive_entry_names(self):
+        """Archive entry names that escape the extraction root are flagged unsafe."""
         unsafe_names = [
             "../escape.txt",
             "safe/../../escape.txt",
@@ -1023,10 +1034,12 @@ class TestRarReaderPerformance(unittest.TestCase):
     """Performance tests"""
 
     def setUp(self):
+        """Set up a fresh RarReader instance and a temporary directory for each test."""
         self.reader = RarReader()
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py`: setUp, tearDown (in all six test classes), test_rejects_unsafe_archive_entry_names.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_rar_reader.py').read())"` — the file remains syntactically valid.
