### PR TITLE
style(examples): strip trailing whitespace in zip_reader_demo.py

### DIFF
--- a/examples/third_party_examples/tools/zip_reader_demo.py
+++ b/examples/third_party_examples/tools/zip_reader_demo.py
@@ -23,15 +23,15 @@ def create_sample_zip():
     print("=" * 80)
     print("创建示例ZIP文件")
     print("=" * 80)
-    
+
     zip_path = Path("sample_archive.zip")
-    
+
     nested_zip = io.BytesIO()
     with zipfile.ZipFile(nested_zip, "w") as nested:
         nested.writestr("nested_docs/report.txt", "这是嵌套压缩包中的报告文档\n包含重要数据分析结果")
         nested.writestr("nested_docs/data.json", '{"type": "analysis", "status": "completed", "score": 95}')
         nested.writestr("nested_code/script.py", "def analyze_data():\n    return {'result': 'success'}")
-    
+
     with zipfile.ZipFile(zip_path, "w") as archive:
         archive.writestr("README.md", """# 示例项目文档
 
@@ -43,13 +43,13 @@ def create_sample_zip():
 2. 处理嵌套ZIP结构
 3. 提取元数据信息
 """)
-        
+
         archive.writestr("docs/introduction.txt", """项目介绍文档
 
 本项目展示了如何使用agentUniverse框架处理压缩包文件。
 支持自动识别和解析多种文档格式。
 """)
-        
+
         archive.writestr("src/main.py", """#!/usr/bin/env python3
 
 def main():
@@ -64,14 +64,14 @@ def process_data():
 if __name__ == "__main__":
     main()
 """)
-        
+
         archive.writestr("src/utils.py", """def helper_function():
     return "utility"
 
 def format_output(data):
     return f"Result: {data}"
 """)
-        
+
         archive.writestr("config/settings.json", """{
     "app_name": "ZipReaderDemo",
     "version": "1.0.0",
@@ -85,7 +85,7 @@ def format_output(data):
         "max_total_size": "512MB"
     }
 }""")
-        
+
         archive.writestr("config/database.yml", """database:
   host: localhost
   port: 5432
@@ -93,14 +93,14 @@ def format_output(data):
   user: demo_user
   pool_size: 10
 """)
-        
+
         archive.writestr("data/users.csv", """姓名,年龄,部门,职位
 张三,28,技术部,工程师
 李四,32,产品部,产品经理
 王五,25,设计部,设计师
 赵六,30,技术部,架构师
 """)
-        
+
         archive.writestr("data/metrics.txt", """性能指标报告
 ==============
 CPU使用率: 45%
@@ -108,7 +108,7 @@ CPU使用率: 45%
 磁盘使用率: 35%
 网络吞吐量: 1.2Gbps
 """)
-        
+
         archive.writestr("logs/app.log", """[2025-10-28 10:00:00] INFO: 应用启动
 [2025-10-28 10:00:01] INFO: 加载配置文件
 [2025-10-28 10:00:02] INFO: 初始化数据库连接
@@ -116,7 +116,7 @@ CPU使用率: 45%
 [2025-10-28 10:05:00] DEBUG: 处理用户请求
 [2025-10-28 10:05:01] INFO: 请求处理完成
 """)
-        
+
         archive.writestr("web/index.html", """<!DOCTYPE html>
 <html>
 <head>
@@ -128,9 +128,9 @@ CPU使用率: 45%
 </body>
 </html>
 """)
-        
+
         archive.writestr("archives/nested_data.zip", nested_zip.getvalue())
-    
+
     print(f"示例ZIP文件创建成功: {zip_path}")
     print(f"文件大小: {zip_path.stat().st_size:,} 字节")
     return zip_path
@@ -141,23 +141,23 @@ def demo_basic_usage(zip_path):
     print("\n" + "=" * 80)
     print("演示1: 基础用法")
     print("=" * 80)
-    
+
     reader = ZipReader()
     documents = reader.load_data(file=zip_path)
-    
+
     print(f"\n成功读取ZIP文件: {zip_path}")
     print(f"提取的文档数量: {len(documents)}")
-    
+
     file_types = {}
     for doc in documents:
         file_name = doc.metadata.get("file_name", "")
         ext = Path(file_name).suffix.lower() or "无扩展名"
         file_types[ext] = file_types.get(ext, 0) + 1
-    
+
     print(f"\n文件类型统计:")
     for ext, count in sorted(file_types.items()):
         print(f"  {ext}: {count} 个文件")
