### PR TITLE
docs(test): document missing docstrings in test_trace.py

### DIFF
--- a/tests/test_agentuniverse/unit/base/annotation/test_trace.py
+++ b/tests/test_agentuniverse/unit/base/annotation/test_trace.py
@@ -5,22 +5,34 @@ from agentuniverse.base.context.framework_context_manager import FrameworkContex
 
 
 class _StubConversationMemoryModule:
+    """ stubconversationmemorymodule.
+    """
     def add_agent_input_info(self, *args, **kwargs):
+        """Add agent input info.
+        """
         pass
 
     def add_agent_result_info(self, *args, **kwargs):
+        """Add agent result info.
+        """
         pass
 
 
 class _StubAgent:
+    """ stubagent.
+    """
     agent_model = None
 
 
 async def _run_agent(self, **kwargs):
+    """ run agent.
+    """
     return "done"
 
 
 def test_async_agent_wrapper_restores_parent_invocation_chain(monkeypatch):
+    """Test that async agent wrapper restores parent invocation chain.
+    """
     trace_module = importlib.import_module("agentuniverse.base.annotation.trace")
     monkeypatch.setattr(
         trace_module,
@@ -29,6 +41,8 @@ def test_async_agent_wrapper_restores_parent_invocation_chain(monkeypatch):
     )
 
     async def run_in_parent_context():
+        """Run in parent context.
+        """
         context_manager = FrameworkContextManager()
         context_manager.clear_all_contexts()
         parent = {"source": "parent-agent", "type": "agent"}


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/base/annotation/test_trace.py`: run_in_parent_context, test_async_agent_wrapper_restores_parent_invocation_chain, _run_agent, _StubAgent, add_agent_result_info, add_agent_input_info, _StubConversationMemoryModule.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/base/annotation/test_trace.py').read())"` — the file remains syntactically valid.
