### PR TITLE
style(base): strip trailing whitespace in log_sink_manager.py

### DIFF
--- a/agentuniverse/base/util/logging/log_sink/log_sink_manager.py
+++ b/agentuniverse/base/util/logging/log_sink/log_sink_manager.py
@@ -17,4 +17,3 @@ class LogSinkManager(ComponentManagerBase[LogSink]):
 
     def __init__(self):
         super().__init__(ComponentEnum.LOG_SINK)
-        


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on line 20 in `agentuniverse/base/util/logging/log_sink/log_sink_manager.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified the listed line had trailing whitespace; ast.parse passed.
