### PR TITLE
docs(test): document missing docstrings in test_jina_reranker.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py
@@ -18,8 +18,10 @@ from agentuniverse.base.config.configer import Configer
 
 
 class TestJinaReranker(unittest.TestCase):
+    """Tests for the JinaReranker doc processor and its configuration."""
 
     def setUp(self):
+        """Build a configured reranker plus sample docs/query for the tests."""
         cfg = Configer()
         cfg.value = {
             'name': 'jina_reranker',
@@ -43,6 +45,7 @@ class TestJinaReranker(unittest.TestCase):
         self.test_query = Query(query_str='test query')
 
     def test_initialize_by_component_configer_with_env(self):
+        """Config values initialize api_key/model_name/top_n attributes."""
         with patch('agentuniverse.base.util.env_util.get_from_env') as mock_get_env:
             mock_get_env.return_value = 'test_api_key'
             self.reranker = JinaReranker()
@@ -54,6 +57,7 @@ class TestJinaReranker(unittest.TestCase):
 
     @patch('requests.post')
     def test_process_docs(self, mock_post):
+        """_process_docs reranks and reorders docs per API relevance scores."""
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'results': [
@@ -93,6 +97,7 @@ class TestJinaReranker(unittest.TestCase):
 
     @patch('requests.post')
     def test_process_docs_with_top_n(self, mock_post):
+        """top_n limits how many reranked results are returned."""
         mock_response = MagicMock()
         mock_response.json.return_value = {
             'results': [
@@ -125,18 +130,21 @@ class TestJinaReranker(unittest.TestCase):
         self.assertEqual(len(result_docs), 2)
 
     def test_process_docs_no_api_key(self):
+        """Processing without an api key raises a descriptive exception."""
         with self.assertRaises(Exception) as context:
             self.reranker._process_docs(self.test_docs, self.test_query)
 
         self.assertTrue('Jina AI API key is not set' in str(context.exception))
 
     def test_process_docs_no_docs(self):
+        """Processing an empty doc list returns an empty result."""
         self.reranker.api_key = 'test_api_key'
         result_docs = self.reranker._process_docs([], self.test_query)
         self.assertEqual(len(result_docs), 0)
 
     @patch('requests.post')
     def test_process_docs_passes_default_timeout(self, mock_post):
+        """The default request timeout (30s) is passed to the API call."""
         mock_response = MagicMock()
         mock_response.json.return_value = {'results': []}
         mock_post.return_value = mock_response
@@ -147,6 +155,7 @@ class TestJinaReranker(unittest.TestCase):
 
     @patch('requests.post')
     def test_process_docs_passes_custom_request_timeout(self, mock_post):
+        """A configured request_timeout is passed to the API call."""
         mock_response = MagicMock()
         mock_response.json.return_value = {'results': []}
         mock_post.return_value = mock_response
@@ -158,6 +167,7 @@ class TestJinaReranker(unittest.TestCase):
 
     @patch('requests.post')
     def test_process_docs_timeout_error_is_surfaced(self, mock_post):
+        """A requests Timeout is surfaced as a descriptive API-call error."""
         mock_post.side_effect = requests.exceptions.Timeout('timed out')
         self.reranker.api_key = 'test_api_key'
         with self.assertRaises(Exception) as context:
@@ -166,6 +176,7 @@ class TestJinaReranker(unittest.TestCase):
 
     @patch('requests.post')
     def test_process_docs_non_json_response_is_surfaced(self, mock_post):
+        """A non-JSON response body is reported distinctly from API errors."""
         # Use a real Response whose .json() raises
         # requests.exceptions.JSONDecodeError — the actual exception a non-JSON
         # body produces. JSONDecodeError inherits from BOTH RequestException
@@ -182,6 +193,7 @@ class TestJinaReranker(unittest.TestCase):
         self.assertNotIn('API call error', str(context.exception))
 
     def _make_configer_with_timeout(self, request_timeout):
+        """Build a ComponentConfiger carrying the given request_timeout."""
         cfg = Configer()
         cfg.value = {
             'name': 'jina_reranker',
@@ -193,6 +205,7 @@ class TestJinaReranker(unittest.TestCase):
         return configer
 
     def test_initialize_rejects_non_numeric_request_timeout(self):
+        """Non-numeric request_timeout values are rejected at init."""
         for bad in ('not-a-number', None, [30]):
             reranker = JinaReranker()
             with self.assertRaises(Exception) as context:
@@ -201,6 +214,7 @@ class TestJinaReranker(unittest.TestCase):
             self.assertIn('request_timeout', str(context.exception))
 
     def test_initialize_rejects_non_positive_request_timeout(self):
+        """Zero, negative and boolean request_timeout values are rejected."""
         # 0 / negative are invalid; True/False are bools (an int subclass) and
         # must also be rejected so a YAML `true` does not silently become 1.
         for bad in (0, -5, True, False):
@@ -211,6 +225,7 @@ class TestJinaReranker(unittest.TestCase):
             self.assertIn('request_timeout', str(context.exception))
 
     def test_initialize_accepts_valid_request_timeout(self):
+        """Positive numeric request_timeout values initialize successfully."""
         for good in (1, 30, 5.5):
             reranker = JinaReranker()
             reranker._initialize_by_component_configer(


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py`: TestJinaReranker, setUp, test_initialize_by_component_configer_with_env, test_process_docs, test_process_docs_with_top_n, test_process_docs_no_api_key, test_process_docs_no_docs, test_process_docs_passes_default_timeout, test_process_docs_passes_custom_request_timeout, test_process_docs_timeout_error_is_surfaced, test_process_docs_non_json_response_is_surfaced, _make_configer_with_timeout, test_initialize_rejects_non_numeric_request_timeout, test_initialize_rejects_non_positive_request_timeout, test_initialize_accepts_valid_request_timeout.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_jina_reranker.py').read())"` — the file remains syntactically valid.
