### PR TITLE
docs(test): document missing docstrings in test_monitor.py

### DIFF
--- a/tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py
+++ b/tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py
@@ -5,12 +5,18 @@ from agentuniverse.llm.llm_output import LLMOutput
 
 
 class _StubLLM:
+    """ stubllm.
+    """
     @staticmethod
     def get_num_tokens(text: str) -> int:
+        """Return num tokens.
+        """
         return len(text)
 
 
 def test_get_llm_token_usage_preserves_llm_input():
+    """Test that get llm token usage preserves llm input.
+    """
     llm_input = {
         "kwargs": {
             "messages": [


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py`: test_get_llm_token_usage_preserves_llm_input, get_num_tokens, _StubLLM.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/base/util/monitor/test_monitor.py').read())"` — the file remains syntactically valid.
