### PR TITLE
style(examples): strip trailing whitespace in prompt_generator.py

### DIFF
--- a/examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_generator.py
+++ b/examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_generator.py
@@ -16,7 +16,7 @@ from agentuniverse.prompt.prompt_model import AgentPromptModel
 
 class PromptScenario(Enum):
     """Enumeration of supported prompt scenarios."""
-    
+
     CONVERSATIONAL = "conversational"
     TASK_ORIENTED = "task_oriented"
     REASONING = "reasoning"
@@ -31,7 +31,7 @@ class PromptScenario(Enum):
 
 class PromptComplexity(Enum):
     """Enumeration of prompt complexity levels."""
-    
+
     SIMPLE = "simple"
     MEDIUM = "medium"
     COMPLEX = "complex"
@@ -40,7 +40,7 @@ class PromptComplexity(Enum):
 @dataclass
 class ScenarioContext:
     """Context information for prompt generation.
-    
+
     Attributes:
         domain: The domain or field of application.
         user_role: The role of the user (e.g., student, developer, analyst).
@@ -49,7 +49,7 @@ class ScenarioContext:
         examples: Example inputs and expected outputs.
         tone: The desired tone (formal, casual, technical, etc.).
     """
-    
+
     domain: str
     user_role: str
     target_audience: str
@@ -61,7 +61,7 @@ class ScenarioContext:
 @dataclass
 class PromptOptimizationResult:
     """Result of prompt optimization.
-    
+
     Attributes:
         original_prompt: The original prompt text.
         optimized_prompt: The optimized prompt text.
@@ -69,7 +69,7 @@ class PromptOptimizationResult:
         confidence_score: Confidence score for the optimization (0-1).
         suggestions: Additional suggestions for further improvement.
     """
-    
+
     original_prompt: str
     optimized_prompt: str
     improvements: List[str]
@@ -79,16 +79,16 @@ class PromptOptimizationResult:
 
 class PromptGenerator:
     """Intelligent prompt generator and optimizer.
-    
+
     This class provides functionality to automatically generate and optimize
     prompts based on user scenarios and content requirements.
     """
-    
+
     def __init__(self):
         """Initialize the PromptGenerator."""
         self._scenario_templates = self._initialize_scenario_templates()
         self._optimization_rules = self._initialize_optimization_rules()
-    
+
     def generate_prompt(
         self,
         scenario: PromptScenario,
@@ -97,82 +97,82 @@ class PromptGenerator:
         custom_requirements: Optional[str] = None
     ) -> AgentPromptModel:
         """Generate a prompt based on scenario and context.
-        
+
         Args:
             scenario: The type of scenario for the prompt.
             context: Context information including domain, user role, etc.
             complexity: The complexity level of the prompt.
             custom_requirements: Additional custom requirements.
-            
+
         Returns:
             AgentPromptModel: Generated prompt model.
-            
+
         Raises:
             ValueError: If scenario or context is invalid.
         """
         if not isinstance(scenario, PromptScenario):
             raise ValueError(f"Invalid scenario: {scenario}")
-        
+
         if not isinstance(context, ScenarioContext):
             raise ValueError(f"Invalid context: {context}")
-        
+
         # Get base template for the scenario
         base_template = self._scenario_templates.get(scenario)
         if not base_template:
             raise ValueError(f"No template found for scenario: {scenario}")
-        
+
         # Generate introduction
         introduction = self._generate_introduction(scenario, context, complexity)
-        
+
         # Generate target
         target = self._generate_target(scenario, context, complexity)
-        
+
         # Generate instruction
         instruction = self._generate_instruction(
             scenario, context, complexity, base_template, custom_requirements
         )
-        
+
         return AgentPromptModel(
             introduction=introduction,
             target=target,
             instruction=instruction
         )
-    
+
     def optimize_prompt(self, prompt: AgentPromptModel) -> PromptOptimizationResult:
         """Optimize an existing prompt.
-        
+
         Args:
             prompt: The prompt model to optimize.
-            
+
         Returns:
             PromptOptimizationResult: The optimization result.
         """
         improvements = []
         suggestions = []
