### PR TITLE
style(tests): strip trailing whitespace in test_ollama_embedding.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_ollama_embedding.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_ollama_embedding.py
@@ -33,18 +33,18 @@ class OllamaEmbeddingTest(unittest.TestCase):
         try:
             # Test with different models
             models_to_test = ["mxbai-embed-large", "nomic-embed-text", "all-minilm"]
-            
+
             for model in models_to_test:
                 with self.subTest(model=model):
                     self.embedding.embedding_model_name = model
                     res = self.embedding.get_embeddings(texts=["hello world"])
                     print(f"Model {model} - Embedding shape: {len(res[0]) if res and res[0] else 'None'}")
-                    
+
                     self.assertIsInstance(res, list)
                     self.assertEqual(len(res), 1)
                     self.assertIsInstance(res[0], list)
                     self.assertGreater(len(res[0]), 0)
-                    
+
         except Exception as e:
             self.skipTest(f"Ollama API not available or model not found: {e}")
 
@@ -58,12 +58,12 @@ class OllamaEmbeddingTest(unittest.TestCase):
             res = asyncio.run(
                 self.embedding.async_get_embeddings(texts=["hello world"]))
             print(f"Async embedding result shape: {len(res[0]) if res and res[0] else 'None'}")
-            
+
             self.assertIsInstance(res, list)
             self.assertEqual(len(res), 1)
             self.assertIsInstance(res[0], list)
             self.assertGreater(len(res[0]), 0)
-            
+
         except Exception as e:
             self.skipTest(f"Ollama API not available: {e}")
 
@@ -76,7 +76,7 @@ class OllamaEmbeddingTest(unittest.TestCase):
             langchain_embedding = self.embedding.as_langchain()
             self.assertIsNotNone(langchain_embedding)
             print(f"LangChain embedding type: {type(langchain_embedding)}")
-            
+
             # Test with LangChain interface if Ollama is available
             try:
                 res = langchain_embedding.embed_documents(texts=["hello world"])
@@ -84,7 +84,7 @@ class OllamaEmbeddingTest(unittest.TestCase):
                 self.assertIsInstance(res, list)
             except Exception as e:
                 print(f"LangChain embedding test skipped: {e}")
-                
+
         except ImportError:
             self.skipTest("langchain_community not available")
         except Exception as e:
@@ -96,16 +96,16 @@ class OllamaEmbeddingTest(unittest.TestCase):
         embedding = OllamaEmbedding()
         embedding.ollama_base_url = None
         embedding.embedding_model_name = "test-model"
-        
+
         with self.assertRaises(Exception) as context:
             embedding.get_embeddings(["test"])
         self.assertIn("OLLAMA_BASE_URL is missing", str(context.exception))
-        
+
         # Test missing model name
         embedding = OllamaEmbedding()
         embedding.ollama_base_url = "http://localhost:11434"
         embedding.embedding_model_name = None
-        
+
         with self.assertRaises(Exception) as context:
             embedding.get_embeddings(["test"])
         self.assertIn("embedding_model_name is missing", str(context.exception))
@@ -113,14 +113,14 @@ class OllamaEmbeddingTest(unittest.TestCase):
     def test_multiple_models_configuration(self) -> None:
         """Test configuration with different supported models"""
         supported_models = ["mxbai-embed-large", "nomic-embed-text", "all-minilm"]
-        
+
         for model in supported_models:
             with self.subTest(model=model):
                 embedding = OllamaEmbedding()
                 embedding.ollama_base_url = "http://localhost:11434"
                 embedding.embedding_model_name = model
                 embedding.timeout = 30
-                
+
                 # Test that configuration is set correctly
                 self.assertEqual(embedding.embedding_model_name, model)
                 self.assertEqual(embedding.ollama_base_url, "http://localhost:11434")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 36, 42, 47, 61, 66, 79, 87, 99, 103, 108, 116, 123 in `tests/test_agentuniverse/unit/agent/action/knowledge/embedding/test_ollama_embedding.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; `ast.parse` passed.