-    
+
     print(f"\n前3个文档预览:")
     for i, doc in enumerate(documents[:3], 1):
         metadata = doc.metadata
@@ -174,12 +174,12 @@ def demo_nested_zip(zip_path):
     print("\n" + "=" * 80)
     print("演示2: 嵌套ZIP处理")
     print("=" * 80)
-    
+
     reader = ZipReader()
     documents = reader.load_data(file=zip_path)
-    
+
     nested_docs = [d for d in documents if "nested_data.zip" in d.metadata.get("archive_path", "")]
-    
+
     print(f"\n在嵌套ZIP中找到 {len(nested_docs)} 个文档:")
     for doc in nested_docs:
         metadata = doc.metadata
@@ -194,22 +194,22 @@ def demo_file_type_filtering(zip_path):
     print("\n" + "=" * 80)
     print("演示3: 按文件类型过滤")
     print("=" * 80)
-    
+
     reader = ZipReader()
     documents = reader.load_data(file=zip_path)
-    
+
     py_files = [d for d in documents if d.metadata.get("file_name", "").endswith(".py")]
     print(f"\nPython文件 ({len(py_files)} 个):")
     for doc in py_files:
         print(f"  - {doc.metadata.get('archive_path', 'Unknown')}")
         print(f"    代码行数: {len(doc.text.splitlines())}")
-    
+
     json_files = [d for d in documents if d.metadata.get("file_name", "").endswith(".json")]
     print(f"\nJSON文件 ({len(json_files)} 个):")
     for doc in json_files:
         print(f"  - {doc.metadata.get('archive_path', 'Unknown')}")
         print(f"    内容预览: {doc.text[:80]}...")
-    
+
     md_files = [d for d in documents if d.metadata.get("file_name", "").endswith(".md")]
     print(f"\nMarkdown文件 ({len(md_files)} 个):")
     for doc in md_files:
@@ -221,7 +221,7 @@ def demo_custom_metadata(zip_path):
     print("\n" + "=" * 80)
     print("演示4: 自定义元数据")
     print("=" * 80)
-    
+
     custom_metadata = {
         "source": "演示数据集",
         "category": "技术文档",
@@ -230,10 +230,10 @@ def demo_custom_metadata(zip_path):
         "timestamp": "2025-10-28",
         "author": "Saladday"
     }
-    
+
     reader = ZipReader()
     documents = reader.load_data(file=zip_path, ext_info=custom_metadata)
-    
+
     print(f"\n已添加自定义元数据")
     print(f"\n第一个文档的完整元数据:")
     if documents:
@@ -247,7 +247,7 @@ def demo_custom_configuration(zip_path):
     print("\n" + "=" * 80)
     print("演示5: 自定义Reader配置")
     print("=" * 80)
-    
+
     reader = ZipReader(
         max_total_size=100 * 1024 * 1024,
         max_file_size=10 * 1024 * 1024,
@@ -256,14 +256,14 @@ def demo_custom_configuration(zip_path):
         max_compression_ratio=200,
         stream_chunk_size=512 * 1024
     )
-    
+
     print("\n自定义配置:")
     print(f"  最大总大小: 100MB")
     print(f"  最大单文件大小: 10MB")
     print(f"  最大嵌套深度: 3层")
     print(f"  最大文件数量: 500个")
     print(f"  最大压缩比: 200")
-    
+
     documents = reader.load_data(file=zip_path)
     print(f"\n使用自定义配置成功读取 {len(documents)} 个文档")
 
@@ -273,10 +273,10 @@ def demo_file_reader_integration(zip_path):
     print("\n" + "=" * 80)
     print("演示6: 与FileReader集成")
     print("=" * 80)
-    
+
     file_reader = FileReader()
     documents = file_reader.load_data(file_paths=[zip_path])
-    
+
     print(f"\nFileReader自动识别ZIP格式")
     print(f"提取的文档数量: {len(documents)}")
     print(f"\nFileReader会自动调用ZipReader处理.zip文件")
@@ -287,13 +287,13 @@ def demo_error_handling():
     print("\n" + "=" * 80)
     print("演示7: 错误处理和安全限制")
     print("=" * 80)
