### PR TITLE
style(tests): strip trailing whitespace in test_aws_bedrock_llm.py

### DIFF
--- a/tests/test_agentuniverse/unit/llm/test_aws_bedrock_llm.py
+++ b/tests/test_agentuniverse/unit/llm/test_aws_bedrock_llm.py
@@ -13,7 +13,7 @@ class TestAWSBedrockLLM(unittest.TestCase):
 
         app_configer = AppConfiger()
         ApplicationConfigManager().app_configer = app_configer
-        
+
         self.llm = AWSBedrockLLM(
             model_name='amazon.nova-lite-v1:0',
             aws_access_key_id='AWS_ACCESS_KEY_ID',
@@ -21,7 +21,7 @@ class TestAWSBedrockLLM(unittest.TestCase):
             aws_region='us-east-1',
         )
 
-    
+
     def test_call(self) -> None:
         """Test synchronous call with real API."""
         messages = [
@@ -34,7 +34,7 @@ class TestAWSBedrockLLM(unittest.TestCase):
         print(output.__str__())
         self.assertIsNotNone(output.text)
 
-    
+
     def test_acall(self) -> None:
         """Test asynchronous call with real API."""
         messages = [
@@ -63,7 +63,7 @@ class TestAWSBedrockLLM(unittest.TestCase):
         print()
         self.assertGreater(len(chunks), 0)
 
-    
+
     def test_acall_stream(self):
         """Test async streaming call with real API."""
         messages = [


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 16, 24, 37, 66 in `tests/test_agentuniverse/unit/llm/test_aws_bedrock_llm.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; ast.parse passed.
