### PR TITLE
docs(test): document missing docstrings in test_sls_sink.py

### DIFF
--- a/tests/test_agentuniverse_extension/unit/logger/test_sls_sink.py
+++ b/tests/test_agentuniverse_extension/unit/logger/test_sls_sink.py
@@ -23,6 +23,8 @@ from tests.test_agentuniverse_extension.mock.logger.mock_log_client import LogCl
 
 @patch('agentuniverse.logger.sls_sink.LogClient', new=LogClient)
 def test_sls_log():
+    """Test that sls log.
+    """
     sls_sender = SlsSender(LoggingConfig.sls_project,
                            LoggingConfig.sls_log_store,
                            LoggingConfig.sls_endpoint,
@@ -34,6 +36,8 @@ def test_sls_log():
     sls_sink = SlsSink(sls_sender)
 
     class Message:
+        """Message.
+        """
         pass
 
     message = Message()


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse_extension/unit/logger/test_sls_sink.py`: Message, test_sls_log.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse_extension/unit/logger/test_sls_sink.py').read())"` — the file remains syntactically valid.
