### PR TITLE
style(base): strip trailing whitespace in singleton.py

### DIFF
--- a/agentuniverse/base/annotation/singleton.py
+++ b/agentuniverse/base/annotation/singleton.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 # @Time    : 2024/4/2 15:21
-# @Author  : jerry.zzw 
+# @Author  : jerry.zzw
 # @Email   : jerry.zzw@antgroup.com
 # @FileName: singleton.py
 from functools import wraps


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 5 in `agentuniverse/base/annotation/singleton.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('agentuniverse/base/annotation/singleton.py').read())"` — the file remains syntactically valid.
