### PR TITLE
style(examples): strip trailing whitespace in rar_reader_demo.py

### DIFF
--- a/examples/third_party_examples/tools/rar_reader_demo.py
+++ b/examples/third_party_examples/tools/rar_reader_demo.py
@@ -23,15 +23,15 @@ def create_sample_archive():
     print("\n" + "=" * 80)
     print("创建示例 RAR 压缩包...")
     print("=" * 80)
-    
+
     temp_dir = tempfile.mkdtemp(prefix="rar_demo_")
-    
+
     os.makedirs(os.path.join(temp_dir, "docs"), exist_ok=True)
     os.makedirs(os.path.join(temp_dir, "src"), exist_ok=True)
     os.makedirs(os.path.join(temp_dir, "config"), exist_ok=True)
     os.makedirs(os.path.join(temp_dir, "logs"), exist_ok=True)
     os.makedirs(os.path.join(temp_dir, "data"), exist_ok=True)
-    
+
     with open(os.path.join(temp_dir, "README.md"), 'w', encoding='utf-8') as f:
         f.write("""# 示例项目
 
@@ -42,10 +42,10 @@ def create_sample_archive():
 - 嵌套压缩包处理
 - 安全限制
 """)
-    
+
     with open(os.path.join(temp_dir, "docs", "introduction.txt"), 'w', encoding='utf-8') as f:
         f.write("欢迎使用 agentUniverse！\n\n这是 RAR 读取器功能的演示。")
-    
+
     with open(os.path.join(temp_dir, "src", "main.py"), 'w', encoding='utf-8') as f:
         f.write("""#!/usr/bin/env python3
 
@@ -58,12 +58,12 @@ def process_data():
     result = analyze(data)
     return result
 """)
-    
+
     with open(os.path.join(temp_dir, "src", "utils.py"), 'w', encoding='utf-8') as f:
         f.write("""def helper_function():
     return True
 """)
-    
+
     with open(os.path.join(temp_dir, "config", "settings.json"), 'w', encoding='utf-8') as f:
         f.write("""{
     "app_name": "RAR读取器演示",
@@ -74,25 +74,25 @@ def process_data():
         "security_limits": true
     }
 }""")
-    
+
     with open(os.path.join(temp_dir, "logs", "app.log"), 'w', encoding='utf-8') as f:
         f.write("""[2025-10-30 23:23:00] INFO: 应用程序已启动
 [2025-10-30 23:23:01] INFO: 正在加载配置
 [2025-10-30 23:23:02] INFO: 正在处理数据
 """)
-    
+
     with open(os.path.join(temp_dir, "data", "data.csv"), 'w', encoding='utf-8') as f:
         f.write("""姓名,年龄,城市
 张三,30,北京
 李四,25,上海
 王五,35,广州
 """)
-    
+
     rar_path = os.path.join(temp_dir, "sample_archive.rar")
-    
+
     try:
         import subprocess
-        
+
         files_to_archive = [
             os.path.join(temp_dir, "README.md"),
             os.path.join(temp_dir, "docs"),
@@ -101,17 +101,17 @@ def process_data():
             os.path.join(temp_dir, "logs"),
             os.path.join(temp_dir, "data"),
         ]
-        
+
         subprocess.run(
             ['rar', 'a', '-r', '-ep1', rar_path] + files_to_archive,
             check=True,
             capture_output=True,
             cwd=temp_dir
         )
-        
+
         print(f"示例压缩包已创建: {rar_path}")
         return rar_path, temp_dir
-        
+
     except FileNotFoundError:
         print("未找到 RAR 命令行工具，请先安装 RAR。")
         print("Ubuntu/Debian: sudo apt-get install rar")
@@ -127,15 +127,15 @@ def demo_rar_reader_direct(rar_path):
     print("\n" + "=" * 80)
     print("演示 1: 直接使用 RarReader")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     try:
         documents = rar_reader.load_data(rar_path)
-        
+
         print(f"\n成功加载 RAR 压缩包: {Path(rar_path).name}")
         print(f"提取的文档总数: {len(documents)}")
-        
+
         print("\n提取的文件:")
         for i, doc in enumerate(documents, 1):
             metadata = doc.metadata
@@ -148,7 +148,7 @@ def demo_rar_reader_direct(rar_path):
                 print(f"    内容: {doc.text[:200]}")
             else:
                 print(f"    内容预览: {doc.text[:200]}...")
