### PR TITLE
style(examples): strip trailing whitespace in __init__.py

### DIFF
--- a/examples/sample_apps/difizen_app/intelligence/agentic/knowledge/rag_router/__init__.py
+++ b/examples/sample_apps/difizen_app/intelligence/agentic/knowledge/rag_router/__init__.py
@@ -3,5 +3,5 @@
 
 # @Time    :
 # @Author  :
-# @Email   : 
+# @Email   :
 # @FileName: __init__.py


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Removed trailing whitespace on lines 6 in `examples/sample_apps/difizen_app/intelligence/agentic/knowledge/rag_router/__init__.py`.
- no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('examples/sample_apps/difizen_app/intelligence/agentic/knowledge/rag_router/__init__.py').read())"` — the file remains syntactically valid.
