### PR TITLE
docs(sample_apps): document missing docstrings in run_demo_agent_with_basic_tool.py

### DIFF
--- a/examples/sample_apps/toolkit_demo_app/intelligence/test/run_demo_agent_with_basic_tool.py
+++ b/examples/sample_apps/toolkit_demo_app/intelligence/test/run_demo_agent_with_basic_tool.py
@@ -13,6 +13,8 @@ AgentUniverse().start(config_path='../../config/config.toml', core_mode=True)
 
 
 def chat(question: str):
+    """Run a chat conversation with the agent and print the response.
+    """
     instance: Agent = AgentManager().get_instance_obj('demo_agent_with_basic_tool')
     instance.run(input=question)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `examples/sample_apps/toolkit_demo_app/intelligence/test/run_demo_agent_with_basic_tool.py`: chat.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/toolkit_demo_app/intelligence/test/run_demo_agent_with_basic_tool.py').read())"` — the file remains syntactically valid.
