### PR TITLE
docs(third_party_examples): document missing docstrings in primary_chinese_teacher_agent_test.py

### DIFF
--- a/examples/third_party_examples/apps/primary_chinese_teacher_agent/intelligence/test/primary_chinese_teacher_agent_test.py
+++ b/examples/third_party_examples/apps/primary_chinese_teacher_agent/intelligence/test/primary_chinese_teacher_agent_test.py
@@ -10,6 +10,8 @@ AgentUniverse().start(config_path='../../config/config.toml', core_mode=True)
 
 
 def chat(question: str):
+    """Run a chat conversation with the agent and print the response.
+    """
     instance: Agent = AgentManager().get_instance_obj('primary_chinese_teacher_agent')
     output_object: OutputObject = instance.run(input=question)
     print(output_object.get_data('output'))


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/third_party_examples/apps/primary_chinese_teacher_agent/intelligence/test/primary_chinese_teacher_agent_test.py`: chat.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/primary_chinese_teacher_agent/intelligence/test/primary_chinese_teacher_agent_test.py').read())"` — the file remains syntactically valid.