-        
+
         # Optimize introduction
         optimized_introduction = self._optimize_introduction(prompt.introduction)
         if optimized_introduction != prompt.introduction:
             improvements.append("Improved introduction clarity and structure")
-        
+
         # Optimize target
         optimized_target = self._optimize_target(prompt.target)
         if optimized_target != prompt.target:
             improvements.append("Enhanced target specificity and focus")
-        
+
         # Optimize instruction
         optimized_instruction = self._optimize_instruction(prompt.instruction)
         if optimized_instruction != prompt.instruction:
             improvements.append("Refined instruction structure and clarity")
-        
+
         # Generate suggestions
         suggestions = self._generate_optimization_suggestions(prompt)
-        
+
         # Calculate confidence score
         confidence_score = self._calculate_confidence_score(
             prompt, optimized_introduction, optimized_target, optimized_instruction
         )
-        
+
         return PromptOptimizationResult(
             original_prompt=self._format_prompt(prompt),
             optimized_prompt=self._format_optimized_prompt(
@@ -182,20 +182,20 @@ class PromptGenerator:
             confidence_score=confidence_score,
             suggestions=suggestions
         )
-    
+
     def analyze_scenario(self, content: str, context: ScenarioContext) -> PromptScenario:
         """Analyze content and context to determine the best scenario.
-        
+
         Args:
             content: The content to analyze.
             context: The context information.
-            
+
         Returns:
             PromptScenario: The recommended scenario type.
         """
         # Simple keyword-based analysis (can be enhanced with ML models)
         content_lower = content.lower()
-        
+
         if any(keyword in content_lower for keyword in ['代码', '编程', '开发', 'code', 'programming']):
             return PromptScenario.CODE_GENERATION
         elif any(keyword in content_lower for keyword in ['分析', '数据', '统计', 'analysis', 'data']):
@@ -212,10 +212,10 @@ class PromptGenerator:
             return PromptScenario.RESEARCH
         else:
             return PromptScenario.CONVERSATIONAL
-    
+
     def _initialize_scenario_templates(self) -> Dict[PromptScenario, Dict[str, str]]:
         """Initialize scenario-specific templates.
-        
+
         Returns:
             Dict[PromptScenario, Dict[str, str]]: Template dictionary.
         """
@@ -271,10 +271,10 @@ class PromptGenerator:
                 "instruction_pattern": "请提供完整的代码实现，包括注释和文档，确保代码质量和可读性。"
             }
         }
-    
+
     def _initialize_optimization_rules(self) -> List[Dict[str, Any]]:
         """Initialize optimization rules for prompt improvement.
-        
+
         Returns:
             List[Dict[str, Any]]: List of optimization rules.
         """
@@ -295,25 +295,25 @@ class PromptGenerator:
                 "description": "Add quality assurance"
             }
         ]
-    
+
     def _generate_introduction(
-        self, 
-        scenario: PromptScenario, 
-        context: ScenarioContext, 
+        self,
+        scenario: PromptScenario,
+        context: ScenarioContext,
         complexity: PromptComplexity
     ) -> str:
         """Generate introduction based on scenario and context.
-        
+
         Args:
             scenario: The prompt scenario.
             context: The context information.
             complexity: The complexity level.
-            
+
         Returns:
             str: Generated introduction.
         """
         template = self._scenario_templates[scenario]["introduction_pattern"]
-        
+
         # Adjust based on complexity
         if complexity == PromptComplexity.SIMPLE:
             role = f"{context.domain}助手"
@@ -321,141 +321,141 @@ class PromptGenerator:
             role = f"资深{context.domain}专家"
         else:
             role = f"{context.domain}专家"
-        
+
         return template.format(
             role=role,
             audience=context.target_audience,
             domain=context.domain
         )
