### PR TITLE
style(examples): strip trailing whitespace in prompt_optimizer.py

### DIFF
--- a/examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_optimizer.py
+++ b/examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_optimizer.py
@@ -17,7 +17,7 @@ from agentuniverse.prompt.prompt_model import AgentPromptModel
 
 class OptimizationStrategy(Enum):
     """Enumeration of optimization strategies."""
-    
+
     CLARITY = "clarity"
     STRUCTURE = "structure"
     SPECIFICITY = "specificity"
@@ -27,7 +27,7 @@ class OptimizationStrategy(Enum):
 
 class PromptQualityMetric(Enum):
     """Enumeration of prompt quality metrics."""
-    
+
     CLARITY = "clarity"
     SPECIFICITY = "specificity"
     COMPLETENESS = "completeness"
@@ -38,7 +38,7 @@ class PromptQualityMetric(Enum):
 @dataclass
 class OptimizationRule:
     """Represents an optimization rule.
-    
+
     Attributes:
         name: The name of the rule.
         pattern: The regex pattern to match.
@@ -47,7 +47,7 @@ class OptimizationRule:
         priority: Priority level (1-10, higher is more important).
         conditions: Additional conditions for applying the rule.
     """
-    
+
     name: str
     pattern: str
     replacement: str
@@ -59,14 +59,14 @@ class OptimizationRule:
 @dataclass
 class QualityScore:
     """Represents a quality score for a prompt.
-    
+
     Attributes:
         metric: The quality metric being scored.
         score: The score value (0-1).
         feedback: Feedback on the metric.
         suggestions: Suggestions for improvement.
     """
-    
+
     metric: PromptQualityMetric
     score: float
     feedback: str
@@ -76,7 +76,7 @@ class QualityScore:
 @dataclass
 class OptimizationResult:
     """Result of prompt optimization.
-    
+
     Attributes:
         original_prompt: The original prompt text.
         optimized_prompt: The optimized prompt text.
@@ -86,7 +86,7 @@ class OptimizationResult:
         suggestions: Additional suggestions for improvement.
         optimization_strategies: Strategies used for optimization.
     """
-    
+
     original_prompt: str
     optimized_prompt: str
     quality_scores: List[QualityScore]
@@ -98,39 +98,39 @@ class OptimizationResult:
 
 class PromptOptimizer:
     """Advanced prompt optimizer with intelligent analysis and optimization.
-    
+
     This class provides sophisticated prompt optimization capabilities including
     quality assessment, intelligent rule application, and context-aware improvements.
     """
-    
+
     def __init__(self):
         """Initialize the PromptOptimizer."""
         self._optimization_rules = self._initialize_optimization_rules()
         self._quality_patterns = self._initialize_quality_patterns()
         self._context_keywords = self._initialize_context_keywords()
-    
+
     def optimize_prompt(
-        self, 
+        self,
         prompt: AgentPromptModel,
         strategies: Optional[List[OptimizationStrategy]] = None,
         custom_rules: Optional[List[OptimizationRule]] = None
     ) -> OptimizationResult:
         """Optimize a prompt using specified strategies.
-        
+
         Args:
             prompt: The prompt model to optimize.
             strategies: List of optimization strategies to apply.
             custom_rules: Custom optimization rules to apply.
-            
+
         Returns:
             OptimizationResult: The optimization result.
         """
         if strategies is None:
             strategies = [OptimizationStrategy.CLARITY, OptimizationStrategy.STRUCTURE]
-        
+
         # Analyze current quality
         quality_scores = self._analyze_prompt_quality(prompt)
-        
+
         # Apply optimization rules
         optimized_intro = self._optimize_section(
             prompt.introduction, strategies, custom_rules
@@ -141,26 +141,26 @@ class PromptOptimizer:
         optimized_instruction = self._optimize_section(
             prompt.instruction, strategies, custom_rules
         )
-        
+
         # Generate improvements list
         improvements = self._generate_improvements(
             prompt, optimized_intro, optimized_target, optimized_instruction
         )
-        
+
         # Generate suggestions
         suggestions = self._generate_suggestions(quality_scores, strategies)
-        
+
         # Calculate confidence score
         confidence_score = self._calculate_confidence_score(
             quality_scores, improvements
         )
-        
+
         # Format results
         original_prompt = self._format_prompt(prompt)
         optimized_prompt = self._format_optimized_prompt(
             optimized_intro, optimized_target, optimized_instruction
         )
-        
+
         return OptimizationResult(
             original_prompt=original_prompt,
             optimized_prompt=optimized_prompt,
@@ -170,38 +170,38 @@ class PromptOptimizer:
             suggestions=suggestions,
             optimization_strategies=strategies
         )
-    
+
     def analyze_prompt_quality(self, prompt: AgentPromptModel) -> List[QualityScore]:
         """Analyze the quality of a prompt.
-        
+
         Args:
             prompt: The prompt model to analyze.
-            
+
         Returns:
             List[QualityScore]: Quality scores for different metrics.
         """
         return self._analyze_prompt_quality(prompt)
-    
+
     def suggest_improvements(self, prompt: AgentPromptModel) -> List[str]:
         """Suggest improvements for a prompt.
-        
+
         Args:
             prompt: The prompt model to analyze.
-            
+
         Returns:
             List[str]: List of improvement suggestions.
         """
         quality_scores = self._analyze_prompt_quality(prompt)
         suggestions = []
-        
+
         for score in quality_scores:
             suggestions.extend(score.suggestions)
-        
+
         return suggestions
-    
+
     def _initialize_optimization_rules(self) -> List[OptimizationRule]:
         """Initialize optimization rules.
-        
+
         Returns:
             List[OptimizationRule]: List of optimization rules.
         """
@@ -228,7 +228,7 @@ class PromptOptimizer:
                 description="Improve specificity in target description",
                 priority=6
             ),
