### PR TITLE
docs(test): document missing docstrings in test_framework_context.py

### DIFF
--- a/tests/test_agentuniverse/unit/base/context/test_framework_context.py
+++ b/tests/test_agentuniverse/unit/base/context/test_framework_context.py
@@ -20,6 +20,8 @@ context_manager: FrameworkContextManager = FrameworkContextManager()
 
 
 def add(q: queue.Queue):
+    """Add.
+    """
     with FrameworkContext({"add_value": 1}):
         for i in range(10):
             add_value = context_manager.get_context("add_value")
@@ -30,11 +32,15 @@ def add(q: queue.Queue):
 
 
 async def async_add(q: queue.Queue):
+    """Async add.
+    """
     await asyncio.get_event_loop().run_in_executor(None, add, q)
 
 
 @pytest.mark.asyncio
 async def test_context_thread_and_async_isolation():
+    """Test that context thread and async isolation.
+    """
     queue1 = queue.Queue()
     queue2 = queue.Queue()
     queue3 = queue.Queue()
@@ -54,6 +60,8 @@ async def test_context_thread_and_async_isolation():
 
 
 def test_set_all_contexts_returns_tokens_for_restoration():
+    """Test that set all contexts returns tokens for restoration.
+    """
     context_manager.clear_all_contexts()
     original_token = context_manager.set_context("request_id", "worker-value")
 
@@ -78,11 +86,15 @@ def test_set_all_contexts_returns_tokens_for_restoration():
 
 
 def test_log_context_isolated_across_copied_contexts():
+    """Test that log context isolated across copied contexts.
+    """
     context_manager.clear_all_contexts()
     context_manager.set_log_context("request_id", "parent")
     child_context = copy_context()
 
     def update_child_context():
+        """Update child context.
+        """
         context_manager.set_log_context("worker_id", "child")
         return context_manager.get_context("LOG_CONTEXT")
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/base/context/test_framework_context.py`: update_child_context, test_log_context_isolated_across_copied_contexts, test_set_all_contexts_returns_tokens_for_restoration, test_context_thread_and_async_isolation, async_add, add.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/base/context/test_framework_context.py').read())"` — the file remains syntactically valid.
