### PR TITLE
style(agent): strip trailing whitespace in website_bs4_reader.py

### DIFF
--- a/agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py
+++ b/agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py
@@ -20,22 +20,22 @@ from pydantic import Field
 
 class WebsiteBs4Reader(Reader):
     """Website content reader based on BeautifulSoup
-    
+
     Crawls website content and extracts main text, with support for limiting crawl depth and max links.
-    
+
     Note:
         Required packages:
             - beautifulsoup4: `pip install beautifulsoup4`
             - httpx: `pip install httpx`
-    
+
     Attributes:
         max_depth: Maximum crawl depth, defaults to 1
         max_links: Maximum number of links to crawl, defaults to 1
     """
-    
+
     max_depth: int = Field(default=1, description="Maximum crawl depth")
     max_links: int = Field(default=1, description="Maximum number of links to crawl")
-    
+
     def __init__(self, **data):
         super().__init__(**data)
         self._visited = set()  # Track visited URLs
@@ -43,14 +43,14 @@ class WebsiteBs4Reader(Reader):
 
     def _load_data(self, url: str, ext_info: Optional[Dict] = None) -> List[Document]:
         """Crawl website content and return list of documents
-        
+
         Args:
             url: Website URL to crawl
             ext_info: Optional metadata dict. Can contain max_depth and max_links to override defaults
-            
+
         Returns:
             List[Document]: List of documents containing webpage content
-            
+
         Raises:
             ValueError: If URL is invalid or empty
             ConnectionError: If network connection fails
@@ -59,7 +59,7 @@ class WebsiteBs4Reader(Reader):
         # Validate URL
         if not url or not isinstance(url, str):
             return []
-            
+
         if not url.startswith(('http://', 'https://')):
             raise ValueError("Invalid URL format")
 
@@ -72,19 +72,19 @@ class WebsiteBs4Reader(Reader):
                 self.max_depth = ext_info['max_depth']
             if 'max_links' in ext_info:
                 self.max_links = ext_info['max_links']
-                
+
         try:
             # Crawl website and create documents
             crawler_result = self._crawl_website(url)
             documents = []
-            
+
             for crawled_url, content in crawler_result.items():
                 metadata = {"source": crawled_url}
                 if ext_info:
                     metadata.update(ext_info)
                 documents.append(Document(text=content, metadata=metadata))
             return documents
-            
+
         except httpx.RequestError as e:
             raise ConnectionError(f"Network connection failed: {str(e)}")
         except Exception as e:
@@ -92,10 +92,10 @@ class WebsiteBs4Reader(Reader):
 
     def _get_primary_domain(self, url: str) -> str:
         """Extract primary domain from URL
-        
+
         Args:
             url: Full URL
-            
+
         Returns:
             str: Primary domain
         """
@@ -104,10 +104,10 @@ class WebsiteBs4Reader(Reader):
 
     def _extract_main_content(self, soup: BeautifulSoup) -> str:
         """Extract main content from webpage
-        
+
         Args:
             soup: BeautifulSoup object
-            
+
         Returns:
             str: Extracted text content
         """
@@ -138,21 +138,21 @@ class WebsiteBs4Reader(Reader):
                 key=len,
                 default=""
             )
-            
+
         return ""
-    
+
     def _crawl_website(self, url: str) -> Dict[str, str]:
         """Execute website crawling
-        
+
         Args:
             url: Starting URL
-            
+
         Returns:
             Dict[str, str]: Mapping of URLs to their content
         """
         num_links = 0
         crawler_result: Dict[str, str] = {}
-        
+
         # Initialize crawl with starting URL
         primary_domain = self._get_primary_domain(url)
         self._urls_to_crawl.append((url, 1))
@@ -185,10 +185,10 @@ class WebsiteBs4Reader(Reader):
                     for link in soup.find_all("a", href=True):
                         full_url = urljoin(current_url, link["href"])
                         parsed_url = urlparse(full_url)
-                        if (parsed_url.netloc.endswith(primary_domain) 
-                            and not any(parsed_url.path.endswith(ext) 
+                        if (parsed_url.netloc.endswith(primary_domain)
+                            and not any(parsed_url.path.endswith(ext)
                                       for ext in [".pdf", ".jpg", ".png"])
-                            and full_url not in self._visited 
+                            and full_url not in self._visited
                             and (full_url, current_depth + 1) not in self._urls_to_crawl):
                             self._urls_to_crawl.append((full_url, current_depth + 1))
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 23, 25, 30, 35, 38, 46, 50, 53, 62, 75, 80, 87, 95, 98, 107, 110, 141, 143, 146, 149, 155, 188, 189, 191 in `agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py`.
- Style-only whitespace cleanup; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/agent/action/knowledge/reader/file/website_bs4_reader.py').read())"` — the file remains syntactically valid.
