### PR TITLE
docs(test): document missing docstrings in test_api_tool_type_conversion.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py
@@ -7,10 +7,13 @@ from agentuniverse.agent.action.tool.api_tool import APITool
 
 
 class TestAPIToolTypeConversion(unittest.TestCase):
+    """Unit tests for APITool JSON-schema property type conversions."""
     def setUp(self):
+        """Create an APITool instance for the conversion tests."""
         self.tool = APITool()
 
     def test_boolean_string_false_is_false(self):
+        """Verify the string "false" converts to the boolean False."""
         result = self.tool.convert_body_property_type(
             {"type": "boolean"},
             "false",
@@ -19,6 +22,7 @@ class TestAPIToolTypeConversion(unittest.TestCase):
         self.assertIs(result, False)
 
     def test_boolean_rejects_unknown_strings(self):
+        """Verify an unrecognized string is returned unchanged instead of being converted."""
         result = self.tool.convert_body_property_type(
             {"type": "boolean"},
             "definitely",
@@ -27,6 +31,7 @@ class TestAPIToolTypeConversion(unittest.TestCase):
         self.assertEqual(result, "definitely")
 
     def test_boolean_numeric_zero_and_one(self):
+        """Verify numeric 0 and 1 convert to False and True respectively."""
         self.assertIs(
             self.tool.convert_body_property_type({"type": "boolean"}, 0),
             False,
@@ -37,6 +42,7 @@ class TestAPIToolTypeConversion(unittest.TestCase):
         )
 
     def test_number_accepts_native_numeric_values(self):
+        """Verify native int and float values pass through the number conversion unchanged."""
         self.assertEqual(
             self.tool.convert_body_property_type({"type": "number"}, 12),
             12,
@@ -47,6 +53,7 @@ class TestAPIToolTypeConversion(unittest.TestCase):
         )
 
     def test_anyof_uses_same_scalar_conversion(self):
+        """Verify anyOf conversion applies the same scalar conversion rules."""
         result = self.tool.convert_body_property_any_of(
             {},
             "false",


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py`: TestAPIToolTypeConversion, setUp and its five test methods.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_api_tool_type_conversion.py').read())"` — the file remains syntactically valid.
