### PR TITLE
style(examples): strip trailing whitespace in __init__.py

### DIFF
--- a/examples/third_party_examples/apps/prompt_generator_app/scripts/__init__.py
+++ b/examples/third_party_examples/apps/prompt_generator_app/scripts/__init__.py
@@ -2,6 +2,6 @@
 # -*- coding:utf-8 -*-
 
 # @Time    : 2025/10/30 20:59
-# @Author  : jerry.zzw 
+# @Author  : jerry.zzw
 # @Email   : jerry.zzw@antgroup.com
 # @FileName: __init__.py.py


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 5 in `examples/third_party_examples/apps/prompt_generator_app/scripts/__init__.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/third_party_examples/apps/prompt_generator_app/scripts/__init__.py').read())"` — the file remains syntactically valid.
