### PR TITLE
docs(test): document missing docstrings in test_tavily_tool.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_tavily_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_tavily_tool.py
@@ -8,7 +8,9 @@ from agentuniverse.agent.action.tool.common_tool import tavily_tool
 
 
 class TavilyToolTest(unittest.TestCase):
+    """Unit tests for TavilyTool behavior."""
     def test_missing_optional_dependency_is_reported_when_used(self):
+        """Verify executing the tool without the optional tavily dependency reports a clear error mentioning tavily-python."""
         tool = tavily_tool.TavilyTool(api_key="test-key")
 
         with patch.object(tavily_tool, "TavilyClient", None), patch.object(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_tavily_tool.py`: TavilyToolTest, test_missing_optional_dependency_is_reported_when_used.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_tavily_tool.py').read())"` — the file remains syntactically valid.
