### PR TITLE
style(base): strip trailing whitespace in app_configer.py

### DIFF
--- a/agentuniverse/base/config/application_configer/app_configer.py
+++ b/agentuniverse/base/config/application_configer/app_configer.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python3
 # -*- coding:utf-8 -*-
 # @Time    : 2024/3/12 16:17
-# @Author  : jerry.zzw 
+# @Author  : jerry.zzw
 # @Email   : jerry.zzw@antgroup.com
 # @FileName: app_configer.py
 import importlib


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on line 4 in `agentuniverse/base/config/application_configer/app_configer.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified the listed line had trailing whitespace; `python3 -c "import ast; ast.parse(open('agentuniverse/base/config/application_configer/app_configer.py').read())"` passed.
