### PR TITLE
docs: fix broken links in How_to_Use_MCP_Servers.md

### DIFF
--- a/docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Use_MCP_Servers.md
+++ b/docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Use_MCP_Servers.md
@@ -76,9 +76,9 @@ metadata:
 ```
 
 Additional Resources:  
-* Sample Application Code: Refer to the [MCP Sample App](/examples/sample_apps/toolkit_demo_app).
-* MCPToolkit Configuration: See the [configuration file](/examples/sample_apps/toolkit_demo_app/intelligence/agentic/toolkit/docx_toolkit.yaml).
-* Agent Configuration: See the [agent configuration file](/examples/sample_apps/toolkit_demo_app/intelligence/agentic/agent/agent_instance/demo_agent_with_mcp_toolkit.yaml).  
-* Test File: Check the [run script](/examples/sample_apps/toolkit_demo_app/intelligence/test/run_demo_agent_with_mcp_toolkit.py).
+* Sample Application Code: Refer to the [MCP Sample App](../../../../../examples/sample_apps/toolkit_demo_app).
+* MCPToolkit Configuration: See the [configuration file](../../../../../examples/sample_apps/toolkit_demo_app/intelligence/agentic/toolkit/docx_toolkit.yaml).
+* Agent Configuration: See the [agent configuration file](../../../../../examples/sample_apps/toolkit_demo_app/intelligence/agentic/agent/agent_instance/demo_agent_with_mcp_toolkit.yaml).  
+* Test File: Check the [run script](../../../../../examples/sample_apps/toolkit_demo_app/intelligence/test/run_demo_agent_with_mcp_toolkit.py).
 
-For more details, consult the following documentation: [MCP Toolkit Guide](/docs/guidebook/en/In-Depth_Guides/Tutorials/Toolkit/MCP_Toolkit_Guide.md), [MCP Tool Guide](/docs/guidebook/en/In-Depth_Guides/Tutorials/Tool/MCP_Tool_Guide.md).
+For more details, consult the following documentation: [MCP Toolkit Guide](../../In-Depth_Guides/Tutorials/Toolkit/MCP_Toolkit_Guide.md), [MCP Tool Guide](../../In-Depth_Guides/Tutorials/Tool/MCP_Tool_Guide.md).


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Use_MCP_Servers.md` — link-only change, no prose/content edits.
- What changed: Rewrote the root-absolute links as file-relative links: the sample app, toolkit config YAML, agent config YAML, run script (`../../../../../examples/sample_apps/toolkit_demo_app/...`) and the MCP Toolkit/Tool guides (`../../In-Depth_Guides/...`).
- Why it matters: Root-absolute links in a nested guidebook file only resolve in the GitHub blob renderer; all other guidebook pages link relatively. All targets were verified against the current repository tree.
- How verified: Each rewritten target was resolved from the file location and exists in the repository.

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Use_MCP_Servers.md