-            
+
             # Structure rules
             OptimizationRule(
                 name="add_numbering",
@@ -245,7 +245,7 @@ class PromptOptimizer:
                 description="Improve text formatting",
                 priority=4
             ),
-            
+
             # Specificity rules
             OptimizationRule(
                 name="add_examples_placeholder",
@@ -262,7 +262,7 @@ class PromptOptimizer:
                 description="Improve constraint formatting",
                 priority=5
             ),
-            
+
             # Efficiency rules
             OptimizationRule(
                 name="remove_redundancy",
@@ -278,7 +278,7 @@ class PromptOptimizer:
                 description="Simplify language for better efficiency",
                 priority=4
             ),
-            
+
             # Comprehensiveness rules
             OptimizationRule(
                 name="add_quality_assurance",
@@ -295,10 +295,10 @@ class PromptOptimizer:
                 priority=5
             )
         ]
-    
+
     def _initialize_quality_patterns(self) -> Dict[PromptQualityMetric, Dict[str, Any]]:
         """Initialize quality assessment patterns.
-        
+
         Returns:
             Dict[PromptQualityMetric, Dict[str, Any]]: Quality patterns.
         """
@@ -361,10 +361,10 @@ class PromptOptimizer:
                 "weight": 0.1
             }
         }
-    
+
     def _initialize_context_keywords(self) -> Dict[str, List[str]]:
         """Initialize context-specific keywords.
-        
+
         Returns:
             Dict[str, List[str]]: Context keywords.
         """
@@ -375,71 +375,71 @@ class PromptOptimizer:
             "creative": ["创意", "设计", "艺术", "创作", "创新", "灵感"],
             "analytical": ["分析", "数据", "统计", "研究", "报告", "洞察"]
         }
-    
+
     def _analyze_prompt_quality(self, prompt: AgentPromptModel) -> List[QualityScore]:
         """Analyze the quality of a prompt.
-        
+
         Args:
             prompt: The prompt model to analyze.
-            
+
         Returns:
             List[QualityScore]: Quality scores for different metrics.
         """
         quality_scores = []
         full_text = self._format_prompt(prompt)
-        
+
         for metric, patterns in self._quality_patterns.items():
             score = self._calculate_metric_score(full_text, patterns)
             feedback = self._generate_feedback(metric, score)
             suggestions = self._generate_suggestions_for_metric(metric, score)
-            
+
             quality_scores.append(QualityScore(
                 metric=metric,
                 score=score,
                 feedback=feedback,
                 suggestions=suggestions
             ))
-        
+
         return quality_scores
-    
+
     def _calculate_metric_score(self, text: str, patterns: Dict[str, Any]) -> float:
         """Calculate score for a specific quality metric.
-        
+
         Args:
             text: The text to analyze.
             patterns: The patterns for the metric.
-            
+
         Returns:
             float: Score between 0 and 1.
         """
         positive_score = 0
         negative_score = 0
-        
+
         # Count positive patterns
         for pattern in patterns["positive_patterns"]:
             matches = len(re.findall(pattern, text, re.IGNORECASE))
             positive_score += matches
-        
+
         # Count negative patterns
         for pattern in patterns["negative_patterns"]:
             matches = len(re.findall(pattern, text, re.IGNORECASE))
             negative_score += matches
-        
+
         # Calculate final score
         total_patterns = positive_score + negative_score
         if total_patterns == 0:
             return 0.5  # Neutral score if no patterns found
-        
+
         score = positive_score / total_patterns
         return min(max(score, 0), 1)  # Clamp between 0 and 1
-    
+
     def _generate_feedback(self, metric: PromptQualityMetric, score: float) -> str:
         """Generate feedback for a quality metric.
-        
+
         Args:
             metric: The quality metric.
             score: The score for the metric.
-            
+
         Returns:
             str: Feedback text.
         """
