### PR TITLE
style(tests): strip trailing whitespace in test_zip_reader.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py
@@ -81,78 +81,78 @@ class TestZipReader(unittest.TestCase):
 
     def test_complex_nested_zip_structure(self) -> None:
         archive_path = Path(self.temp_dir.name) / "complex_archive.zip"
-        
+
         level3_zip = io.BytesIO()
         with zipfile.ZipFile(level3_zip, "w") as z3:
             z3.writestr("deep/secret.txt", "这是第三层深度的秘密文档")
             z3.writestr("deep/config.json", '{"level": 3, "type": "configuration"}')
-        
+
         level2_zip = io.BytesIO()
         with zipfile.ZipFile(level2_zip, "w") as z2:
             z2.writestr("reports/report.md", "# 第二层报告\n\n这是嵌套的markdown文档")
             z2.writestr("data/metrics.txt", "CPU: 85%\nMemory: 60%\nDisk: 40%")
             z2.writestr("archives/level3.zip", level3_zip.getvalue())
-        
+
         with zipfile.ZipFile(archive_path, "w") as main_zip:
             main_zip.writestr("README.md", "# 主文档\n\n这是根目录的说明文件")
             main_zip.writestr("docs/intro.txt", "欢迎使用复杂压缩包测试系统")
             main_zip.writestr("docs/guide.md", "## 使用指南\n\n1. 解压文件\n2. 阅读文档\n3. 运行测试")
-            
+
             main_zip.writestr("src/main.py", "def main():\n    print('Hello from ZIP')\n\nif __name__ == '__main__':\n    main()")
             main_zip.writestr("src/utils.py", "def helper():\n    return 'utility function'")
-            
+
             main_zip.writestr("config/settings.json", '{"app": "test", "version": "1.0.0"}')
             main_zip.writestr("config/database.yml", "host: localhost\nport: 5432\ndatabase: testdb")
-            
+
             main_zip.writestr("data/sample.csv", "Name,Age,City\nAlice,28,Beijing\nBob,32,Shanghai\nCarol,25,Guangzhou")
-            
+
             docx_content = self._create_docx_file("这是一个Word文档，包含重要信息")
             if docx_content:
                 main_zip.writestr("documents/report.docx", docx_content)
-            
+
             pdf_content = self._create_pdf_file("这是PDF文档的内容")
             if pdf_content:
                 main_zip.writestr("documents/presentation.pdf", pdf_content)
-            
+
             pptx_content = self._create_pptx_file("项目演示PPT")
             if pptx_content:
                 main_zip.writestr("documents/slides.pptx", pptx_content)
-            
+
             xlsx_content = self._create_xlsx_file()
             if xlsx_content:
                 main_zip.writestr("data/employees.xlsx", xlsx_content)
-            
+
             main_zip.writestr("logs/app.log", "[INFO] Application started\n[DEBUG] Loading configuration\n[INFO] Ready")
             main_zip.writestr("logs/error.log", "[ERROR] Sample error message")
-            
+
             main_zip.writestr("web/index.html", "<html><body><h1>欢迎</h1></body></html>")
             main_zip.writestr("web/style.css", "body { font-family: Arial; }")
-            
+
             main_zip.writestr("nested_archives/level2.zip", level2_zip.getvalue())
-        
+
         docs = self.reader._load_data(archive_path)
-        
+
         self.assertGreater(len(docs), 0)
-        
+
         file_names = [doc.metadata.get("file_name") for doc in docs]
         archive_paths = [doc.metadata.get("archive_path") for doc in docs]
-        
+
         self.assertIn("README.md", file_names)
         self.assertIn("main.py", file_names)
         self.assertIn("settings.json", file_names)
-        
+
         nested_docs = [d for d in docs if "level2.zip" in d.metadata.get("archive_path", "")]
         self.assertGreater(len(nested_docs), 0)
-        
+
         deep_nested = [d for d in docs if "level3.zip" in d.metadata.get("archive_path", "")]
         self.assertGreater(len(deep_nested), 0)
-        
+
         txt_docs = [d for d in docs if d.metadata.get("file_name", "").endswith(".txt")]
         self.assertGreater(len(txt_docs), 0)
-        
+
         py_docs = [d for d in docs if d.metadata.get("file_name", "").endswith(".py")]
         self.assertEqual(len(py_docs), 2)
-        
+
         depths = [doc.metadata.get("archive_depth", 0) for doc in docs]
         self.assertIn(0, depths)
         self.assertIn(1, depths)
