### PR TITLE
docs(test): document missing docstrings in mock_application_config_manager.py

### DIFF
--- a/tests/test_agentuniverse/mock/agent_serve/mock_application_config_manager.py
+++ b/tests/test_agentuniverse/mock/agent_serve/mock_application_config_manager.py
@@ -11,7 +11,11 @@ BASE_INFO_APPNAME = "test_app"
 
 class MockAppConfiger:
 
+    """Mockappconfiger.
+    """
     def __init__(self):
+        """Initialize the __init__ instance.
+        """
         self.base_info_appname = BASE_INFO_APPNAME
 
 
@@ -19,4 +23,6 @@ class MockApplicationConfigManager:
     """Mock class of ApplicationConfigManager."""
 
     def __init__(self):
+        """Initialize the __init__ instance.
+        """
         self.app_configer = MockAppConfiger()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/mock/agent_serve/mock_application_config_manager.py`: __init__, __init__, MockAppConfiger.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/mock/agent_serve/mock_application_config_manager.py').read())"` — the file remains syntactically valid.
