### PR TITLE
docs(agent): document missing docstrings in query.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/query.py
+++ b/agentuniverse/agent/action/knowledge/store/query.py
@@ -24,6 +24,8 @@ class Query(BaseModel):
         ext_info (dict): extra information used in query.
     """
     class Config:
+        """Pydantic model configuration for this component, allowing arbitrary types.
+        """
         arbitrary_types_allowed = True
 
     query_str: Optional[str] = None


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `agentuniverse/agent/action/knowledge/store/query.py`: Config.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/store/query.py').read())"` — the file remains syntactically valid.