@@ -451,131 +451,131 @@ class PromptOptimizer:
             return f"{metric.value}表现一般，需要改进"
         else:
             return f"{metric.value}表现较差，需要重点改进"
-    
+
     def _generate_suggestions_for_metric(
-        self, 
-        metric: PromptQualityMetric, 
+        self,
+        metric: PromptQualityMetric,
         score: float
     ) -> List[str]:
         """Generate suggestions for a specific metric.
-        
+
         Args:
             metric: The quality metric.
             score: The score for the metric.
-            
+
         Returns:
             List[str]: List of suggestions.
         """
         suggestions = []
-        
+
         if metric == PromptQualityMetric.CLARITY and score < 0.7:
             suggestions.extend([
                 "使用更清晰、具体的语言",
                 "避免模糊或歧义的表达",
                 "提供明确的指导步骤"
             ])
-        
+
         if metric == PromptQualityMetric.SPECIFICITY and score < 0.7:
             suggestions.extend([
                 "添加具体的示例和说明",
                 "提供详细的执行步骤",
                 "明确约束条件和要求"
             ])
-        
+
         if metric == PromptQualityMetric.COMPLETENESS and score < 0.7:
             suggestions.extend([
                 "确保包含所有必要的部分",
                 "添加缺失的介绍、目标或指令",
                 "提供完整的上下文信息"
             ])
-        
+
         if metric == PromptQualityMetric.STRUCTURE and score < 0.7:
             suggestions.extend([
                 "使用有序的步骤和流程",
                 "添加编号或列表格式",
                 "确保逻辑结构清晰"
             ])
-        
+
         if metric == PromptQualityMetric.TONE and score < 0.7:
             suggestions.extend([
                 "使用更专业、友好的语调",
                 "避免命令式语言",
                 "添加礼貌用语"
             ])
-        
+
         return suggestions
-    
+
     def _optimize_section(
-        self, 
-        section: Optional[str], 
+        self,
+        section: Optional[str],
         strategies: List[OptimizationStrategy],
         custom_rules: Optional[List[OptimizationRule]]
     ) -> str:
         """Optimize a specific section of the prompt.
-        
+
         Args:
             section: The section text to optimize.
             strategies: Optimization strategies to apply.
             custom_rules: Custom rules to apply.
-            
+
         Returns:
             str: Optimized section text.
         """
         if not section:
             return ""
-        
+
         optimized = section
-        
+
         # Apply standard rules
         applicable_rules = self._get_applicable_rules(strategies, custom_rules)
-        
+
         for rule in applicable_rules:
             if re.search(rule.pattern, optimized):
                 optimized = re.sub(rule.pattern, rule.replacement, optimized)
-        
+
         return optimized
-    
+
     def _get_applicable_rules(
-        self, 
+        self,
         strategies: List[OptimizationStrategy],
         custom_rules: Optional[List[OptimizationRule]]
     ) -> List[OptimizationRule]:
         """Get applicable optimization rules.
-        
+
         Args:
             strategies: Optimization strategies.
             custom_rules: Custom rules.
-            
+
         Returns:
             List[OptimizationRule]: Applicable rules.
         """
         applicable_rules = []
-        
+
         # Add custom rules first
         if custom_rules:
             applicable_rules.extend(custom_rules)
-        
+
         # Add standard rules based on strategies
         for rule in self._optimization_rules:
             if self._rule_applies_to_strategies(rule, strategies):
                 applicable_rules.append(rule)
-        
+
         # Sort by priority
         applicable_rules.sort(key=lambda r: r.priority, reverse=True)
-        
+
         return applicable_rules
-    
+
     def _rule_applies_to_strategies(
-        self, 
-        rule: OptimizationRule, 
+        self,
+        rule: OptimizationRule,
         strategies: List[OptimizationStrategy]
     ) -> bool:
         """Check if a rule applies to the given strategies.
-        
+
         Args:
             rule: The optimization rule.
             strategies: The optimization strategies.
-            
+
         Returns:
             bool: True if the rule applies.
         """
@@ -587,111 +587,111 @@ class PromptOptimizer:
             "efficiency": OptimizationStrategy.EFFICIENCY,
             "comprehensiveness": OptimizationStrategy.COMPREHENSIVENESS
         }
-        
+
         for strategy in strategies:
             if strategy in strategy_mapping.values():
                 return True
-        
+
         return False
-    
+
     def _generate_improvements(
-        self, 
+        self,
         original: AgentPromptModel,
         optimized_intro: str,
         optimized_target: str,
         optimized_instruction: str
     ) -> List[str]:
         """Generate list of improvements made.
-        
+
         Args:
             original: Original prompt model.
             optimized_intro: Optimized introduction.
             optimized_target: Optimized target.
             optimized_instruction: Optimized instruction.
-            
+
         Returns:
             List[str]: List of improvements.
         """
         improvements = []
