### PR TITLE
docs(test): document missing docstrings in test_json_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_json_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_json_reader.py
@@ -10,8 +10,10 @@ from agentuniverse.agent.action.knowledge.reader.file.json_reader import JsonRea
 
 
 class TestJsonReader(unittest.TestCase):
+    """Unit tests for JsonReader covering objects, arrays, and error cases."""
 
     def setUp(self):
+        """Create a fresh JsonReader, temp dir, and sample JSON files for each test."""
         self.reader = JsonReader()
         self.temp_dir = tempfile.TemporaryDirectory()
 
@@ -75,6 +77,7 @@ class TestJsonReader(unittest.TestCase):
             f.write('{"invalid": json syntax}')
 
     def tearDown(self):
+        """Remove the temporary directory created in setUp."""
         self.temp_dir.cleanup()
 
     def test_load_json_object(self):


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_json_reader.py`: TestJsonReader, setUp, tearDown.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_json_reader.py').read())"` — the file remains syntactically valid.
