### PR TITLE
style(tests): strip trailing whitespace in test_xlsx_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py
@@ -35,17 +35,17 @@ class TestXlsxReader:
         mock_worksheet.sheetnames = ['Sheet1']
         mock_worksheet.max_row = 3
         mock_worksheet.max_column = 2
-        
+
         # Mock cell values
         mock_cells = [
             [MagicMock(value='Name'), MagicMock(value='Age')],
             [MagicMock(value='Alice'), MagicMock(value=25)],
             [MagicMock(value='Bob'), MagicMock(value=30)]
         ]
-        
+
         def mock_cell(row, column):
             return mock_cells[row-1][column-1]
-        
+
         mock_worksheet.cell = mock_cell
         mock_workbook.__getitem__.return_value = mock_worksheet
         mock_workbook.sheetnames = ['Sheet1']
@@ -53,7 +53,7 @@ class TestXlsxReader:
 
         # Test with string path
         result = self.reader._load_data('test.xlsx')
-        
+
         assert len(result) == 1
         assert isinstance(result[0], Document)
         assert 'Name | Age' in result[0].text
@@ -68,31 +68,31 @@ class TestXlsxReader:
         # Mock workbook with multiple sheets
         mock_workbook = MagicMock()
         mock_workbook.sheetnames = ['Sheet1', 'Sheet2']
-        
+
         # Mock first sheet
         mock_sheet1 = MagicMock()
         mock_sheet1.max_row = 2
         mock_sheet1.max_column = 2
         mock_sheet1.cell.return_value = MagicMock(value='Data1')
-        
+
         # Mock second sheet
         mock_sheet2 = MagicMock()
         mock_sheet2.max_row = 2
         mock_sheet2.max_column = 2
         mock_sheet2.cell.return_value = MagicMock(value='Data2')
-        
+
         def mock_getitem(sheet_name):
             if sheet_name == 'Sheet1':
                 return mock_sheet1
             elif sheet_name == 'Sheet2':
                 return mock_sheet2
             return None
-        
+
         mock_workbook.__getitem__ = mock_getitem
         mock_load_workbook.return_value = mock_workbook
 
         result = self.reader._load_data('test.xlsx')
-        
+
         assert len(result) == 2
         assert result[0].metadata['sheet_name'] == 'Sheet1'
         assert result[1].metadata['sheet_name'] == 'Sheet2'
@@ -114,14 +114,14 @@ class TestXlsxReader:
         mock_worksheet.max_row = 1
         mock_worksheet.max_column = 1
         mock_worksheet.cell.return_value = MagicMock(value='Test')
-        
+
         mock_workbook.__getitem__.return_value = mock_worksheet
         mock_workbook.sheetnames = ['Sheet1']
         mock_load_workbook.return_value = mock_workbook
 
         ext_info = {'custom_key': 'custom_value'}
         result = self.reader._load_data('test.xlsx', ext_info=ext_info)
-        
+
         assert len(result) == 1
         assert result[0].metadata['custom_key'] == 'custom_value'
         assert result[0].metadata['file_name'] == 'test.xlsx'
@@ -136,13 +136,13 @@ class TestXlsxReader:
         mock_worksheet.max_row = 0
         mock_worksheet.max_column = 0
         mock_worksheet.cell.return_value = MagicMock(value=None)
-        
+
         mock_workbook.__getitem__.return_value = mock_worksheet
         mock_workbook.sheetnames = ['Sheet1']
         mock_load_workbook.return_value = mock_workbook
 
         result = self.reader._load_data('test.xlsx')
-        
+
         # Empty sheet should not create any documents
         assert len(result) == 0
 
@@ -156,13 +156,13 @@ class TestXlsxReader:
             mock_worksheet.max_row = 1
             mock_worksheet.max_column = 1
             mock_worksheet.cell.return_value = MagicMock(value='Test')
-            
+
             mock_workbook.__getitem__.return_value = mock_worksheet
             mock_workbook.sheetnames = ['Sheet1']
             mock_load_workbook.return_value = mock_workbook
 
             file_path = Path('test.xlsx')
             result = self.reader._load_data(file_path)
-            
+
             assert len(result) == 1
             assert result[0].metadata['file_name'] == 'test.xlsx'


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 38, 45, 48, 56, 71, 77, 83, 90, 95, 117, 124, 139, 145, 159, 166 in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_xlsx_reader.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; ast.parse passed.
