### PR TITLE
docs: fix broken links in 如何发布MCP服务.md

### DIFF
--- a/docs/guidebook/zh/How-to/使用与发布MCP服务/如何发布MCP服务.md
+++ b/docs/guidebook/zh/How-to/使用与发布MCP服务/如何发布MCP服务.md
@@ -32,6 +32,6 @@ if __name__ == "__main__":
 启动后您可以通过下列地址访问：
 - `http://0.0.0.0:8890/default_mcp_server/sse`
 
-完整的MCP服务发布用例您可以在[标准样例工程](/examples/sample_standard_app)中查看, 您可以使用[mcp_application.py](/examples/sample_standard_app/bootstrap/intelligence/mcp_application.py)进行MCP服务启动, 在该样例中我们将[mock_search_tool工具](/examples/sample_standard_app/intelligence/agentic/tool/custom/mock_search_tool.yaml)发布为了default_mcp_server。
+完整的MCP服务发布用例您可以在[标准样例工程](../../../../../examples/sample_standard_app)中查看, 您可以使用[mcp_application.py](../../../../../examples/sample_standard_app/bootstrap/intelligence/mcp_application.py)进行MCP服务启动, 在该样例中我们将[mock_search_tool工具](../../../../../examples/sample_standard_app/intelligence/agentic/tool/custom/mock_search_tool.yaml)发布为了default_mcp_server。
 
-您可以进一步指定所发布的MCP服务端口、host地址、通信类型等，更详细的内容请参考文档[MCP_Server](/docs/guidebook/zh/In-Depth_Guides/技术组件/服务化/MCP_Server.md)。
+您可以进一步指定所发布的MCP服务端口、host地址、通信类型等，更详细的内容请参考文档[MCP_Server](../../In-Depth_Guides/技术组件/服务化/MCP_Server.md)。


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `docs/guidebook/zh/How-to/使用与发布MCP服务/如何发布MCP服务.md` — link-only change, no prose/content edits.
- What changed: Rewrote the four repo-root-absolute links (`/examples/...` and `/docs/...`) as file-relative links that resolve from this document: the sample project, `mcp_application.py`, `mock_search_tool.yaml`, and the MCP_Server doc now use `../../../../../examples/...` / `../../In-Depth_Guides/...` paths.
- Why it matters: Root-absolute links in a nested guidebook file only resolve in the GitHub blob renderer and break everywhere else; every other guidebook page links relatively. All targets were verified against the current repository tree.
- How verified: Each rewritten target was resolved from the file location and exists in the repository (`examples/sample_standard_app`, `docs/guidebook/zh/In-Depth_Guides/技术组件/服务化/MCP_Server.md`).

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- docs/guidebook/zh/How-to/使用与发布MCP服务/如何发布MCP服务.md
