### PR TITLE
style(agent): strip trailing whitespace in xlsx_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/xlsx_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/xlsx_reader.py
@@ -13,7 +13,7 @@ from agentuniverse.agent.action.knowledge.store.document import Document
 
 class XlsxReader(Reader):
     """Excel (.xlsx) file reader.
-    
+
     Used to read and parse Excel format files, supports multiple sheets and various data types.
     """
 
@@ -48,12 +48,12 @@ class XlsxReader(Reader):
         # Process each worksheet
         for sheet_name in workbook.sheetnames:
             worksheet = workbook[sheet_name]
-            
+
             # Extract data from the worksheet
             sheet_data = []
             max_row = worksheet.max_row
             max_col = worksheet.max_column
-            
+
             # Read all data from the worksheet
             for row in range(1, max_row + 1):
                 row_data = []
@@ -67,7 +67,7 @@ class XlsxReader(Reader):
                             row_data.append(str(cell.value))
                     else:
                         row_data.append("")
-                
+
                 # Only add non-empty rows
                 if any(cell.strip() for cell in row_data):
                     sheet_data.append(" | ".join(row_data))
@@ -83,7 +83,7 @@ class XlsxReader(Reader):
                 }
                 if ext_info is not None:
                     metadata.update(ext_info)
-                
+
                 document_list.append(Document(text=sheet_content, metadata=metadata))
 
         return document_list


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 16, 51, 56, 70, 86 in `agentuniverse/agent/action/knowledge/reader/file/xlsx_reader.py`.
- Style-only whitespace cleanup; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/reader/file/xlsx_reader.py').read())"` — the file remains syntactically valid.
