### PR TITLE
docs: add docstrings to test_arxiv_tool

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py
@@ -15,6 +15,8 @@ from agentuniverse.agent.action.tool.tool import ToolInput
 
 
 class FakeArxivClient:
+    """Fakearxivclient.
+    """
     pass
 
 
@@ -24,9 +26,13 @@ class ArxivToolTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        """Set up the test fixture before each test.
+        """
         self.tool = ArxivTool()
 
     def test_search_papers(self) -> None:
+        """Test that search papers.
+        """
         tool_input = ToolInput({
             'input': 'machine learning',
             'mode': SearchMode.SEARCH.value
@@ -41,6 +47,8 @@ class ArxivToolTest(unittest.TestCase):
         mock_search.assert_called_once_with(self.tool, "machine learning")
 
     def test_get_paper_detail(self) -> None:
+        """Test that get paper detail.
+        """
         tool_input = ToolInput({
             'input': '1605.08386v1',
             'mode': SearchMode.DETAIL.value
@@ -55,6 +63,8 @@ class ArxivToolTest(unittest.TestCase):
         mock_detail.assert_called_once_with(self.tool, "1605.08386v1")
 
     def test_invalid_mode(self) -> None:
+        """Test that invalid mode.
+        """
         tool_input = ToolInput({
             'input': 'test',
             'mode': 'invalid_mode'


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added missing Google-style docstrings for the following symbols in `tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py`: test_invalid_mode, test_get_paper_detail, test_search_papers, setUp, FakeArxivClient.
- Completes the module documentation and improves IDE/doc-tool hints; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/tool/test_arxiv_tool.py').read())"` — the file remains syntactically valid.
