### PR TITLE
docs(test): document missing docstrings in test_command_status.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
@@ -21,11 +21,14 @@ from agentuniverse.agent.action.tool.common_tool.command_status_tool import Comm
 
 
 class CommandStatusToolTest(unittest.TestCase):
+    """Unit tests for the CommandStatusTool thread-status lookup."""
     def setUp(self):
+        """Create a RunCommandTool and a CommandStatusTool for the tests."""
         self.run_tool = RunCommandTool(allow_command_execution=True)
         self.status_tool = CommandStatusTool()
 
     def test_command_status_check(self):
+        """Verify querying a completed command's thread id returns its status and stdout."""
         tool_input = ToolInput({
             'command': 'echo "Hello World"',
             'cwd': os.getcwd(),
@@ -47,6 +50,7 @@ class CommandStatusToolTest(unittest.TestCase):
         self.assertEqual(status_result['exit_code'], 0)
 
     def test_running_command_status(self):
+        """Verify a non-blocking command is reported running and completes with output later."""
         tool_input = ToolInput({
             'command': f'"{sys.executable}" -c "import time; time.sleep(2); print(\'Long running command finished\')"',
             'cwd': os.getcwd(),
@@ -71,6 +75,7 @@ class CommandStatusToolTest(unittest.TestCase):
         self.assertEqual(status_result['exit_code'], 0)
 
     def test_invalid_thread_id(self):
+        """Verify querying a nonexistent numeric thread id returns a not_found error."""
         status_input = ToolInput({
             'thread_id': 12345678  # A thread ID that shouldn't exist
         })
@@ -81,6 +86,7 @@ class CommandStatusToolTest(unittest.TestCase):
         self.assertEqual(status_result['status'], 'not_found')
 
     def test_string_thread_id_is_parsed(self):
+        """Verify a numeric string thread id is parsed and yields a not_found error for an unknown id."""
         status_input = ToolInput({
             'thread_id': '12345678'
         })
@@ -91,6 +97,7 @@ class CommandStatusToolTest(unittest.TestCase):
         self.assertEqual(status_result['status'], 'not_found')
 
     def test_malformed_thread_id_returns_input_error(self):
+        """Verify a non-numeric thread id returns an input error."""
         status_input = ToolInput({
             'thread_id': 'abc'
         })
@@ -101,6 +108,7 @@ class CommandStatusToolTest(unittest.TestCase):
         self.assertIn('thread_id must be an integer', status_result['error'])
 
     def test_boolean_thread_id_returns_input_error(self):
+        """Verify a boolean thread id returns an input error."""
         status_input = ToolInput({
             'thread_id': True
         })


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py`: CommandStatusToolTest, setUp, and 6 test methods (test_command_status_check, test_running_command_status, test_invalid_thread_id, test_string_thread_id_is_parsed, test_malformed_thread_id_returns_input_error, test_boolean_thread_id_returns_input_error).
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py').read())"` — the file remains syntactically valid.