-    
+
     def _generate_target(
-        self, 
-        scenario: PromptScenario, 
-        context: ScenarioContext, 
+        self,
+        scenario: PromptScenario,
+        context: ScenarioContext,
         complexity: PromptComplexity
     ) -> str:
         """Generate target based on scenario and context.
-        
+
         Args:
             scenario: The prompt scenario.
             context: The context information.
             complexity: The complexity level.
-            
+
         Returns:
             str: Generated target.
         """
         template = self._scenario_templates[scenario]["target_pattern"]
-        
+
         # Add complexity-specific enhancements
         if complexity == PromptComplexity.COMPLEX:
             template += " 请提供深入、全面的分析和解决方案。"
         elif complexity == PromptComplexity.SIMPLE:
             template += " 请提供简洁、易懂的回答。"
-        
+
         return template
-    
+
     def _generate_instruction(
-        self, 
-        scenario: PromptScenario, 
-        context: ScenarioContext, 
+        self,
+        scenario: PromptScenario,
+        context: ScenarioContext,
         complexity: PromptComplexity,
         base_template: Dict[str, str],
         custom_requirements: Optional[str]
     ) -> str:
         """Generate instruction based on scenario and context.
-        
+
         Args:
             scenario: The prompt scenario.
             context: The context information.
             complexity: The complexity level.
             base_template: Base template for the scenario.
             custom_requirements: Custom requirements.
-            
+
         Returns:
             str: Generated instruction.
         """
         template = base_template["instruction_pattern"]
-        
+
         # Format with context
         instruction = template.format(
             tone=context.tone,
             domain=context.domain,
             audience=context.target_audience
         )
-        
+
         # Add constraints
         if context.constraints:
             instruction += "\n\n约束条件：\n"
             for constraint in context.constraints:
                 instruction += f"- {constraint}\n"
-        
+
         # Add examples
         if context.examples:
             instruction += "\n\n示例：\n"
             for i, example in enumerate(context.examples, 1):
                 instruction += f"{i}. 输入：{example.get('input', '')}\n"
                 instruction += f"   输出：{example.get('output', '')}\n"
-        
+
         # Add custom requirements
         if custom_requirements:
             instruction += f"\n\n特殊要求：\n{custom_requirements}"
-        
+
         return instruction
-    
+
     def _optimize_introduction(self, introduction: Optional[str]) -> str:
         """Optimize the introduction section.
-        
+
         Args:
             introduction: The original introduction.
-            
+
         Returns:
             str: Optimized introduction.
         """
         if not introduction:
             return ""
-        
+
         # Apply optimization rules
         optimized = introduction
         for rule in self._optimization_rules:
             if re.search(rule["pattern"], optimized):
                 optimized = re.sub(rule["pattern"], rule["replacement"], optimized)
-        
+
         return optimized
-    
+
     def _optimize_target(self, target: Optional[str]) -> str:
         """Optimize the target section.
-        
+
         Args:
             target: The original target.
-            
+
         Returns:
             str: Optimized target.
         """
         if not target:
             return ""
-        
+
         # Add specificity if missing
         if "目标" not in target and "goal" not in target.lower():
             target = f"你的目标是：{target}"
-        
+
         return target
-    
+
     def _optimize_instruction(self, instruction: Optional[str]) -> str:
         """Optimize the instruction section.
-        
+
         Args:
             instruction: The original instruction.
-            
+
         Returns:
             str: Optimized instruction.
         """
         if not instruction:
             return ""
-        
+
         # Structure the instruction better
         lines = instruction.split('\n')
         structured_lines = []
-        
+
         for line in lines:
             line = line.strip()
             if line:
@@ -464,60 +464,60 @@ class PromptGenerator:
                     if not line.startswith(('1.', '2.', '3.')):
                         line = f"• {line.lstrip('-• ')}"
                 structured_lines.append(line)
-        
+
         return '\n'.join(structured_lines)
-    
+
     def _generate_optimization_suggestions(self, prompt: AgentPromptModel) -> List[str]:
         """Generate optimization suggestions for a prompt.
-        
+
         Args:
             prompt: The prompt model to analyze.
-            
+
         Returns:
             List[str]: List of optimization suggestions.
         """
         suggestions = []
