### PR TITLE
docs: fix stale organization links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,9 +194,9 @@ This version introduces new capabilities such as intelligent agent canvas orches
 
 ### Note 
 - Default path optimization for system_db_uri
-The default path is already compatible with the Windows platform, for more details, please refer to [issue142](https://github.com/antgroup/agentUniverse/issues/142)
+The default path is already compatible with the Windows platform, for more details, please refer to [issue142](https://github.com/agentuniverse-ai/agentUniverse/issues/142)
 - Support for configurable chain stop words in ReactAgent
-The ReactAgent YAML configuration now supports the stop_sequence keyword, allowing users to customize chain stop words. For more details, please refer to [issue127](https://github.com/antgroup/agentUniverse/issues/127)
+The ReactAgent YAML configuration now supports the stop_sequence keyword, allowing users to customize chain stop words. For more details, please refer to [issue127](https://github.com/agentuniverse-ai/agentUniverse/issues/127)
 - Added an introduction to RAG principles and a quick guide for building RAG, please pay attention to the corresponding parts in the README and user guide.
 - Added advanced guidance documents for the intelligent agent productization platform, please pay attention to the corresponding parts in the README and user guide.
 - Various code optimizations and documentation updates.


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `CHANGELOG.md` — link-only change, no prose/content edits.
- What changed: Replaced the two issue tracker links (`#142` and `#127`) that still pointed at the old `github.com/antgroup/agentUniverse` location with the current `github.com/agentuniverse-ai/agentUniverse` URLs.
- Why it matters: The agentUniverse repository has moved to the `agentuniverse-ai` organization; links under the old `antgroup` organization no longer resolve to the project.
- How verified: Both updated URLs point at the canonical repository issue tracker (HTTP 200 on the new-org issue pages).

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- CHANGELOG.md
