### PR TITLE
docs(test): document missing docstrings in test_service_configer.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent_serve/test_service_configer.py
+++ b/tests/test_agentuniverse/unit/agent_serve/test_service_configer.py
@@ -12,12 +12,16 @@ from agentuniverse.base.config.configer import Configer
 
 
 def _build_configer(value: dict, path: str = "config/test_service.yaml") -> Configer:
+    """Build and return configer.
+    """
     configer = Configer(path)
     configer.value = value
     return configer
 
 
 def test_service_configer_requires_agent():
+    """Test that service configer requires agent.
+    """
     configer = _build_configer({
         "name": "test_service",
         "description": "service without agent",
@@ -33,6 +37,8 @@ def test_service_configer_requires_agent():
 
 
 def test_service_configer_reports_missing_agent_context():
+    """Test that service configer reports missing agent context.
+    """
     mock_agent_manager = MagicMock()
     mock_agent_manager.get_instance_obj.return_value = None
     mock_agent_manager.get_instance_name_list.return_value = [


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent_serve/test_service_configer.py`: test_service_configer_reports_missing_agent_context, test_service_configer_requires_agent, _build_configer.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent_serve/test_service_configer.py').read())"` — the file remains syntactically valid.
