### PR TITLE
docs: fix stale organization links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Thank you for your interest in agentUniverse and your willingness to contribute. We welcome you to join the agentUniverse community family. As an open-source project in the field of artificial intelligence, your contributions are important to the development and improvement of our project. We welcome all types of contributions, such as introducing new features, fixing code issues, improving documentation, submitting issues, and adding examples.
 
 ### Communicate with Us
-If you have any ideas or questions related to contributions, feel free to reach out to us in advance. You can communicate through the [issue](https://github.com/antgroup/agentUniverse/issues) section of the agentUniverse project, send us an email, or join our community for discussions. For more detailed communication methods, please refer to the [Contact Information](docs/guidebook/en/Contact_Us.md)。
+If you have any ideas or questions related to contributions, feel free to reach out to us in advance. You can communicate through the [issue](https://github.com/agentuniverse-ai/agentUniverse/issues) section of the agentUniverse project, send us an email, or join our community for discussions. For more detailed communication methods, please refer to the [Contact Information](docs/guidebook/en/Contact_Us.md)。
 
 ### Guidelines
 #### Contributing to the Code & Docs
@@ -23,7 +23,7 @@ During the PR submission process, we follow the aforementioned commit types. You
 
 Please ensure that you meet the following requirements when submitting your PR:
 
-- Read and understand the requirements outlined in the [Contributor Guidelines](https://github.com/antgroup/agentUniverse/blob/master/CONTRIBUTING.md).
+- Read and understand the requirements outlined in the [Contributor Guidelines](https://github.com/agentuniverse-ai/agentUniverse/blob/master/CONTRIBUTING.md).
 - Check for any duplicate features related to this request and communicated with the project maintainers.
 - Accept the suggestion of the maintainers to make changes to or close this PR.
 - Submit the test files and can provide screenshots of the test results (required for feature or bug fixes).


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `CONTRIBUTING.md` — link-only change, no prose/content edits.
- What changed: Updated the Issues link and the contributor-guidelines link in CONTRIBUTING.md from `github.com/antgroup/agentUniverse` to `github.com/agentuniverse-ai/agentUniverse`.
- Why it matters: The repository was transferred to the `agentuniverse-ai` organization, so the old URLs point to the archived/redirected org.
- How verified: New URLs resolve to the existing repository and file on the current default branch.

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- CONTRIBUTING.md
