### PR TITLE
docs(agent): document missing docstrings in rag_router_manager.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/rag_router/rag_router_manager.py
+++ b/agentuniverse/agent/action/knowledge/rag_router/rag_router_manager.py
@@ -17,4 +17,6 @@ class RagRouterManager(ComponentManagerBase[RagRouter]):
     """A singleton manager class of the RagRouter."""
 
     def __init__(self):
+        """Initialize the rag router manager.
+        """
         super().__init__(ComponentEnum.RAG_ROUTER)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/knowledge/rag_router/rag_router_manager.py`: __init__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/rag_router/rag_router_manager.py').read())"` — the file remains syntactically valid.
