### PR TITLE
docs: fix broken links in How_to_Publish_MCP_Servers.md

### DIFF
--- a/docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Publish_MCP_Servers.md
+++ b/docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Publish_MCP_Servers.md
@@ -32,6 +32,6 @@ if __name__ == "__main__":
 After starting, you can access the MCP service using the following address:
 - `http://0.0.0.0:8890/default_mcp_server/sse`
 
-For the example of MCP server deployment, refer to the [Standard Sample Project](/examples/sample_standard_app). You can start the MCP server using [mcp_application.py](/examples/sample_standard_app/bootstrap/intelligence/mcp_application.py). In this example, the [mock_search_tool](/examples/sample_standard_app/intelligence/agentic/tool/custom/mock_search_tool.yaml) is published to the default_mcp_server.
+For the example of MCP server deployment, refer to the [Standard Sample Project](../../../../../examples/sample_standard_app). You can start the MCP server using [mcp_application.py](../../../../../examples/sample_standard_app/bootstrap/intelligence/mcp_application.py). In this example, the [mock_search_tool](../../../../../examples/sample_standard_app/intelligence/agentic/tool/custom/mock_search_tool.yaml) is published to the default_mcp_server.
 
-You can further customize the MCP server's port, host address, communication type, etc. For more details, please refer to the documentation: [MCP_Server](/docs/guidebook/en/In-Depth_Guides/Tech_Capabilities/Service/MCP_Server.md).
+You can further customize the MCP server's port, host address, communication type, etc. For more details, please refer to the documentation: [MCP_Server](../../In-Depth_Guides/Tech_Capabilities/Service/MCP_Server.md).


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Publish_MCP_Servers.md` — link-only change, no prose/content edits.
- What changed: Rewrote the four root-absolute links (`/examples/...`, `/docs/...`) as file-relative links (`../../../../../examples/sample_standard_app/...`, `../../In-Depth_Guides/Tech_Capabilities/Service/MCP_Server.md`).
- Why it matters: Root-absolute links in a nested guidebook file only resolve in the GitHub blob renderer and break everywhere else; every other guidebook page links relatively. Targets were verified against the current tree.
- How verified: Each rewritten target resolves from the file location and exists in the repository.

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- docs/guidebook/en/How-to/Use and Publish MCP Server/How_to_Publish_MCP_Servers.md