-                
+
     except Exception as e:
         print(f"读取 RAR 文件错误: {e}")
 
@@ -158,17 +158,17 @@ def demo_file_reader_integration(rar_path):
     print("\n" + "=" * 80)
     print("演示 2: FileReader 集成")
     print("=" * 80)
-    
+
     file_reader = FileReader()
-    
+
     try:
         documents = file_reader.load_data([Path(rar_path)])
-        
+
         print(f"\nFileReader 自动检测到 RAR 格式")
         print(f"提取的文档数: {len(documents)}")
-        
+
         print("\nFileReader 会自动为 .rar 文件调用 RarReader")
-        
+
     except Exception as e:
         print(f"FileReader 错误: {e}")
 
@@ -178,9 +178,9 @@ def demo_custom_metadata(rar_path):
     print("\n" + "=" * 80)
     print("演示 3: 自定义元数据")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     custom_metadata = {
         "project": "agentUniverse",
         "author": "SaladDay",
@@ -188,19 +188,19 @@ def demo_custom_metadata(rar_path):
         "timestamp": "2025-10-30",
         "source": "演示数据集"
     }
-    
+
     try:
         documents = rar_reader.load_data(rar_path, ext_info=custom_metadata)
-        
+
         print(f"\n已加载自定义元数据")
         print(f"文档数: {len(documents)}")
-        
+
         if documents:
             print("\n第一个文档的元数据:")
             sample_doc = documents[0]
             for key, value in sample_doc.metadata.items():
                 print(f"  {key}: {value}")
-                
+
     except Exception as e:
         print(f"错误: {e}")
 
@@ -210,9 +210,9 @@ def demo_custom_config(rar_path):
     print("\n" + "=" * 80)
     print("演示 4: 自定义读取器配置")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     config = {
         "max_total_size": 100 * 1024 * 1024,
         "max_file_size": 10 * 1024 * 1024,
@@ -220,18 +220,18 @@ def demo_custom_config(rar_path):
         "max_files": 500,
         "max_compression_ratio": 200.0
     }
-    
+
     print("\n自定义配置:")
     print(f"  最大总大小: {config['max_total_size'] // 1024 // 1024}MB")
     print(f"  最大单文件大小: {config['max_file_size'] // 1024 // 1024}MB")
     print(f"  最大嵌套深度: {config['max_depth']} 层")
     print(f"  最大文件数: {config['max_files']}")
     print(f"  最大压缩比: {config['max_compression_ratio']}")
-    
+
     try:
         documents = rar_reader.load_data(rar_path, **config)
         print(f"\n使用自定义配置处理成功: {len(documents)} 个文档")
-        
+
     except Exception as e:
         print(f"错误: {e}")
 
@@ -241,25 +241,25 @@ def demo_filter_by_type(rar_path):
     print("\n" + "=" * 80)
     print("演示 5: 按文件类型过滤")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     try:
         documents = rar_reader.load_data(rar_path)
-        
+
         by_type = {}
         for doc in documents:
             suffix = doc.metadata.get('file_suffix', 'unknown')
             if suffix not in by_type:
                 by_type[suffix] = []
             by_type[suffix].append(doc)
-        
+
         print("\n按文件类型分类的文档:")
         for suffix, docs in sorted(by_type.items()):
             print(f"\n  {suffix} 文件 ({len(docs)} 个文档):")
             for doc in docs:
                 print(f"    - {doc.metadata.get('archive_path')}")
-                
+
     except Exception as e:
         print(f"错误: {e}")
 
@@ -269,29 +269,29 @@ def demo_content_search(rar_path):
     print("\n" + "=" * 80)
     print("演示 6: 内容搜索")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     try:
         documents = rar_reader.load_data(rar_path)
-        
+
         search_keywords = ["agentUniverse", "演示", "配置", "Python"]
-        
+
         print("\n搜索关键词:\n")
-        
+
         for keyword in search_keywords:
             matching_docs = []
             for doc in documents:
                 if keyword.lower() in doc.text.lower():
                     matching_docs.append(doc)
-            
+
             if matching_docs:
                 print(f"  '{keyword}' - 在 {len(matching_docs)} 个文档中找到:")
                 for doc in matching_docs:
                     print(f"    - {doc.metadata.get('file_name')} ({doc.metadata.get('archive_path')})")
             else:
                 print(f"  '{keyword}' - 未找到")
