### PR TITLE
docs(tests): document test_top_n_zero_returns_empty in test_reciprocal_rank_fusion_processor.py

### DIFF
--- a/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py
+++ b/tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py
@@ -193,6 +193,8 @@ class TestTopNAndScoreField(unittest.TestCase):
         self.assertEqual([d.text for d in out], ["a", "b"])
 
     def test_top_n_zero_returns_empty(self) -> None:
+        """Test that top n zero returns empty.
+        """
         proc = ReciprocalRankFusionProcessor(top_n=0)
         out = proc._process_docs([_doc("a"), _doc("b")])
         self.assertEqual(out, [])


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `test_top_n_zero_returns_empty` in `tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py`.
- Completes the module documentation; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/agent/action/knowledge/doc_processor/test_reciprocal_rank_fusion_processor.py').read())"` — the file remains syntactically valid.