-    
+
     test_zip = Path("test_compression.zip")
     with zipfile.ZipFile(test_zip, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("repetitive.txt", "A" * 10000)
-    
+
     strict_reader = ZipReader(max_compression_ratio=50)
-    
+
     print("\n测试压缩比限制:")
     try:
         documents = strict_reader.load_data(file=test_zip)
@@ -303,7 +303,7 @@ def demo_error_handling():
     finally:
         if test_zip.exists():
             test_zip.unlink()
-    
+
     print("\n测试文件不存在:")
     try:
         reader = ZipReader()
@@ -317,12 +317,12 @@ def demo_content_search(zip_path):
     print("\n" + "=" * 80)
     print("演示8: 内容搜索")
     print("=" * 80)
-    
+
     reader = ZipReader()
     documents = reader.load_data(file=zip_path)
-    
+
     keywords = ["agentUniverse", "数据", "配置", "Python"]
-    
+
     print(f"\n搜索关键词:")
     for keyword in keywords:
         matching_docs = [d for d in documents if keyword in d.text]
@@ -338,32 +338,32 @@ def demo_statistics(zip_path):
     print("\n" + "=" * 80)
     print("演示9: 统计信息")
     print("=" * 80)
-    
+
     reader = ZipReader()
     documents = reader.load_data(file=zip_path)
-    
+
     total_chars = sum(len(doc.text) for doc in documents)
     total_words = sum(len(doc.text.split()) for doc in documents)
-    
+
     depth_stats = {}
     for doc in documents:
         depth = doc.metadata.get("archive_depth", 0)
         depth_stats[depth] = depth_stats.get(depth, 0) + 1
-    
+
     print(f"\n整体统计:")
     print(f"  文档总数: {len(documents)}")
     print(f"  总字符数: {total_chars:,}")
     print(f"  总词数: {total_words:,}")
     print(f"  平均文档长度: {total_chars // len(documents) if documents else 0} 字符")
-    
+
     print(f"\n深度分布:")
     for depth in sorted(depth_stats.keys()):
         print(f"  深度 {depth}: {depth_stats[depth]} 个文档")
-    
+
     if documents:
         largest_doc = max(documents, key=lambda d: len(d.text))
         smallest_doc = min(documents, key=lambda d: len(d.text))
-        
+
         print(f"\n文档大小:")
         print(f"  最大: {largest_doc.metadata.get('file_name', 'Unknown')} ({len(largest_doc.text):,} 字符)")
         print(f"  最小: {smallest_doc.metadata.get('file_name', 'Unknown')} ({len(smallest_doc.text):,} 字符)")
@@ -374,7 +374,7 @@ def cleanup(zip_path):
     print("\n" + "=" * 80)
     print("清理示例文件")
     print("=" * 80)
-    
+
     if zip_path.exists():
         zip_path.unlink()
         print(f"已删除: {zip_path}")
@@ -386,9 +386,9 @@ def main():
     print("=" * 80)
     print("ZIP Reader 完整演示 - agentUniverse Knowledge Reader")
     print("=" * 80)
-    
+
     zip_path = create_sample_zip()
-    
+
     try:
         demo_basic_usage(zip_path)
         demo_nested_zip(zip_path)
@@ -399,26 +399,26 @@ def main():
         demo_error_handling()
         demo_content_search(zip_path)
         demo_statistics(zip_path)
-        
+
         print("\n" + "=" * 80)
         print("演示完成")
         print("=" * 80)
-        
+
         print("\n使用提示:")
         print("  1. ZipReader支持多种文件格式的自动识别和解析")
         print("  2. 可以处理嵌套的ZIP文件结构")
         print("  3. 提供丰富的安全限制配置")
         print("  4. 支持自定义元数据传递")
         print("  5. 与FileReader无缝集成")
-        
+
         print("\n更多信息:")
         print("  - 文档: https://github.com/agentuniverse-ai/agentUniverse")
         print("  - 示例代码: examples/sample_apps/zip_reader_demo.py")
         print("  - 测试文件: tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py")
-        
+
     finally:
         cleanup(zip_path)
-    
+
     print("\n")
 
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 26, 28, 34, 46, 52, 67, 74, 88, 96, 103, 111, 119, 131, 133, 144, 147, 150, 156, 160, 177, 180, 182, 197, 200, 206, 212, 224, 233, 236, 250, 259, 266, 276, 279, 290, 294, 296, 306, 320, 323, 325, 341, 344, 347, 352, 358, 362, 366, 377, 389, 391, 402, 406, 413, 418, 421 in `examples/third_party_examples/tools/zip_reader_demo.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/tools/zip_reader_demo.py').read())"` — the file remains syntactically valid.
