### PR TITLE
style(tests): strip trailing whitespace in test_command_status.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
+++ b/tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py
@@ -34,13 +34,13 @@ class CommandStatusToolTest(unittest.TestCase):
         result_json = self.run_tool.execute(tool_input)
         result = json.loads(result_json)
         thread_id = result['thread_id']
-        
+
         status_input = ToolInput({
             'thread_id': thread_id
         })
         status_json = self.status_tool.execute(status_input)
         status_result = json.loads(status_json)
-        
+
         self.assertEqual(status_result['thread_id'], thread_id)
         self.assertEqual(status_result['status'], CommandStatus.COMPLETED.value)
         self.assertIn('Hello World', status_result['stdout'])
@@ -55,17 +55,17 @@ class CommandStatusToolTest(unittest.TestCase):
         result_json = self.run_tool.execute(tool_input)
         result = json.loads(result_json)
         thread_id = result['thread_id']
-        
+
         status_input = ToolInput({
             'thread_id': thread_id
         })
         status_json = self.status_tool.execute(status_input)
-        status_result = json.loads(status_json)        
-        
+        status_result = json.loads(status_json)
+
         time.sleep(3)
         status_json = self.status_tool.execute(status_input)
         status_result = json.loads(status_json)
-        
+
         self.assertEqual(status_result['status'], CommandStatus.COMPLETED.value)
         self.assertIn('Long running command finished', status_result['stdout'])
         self.assertEqual(status_result['exit_code'], 0)
@@ -76,7 +76,7 @@ class CommandStatusToolTest(unittest.TestCase):
         })
         status_json = self.status_tool.execute(status_input)
         status_result = json.loads(status_json)
-        
+
         self.assertIn('error', status_result)
         self.assertEqual(status_result['status'], 'not_found')
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 37, 43, 58, 63, 64, 68, 79 in `tests/test_agentuniverse/unit/agent/action/tool/test_command_status.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; `ast.parse` passed.
