### PR TITLE
docs(startup_app): document missing docstrings in insurance_consult_pro_agent_test.py

### DIFF
--- a/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/test/insurance_consult_pro_agent_test.py
+++ b/examples/startup_app/demo_startup_app_with_agent_templates/intelligence/test/insurance_consult_pro_agent_test.py
@@ -12,6 +12,8 @@ AgentUniverse().start(config_path='../../config/config.toml', core_mode=True)
 
 
 def chat(question: str):
+    """Run a chat conversation with the agent and print the response.
+    """
     instance: Agent = AgentManager().get_instance_obj('insurance_consult_pro_agent')
     output = instance.run(input=question)
     return output.get_data('output')


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/startup_app/demo_startup_app_with_agent_templates/intelligence/test/insurance_consult_pro_agent_test.py`: chat.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/startup_app/demo_startup_app_with_agent_templates/intelligence/test/insurance_consult_pro_agent_test.py').read())"` — the file remains syntactically valid.
