### PR TITLE
docs: fix broken links in Contents.md

### DIFF
--- a/docs/guidebook/en/Contents.md
+++ b/docs/guidebook/en/Contents.md
@@ -39,8 +39,8 @@
     * 2.2.5.2 [Related Domain Objects](In-Depth_Guides/Tutorials/Plan/Planner_Related_Domain_Objects.md)
 * 2.3 Technical Components
   * 2.3.1 [RAG](In-Depth_Guides/Tutorials/RAG.md) 
-    * 2.3.1.1 [How to Build Knowledge Base](How-to/Build%20and%20Use%20a%20Knowledge%20Base/How_to_Build_Knowledge_Base.md) 
-    * 2.3.1.1 [How to Use Knowledge Base](How-to/Build%20and%20Use%20a%20Knowledge%20Base/How_to_Use_Knowledge_Base.md) 
+    * 2.3.1.1 [How to Build Knowledge Base](How-to/Build and Use a Knowledge Base/How_to_Build_Knowledge_Base.md) 
+    * 2.3.1.1 [How to Use Knowledge Base](How-to/Build and Use a Knowledge Base/How_to_Use_Knowledge_Base.md) 
 * 2.4 Others
   * 2.4.1 Service
     * 2.4.1.1 [Registration and Usage](In-Depth_Guides/Tech_Capabilities/Service/Service_Registration_and_Usage.md)
@@ -106,8 +106,8 @@
 * 6.5 [Andrew Ng's Reflexive Workflow Translation Agent Replication](Examples/Translation_Assistant.md)
 
 **7.Product Platform**
-* 7.1 [Quick Use](How-to/Guide%20to%20Visual%20Agentic%20Workflow%20Platform/Product_Platform_Quick_Start.md)
-* 7.2 [Advancement Guide](How-to/Guide%20to%20Visual%20Agentic%20Workflow%20Platform/Product_Platform_Advancement_Guide.md)
+* 7.1 [Quick Use](How-to/Guide to Visual Agentic Workflow Platform/Product_Platform_Quick_Start.md)
+* 7.2 [Advancement Guide](How-to/Guide to Visual Agentic Workflow Platform/Product_Platform_Advancement_Guide.md)
 
 **8. Series of Articles**
 


### PR DESCRIPTION
**Checklist | 检查项**
- [x] I have read and understood the contributor guidelines. | 我已阅读并理解贡献者指南。
- [x] I have checked for any duplicate features related to this request and communicated with the project maintainers. | 我已检查没有与此请求重复的功能并与项目维护者进行了沟通。
- [x] I accept the suggestion of the maintainers to make changes to or close this PR. | 我接受此PR配合维护人员的建议进行修改或关闭。
- [ ] I have submitted the test files and can provide screenshots of the test results (required for feature or bug fixes) | 我已经提交了测试文件并可提供测试结果截图(功能修改、BUG修复类PR必须提供，其他按需)
- [x] I have added or modified the documentation related to this PR | 我已经添加或修改了本次pr对应的文档说明
- [ ] I have added examples and notes if needed | 我已经添加了使用案例代码与文档说明(非必要)

**Please fill in the specific details of this PR:** | **请详细填写本次PR的内容:**
- File changed: `docs/guidebook/en/Contents.md` — link-only change, no prose/content edits.
- What changed: De-encoded the four URL-encoded relative links so they point at the real files: `How-to/Build and Use a Knowledge Base/...` (two entries) and `How-to/Guide to Visual Agentic Workflow Platform/...` (two entries).
- Why it matters: The `%20`-encoded targets do not resolve as literal repository paths; the referenced directories contain spaces and exist under those names. The decoded links match the naming convention used by every other entry in Contents.md.
- How verified: Each decoded target resolves from `docs/guidebook/en/` and exists in the repository tree.

**Please list the names of the docs that were added or modified in this PR:** | **请列出本次PR新增或修改的文档名称:**
- docs/guidebook/en/Contents.md
