### PR TITLE
style(agent): strip trailing whitespace in conversation_message.py

### DIFF
--- a/agentuniverse/agent/memory/conversation_memory/conversation_message.py
+++ b/agentuniverse/agent/memory/conversation_memory/conversation_message.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 # @Time    : 2024/12/5 17:43
-# @Author  : weizjajj 
+# @Author  : weizjajj
 # @Email   : weizhongjie.wzj@antgroup.com
 # @FileName: conversation_message.py
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 5 in `agentuniverse/agent/memory/conversation_memory/conversation_message.py`.
- Style-only whitespace cleanup; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/memory/conversation_memory/conversation_message.py').read())"` — the file remains syntactically valid.