@@ -192,10 +192,10 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("data.json", '{"key": "value"}')
             archive.writestr("config.yml", "setting: true")
             archive.writestr("data.csv", "列1,列2\n值1,值2")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 6)
-        
+
         extensions = {doc.metadata["file_name"].split(".")[-1] for doc in docs}
         self.assertIn("txt", extensions)
         self.assertIn("md", extensions)
@@ -212,20 +212,20 @@ class TestZipReader(unittest.TestCase):
 
     def test_exceeds_depth_limit(self) -> None:
         archive_path = Path(self.temp_dir.name) / "deep.zip"
-        
+
         current = io.BytesIO()
         with zipfile.ZipFile(current, "w") as z:
             z.writestr("data.txt", "deepest")
-        
+
         for i in range(10):
             parent = io.BytesIO()
             with zipfile.ZipFile(parent, "w") as z:
                 z.writestr(f"level{i}.zip", current.getvalue())
             current = parent
-        
+
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("nested.zip", current.getvalue())
-        
+
         shallow_reader = ZipReader(max_depth=2)
         with self.assertRaises(ValueError):
             shallow_reader._load_data(archive_path)
@@ -233,10 +233,10 @@ class TestZipReader(unittest.TestCase):
     def test_compression_ratio_limit(self) -> None:
         archive_path = Path(self.temp_dir.name) / "compressed.zip"
         highly_compressible = "a" * 100000
-        
+
         with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             archive.writestr("repetitive.txt", highly_compressible)
-        
+
         strict_reader = ZipReader(max_compression_ratio=10)
         with self.assertRaises(ValueError):
             strict_reader._load_data(archive_path)
@@ -245,13 +245,13 @@ class TestZipReader(unittest.TestCase):
         archive_path = Path(self.temp_dir.name) / "meta.zip"
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("file.txt", "content")
-        
+
         custom_meta = {
             "source": "测试来源",
             "category": "文档类别",
             "priority": "高"
         }
-        
+
         docs = self.reader._load_data(archive_path, ext_info=custom_meta)
         self.assertEqual(len(docs), 1)
         doc = docs[0]
@@ -264,7 +264,7 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("empty.txt", "")
             archive.writestr("not_empty.txt", "有内容")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertGreater(len(docs), 0)
         non_empty_docs = [d for d in docs if d.text.strip()]
@@ -276,7 +276,7 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("中文目录/文件名.txt", "中文内容")
             archive.writestr("folder with spaces/file name.txt", "content")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 2)
         file_names = [doc.metadata["file_name"] for doc in docs]
@@ -285,20 +285,20 @@ class TestZipReader(unittest.TestCase):
 
     def test_ultra_complex_nested_structure(self) -> None:
         archive_path = Path(self.temp_dir.name) / "ultra_complex.zip"
-        
+
         level4_zip = io.BytesIO()
         with zipfile.ZipFile(level4_zip, "w") as z4:
             z4.writestr("final/ultimate.txt", "最深层文档内容")
             z4.writestr("final/data.json", '{"depth": 4}')
             z4.writestr("final/script.py", "print('level 4')")
-        
+
         level3_zip = io.BytesIO()
         with zipfile.ZipFile(level3_zip, "w") as z3:
             z3.writestr("deep/secret.txt", "第三层秘密")
             z3.writestr("deep/config.yml", "level: 3\ntype: config")
             z3.writestr("deep/code.py", "def level3(): pass")
             z3.writestr("archives/level4.zip", level4_zip.getvalue())
-        
+
         level2_zip = io.BytesIO()
         with zipfile.ZipFile(level2_zip, "w") as z2:
             z2.writestr("reports/report.md", "# 第二层报告")
@@ -307,14 +307,14 @@ class TestZipReader(unittest.TestCase):
             z2.writestr("data/analysis.json", '{"status": "ok"}')
             z2.writestr("scripts/process.py", "def process(): return True")
             z2.writestr("archives/level3.zip", level3_zip.getvalue())
-        
+
         level1_zip = io.BytesIO()
         with zipfile.ZipFile(level1_zip, "w") as z1:
             z1.writestr("docs/readme.md", "# Level 1 文档")
             z1.writestr("docs/notes.txt", "笔记内容")
             z1.writestr("code/main.py", "def main(): print('level1')")
             z1.writestr("nested/level2.zip", level2_zip.getvalue())
