### PR TITLE
style(tests): strip trailing whitespace in excel_reader_demo.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/excel_reader_demo.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/excel_reader_demo.py
@@ -17,17 +17,17 @@ def create_sample_excel():
     try:
         import openpyxl
         from openpyxl import Workbook
-        
+
         # 创建工作簿
         wb = Workbook()
         ws = wb.active
         ws.title = "员工信息"
-        
+
         # 添加表头
         headers = ["姓名", "年龄", "部门", "工资"]
         for col, header in enumerate(headers, 1):
             ws.cell(row=1, column=col, value=header)
-        
+
         # 添加示例数据
         sample_data = [
             ["张三", 25, "技术部", 8000],
@@ -35,11 +35,11 @@ def create_sample_excel():
             ["王五", 28, "人事部", 7500],
             ["赵六", 35, "财务部", 8500]
         ]
-        
+
         for row, data in enumerate(sample_data, 2):
             for col, value in enumerate(data, 1):
                 ws.cell(row=row, column=col, value=value)
-        
+
         # 创建第二个工作表
         ws2 = wb.create_sheet("部门统计")
         ws2.cell(row=1, column=1, value="部门")
@@ -52,13 +52,13 @@ def create_sample_excel():
         ws2.cell(row=4, column=2, value=1)
         ws2.cell(row=5, column=1, value="财务部")
         ws2.cell(row=5, column=2, value=1)
-        
+
         # 保存文件
         file_path = "sample_employees.xlsx"
         wb.save(file_path)
         print(f"✅ 示例Excel文件已创建: {file_path}")
         return file_path
-        
+
     except ImportError:
         print("❌ 需要安装openpyxl: pip install openpyxl")
         return None
@@ -66,24 +66,24 @@ def create_sample_excel():
 def demo_excel_reader():
     """演示Excel读取器功能"""
     print("🚀 开始演示Excel读取器功能...")
-    
+
     # 创建示例文件
     excel_file = create_sample_excel()
     if not excel_file:
         return
-    
+
     try:
         # 导入必要的模块
         from agentuniverse.agent.action.knowledge.reader.file.xlsx_reader import XlsxReader
         from agentuniverse.agent.action.knowledge.reader.file.file_reader import FileReader
-        
+
         print("\n📖 方法1: 直接使用XlsxReader")
         print("-" * 50)
-        
+
         # 直接使用XlsxReader
         xlsx_reader = XlsxReader()
         documents = xlsx_reader.load_data(file=excel_file)
-        
+
         print(f"📊 读取到 {len(documents)} 个文档:")
         for i, doc in enumerate(documents, 1):
             print(f"\n📄 文档 {i} (工作表: {doc.metadata['sheet_name']}):")
@@ -93,14 +93,14 @@ def demo_excel_reader():
             # 显示前200个字符
             content_preview = doc.text[:200] + "..." if len(doc.text) > 200 else doc.text
             print(f"   {content_preview}")
-        
+
         print("\n📖 方法2: 使用FileReader (自动识别文件类型)")
         print("-" * 50)
-        
+
         # 使用FileReader自动识别文件类型
         file_reader = FileReader()
         documents2 = file_reader.load_data(file_paths=[Path(excel_file)])
-        
+
         print(f"📊 通过FileReader读取到 {len(documents2)} 个文档:")
         for i, doc in enumerate(documents2, 1):
             print(f"\n📄 文档 {i} (工作表: {doc.metadata['sheet_name']}):")
@@ -108,9 +108,9 @@ def demo_excel_reader():
             print(f"   内容预览:")
             content_preview = doc.text[:150] + "..." if len(doc.text) > 150 else doc.text
             print(f"   {content_preview}")
-        
+
         print("\n✅ Excel读取器演示完成!")
-        
+
     except ImportError as e:
         print(f"❌ 导入错误: {e}")
         print("请确保已安装所需依赖: pip install openpyxl")


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Stripped trailing whitespace on lines 20, 25, 30, 38, 42, 55, 61, 69, 74, 79, 82, 86, 96, 99, 103, 111, 113 in `tests/test_agentuniverse/unit/agent/action/knowledge/reader/file/excel_reader_demo.py`.
- Housekeeping: keeps the tree whitespace-clean; no functional changes.
- Verified each listed line had trailing whitespace; ast.parse passed.
