### PR TITLE
docs(test): document missing docstrings in test_jina_ai_tool.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py
@@ -17,12 +17,14 @@ class JinaAIToolTLSTest(unittest.TestCase):
     """TLS verification must be on by default, not hardcoded off."""
 
     def _mock_ok_response(self) -> MagicMock:
+        """Build a mock HTTP response that succeeds and returns an ok JSON payload."""
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = {"code": 200, "data": {"content": "ok"}}
         return resp
 
     def test_verify_tls_true_by_default(self) -> None:
+        """Verify TLS certificate verification is enabled by default on API requests."""
         tool = JinaAITool()
         self.assertTrue(tool.verify_tls)
         with patch.object(jina_module.requests, "get") as mock_get:
@@ -33,6 +35,7 @@ class JinaAIToolTLSTest(unittest.TestCase):
             self.assertIs(kwargs.get("verify"), True)
 
     def test_verify_tls_can_be_disabled_via_config(self) -> None:
+        """Verify TLS verification can be turned off through the tool config."""
         tool = JinaAITool(verify_tls=False)
         with patch.object(jina_module.requests, "get") as mock_get:
             mock_get.return_value = self._mock_ok_response()
@@ -41,6 +44,7 @@ class JinaAIToolTLSTest(unittest.TestCase):
             self.assertIs(kwargs.get("verify"), False)
 
     def test_non_200_logs_warning_without_writing_stdout(self) -> None:
+        """Verify a non-200 payload is logged and returns None without writing to stdout."""
         tool = JinaAITool()
         with patch.object(jina_module.requests, "get") as mock_get:
             resp = MagicMock()
@@ -55,6 +59,7 @@ class JinaAIToolTLSTest(unittest.TestCase):
         self.assertEqual(out.getvalue(), "")
 
     def test_make_api_request_handles_http_error_without_response(self) -> None:
+        """Verify an HTTP error without a response body yields an error message."""
         tool = JinaAITool()
         with (
             patch.object(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py`: _mock_ok_response, test_verify_tls_true_by_default, test_verify_tls_can_be_disabled_via_config, test_non_200_logs_warning_without_writing_stdout, test_make_api_request_handles_http_error_without_response.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_jina_ai_tool.py').read())"` — the file remains syntactically valid.