-        
+
         # Check introduction
         if not prompt.introduction:
             suggestions.append("考虑添加一个清晰的介绍，说明AI助手的角色和专长")
         elif len(prompt.introduction) < 20:
             suggestions.append("介绍部分可以更详细，增加专业性和可信度")
-        
+
         # Check target
         if not prompt.target:
             suggestions.append("建议添加明确的目标描述，让AI知道要达成什么")
         elif "目标" not in prompt.target:
             suggestions.append("目标描述可以更明确，使用'目标'等关键词")
-        
+
         # Check instruction
         if not prompt.instruction:
             suggestions.append("指令部分是必需的，请添加具体的执行指导")
         elif len(prompt.instruction) < 50:
             suggestions.append("指令部分可以更详细，提供更多具体的执行步骤")
-        
+
         return suggestions
-    
+
     def _calculate_confidence_score(
-        self, 
-        original: AgentPromptModel, 
-        optimized_intro: str, 
-        optimized_target: str, 
+        self,
+        original: AgentPromptModel,
+        optimized_intro: str,
+        optimized_target: str,
         optimized_instruction: str
     ) -> float:
         """Calculate confidence score for optimization.
-        
+
         Args:
             original: Original prompt model.
             optimized_intro: Optimized introduction.
             optimized_target: Optimized target.
             optimized_instruction: Optimized instruction.
-            
+
         Returns:
             float: Confidence score between 0 and 1.
         """
         score = 0.0
-        
+
         # Check if all sections exist
         if optimized_intro:
             score += 0.3
@@ -525,7 +525,7 @@ class PromptGenerator:
             score += 0.3
         if optimized_instruction:
             score += 0.4
-        
+
         # Check for improvements
         if original.introduction != optimized_intro:
             score += 0.1
@@ -533,15 +533,15 @@ class PromptGenerator:
             score += 0.1
         if original.instruction != optimized_instruction:
             score += 0.1
-        
+
         return min(score, 1.0)
-    
+
     def _format_prompt(self, prompt: AgentPromptModel) -> str:
         """Format prompt model as string.
-        
+
         Args:
             prompt: The prompt model.
-            
+
         Returns:
             str: Formatted prompt string.
         """
@@ -552,22 +552,22 @@ class PromptGenerator:
             parts.append(f"目标：{prompt.target}")
         if prompt.instruction:
             parts.append(f"指令：{prompt.instruction}")
-        
+
         return "\n\n".join(parts)
-    
+
     def _format_optimized_prompt(
-        self, 
-        introduction: str, 
-        target: str, 
+        self,
+        introduction: str,
+        target: str,
         instruction: str
     ) -> str:
         """Format optimized prompt as string.
-        
+
         Args:
             introduction: Optimized introduction.
             target: Optimized target.
             instruction: Optimized instruction.
-            
+
         Returns:
             str: Formatted optimized prompt string.
         """
@@ -578,5 +578,5 @@ class PromptGenerator:
             parts.append(f"目标：{target}")
         if instruction:
             parts.append(f"指令：{instruction}")
-        
+
         return "\n\n".join(parts)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 19, 34, 43, 52, 64, 72, 82, 86, 91, 100, 106, 109, 115, 118, 123, 126, 129, 134, 140, 143, 146, 152, 157, 162, 167, 170, 175, 185, 188, 192, 198, 215, 218, 274, 277, 298, 300, 301, 302, 306, 311, 316, 324, 330, 332, 333, 334, 338, 343, 348, 354, 356, 358, 359, 360, 366, 373, 378, 385, 391, 398, 402, 404, 407, 410, 416, 422, 424, 427, 430, 436, 440, 442, 445, 448, 454, 458, 467, 469, 472, 475, 480, 486, 492, 498, 500, 502, 503, 504, 505, 509, 515, 520, 528, 536, 538, 541, 544, 555, 557, 559, 560, 561, 565, 570, 581 in `examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_generator.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_generator.py').read())"` — the file remains syntactically valid.