-        
+
         if original.introduction != optimized_intro:
             improvements.append("优化了介绍部分，增强了专业性和清晰度")
-        
+
         if original.target != optimized_target:
             improvements.append("改进了目标描述，提高了具体性和可操作性")
-        
+
         if original.instruction != optimized_instruction:
             improvements.append("重构了指令部分，改善了结构和可读性")
-        
+
         return improvements
-    
+
     def _generate_suggestions(
-        self, 
+        self,
         quality_scores: List[QualityScore],
         strategies: List[OptimizationStrategy]
     ) -> List[str]:
         """Generate optimization suggestions.
-        
+
         Args:
             quality_scores: Quality scores for the prompt.
             strategies: Applied optimization strategies.
-            
+
         Returns:
             List[str]: List of suggestions.
         """
         suggestions = []
-        
+
         # Add suggestions based on quality scores
         for score in quality_scores:
             if score.score < 0.7:
                 suggestions.extend(score.suggestions)
-        
+
         # Add strategy-specific suggestions
         if OptimizationStrategy.CLARITY in strategies:
             suggestions.append("考虑使用更简洁明了的语言表达")
-        
+
         if OptimizationStrategy.STRUCTURE in strategies:
             suggestions.append("建议使用编号或列表来组织信息")
-        
+
         if OptimizationStrategy.SPECIFICITY in strategies:
             suggestions.append("添加具体示例和详细说明")
-        
+
         return list(set(suggestions))  # Remove duplicates
-    
+
     def _calculate_confidence_score(
-        self, 
+        self,
         quality_scores: List[QualityScore],
         improvements: List[str]
     ) -> float:
         """Calculate overall confidence score.
-        
+
         Args:
             quality_scores: Quality scores for the prompt.
             improvements: List of improvements made.
-            
+
         Returns:
             float: Confidence score between 0 and 1.
         """
         if not quality_scores:
             return 0.5
-        
+
         # Calculate average quality score
         avg_quality = sum(score.score for score in quality_scores) / len(quality_scores)
-        
+
         # Factor in number of improvements
         improvement_factor = min(len(improvements) * 0.1, 0.3)
-        
+
         # Calculate final confidence score
         confidence = (avg_quality * 0.7) + (improvement_factor * 0.3)
-        
+
         return min(max(confidence, 0), 1)  # Clamp between 0 and 1
-    
+
     def _format_prompt(self, prompt: AgentPromptModel) -> str:
         """Format prompt model as string.
-        
+
         Args:
             prompt: The prompt model.
-            
+
         Returns:
             str: Formatted prompt string.
         """
@@ -702,22 +702,22 @@ class PromptOptimizer:
             parts.append(f"目标：{prompt.target}")
         if prompt.instruction:
             parts.append(f"指令：{prompt.instruction}")
-        
+
         return "\n\n".join(parts)
-    
+
     def _format_optimized_prompt(
-        self, 
-        introduction: str, 
-        target: str, 
+        self,
+        introduction: str,
+        target: str,
         instruction: str
     ) -> str:
         """Format optimized prompt as string.
-        
+
         Args:
             introduction: Optimized introduction.
             target: Optimized target.
             instruction: Optimized instruction.
-            
+
         Returns:
             str: Formatted optimized prompt string.
         """
@@ -728,5 +728,5 @@ class PromptOptimizer:
             parts.append(f"目标：{target}")
         if instruction:
             parts.append(f"指令：{instruction}")
-        
+
         return "\n\n".join(parts)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 20, 30, 41, 50, 62, 69, 79, 89, 101, 105, 111, 113, 119, 124, 130, 133, 144, 149, 152, 157, 163, 173, 176, 179, 184, 187, 190, 196, 199, 201, 204, 231, 248, 265, 281, 298, 301, 364, 367, 378, 381, 384, 390, 395, 402, 404, 407, 411, 417, 422, 427, 432, 435, 438, 442, 454, 456, 457, 461, 465, 470, 477, 484, 491, 498, 505, 507, 509, 510, 515, 520, 526, 528, 531, 535, 537, 539, 544, 548, 553, 557, 562, 565, 567, 569, 570, 574, 578, 590, 594, 596, 598, 605, 611, 616, 619, 622, 625, 627, 629, 634, 638, 643, 648, 652, 655, 658, 660, 662, 667, 671, 677, 680, 683, 686, 688, 691, 694, 705, 707, 709, 710, 711, 715, 720, 731 in `examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_optimizer.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/prompt_toolkit_app/prompt/prompt_optimizer.py').read())"` — the file remains syntactically valid.
