### PR TITLE
style(base): strip trailing whitespace in config_type_enum.py

### DIFF
--- a/agentuniverse/base/config/config_type_enum.py
+++ b/agentuniverse/base/config/config_type_enum.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 # @Time    : 2024/3/12 15:39
-# @Author  : jerry.zzw 
+# @Author  : jerry.zzw
 # @Email   : jerry.zzw@antgroup.com
 # @FileName: config_type_enum.py
 from enum import Enum


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on line 5 in `agentuniverse/base/config/config_type_enum.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified the listed line had trailing whitespace; `python3 -c "import ast; ast.parse(open('agentuniverse/base/config/config_type_enum.py').read())"` passed.