-                
+
     except Exception as e:
         print(f"错误: {e}")
 
@@ -301,38 +301,38 @@ def demo_statistics(rar_path):
     print("\n" + "=" * 80)
     print("演示 7: 压缩包统计信息")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     try:
         documents = rar_reader.load_data(rar_path)
-        
+
         total_chars = sum(len(doc.text) for doc in documents)
         total_words = sum(len(doc.text.split()) for doc in documents)
-        
+
         depths = {}
         for doc in documents:
             depth = doc.metadata.get('archive_depth', 0)
             depths[depth] = depths.get(depth, 0) + 1
-        
+
         print(f"\n整体统计:")
         print(f"  文档总数: {len(documents)}")
         print(f"  总字符数: {total_chars:,}")
         print(f"  总词数: {total_words:,}")
         print(f"  平均文档长度: {total_chars // len(documents) if documents else 0} 字符")
-        
+
         print(f"\n深度分布:")
         for depth in sorted(depths.keys()):
             print(f"  深度 {depth}: {depths[depth]} 个文档")
-        
+
         if documents:
             max_doc = max(documents, key=lambda x: len(x.text))
             min_doc = min(documents, key=lambda x: len(x.text))
-            
+
             print(f"\n文档大小:")
             print(f"  最大: {max_doc.metadata.get('file_name')} ({len(max_doc.text)} 字符)")
             print(f"  最小: {min_doc.metadata.get('file_name')} ({len(min_doc.text)} 字符)")
-            
+
     except Exception as e:
         print(f"错误: {e}")
 
@@ -342,24 +342,24 @@ def demo_nested_rar(temp_dir):
     print("\n" + "=" * 80)
     print("演示 8: 多层嵌套 RAR 压缩包")
     print("=" * 80)
-    
+
     rar_reader = RarReader()
-    
+
     try:
         import subprocess
-        
+
         nested_base = os.path.join(temp_dir, "nested_demo")
         os.makedirs(nested_base, exist_ok=True)
-        
+
         print("\n创建多层嵌套结构...")
-        
+
         level3_dir = os.path.join(nested_base, "level3")
         os.makedirs(level3_dir, exist_ok=True)
         with open(os.path.join(level3_dir, "第三层文件.txt"), 'w', encoding='utf-8') as f:
             f.write("这是嵌套在最深层的文件内容。\n包含重要的配置信息。")
         with open(os.path.join(level3_dir, "deep_config.json"), 'w', encoding='utf-8') as f:
             f.write('{"level": 3, "message": "深层配置", "secret": "深层秘密"}')
-        
+
         level3_rar = os.path.join(nested_base, "level3.rar")
         subprocess.run(
             ['rar', 'a', '-r', '-ep1', level3_rar, level3_dir],
@@ -368,7 +368,7 @@ def demo_nested_rar(temp_dir):
             cwd=nested_base
         )
         print("  ✓ 创建第 3 层 RAR")
-        
+
         level2_dir = os.path.join(nested_base, "level2")
         os.makedirs(level2_dir, exist_ok=True)
         with open(os.path.join(level2_dir, "第二层文件.txt"), 'w', encoding='utf-8') as f:
@@ -376,7 +376,7 @@ def demo_nested_rar(temp_dir):
         shutil.copy(level3_rar, level2_dir)
         with open(os.path.join(level2_dir, "中层数据.csv"), 'w', encoding='utf-8') as f:
             f.write("层级,名称,值\n2,中层A,200\n2,中层B,250")
-        
+
         level2_rar = os.path.join(nested_base, "level2.rar")
         subprocess.run(
             ['rar', 'a', '-r', '-ep1', level2_rar, level2_dir],
@@ -385,7 +385,7 @@ def demo_nested_rar(temp_dir):
             cwd=nested_base
         )
         print("  ✓ 创建第 2 层 RAR（包含第 3 层）")
-        
+
         level1_dir = os.path.join(nested_base, "level1")
         os.makedirs(level1_dir, exist_ok=True)
         with open(os.path.join(level1_dir, "第一层文件.txt"), 'w', encoding='utf-8') as f:
