### PR TITLE
style(base): strip trailing whitespace in reasoning_output_parse.py

### DIFF
--- a/agentuniverse/base/util/reasoning_output_parse.py
+++ b/agentuniverse/base/util/reasoning_output_parse.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 # @Time    : 2025/2/14 14:47
-# @Author  : weizjajj 
+# @Author  : weizjajj
 # @Email   : weizhongjie.wzj@antgroup.com
 # @FileName: reasoning_output_parse.py
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on line 5 in `agentuniverse/base/util/reasoning_output_parse.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified the listed line had trailing whitespace; ast.parse passed.
