### PR TITLE
docs(third_party_examples): document missing docstrings in search_agent.py

### DIFF
--- a/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_instance/search_agent.py
+++ b/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_instance/search_agent.py
@@ -16,4 +16,6 @@ class SearchAgent(AgentTemplate):
     """
     
     def __init__(self, **kwargs):
+        """Initialize the search agent.
+        """
         super().__init__(**kwargs)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_instance/search_agent.py`: __init__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/agent/agent_instance/search_agent.py').read())"` — the file remains syntactically valid.
