### PR TITLE
docs: fix broken links in K8S部署.md

### DIFF
--- a/docs/guidebook/zh/In-Depth_Guides/部署运维/K8S部署.md
+++ b/docs/guidebook/zh/In-Depth_Guides/部署运维/K8S部署.md
@@ -64,7 +64,7 @@ spec:
 
 #### 方式2
 
-请参考配置文件开始部分的描述: [快速开始指南](../../../开始使用/3.快速构建单体智能体.md)
+请参考配置文件开始部分的描述: [快速开始指南](../../../zh/开始使用/3.快速构建单体智能体.md)
 
 ## 2. 构建资源
 
@@ -81,7 +81,7 @@ kubectl apply -f agentuniverse.yaml
 ```
 kubectl get all -n agent-namespace
 ```
-![资源部署情况](../../../../_picture/k8s_resource.png)
+![资源部署情况](../../../../guidebook/_picture/k8s_resource.png)
 ## 4. 从集群内部访问agentUniverse 服务
 
 要从集群内部访问 agentUniverse 服务，请使用以下命令行示例：
@@ -98,11 +98,11 @@ kubectl exec -it [Pod名称] -n agent-namespace -- curl http://agentuniverse-ser
 kubectl exec -it agentuniverse-deployment-55cfd778d-g7d9d -n agent-namespace -- curl http://agentuniverse-service:9999/echo
 ```
 
-![连通性测试](../../../../_picture/k8s_hello.png)
+![连通性测试](../../../../guidebook/_picture/k8s_hello.png)
 #### 4.1.2 问答测试
 
 ```
 kubectl exec -it agentuniverse-deployment-55cfd778d-g7d9d -n agent-namespace -- curl -X POST -H "Content-Type: application/json" -d '{"service_id":"demo_service","params":{"input":"(18+3-5)/2*4=?"}}' http://agentuniverse-service:9999/service_run
 ```
 
-![问答测试](../../../../_picture/k8s_question.png)
+![问答测试](../../../../guidebook/_picture/k8s_question.png)


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `docs/guidebook/zh/In-Depth_Guides/部署运维/K8S部署.md` — link-only change, no prose/content edits.
- What changed: Fixed the Quick Start link (now `../../../zh/开始使用/3.快速构建单体智能体.md`) and the three K8S screenshots (now `../../../../guidebook/_picture/k8s_*.png`) so they point at the real files.
- Why it matters: The relative links resolved to `docs/guidebook/开始使用/...` and `docs/_picture/...`, which do not exist; the actual files live under `docs/guidebook/zh/开始使用/` and `docs/guidebook/_picture/`.
- How verified: Resolved each target from the file directory and confirmed existence with `find`/`ls`.

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- docs/guidebook/zh/In-Depth_Guides/部署运维/K8S部署.md