-        
+
         with zipfile.ZipFile(archive_path, "w") as main_zip:
             main_zip.writestr("README.md", "# 超级复杂压缩包\n\n包含4层嵌套结构")
             main_zip.writestr("LICENSE.txt", "MIT License")
@@ -329,23 +329,23 @@ class TestZipReader(unittest.TestCase):
             main_zip.writestr("data/output.txt", "结果数据")
             main_zip.writestr("tests/test_app.py", "def test_run(): assert True")
             main_zip.writestr("archives/level1.zip", level1_zip.getvalue())
-        
+
         docs = self.reader._load_data(archive_path)
-        
+
         self.assertGreater(len(docs), 20)
-        
+
         depths = [doc.metadata.get("archive_depth", 0) for doc in docs]
         self.assertIn(0, depths)
         self.assertIn(1, depths)
         self.assertIn(2, depths)
         self.assertIn(3, depths)
-        
+
         level4_docs = [d for d in docs if "level4.zip" in d.metadata.get("archive_path", "")]
         self.assertGreater(len(level4_docs), 0)
-        
+
         py_files = [d for d in docs if d.metadata.get("file_name", "").endswith(".py")]
         self.assertGreater(len(py_files), 5)
-        
+
         md_files = [d for d in docs if d.metadata.get("file_name", "").endswith(".md")]
         self.assertGreater(len(md_files), 3)
 
@@ -362,10 +362,10 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("script.sh", "#!/bin/bash\necho 'Shell'")
             archive.writestr("app.rb", "puts 'Ruby'")
             archive.writestr("index.php", "<?php echo 'PHP'; ?>")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 10)
-        
+
         languages = [doc.metadata.get("language") for doc in docs]
         self.assertIn("python", languages)
         self.assertIn("javascript", languages)
@@ -378,7 +378,7 @@ class TestZipReader(unittest.TestCase):
 
     def test_mixed_documents_extraction(self) -> None:
         archive_path = Path(self.temp_dir.name) / "docs_archive.zip"
-        
+
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("notes.txt", "这是文本笔记\n第二行内容")
             archive.writestr("readme.md", "# 项目说明\n\n## 功能\n- 功能1\n- 功能2")
@@ -389,18 +389,18 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("style.css", "body { margin: 0; padding: 0; }\nh1 { color: blue; }")
             archive.writestr("data.xml", '<?xml version="1.0"?>\n<root><item>数据</item></root>')
             archive.writestr("app.log", "[2025-10-28 10:00:00] INFO: 应用启动\n[2025-10-28 10:00:01] DEBUG: 初始化完成")
-            
+
             docx_content = self._create_docx_file("Word文档测试内容\n包含多行文字")
             if docx_content:
                 archive.writestr("report.docx", docx_content)
-            
+
             pdf_content = self._create_pdf_file("PDF测试文档")
             if pdf_content:
                 archive.writestr("document.pdf", pdf_content)
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertGreater(len(docs), 8)
-        
+
         file_types = {doc.metadata.get("file_name", "").split(".")[-1] for doc in docs}
         self.assertIn("txt", file_types)
         self.assertIn("md", file_types)
@@ -416,10 +416,10 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("level1/level2/level3/level4/file4.txt", "内容4")
             archive.writestr("level1/level2/level3/level4/level5/file5.txt", "内容5")
             archive.writestr("a/b/c/d/e/f/g/deep.txt", "很深的目录")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 6)
-        
+
         paths = [doc.metadata.get("archive_path", "") for doc in docs]
         self.assertTrue(any("level5" in p for p in paths))
         self.assertTrue(any("a/b/c/d/e/f/g" in p for p in paths))
@@ -432,13 +432,13 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("dir3/config.txt", "配置3")
             archive.writestr("a/b/readme.md", "# 说明A")
             archive.writestr("c/d/readme.md", "# 说明B")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 5)
-        
+
         config_docs = [d for d in docs if d.metadata.get("file_name") == "config.txt"]
         self.assertEqual(len(config_docs), 3)
-        
+
         paths = [d.metadata.get("archive_path") for d in config_docs]
         self.assertIn("dir1/config.txt", paths)
         self.assertIn("dir2/config.txt", paths)
@@ -449,7 +449,7 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             for i in range(100):
                 archive.writestr(f"file_{i}.txt", f"内容 {i}")
-        
+
         limited_reader = ZipReader(max_files=50)
         with self.assertRaises(ValueError) as context:
             limited_reader._load_data(archive_path)