@@ -393,7 +393,7 @@ def demo_nested_rar(temp_dir):
         shutil.copy(level2_rar, level1_dir)
         with open(os.path.join(level1_dir, "顶层说明.md"), 'w', encoding='utf-8') as f:
             f.write("# 嵌套压缩包项目\n\n本项目演示了 RarReader 处理多层嵌套的能力。")
-        
+
         nested_rar = os.path.join(nested_base, "nested_archive.rar")
         subprocess.run(
             ['rar', 'a', '-r', '-ep1', nested_rar, level1_dir],
@@ -403,19 +403,19 @@ def demo_nested_rar(temp_dir):
         )
         print("  ✓ 创建第 1 层 RAR（包含第 2 层）")
         print(f"\n已创建嵌套压缩包: {nested_rar}")
-        
+
         print("\n正在提取嵌套压缩包...")
         documents = rar_reader.load_data(nested_rar, max_depth=5)
-        
+
         print(f"\n成功提取 {len(documents)} 个文档")
-        
+
         by_depth = {}
         for doc in documents:
             depth = doc.metadata.get('archive_depth', 0)
             if depth not in by_depth:
                 by_depth[depth] = []
             by_depth[depth].append(doc)
-        
+
         print("\n按嵌套深度分类:")
         for depth in sorted(by_depth.keys()):
             docs = by_depth[depth]
@@ -427,15 +427,15 @@ def demo_nested_rar(temp_dir):
                 print(f"    - {file_name}")
                 print(f"      路径: {archive_path}")
                 print(f"      内容: {content_preview}...")
-        
+
         print("\n嵌套统计:")
         print(f"  最大嵌套深度: {max(by_depth.keys())}")
         print(f"  总文档数: {len(documents)}")
-        
+
         nested_rars = [d for d in documents if d.metadata.get('file_suffix') == '.rar']
         if nested_rars:
             print(f"  包含的嵌套 RAR: {len(nested_rars)} 个")
-        
+
     except FileNotFoundError:
         print("\n未找到 RAR 工具，跳过嵌套演示")
     except Exception as e:
@@ -447,7 +447,7 @@ def cleanup(temp_dir):
     print("\n" + "=" * 80)
     print("清理演示文件")
     print("=" * 80)
-    
+
     import shutil
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir, ignore_errors=True)
@@ -464,9 +464,9 @@ if __name__ == "__main__":
     print("  - 安全限制")
     print("  - 自定义元数据")
     print("  - FileReader 集成")
-    
+
     rar_path, temp_dir = create_sample_archive()
-    
+
     if rar_path and os.path.exists(rar_path):
         try:
             demo_rar_reader_direct(rar_path)
@@ -477,18 +477,18 @@ if __name__ == "__main__":
             demo_content_search(rar_path)
             demo_statistics(rar_path)
             demo_nested_rar(temp_dir)
-            
+
             print("\n" + "=" * 80)
             print("演示完成！")
             print("=" * 80)
-            
+
             print("\n使用提示:")
             print("  1. RarReader 自动支持多种文件格式")
             print("  2. 可处理嵌套的 RAR 压缩包（默认最大深度：5 层）")
             print("  3. 安全限制可防护恶意压缩包")
             print("  4. 可为所有提取的文档添加自定义元数据")
             print("  5. FileReader 无缝集成 RarReader")
-            
+
         finally:
             cleanup(temp_dir)
     else:
@@ -499,7 +499,7 @@ if __name__ == "__main__":
         print("    - Ubuntu/Debian: sudo apt-get install rar")
         print("    - macOS: brew install rar")
         print("    - Windows: 从 https://www.rarlab.com/ 下载安装")
-        
+
         if temp_dir and os.path.exists(temp_dir):
             cleanup(temp_dir)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 26, 28, 34, 45, 48, 61, 66, 77, 83, 90, 92, 95, 104, 111, 114, 130, 132, 135, 138, 151, 161, 163, 166, 169, 171, 181, 183, 191, 194, 197, 203, 213, 215, 223, 230, 234, 244, 246, 249, 256, 262, 272, 274, 277, 279, 281, 287, 294, 304, 306, 309, 312, 317, 323, 327, 331, 335, 345, 347, 350, 353, 355, 362, 371, 379, 388, 396, 406, 409, 411, 418, 430, 434, 438, 450, 467, 469, 480, 484, 491, 502 in `examples/third_party_examples/tools/rar_reader_demo.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/tools/rar_reader_demo.py').read())"` — the file remains syntactically valid.
