### PR TITLE
style(examples): strip trailing whitespace in __init__.py

### DIFF
--- a/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/knowledge/rag_router/__init__.py
+++ b/examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/knowledge/rag_router/__init__.py
@@ -3,5 +3,5 @@
 
 # @Time    :
 # @Author  :
-# @Email   : 
+# @Email   :
 # @FileName: __init__.py


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 6 in `examples/third_party_examples/apps/app_with_goole_search_tool/intelligence/agentic/knowledge/rag_router/__init__.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; ast.parse passed.