@@ -460,7 +460,7 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             for i in range(20):
                 archive.writestr(f"file_{i}.txt", "x" * 1000)
-        
+
         limited_reader = ZipReader(max_total_size=5000)
         with self.assertRaises(ValueError) as context:
             limited_reader._load_data(archive_path)
@@ -473,9 +473,9 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("./../../sensitive.txt", "should be blocked")
             archive.writestr("normal/file.txt", "正常文件")
             archive.writestr("../outside.txt", "应该被阻止")
-        
+
         docs = self.reader._load_data(archive_path)
-        
+
         for doc in docs:
             path = doc.metadata.get("archive_path", "")
             self.assertNotIn("..", path)
@@ -501,7 +501,7 @@ class TestZipReader(unittest.TestCase):
             archive.writestr(".env", "SECRET_KEY=abc123")
             archive.writestr("normal.txt", "正常文件")
             archive.writestr("dir/.hidden_in_dir", "目录中的隐藏文件")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertGreater(len(docs), 0)
 
@@ -513,21 +513,21 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("korean.txt", "한국어 텍스트: 안녕하세요")
             archive.writestr("emoji.txt", "表情符号测试 😀 🎉 ✨ 🚀")
             archive.writestr("mixed.txt", "混合内容 Mixed Content مرحبا Привет")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 5)
-        
+
         chinese_doc = [d for d in docs if "chinese.txt" in d.metadata.get("file_name", "")][0]
         self.assertIn("你好世界", chinese_doc.text)
 
     def test_various_compression_levels(self) -> None:
         content = "重复内容 " * 100
-        
+
         for compression in [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED]:
             archive_path = Path(self.temp_dir.name) / f"compress_{compression}.zip"
             with zipfile.ZipFile(archive_path, "w", compression=compression) as archive:
                 archive.writestr("data.txt", content)
-            
+
             reader = ZipReader(max_compression_ratio=500)
             docs = reader._load_data(archive_path)
             self.assertEqual(len(docs), 1)
@@ -537,7 +537,7 @@ class TestZipReader(unittest.TestCase):
         archive_path = Path(self.temp_dir.name) / "empty.zip"
         with zipfile.ZipFile(archive_path, "w") as archive:
             pass
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 0)
 
@@ -547,7 +547,7 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("dir1/", "")
             archive.writestr("dir2/subdir/", "")
             archive.writestr("dir3/", "")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 0)
 
@@ -559,7 +559,7 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("empty2.md", "")
             archive.writestr("data.json", '{}')
             archive.writestr("empty3.py", "")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertGreater(len(docs), 0)
         self.assertLessEqual(len(docs), 5)
@@ -570,34 +570,34 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr(long_name, "内容")
             archive.writestr("dir/" + "b" * 150 + ".md", "# 标题")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 2)
 
     def test_multiple_nested_zips_same_level(self) -> None:
         archive_path = Path(self.temp_dir.name) / "multi_nested.zip"
-        
+
         nested1 = io.BytesIO()
         with zipfile.ZipFile(nested1, "w") as z:
             z.writestr("data1.txt", "嵌套包1数据")
-        
+
         nested2 = io.BytesIO()
         with zipfile.ZipFile(nested2, "w") as z:
             z.writestr("data2.txt", "嵌套包2数据")
-        
+
         nested3 = io.BytesIO()
         with zipfile.ZipFile(nested3, "w") as z:
             z.writestr("data3.txt", "嵌套包3数据")
-        
+
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("root.txt", "根文件")
             archive.writestr("archives/pack1.zip", nested1.getvalue())
             archive.writestr("archives/pack2.zip", nested2.getvalue())
             archive.writestr("archives/pack3.zip", nested3.getvalue())
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 4)
-        
+
         nested_docs = [d for d in docs if ".zip/" in d.metadata.get("archive_path", "")]
         self.assertEqual(len(nested_docs), 3)
 
@@ -606,47 +606,47 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("data/sales.csv", "产品,数量,价格\n笔记本,100,5000\n鼠标,200,50")
             archive.writestr("data/users.csv", "用户名,邮箱\nzhangsan,zhang@test.com\nlisi,li@test.com")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 2)
 
     def test_json_and_yaml_in_nested_zip(self) -> None:
         archive_path = Path(self.temp_dir.name) / "config_archive.zip"
-        
+
         nested = io.BytesIO()
         with zipfile.ZipFile(nested, "w") as z:
             z.writestr("app.json", '{"name": "app", "version": "2.0"}')
             z.writestr("db.yml", "host: localhost\nport: 3306")
