### PR TITLE
docs(tests): document test_load_by_configer_preserves_planner_keys in test_planner_configer.py

### DIFF
--- a/tests/test_agentuniverse/unit/base/config/test_planner_configer.py
+++ b/tests/test_agentuniverse/unit/base/config/test_planner_configer.py
@@ -5,6 +5,8 @@ from agentuniverse.base.config.configer import Configer
 
 
 def test_load_by_configer_preserves_planner_keys():
+    """Test that load by configer preserves planner keys.
+    """
     configer = Configer()
     configer.value = {
         "name": "custom_planner",


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines.
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers.
- [x] I accept the suggestion of the maintainers to make changes to or close this PR.
- [x] I have submitted the test files and can provide screenshots of the test results
- [ ] I have added or modified the documentation related to this PR
- [ ] I have added examples and notes if needed

**Please fill in the specific details of this PR:**
- Added a Google-style docstring to `test_load_by_configer_preserves_planner_keys` in `tests/test_agentuniverse/unit/base/config/test_planner_configer.py`.
- Completes the module documentation; no functional changes.
- Verified with `python3 -c "import ast; ast.parse(open('tests/test_agentuniverse/unit/base/config/test_planner_configer.py').read())"` — the file remains syntactically valid.
