### PR TITLE
docs(test): document missing docstrings in mock_service_manager.py

### DIFF
--- a/tests/test_agentuniverse/mock/agent_serve/mock_service_manager.py
+++ b/tests/test_agentuniverse/mock/agent_serve/mock_service_manager.py
@@ -18,10 +18,14 @@ class ServiceManager:
     """Mock class of agentuniverse.agent_serve.service.Service."""
 
     def __init__(self):
+        """Initialize the __init__ instance.
+        """
         self.__service_list: list = TEST_SERVICE_LIST
         self.__service_map: dict = TEST_SERVICE_MAP
 
     def get_instance_obj(self, service_code: str):
+        """Return instance obj.
+        """
         service_base = self.__service_map.get(service_code)
         if service_base is None:
             raise ValueError(f"Service {service_code} not found.")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/mock/agent_serve/mock_service_manager.py`: get_instance_obj, __init__.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/mock/agent_serve/mock_service_manager.py').read())"` — the file remains syntactically valid.