-        
+
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("main.json", '{"type": "main"}')
             archive.writestr("configs/nested.zip", nested.getvalue())
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 3)
-        
+
         json_docs = [d for d in docs if d.metadata.get("file_name", "").endswith(".json")]
         self.assertEqual(len(json_docs), 2)
 
     def test_metadata_propagation_through_nesting(self) -> None:
         archive_path = Path(self.temp_dir.name) / "meta_nest.zip"
-        
+
         nested = io.BytesIO()
         with zipfile.ZipFile(nested, "w") as z:
             z.writestr("inner.txt", "内部内容")
-        
+
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("outer.txt", "外部内容")
             archive.writestr("nest/inner.zip", nested.getvalue())
-        
+
         custom_meta = {
             "project": "测试项目",
             "version": "1.0",
             "author": "测试者"
         }
-        
+
         docs = self.reader._load_data(archive_path, ext_info=custom_meta)
-        
+
         for doc in docs:
             self.assertEqual(doc.metadata.get("project"), "测试项目")
             self.assertEqual(doc.metadata.get("version"), "1.0")
@@ -656,10 +656,10 @@ class TestZipReader(unittest.TestCase):
         archive_path = Path(self.temp_dir.name) / "test_archive.zip"
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("level1/file.txt", "内容")
-        
+
         docs = self.reader._load_data(archive_path)
         doc = docs[0]
-        
+
         self.assertEqual(doc.metadata.get("archive_root"), "test_archive.zip")
         self.assertEqual(doc.metadata.get("archive_path"), "level1/file.txt")
         self.assertEqual(doc.metadata.get("file_name"), "file.txt")
@@ -667,17 +667,17 @@ class TestZipReader(unittest.TestCase):
 
     def test_nested_archive_path_construction(self) -> None:
         archive_path = Path(self.temp_dir.name) / "path_test.zip"
-        
+
         level2 = io.BytesIO()
         with zipfile.ZipFile(level2, "w") as z:
             z.writestr("deep/file.txt", "深层内容")
-        
+
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("container/level2.zip", level2.getvalue())
-        
+
         docs = self.reader._load_data(archive_path)
         doc = docs[0]
-        
+
         expected_path = "container/level2.zip/deep/file.txt"
         self.assertEqual(doc.metadata.get("archive_path"), expected_path)
         self.assertEqual(doc.metadata.get("archive_depth"), 1)
@@ -687,7 +687,7 @@ class TestZipReader(unittest.TestCase):
         with zipfile.ZipFile(archive_path, "w") as archive:
             for i in range(500):
                 archive.writestr(f"files/batch_{i // 100}/file_{i}.txt", f"内容 {i}")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertEqual(len(docs), 500)
 
@@ -699,7 +699,7 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("newlines.txt", "\n\n\n")
             archive.writestr("mixed.txt", "  \n\t  \n  ")
             archive.writestr("normal.txt", "正常内容")
-        
+
         docs = self.reader._load_data(archive_path)
         self.assertGreater(len(docs), 0)
         self.assertLessEqual(len(docs), 5)
@@ -710,9 +710,9 @@ class TestZipReader(unittest.TestCase):
             archive.writestr("image.png", bytes([0x89, 0x50, 0x4E, 0x47] + [0] * 100))
             archive.writestr("data.bin", bytes(range(256)))
             archive.writestr("text.txt", "文本内容")
-        
+
         docs = self.reader._load_data(archive_path)
-        
+
         text_docs = [d for d in docs if d.metadata.get("file_name") == "text.txt"]
         self.assertEqual(len(text_docs), 1)
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 84, 89, 95, 100, 103, 106, 108, 112, 116, 120, 124, 127, 130, 132, 134, 136, 139, 143, 146, 149, 152, 155, 195, 198, 215, 219, 225, 228, 236, 239, 248, 254, 267, 279, 288, 294, 301, 310, 317, 332, 334, 336, 342, 345, 348, 365, 368, 381, 392, 396, 400, 403, 419, 422, 435, 438, 441, 452, 463, 476, 478, 504, 516, 519, 525, 530, 540, 550, 562, 573, 579, 583, 587, 591, 597, 600, 609, 615, 620, 624, 627, 633, 637, 641, 647, 649, 659, 662, 670, 674, 677, 680, 690, 702, 713, 715 in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/test_zip_reader.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; ast.parse passed.
